### PR TITLE
introduce zk-stats: zk-latency + zk-rate

### DIFF
--- a/managed-ledger/pom.xml
+++ b/managed-ledger/pom.xml
@@ -57,7 +57,12 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-
+  
+    <dependency>
+      <groupId>org.hdrhistogram</groupId>
+      <artifactId>HdrHistogram</artifactId>
+    </dependency>
+        
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -222,9 +222,9 @@ public class ManagedCursorImpl implements ManagedCursor {
         // a new ledger and write the position into it
         ledger.mbean.startCursorLedgerOpenOp();
         long ledgerId = info.getCursorsLedgerId();
-        final long now = System.currentTimeMillis();
+        final long now = System.nanoTime();
         bookkeeper.asyncOpenLedger(ledgerId, config.getDigestType(), config.getPassword(), (rc, lh, ctx) -> {
-            ledger.getStore().recordRead(System.currentTimeMillis() - now);
+            ledger.getStore().recordReadLatency(System.nanoTime() - now, 1L);
             if (log.isDebugEnabled()) {
                 log.debug("[{}] Opened ledger {} for consumer {}. rc={}", ledger.getName(), ledgerId, name, rc);
             }
@@ -1825,10 +1825,9 @@ public class ManagedCursorImpl implements ManagedCursor {
 
     void createNewMetadataLedger(final VoidCallback callback) {
         ledger.mbean.startCursorLedgerCreateOp();
-        final long now = System.currentTimeMillis();
         bookkeeper.asyncCreateLedger(config.getMetadataEnsemblesize(), config.getMetadataWriteQuorumSize(),
                 config.getMetadataAckQuorumSize(), config.getDigestType(), config.getPassword(), (rc, lh, ctx) -> {
-                    ledger.getStore().recordWrite(System.currentTimeMillis() - now);
+                    ledger.getStore().recordWriteCount(3L); // create-ledger-performs-3-write
                     ledger.getExecutor().submit(safeRun(() -> {
                         ledger.mbean.endCursorLedgerCreateOp();
                         if (rc != BKException.Code.OK) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStore.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStore.java
@@ -133,4 +133,30 @@ public interface MetaStore {
      * @throws MetaStoreException
      */
     Iterable<String> getManagedLedgers() throws MetaStoreException;
+
+    /**
+     * Record write zk operation with latency for zk-op stats
+     * 
+     * @param latency
+     */
+    void recordWrite(long latency);
+
+    /**
+     * Record write zk operation for zk-op stats
+     * 
+     */
+    void recordWrite();
+
+    /**
+     * Record read zk operation with latency for zk-op stats
+     * 
+     * @param latency
+     */
+    void recordRead(long latency);
+
+    /**
+     * Record read zk operation for zk-op stats
+     * 
+     */
+    void recordRead();
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStore.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStore.java
@@ -135,28 +135,28 @@ public interface MetaStore {
     Iterable<String> getManagedLedgers() throws MetaStoreException;
 
     /**
-     * Record write zk operation with latency for zk-op stats
+     * Record write zk write with latency (in nano-seconds) for zk-op stats
      * 
      * @param latency
      */
-    void recordWrite(long latency);
+    void recordWriteLatency(long latencyInNs, long count);
 
     /**
      * Record write zk operation for zk-op stats
      * 
      */
-    void recordWrite();
+    void recordWriteCount(long count);
 
     /**
-     * Record read zk operation with latency for zk-op stats
+     * Record read zk read with latency (in nano-seconds) for zk-op stats
      * 
      * @param latency
      */
-    void recordRead(long latency);
+    void recordReadLatency(long latency, long count);
 
     /**
      * Record read zk operation for zk-op stats
      * 
      */
-    void recordRead();
+    void recordReadCount(long count);
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImplZookeeper.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/MetaStoreImplZookeeper.java
@@ -20,6 +20,7 @@ import static org.apache.bookkeeper.mledger.util.SafeRun.safeRun;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
 
 import org.apache.bookkeeper.mledger.ManagedLedgerException.BadVersionException;
@@ -61,7 +62,8 @@ public class MetaStoreImplZookeeper implements MetaStore {
     private final OrderedSafeExecutor executor;
     private final LongAdder numWrite;
     private final LongAdder numRead;
-    private final DimensionStats zkOpLatencyStats;
+    private final DimensionStats zkWriteLatencyStats;
+    private final DimensionStats zkReadLatencyStats;
 
     private static class ZKStat implements Stat {
         private final int version;
@@ -107,7 +109,8 @@ public class MetaStoreImplZookeeper implements MetaStore {
         this.executor = executor;
         this.numWrite = new LongAdder();
         this.numRead = new LongAdder();
-        this.zkOpLatencyStats = new DimensionStats();
+        this.zkWriteLatencyStats = new DimensionStats();
+        this.zkReadLatencyStats = new DimensionStats();
 
         if (zk.exists(prefixName, false) == null) {
             zk.create(prefixName, new byte[0], Acl, CreateMode.PERSISTENT);
@@ -141,9 +144,9 @@ public class MetaStoreImplZookeeper implements MetaStore {
     @Override
     public void getManagedLedgerInfo(final String ledgerName, final MetaStoreCallback<ManagedLedgerInfo> callback) {
         // Try to get the content or create an empty node
-        final long now = System.currentTimeMillis();
+        final long now = System.nanoTime();
         zk.getData(prefix + ledgerName, false, (rc, path, ctx, readData, stat) -> executor.submit(safeRun(() -> {
-            recordRead(System.currentTimeMillis() - now);
+            recordReadLatency(System.nanoTime() - now, 1L);
             if (rc == Code.OK.intValue()) {
                 try {
                     ManagedLedgerInfo info = parseManagedLedgerInfo(readData);
@@ -185,10 +188,10 @@ public class MetaStoreImplZookeeper implements MetaStore {
                 mlInfo.toString().getBytes(Encoding) : // Text format
                 mlInfo.toByteArray(); // Binary format
 
-        final long now = System.currentTimeMillis();
+        final long now = System.nanoTime();
         zk.setData(prefix + ledgerName, serializedMlInfo, zkStat.getVersion(),
                 (rc, path, zkCtx, stat1) -> executor.submit(safeRun(() -> {
-                    recordWrite(System.currentTimeMillis() - now);
+                    recordWriteLatency(System.nanoTime() - now, 1L);
                     if (log.isDebugEnabled()) {
                         log.debug("[{}] UpdateLedgersIdsCallback.processResult rc={} newVersion={}", ledgerName,
                                 Code.get(rc), stat != null ? stat.getVersion() : "null");
@@ -212,9 +215,9 @@ public class MetaStoreImplZookeeper implements MetaStore {
         if (log.isDebugEnabled()) {
             log.debug("[{}] Get cursors list", ledgerName);
         }
-        final long now = System.currentTimeMillis();
+        final long now = System.nanoTime();
         zk.getChildren(prefix + ledgerName, false, (rc, path, ctx, children, stat) -> executor.submit(safeRun(() -> {
-            recordRead(System.currentTimeMillis() - now);
+            recordReadLatency(System.nanoTime() - now, 1L);
             if (log.isDebugEnabled()) {
                 log.debug("[{}] getConsumers complete rc={} children={}", ledgerName, Code.get(rc), children);
             }
@@ -237,9 +240,9 @@ public class MetaStoreImplZookeeper implements MetaStore {
         if (log.isDebugEnabled()) {
             log.debug("Reading from {}", path);
         }
-        final long now = System.currentTimeMillis();
+        final long now = System.nanoTime();
         zk.getData(path, false, (rc, path1, ctx, data, stat) -> executor.submit(safeRun(() -> {
-            recordRead(System.currentTimeMillis() - now);
+            recordReadLatency(System.nanoTime() - now, 1L);
             if (rc != Code.OK.intValue()) {
                 callback.operationFailed(new MetaStoreException(KeeperException.create(Code.get(rc))));
             } else {
@@ -272,10 +275,10 @@ public class MetaStoreImplZookeeper implements MetaStore {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] Creating consumer {} on meta-data store with {}", ledgerName, cursorName, info);
             }
-            final long now = System.currentTimeMillis();
+            final long now = System.nanoTime();
             zk.create(path, content, Acl, CreateMode.PERSISTENT,
                     (rc, path1, ctx, name) -> executor.submit(safeRun(() -> {
-                        recordWrite(System.currentTimeMillis() - now);
+                        recordWriteLatency(System.nanoTime() - now, 1L);
                         if (rc != Code.OK.intValue()) {
                             log.warn("[{}] Error creating cosumer {} node on meta-data store with {}: ", ledgerName,
                                     cursorName, info, Code.get(rc));
@@ -293,9 +296,9 @@ public class MetaStoreImplZookeeper implements MetaStore {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] Updating consumer {} on meta-data store with {}", ledgerName, cursorName, info);
             }
-            final long now = System.currentTimeMillis();
+            final long now = System.nanoTime();
             zk.setData(path, content, zkStat.getVersion(), (rc, path1, ctx, stat1) -> executor.submit(safeRun(() -> {
-                recordWrite(System.currentTimeMillis() - now);
+                recordWriteLatency(System.nanoTime() - now, 1L);
                 if (rc == Code.BADVERSION.intValue()) {
                     callback.operationFailed(new BadVersionException(KeeperException.create(Code.get(rc))));
                 } else if (rc != Code.OK.intValue()) {
@@ -311,9 +314,9 @@ public class MetaStoreImplZookeeper implements MetaStore {
     public void asyncRemoveCursor(final String ledgerName, final String consumerName,
             final MetaStoreCallback<Void> callback) {
         log.info("[{}] Remove consumer={}", ledgerName, consumerName);
-        final long now = System.currentTimeMillis();
+        final long now = System.nanoTime();
         zk.delete(prefix + ledgerName + "/" + consumerName, -1, (rc, path, ctx) -> executor.submit(safeRun(() -> {
-            recordWrite(System.currentTimeMillis() - now);
+            recordWriteLatency(System.nanoTime() - now, 1L);
             if (log.isDebugEnabled()) {
                 log.debug("[{}] [{}] zk delete done. rc={}", ledgerName, consumerName, Code.get(rc));
             }
@@ -328,9 +331,9 @@ public class MetaStoreImplZookeeper implements MetaStore {
     @Override
     public void removeManagedLedger(String ledgerName, MetaStoreCallback<Void> callback) {
         log.info("[{}] Remove ManagedLedger", ledgerName);
-        final long now = System.currentTimeMillis();
+        final long now = System.nanoTime();
         zk.delete(prefix + ledgerName, -1, (rc, path, ctx) -> executor.submit(safeRun(() -> {
-            recordWrite(System.currentTimeMillis() - now);
+            recordWriteLatency(System.nanoTime() - now, 1L);
             if (log.isDebugEnabled()) {
                 log.debug("[{}] zk delete done. rc={}", ledgerName, Code.get(rc));
             }
@@ -410,25 +413,25 @@ public class MetaStoreImplZookeeper implements MetaStore {
     }
 
     @Override
-    public void recordWrite(long latency) {
-        zkOpLatencyStats.recordValue(latency);
-        numWrite.increment();
-    }
- 
-    @Override
-    public void recordWrite() {
-        numWrite.increment();
+    public void recordWriteLatency(long latencyInNs, long count) {
+        zkWriteLatencyStats.recordValue(TimeUnit.NANOSECONDS.toMillis(latencyInNs) / count);
+        numWrite.add(count);
     }
 
     @Override
-    public void recordRead(long latency) {
-        zkOpLatencyStats.recordValue(latency);
-        numRead.increment();
+    public void recordWriteCount(long count) {
+        numWrite.add(count);
     }
 
     @Override
-    public void recordRead() {
-        numRead.increment();
+    public void recordReadLatency(long latencyInNs, long count) {
+        zkReadLatencyStats.recordValue(TimeUnit.NANOSECONDS.toMillis(latencyInNs) / count);
+        numRead.add(count);
+    }
+
+    @Override
+    public void recordReadCount(long count) {
+        numRead.add(count);
     }
 
     public long getAndResetNumOfWrite() {
@@ -439,8 +442,12 @@ public class MetaStoreImplZookeeper implements MetaStore {
         return numRead.sumThenReset();
     }
 
-    public DimensionStats getZkOpLatencyStats() {
-        return this.zkOpLatencyStats;
+    public DimensionStats getZkWriteLatencyStats() {
+        return this.zkWriteLatencyStats;
+    }
+
+    public DimensionStats getZkReadLatencyStats() {
+        return this.zkReadLatencyStats;
     }
     
     private static final Logger log = LoggerFactory.getLogger(MetaStoreImplZookeeper.class);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/DimensionStats.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/DimensionStats.java
@@ -41,7 +41,8 @@ public class DimensionStats {
 
     public double elapsedIntervalMs;
 
-    private Recorder dimensionTimeRecorder = new Recorder(TimeUnit.MINUTES.toMillis(10), 2);
+    private final long maxTrackableSeconds = 120;
+    private Recorder dimensionTimeRecorder = new Recorder(TimeUnit.SECONDS.toMillis(maxTrackableSeconds), 2);
     private Histogram dimensionHistogram = null;
 
     public void updateStats() {
@@ -58,6 +59,7 @@ public class DimensionStats {
     }
 
     public void recordValue(long dimensionLatencyMs) {
+        dimensionLatencyMs = dimensionLatencyMs > maxTrackableSeconds ? maxTrackableSeconds : dimensionLatencyMs;
         dimensionTimeRecorder.recordValue(dimensionLatencyMs);
     }
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/DimensionStats.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/DimensionStats.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.bookkeeper.mledger.util;
+
+import org.HdrHistogram.Histogram;
+import org.HdrHistogram.Recorder;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ */
+public class DimensionStats {
+
+    /** Statistics for given dimension **/
+    public double meanDimensionMs;
+
+    public double medianDimensionMs;
+
+    public double dimension95Ms;
+
+    public double dimension99Ms;
+
+    public double dimension999Ms;
+
+    public double dimension9999Ms;
+
+    public double dimensionCounts;
+
+    public double elapsedIntervalMs;
+
+    private Recorder dimensionTimeRecorder = new Recorder(TimeUnit.MINUTES.toMillis(10), 2);
+    private Histogram dimensionHistogram = null;
+
+    public void updateStats() {
+
+        dimensionHistogram = dimensionTimeRecorder.getIntervalHistogram(dimensionHistogram);
+
+        this.meanDimensionMs = dimensionHistogram.getMean();
+        this.medianDimensionMs = dimensionHistogram.getValueAtPercentile(50);
+        this.dimension95Ms = dimensionHistogram.getValueAtPercentile(95);
+        this.dimension99Ms = dimensionHistogram.getValueAtPercentile(99);
+        this.dimension999Ms = dimensionHistogram.getValueAtPercentile(99.9);
+        this.dimension9999Ms = dimensionHistogram.getValueAtPercentile(99.99);
+        this.dimensionCounts = dimensionHistogram.getTotalCount();
+    }
+
+    public void recordValue(long dimensionLatencyMs) {
+        dimensionTimeRecorder.recordValue(dimensionLatencyMs);
+    }
+}

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/namespace/OwnershipCache.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/namespace/OwnershipCache.java
@@ -15,8 +15,6 @@
  */
 package com.yahoo.pulsar.broker.namespace;
 
-import static com.google.common.base.Preconditions.checkState;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -24,6 +22,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
+import org.apache.bookkeeper.mledger.impl.MetaStore;
 import org.apache.bookkeeper.util.ZkUtils;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -36,8 +36,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.AsyncCacheLoader;
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.RemovalCause;
-import com.github.benmanes.caffeine.cache.RemovalListener;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.yahoo.pulsar.broker.PulsarService;
@@ -105,6 +103,11 @@ public class OwnershipCache {
      * The <code>NamespaceBundleFactory</code> to construct <code>NamespaceBundles</code>
      */
     private final NamespaceBundleFactory bundleFactory;
+    
+    /**
+     * Use to record zk-write operations
+     */
+    private final MetaStore metaStore;
 
     private class OwnedServiceUnitCacheLoader implements AsyncCacheLoader<String, OwnedBundle> {
 
@@ -124,8 +127,10 @@ public class OwnershipCache {
             }
 
             CompletableFuture<OwnedBundle> future = new CompletableFuture<>();
+            final long now = System.currentTimeMillis();
             ZkUtils.asyncCreateFullPathOptimistic(localZkCache.getZooKeeper(), namespaceBundleZNode, znodeContent,
                     Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL, (rc, path, ctx, name) -> {
+                        metaStore.recordWrite(System.currentTimeMillis() - now);
                         if (rc == KeeperException.Code.OK.intValue()) {
                             if (LOG.isDebugEnabled()) {
                                 LOG.debug("Successfully acquired zk lock on {}", namespaceBundleZNode);
@@ -162,6 +167,7 @@ public class OwnershipCache {
         // ownedBundlesCache contains all namespaces that are owned by the local broker
         this.ownedBundlesCache = Caffeine.newBuilder().executor(MoreExecutors.sameThreadExecutor())
                 .buildAsync(new OwnedServiceUnitCacheLoader());
+        this.metaStore = ((ManagedLedgerFactoryImpl) pulsar.getManagedLedgerFactory()).getMetaStore();
     }
 
     /**
@@ -252,7 +258,9 @@ public class OwnershipCache {
     public CompletableFuture<Void> removeOwnership(NamespaceBundle bundle) {
         CompletableFuture<Void> result = new CompletableFuture<>();
         String key = ServiceUnitZkUtils.path(bundle);
+        final long now = System.currentTimeMillis();
         localZkCache.getZooKeeper().delete(key, -1, (rc, path, ctx) -> {
+            metaStore.recordWrite(System.currentTimeMillis() - now);
             if (rc == KeeperException.Code.OK.intValue() || rc == KeeperException.Code.NONODE.intValue()) {
                 LOG.info("[{}] Removed zk lock for service unit: {}", key, KeeperException.Code.get(rc));
                 ownedBundlesCache.synchronous().invalidate(key);

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/namespace/OwnershipCache.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/namespace/OwnershipCache.java
@@ -127,10 +127,10 @@ public class OwnershipCache {
             }
 
             CompletableFuture<OwnedBundle> future = new CompletableFuture<>();
-            final long now = System.currentTimeMillis();
+            final long now = System.nanoTime();
             ZkUtils.asyncCreateFullPathOptimistic(localZkCache.getZooKeeper(), namespaceBundleZNode, znodeContent,
                     Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL, (rc, path, ctx, name) -> {
-                        metaStore.recordWrite(System.currentTimeMillis() - now);
+                        metaStore.recordWriteLatency(System.nanoTime() - now, 1L);
                         if (rc == KeeperException.Code.OK.intValue()) {
                             if (LOG.isDebugEnabled()) {
                                 LOG.debug("Successfully acquired zk lock on {}", namespaceBundleZNode);
@@ -258,9 +258,9 @@ public class OwnershipCache {
     public CompletableFuture<Void> removeOwnership(NamespaceBundle bundle) {
         CompletableFuture<Void> result = new CompletableFuture<>();
         String key = ServiceUnitZkUtils.path(bundle);
-        final long now = System.currentTimeMillis();
+        final long now = System.nanoTime();
         localZkCache.getZooKeeper().delete(key, -1, (rc, path, ctx) -> {
-            metaStore.recordWrite(System.currentTimeMillis() - now);
+            metaStore.recordWriteLatency(System.nanoTime() - now, 1L);
             if (rc == KeeperException.Code.OK.intValue() || rc == KeeperException.Code.NONODE.intValue()) {
                 LOG.info("[{}] Removed zk lock for service unit: {}", key, KeeperException.Code.get(rc));
                 ownedBundlesCache.synchronous().invalidate(key);

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/stats/BrokerOperabilityMetrics.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/stats/BrokerOperabilityMetrics.java
@@ -76,16 +76,27 @@ public class BrokerOperabilityMetrics {
         dimensionMap.put("metric", "zk_op_stats");
         Metrics dMetrics = Metrics.create(dimensionMap);
 
-        DimensionStats zkOpLatencyStats = metaStore.getZkOpLatencyStats();
-        zkOpLatencyStats.updateStats();
+        DimensionStats zkWriteLatencyStats = metaStore.getZkWriteLatencyStats();
+        DimensionStats zkReadLatencyStats = metaStore.getZkReadLatencyStats();
+        zkWriteLatencyStats.updateStats();
+        zkReadLatencyStats.updateStats();
 
-        dMetrics.put("zk_latency_mean_ms", zkOpLatencyStats.meanDimensionMs);
-        dMetrics.put("zk_latency_time_median_ms", zkOpLatencyStats.medianDimensionMs);
-        dMetrics.put("zk_latency_95percentile_ms", zkOpLatencyStats.dimension95Ms);
-        dMetrics.put("zk_latency_99_percentile_ms", zkOpLatencyStats.dimension99Ms);
-        dMetrics.put("zk_latency_99_9_percentile_ms", zkOpLatencyStats.dimension999Ms);
-        dMetrics.put("zk_latency_99_99_percentile_ms", zkOpLatencyStats.dimension999Ms);
-        dMetrics.put("zk_op_count", zkOpLatencyStats.dimensionCounts);
+        dMetrics.put("zk_latency_write_mean_ms", zkWriteLatencyStats.meanDimensionMs);
+        dMetrics.put("zk_latency_write_time_median_ms", zkWriteLatencyStats.medianDimensionMs);
+        dMetrics.put("zk_latency_write_95percentile_ms", zkWriteLatencyStats.dimension95Ms);
+        dMetrics.put("zk_latency_write_99_percentile_ms", zkWriteLatencyStats.dimension99Ms);
+        dMetrics.put("zk_latency_write_99_9_percentile_ms", zkWriteLatencyStats.dimension999Ms);
+        dMetrics.put("zk_latency_write_99_99_percentile_ms", zkWriteLatencyStats.dimension999Ms);
+        dMetrics.put("zk_latency_write_count", zkWriteLatencyStats.dimensionCounts);
+        
+        dMetrics.put("zk_latency_read_mean_ms", zkReadLatencyStats.meanDimensionMs);
+        dMetrics.put("zk_latency_read_time_median_ms", zkReadLatencyStats.medianDimensionMs);
+        dMetrics.put("zk_latency_read_95percentile_ms", zkReadLatencyStats.dimension95Ms);
+        dMetrics.put("zk_latency_read_99_percentile_ms", zkReadLatencyStats.dimension99Ms);
+        dMetrics.put("zk_latency_read_99_9_percentile_ms", zkReadLatencyStats.dimension999Ms);
+        dMetrics.put("zk_latency_read_99_99_percentile_ms", zkReadLatencyStats.dimension999Ms);
+        dMetrics.put("zk_latency_read_count", zkReadLatencyStats.dimensionCounts);
+        
         dMetrics.put("zk_write_rate", metaStore.getAndResetNumOfWrite());
         dMetrics.put("zk_read_rate", metaStore.getAndResetNumOfRead());
 

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/stats/BrokerOperabilityMetrics.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/stats/BrokerOperabilityMetrics.java
@@ -21,6 +21,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.bookkeeper.mledger.impl.MetaStoreImplZookeeper;
+import org.apache.bookkeeper.mledger.util.DimensionStats;
+
 /**
  */
 public class BrokerOperabilityMetrics {
@@ -62,6 +65,29 @@ public class BrokerOperabilityMetrics {
         dMetrics.put("brk_topic_load_time_99_99_percentile_ms", topicLoadStats.topicsLoad9999Ms);
         dMetrics.put("brk_topic_load_rate_s",
                 (1000 * topicLoadStats.topicLoadCounts) / topicLoadStats.elapsedIntervalMs);
+
+        return dMetrics;
+    }
+
+    public Metrics getZkLatencyMetrics(MetaStoreImplZookeeper metaStore) {
+        Map<String, String> dimensionMap = Maps.newHashMap();
+        dimensionMap.put("broker", brokerName);
+        dimensionMap.put("cluster", localCluster);
+        dimensionMap.put("metric", "zk_op_stats");
+        Metrics dMetrics = Metrics.create(dimensionMap);
+
+        DimensionStats zkOpLatencyStats = metaStore.getZkOpLatencyStats();
+        zkOpLatencyStats.updateStats();
+
+        dMetrics.put("zk_latency_mean_ms", zkOpLatencyStats.meanDimensionMs);
+        dMetrics.put("zk_latency_time_median_ms", zkOpLatencyStats.medianDimensionMs);
+        dMetrics.put("zk_latency_95percentile_ms", zkOpLatencyStats.dimension95Ms);
+        dMetrics.put("zk_latency_99_percentile_ms", zkOpLatencyStats.dimension99Ms);
+        dMetrics.put("zk_latency_99_9_percentile_ms", zkOpLatencyStats.dimension999Ms);
+        dMetrics.put("zk_latency_99_99_percentile_ms", zkOpLatencyStats.dimension999Ms);
+        dMetrics.put("zk_op_count", zkOpLatencyStats.dimensionCounts);
+        dMetrics.put("zk_write_rate", metaStore.getAndResetNumOfWrite());
+        dMetrics.put("zk_read_rate", metaStore.getAndResetNumOfRead());
 
         return dMetrics;
     }

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/BrokerServiceTest.java
@@ -302,7 +302,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         consumer.close();
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
         JsonArray metrics = brokerStatsClient.getMetrics();
-        assertEquals(metrics.size(), 4, metrics.toString());
+        assertEquals(metrics.size(), 5, metrics.toString());
 
         // these metrics seem to be arriving in different order at different times...
         // is the order really relevant here?

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/stats/ManagedLedgerMetricsTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/stats/ManagedLedgerMetricsTest.java
@@ -26,6 +26,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import com.yahoo.pulsar.broker.service.BrokerService;
 import com.yahoo.pulsar.broker.service.BrokerTestBase;
 import com.yahoo.pulsar.broker.stats.metrics.ManagedLedgerMetrics;
 import com.yahoo.pulsar.client.api.Producer;
@@ -85,4 +86,55 @@ public class ManagedLedgerMetricsTest extends BrokerTestBase {
 
     }
 
+    
+    @Test
+    public void testZkOpStatsMetrics() throws Exception {
+
+        pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic1");
+        Metrics zkOpMetric = getMetric("zk_op_stats");
+        Assert.assertNotNull(zkOpMetric);
+        Assert.assertTrue((double) zkOpMetric.getMetrics().get("zk_latenc_99_99_percentile_ms") > 0);
+        Assert.assertTrue((long) zkOpMetric.getMetrics().get("zk_read_rate") > 0);
+        Assert.assertTrue((long) zkOpMetric.getMetrics().get("zk_write_rate") > 0);
+
+        // create another topic
+        pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic2");
+        zkOpMetric = getMetric("zk_op_stats");
+        // save read and write rate per topic: which should be the same for all topics
+        long readRate = (long) zkOpMetric.getMetrics().get("zk_read_rate");
+        long writeRete = (long) zkOpMetric.getMetrics().get("zk_write_rate");
+        Assert.assertTrue(readRate > 0);
+        Assert.assertTrue(writeRete > 0);
+
+        // create three new topics : which should create thrice read/write rate compare to previous one
+        pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic3");
+        pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic4");
+        pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic5");
+        zkOpMetric = getMetric("zk_op_stats");
+        long readRate2 = (long) zkOpMetric.getMetrics().get("zk_read_rate");
+        long writeRete2 = (long) zkOpMetric.getMetrics().get("zk_write_rate");
+        Assert.assertEquals(readRate2, 3 * readRate);
+        Assert.assertEquals(writeRete2, 3 * writeRete);
+
+        // same topic doesn't create any zk-operation
+        pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic5");
+        zkOpMetric = getMetric("zk_op_stats");
+        readRate2 = (long) zkOpMetric.getMetrics().get("zk_read_rate");
+        writeRete2 = (long) zkOpMetric.getMetrics().get("zk_write_rate");
+        Assert.assertEquals(readRate2, 0);
+        Assert.assertEquals(writeRete2, 0);
+
+    }
+
+    private Metrics getMetric(String dimension) {
+        BrokerService brokerService = pulsar.getBrokerService();
+        brokerService.updateRates();
+        for (Metrics metric : brokerService.getDestinationMetrics()) {
+            if (dimension.equalsIgnoreCase(metric.getDimension("metric"))) {
+                return metric;
+            }
+        }
+        return null;
+    }
+    
 }

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/stats/ManagedLedgerMetricsTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/stats/ManagedLedgerMetricsTest.java
@@ -93,7 +93,8 @@ public class ManagedLedgerMetricsTest extends BrokerTestBase {
         pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic1");
         Metrics zkOpMetric = getMetric("zk_op_stats");
         Assert.assertNotNull(zkOpMetric);
-        Assert.assertTrue((double) zkOpMetric.getMetrics().get("zk_latenc_99_99_percentile_ms") > 0);
+        Assert.assertTrue(zkOpMetric.getMetrics().containsKey("zk_latency_write_99_99_percentile_ms"));
+        Assert.assertTrue(zkOpMetric.getMetrics().containsKey("zk_latency_read_99_99_percentile_ms"));
         Assert.assertTrue((long) zkOpMetric.getMetrics().get("zk_read_rate") > 0);
         Assert.assertTrue((long) zkOpMetric.getMetrics().get("zk_write_rate") > 0);
 


### PR DESCRIPTION
### Motivation

Right now, zk `mntr -> nc stats` gives limited information and couldn't give complete stats about zk-latency which broker is seeing and number of read/write request rate. So, adding zk-op-stats into existing broker's stat-metrics which covers zk-latency and read/write rate.

### Modifications

Add zk-op-stats into existing broker's stat-metrics which covers zk-latency and read/write rate.

### Result

Broker can provide zk-stats.
