### PR TITLE
Make cache put watch even when node doesn't exist yet

### DIFF
--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -1238,7 +1238,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(unAckedMessages);
         }
     }
-    
+
     @Test
     public void testShouldNotBlockConsumerIfRedeliverBeforeReceive() throws Exception {
         log.info("-- Starting {} test --", methodName);
@@ -1690,7 +1690,6 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
      *
      * @throws Exception
      */
-    @Test
     public void testBlockUnackedConsumerRedeliverySpecificMessagesCloseConsumerWhileProduce() throws Exception {
         log.info("-- Starting {} test --", methodName);
 
@@ -1772,7 +1771,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(unAckedMessages);
         }
     }
-    
+
     @Test
     public void testPriorityConsumer() throws Exception {
         log.info("-- Starting {} test --", methodName);
@@ -1814,10 +1813,10 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         }
 
         /**
-         * a. consumer1 and consumer2 now has more permits (as received and sent more permits) 
-         * b. try to produce more messages: which will again distribute among consumer1 and consumer2 
+         * a. consumer1 and consumer2 now has more permits (as received and sent more permits)
+         * b. try to produce more messages: which will again distribute among consumer1 and consumer2
          * and should not dispatch to consumer4
-         * 
+         *
          */
         for (int i = 0; i < 5; i++) {
             final String message = "my-message-" + i;
@@ -1840,12 +1839,12 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
      * <pre>
      * Verifies Dispatcher dispatches messages properly with shared-subscription consumers with combination of blocked
      * and unblocked consumers.
-     * 
-     * 1. Dispatcher will have 5 consumers : c1, c2, c3, c4, c5. 
+     *
+     * 1. Dispatcher will have 5 consumers : c1, c2, c3, c4, c5.
      *      Out of which : c1,c2,c4,c5 will be blocked due to MaxUnackedMessages limit.
      * 2. So, dispatcher should moves round-robin and make sure it delivers unblocked consumer : c3
      * </pre>
-     * 
+     *
      * @throws Exception
      */
     @Test(timeOut=5000)
@@ -2034,5 +2033,5 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         log.info("-- Exiting {} test --", methodName);
 
     }
-    
+
 }

--- a/pulsar-zookeeper-utils/src/main/java/com/yahoo/pulsar/zookeeper/ZooKeeperCache.java
+++ b/pulsar-zookeeper-utils/src/main/java/com/yahoo/pulsar/zookeeper/ZooKeeperCache.java
@@ -286,49 +286,62 @@ public abstract class ZooKeeperCache implements Watcher {
         CompletableFuture<Optional<Entry<T, Stat>>> future = new CompletableFuture<>();
         dataCache.get(path, (p, executor) -> {
             // Return a future for the z-node to be fetched from ZK
+            final CompletableFuture<Boolean> existsFuture = new CompletableFuture<>();
             CompletableFuture<Entry<Object, Stat>> zkFuture = new CompletableFuture<>();
 
             // Broker doesn't restart on global-zk session lost: so handling unexpected exception
             try {
-                this.zkSession.get().getData(path, watcher, (rc, path1, ctx, content, stat) -> {
-                    Executor exec = scheduledExecutor != null ? scheduledExecutor : executor;
+                // Check for existence first, then get data: this allows us to put the watch on unconditionally.
+                zkSession.get().exists(path, watcher, (rc, path1, ctx, stat) -> {
+                    final Executor exec = scheduledExecutor != null ? scheduledExecutor : executor;
                     if (rc == Code.OK.intValue()) {
-                        try {
-                            T obj = deserializer.deserialize(path, content);
-                            // avoid using the zk-client thread to process the result
-                            exec.execute(() -> zkFuture.complete(new SimpleImmutableEntry<Object, Stat>(obj, stat)));
-                        } catch (Exception e) {
-                            exec.execute(() -> zkFuture.completeExceptionally(e));
-                        }
+                        exec.execute(() -> existsFuture.complete(true));
                     } else if (rc == Code.NONODE.intValue()) {
-                        // Return null values for missing z-nodes, as this is not "exceptional" condition
-                        // Later, we will put a watch on via exists.
-                        exec.execute(() -> zkFuture.complete(null));
+                        exec.execute(() -> existsFuture.complete(false));
                     } else {
-                        exec.execute(() -> zkFuture.completeExceptionally(KeeperException.create(rc)));
+                        exec.execute(() -> existsFuture.completeExceptionally(KeeperException.create(rc)));
                     }
                 }, null);
             } catch (Exception e) {
                 LOG.warn("Failed to access zkSession for {} {}", path, e.getMessage(), e);
-                zkFuture.completeExceptionally(e);
+                existsFuture.completeExceptionally(e);
             }
-
+            existsFuture.thenAccept(existed -> {
+                if (existed) {
+                    try {
+                        this.zkSession.get().getData(path, null, (rc, path1, ctx, content, stat) -> {
+                            Executor exec = scheduledExecutor != null ? scheduledExecutor : executor;
+                            if (rc == Code.OK.intValue()) {
+                                try {
+                                    T obj = deserializer.deserialize(path, content);
+                                    // avoid using the zk-client thread to process the result
+                                    exec.execute(() -> zkFuture.complete(new SimpleImmutableEntry<Object, Stat>(obj, stat)));
+                                } catch (Exception e) {
+                                    exec.execute(() -> zkFuture.completeExceptionally(e));
+                                }
+                            } else if (rc == Code.NONODE.intValue()) {
+                                // Return null values for missing z-nodes, as this is not "exceptional" condition
+                                exec.execute(() -> zkFuture.complete(null));
+                            } else {
+                                exec.execute(() -> zkFuture.completeExceptionally(KeeperException.create(rc)));
+                            }
+                        }, null);
+                    } catch (Exception e) {
+                        LOG.warn("Failed to access zkSession for {} {}", path, e.getMessage(), e);
+                        zkFuture.completeExceptionally(e);
+                    }
+                } else {
+                    zkFuture.complete(null);
+                }
+            }).exceptionally(e -> {
+                zkFuture.completeExceptionally(e);
+                return null;
+            });
             return zkFuture;
         }).thenAccept(result -> {
             if (result != null) {
                 future.complete(Optional.of((Entry<T, Stat>) result));
             } else {
-                // Put a watch via exists since get failed.
-                try {
-                    if (zkSession.get().exists(path, watcher) != null) {
-                        // Node got created, try again.
-                        // Null watcher so we are not double watching the event.
-                        dataCache.synchronous().invalidate(path);
-                        future.complete(getDataAsync(path, null, deserializer).get());
-                    }
-                } catch (Exception e) {
-                    future.completeExceptionally(e);
-                }
                 future.complete(Optional.empty());
             }
         }).exceptionally(ex -> {

--- a/pulsar-zookeeper-utils/src/main/java/com/yahoo/pulsar/zookeeper/ZooKeeperCache.java
+++ b/pulsar-zookeeper-utils/src/main/java/com/yahoo/pulsar/zookeeper/ZooKeeperCache.java
@@ -289,36 +289,31 @@ public abstract class ZooKeeperCache implements Watcher {
             CompletableFuture<Entry<Object, Stat>> zkFuture = new CompletableFuture<>();
 
             // Broker doesn't restart on global-zk session lost: so handling unexpected exception
-            try {
-                // Put watch on the node no matter what
-                zkSession.get().getData(path, watcher, (rc, path1, ctx, content, stat) -> {
-                    Executor exec = scheduledExecutor != null ? scheduledExecutor : executor;
-                    // If node exists, get the data from the node.
-                    // avoid using the zk-client thread to process the result
-                    try {
-                        if (rc == KeeperException.Code.OK.intValue()) {
-                            try {
-                                T obj = deserializer.deserialize(path, content);
 
-                                exec.execute(() -> zkFuture.complete(new SimpleImmutableEntry<Object, Stat>(obj, stat)));
-                            } catch (Exception e) {
-                                exec.execute(() -> zkFuture.completeExceptionally(e));
-                            }
-                        } else if (rc == Code.NONODE.intValue()) {
-                            // Not exceptional, so complete with null. Later, we will put a watch on via exists.
-                            exec.execute(() -> zkFuture.complete(null));
-                        } else {
-                            // Actually exceptional case.
-                            exec.execute(() -> zkFuture.completeExceptionally(KeeperException.create(rc)));
+            zkSession.get().getData(path, watcher, (rc, path1, ctx, content, stat) -> {
+                Executor exec = scheduledExecutor != null ? scheduledExecutor : executor;
+                // If node exists, get the data from the node.
+                // avoid using the zk-client thread to process the result
+                try {
+                    if (rc == KeeperException.Code.OK.intValue()) {
+                        try {
+                            T obj = deserializer.deserialize(path, content);
+
+                            exec.execute(() -> zkFuture.complete(new SimpleImmutableEntry<Object, Stat>(obj, stat)));
+                        } catch (Exception e) {
+                            exec.execute(() -> zkFuture.completeExceptionally(e));
                         }
-                    } catch (Exception e) {
-                        exec.execute(() -> zkFuture.completeExceptionally(e));
+                    } else if (rc == Code.NONODE.intValue()) {
+                        // Not exceptional, so complete with null. Later, we will put a watch on via exists.
+                        exec.execute(() -> zkFuture.complete(null));
+                    } else {
+                        // Actually exceptional case.
+                        exec.execute(() -> zkFuture.completeExceptionally(KeeperException.create(rc)));
                     }
-                }, null);
-            } catch (Throwable e) {
-                LOG.warn("Failed to access zkSession for {} {}", path, e.getMessage(), e);
-                zkFuture.completeExceptionally(e);
-            }
+                } catch (Exception e) {
+                    exec.execute(() -> zkFuture.completeExceptionally(e));
+                }
+            }, null);
             return zkFuture;
         }).thenAccept(result -> {
             if (result != null) {

--- a/pulsar-zookeeper-utils/src/test/java/com/yahoo/pulsar/zookeeper/ZookeeperCacheTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/com/yahoo/pulsar/zookeeper/ZookeeperCacheTest.java
@@ -474,5 +474,8 @@ public class ZookeeperCacheTest {
         // Give time for watch to fire.
         Thread.sleep(100);
         assert (counter.get() == 1);
+        zkExecutor.shutdown();
+        executor.shutdown();
+        scheduledExecutor.shutdown();
     }
 }

--- a/pulsar-zookeeper-utils/src/test/java/com/yahoo/pulsar/zookeeper/ZookeeperCacheTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/com/yahoo/pulsar/zookeeper/ZookeeperCacheTest.java
@@ -16,8 +16,8 @@
 package com.yahoo.pulsar.zookeeper;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertNull;
@@ -31,16 +31,16 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.bookkeeper.mledger.util.Pair;
 import org.apache.bookkeeper.util.OrderedSafeExecutor;
+import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException.Code;
 import org.apache.zookeeper.MockZooKeeper;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher.Event;
 import org.apache.zookeeper.Watcher.Event.KeeperState;
+import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -113,7 +113,7 @@ public class ZookeeperCacheTest {
     void testChildrenCache() throws Exception {
         OrderedSafeExecutor executor = new OrderedSafeExecutor(1, "test");
         ScheduledExecutorService scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
-        
+
         zkClient.create("/test", new byte[0], null, null);
 
         ZooKeeperCache zkCacheService = new LocalZooKeeperCache(zkClient, executor, scheduledExecutor);
@@ -170,7 +170,7 @@ public class ZookeeperCacheTest {
     void testExistsCache() throws Exception {
         OrderedSafeExecutor executor = new OrderedSafeExecutor(1, "test");
         ScheduledExecutorService scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
-        
+
         // Check existence after creation of the node
         zkClient.create("/test", new byte[0], null, null);
         Thread.sleep(20);
@@ -191,7 +191,7 @@ public class ZookeeperCacheTest {
     void testInvalidateCache() throws Exception {
         OrderedSafeExecutor executor = new OrderedSafeExecutor(1, "test");
         ScheduledExecutorService scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
-        
+
         zkClient.create("/test", new byte[0], null, null);
         zkClient.create("/test/c1", new byte[0], null, null);
         zkClient.create("/test/c2", new byte[0], null, null);
@@ -329,7 +329,7 @@ public class ZookeeperCacheTest {
         // Update shouldn't happen after the last check
         assertEquals(notificationCount.get(), 1);
     }
-    
+
     /**
      * Verifies that blocking call on zkCache-callback will not introduce deadlock because zkCache completes
      * future-result with different thread than zookeeper-client thread.
@@ -376,7 +376,7 @@ public class ZookeeperCacheTest {
         zkExecutor.shutdown();
         scheduledExecutor.shutdown();
     }
-    
+
     /**
      * <pre>
      * Verifies that if {@link ZooKeeperCache} fails to fetch data into the cache then 
@@ -448,5 +448,31 @@ public class ZookeeperCacheTest {
         executor.shutdown();
         scheduledExecutor.shutdown();
 
+    }
+
+    /**
+     * Test to ensure that the cache puts on watch even on nodes that do not yet exist.
+     */
+    @Test
+    public void testExistsWatch() throws Exception {
+        ExecutorService zkExecutor = Executors.newSingleThreadExecutor(new DefaultThreadFactory("mockZk"));
+        OrderedSafeExecutor executor = new OrderedSafeExecutor(1, "test");
+        ScheduledExecutorService scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
+        MockZooKeeper zkClient = MockZooKeeper.newInstance(zkExecutor);
+        ZooKeeperCache zkCacheService = new LocalZooKeeperCache(zkClient, executor, scheduledExecutor);
+        AtomicInteger counter = new AtomicInteger(0);
+        ZooKeeperCacheListener<Integer> listener = (path, data, stat) -> counter.incrementAndGet();
+        ZooKeeperDataCache<Integer> dataCache = new ZooKeeperDataCache<Integer>(zkCacheService) {
+            @Override
+            public Integer deserialize(String key, byte[] content) throws Exception {
+                return 0;
+            }
+        };
+        dataCache.registerListener(listener);
+        assert (!dataCache.get("/existsWatchTest").isPresent());
+        zkClient.create("/existsWatchTest", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        // Give time for watch to fire.
+        Thread.sleep(100);
+        assert (counter.get() == 1);
     }
 }


### PR DESCRIPTION
### Motivation
Previously, nodes which had not yet been created for `ZooKeeperCache` did not have a watch put on them, and thus had to be manually invalidated. This PR is a stepping stone for #385, which required this feature in order for the split-and-unload feature to work correctly and without as much pain.

### Modifications

When `ZooKeeperCache` is queried for a non-existent node, an exists watch is added to that node so that the most recent updates are obtained. When the node did exist, the behavior is the same.

### Result

`ZooKeeperCache` will now always add a watch to a node and #385 will be closer to being merged.
