### PR TITLE
Make broker configurable to own non-persistent namespace

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -84,23 +84,6 @@ statusFilePath=
 # use only brokers running the latest software version (to minimize impact to bundles)
 preferLaterVersions=false
 
-### --- Authentication --- ###
-
-# Enable TLS
-tlsEnabled=false
-
-# Path for the TLS certificate file
-tlsCertificateFilePath=
-
-# Path for the TLS private key file
-tlsKeyFilePath=
-
-# Path for the trusted TLS certificate file
-tlsTrustCertsFilePath=
-
-# Accept untrusted TLS certificate from client
-tlsAllowInsecureConnection=false
-
 # Max number of unacknowledged messages allowed to receive messages by a consumer on a shared subscription. Broker will stop sending
 # messages to consumer once, this limit reaches until consumer starts acknowledging messages back.
 # Using a value of 0, is disabling unackeMessage limit check and consumer can receive messages without any restriction
@@ -117,6 +100,36 @@ maxConcurrentLookupRequest=10000
 
 # Max number of concurrent topic loading request broker allows to control number of zk-operations
 maxConcurrentTopicLoadRequest=5000
+
+# Max concurrent non-persistent message can be processed per connection
+maxConcurrentNonPersistentMessagePerConnection=1000
+
+# Number of worker threads to serve non-persistent topic 
+numWorkerThreadsForNonPersistentTopic=8
+
+# Allow broker to own non-persistent namespaces along with persistent topics
+nonPersistentNamespaceAllowed=true
+
+# Broker is only allowed to own non-persistent topic. It helps to isolate broker which only serves non-persistent
+# topics and does not impact performance of persistent topics
+onlyNonPersistentNamespaceAllowed=false
+
+### --- Authentication --- ###
+
+# Enable TLS
+tlsEnabled=false
+
+# Path for the TLS certificate file
+tlsCertificateFilePath=
+
+# Path for the TLS private key file
+tlsKeyFilePath=
+
+# Path for the trusted TLS certificate file
+tlsTrustCertsFilePath=
+
+# Accept untrusted TLS certificate from client
+tlsAllowInsecureConnection=false
 
 ### --- Authentication --- ###
 

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -81,6 +81,25 @@ maxUnackedMessagesPerConsumer=50000
 # check and dispatcher can dispatch messages without any restriction
 maxUnackedMessagesPerSubscription=200000
 
+# Max number of concurrent lookup request broker allows to throttle heavy incoming lookup traffic
+maxConcurrentLookupRequest=10000
+
+# Max number of concurrent topic loading request broker allows to control number of zk-operations
+maxConcurrentTopicLoadRequest=5000
+
+# Max concurrent non-persistent message can be processed per connection
+maxConcurrentNonPersistentMessagePerConnection=1000
+
+# Number of worker threads to serve non-persistent topic 
+numWorkerThreadsForNonPersistentTopic=8
+
+# Allow broker to own non-persistent namespaces along with persistent topics
+nonPersistentNamespaceAllowed=true
+
+# Broker is only allowed to own non-persistent topic. It helps to isolate broker which only serves non-persistent
+# topics and does not impact performance of persistent topics
+onlyNonPersistentNamespaceAllowed=false
+
 ### --- Authentication --- ###
 
 # Enable authentication

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheManager.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheManager.java
@@ -40,6 +40,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.primitives.Longs;
 
+import io.netty.buffer.ByteBuf;
+
 public class EntryCacheManager {
 
     private final long maxSize;
@@ -233,5 +235,9 @@ public class EntryCacheManager {
 
     }
 
+    public static Entry create(long ledgerId, long entryId, ByteBuf data) {
+        return EntryImpl.create(ledgerId, entryId, data);
+    }
+    
     private static final Logger log = LoggerFactory.getLogger(EntryCacheManager.class);
 }

--- a/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
@@ -104,6 +104,11 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private int maxConcurrentNonPersistentMessagePerConnection = 1000;
     // Number of worker threads to serve non-persistent topic 
     private int numWorkerThreadsForNonPersistentTopic = 8;
+    // Allow broker to own non-persistent namespaces along with persistent topics
+    private boolean nonPersistentNamespaceAllowed = true;
+    // Broker is only allowed to own non-persistent topic. It helps to isolate broker which only serves non-persistent
+    // topics and does not impact performance of persistent topics
+    private boolean onlyNonPersistentNamespaceAllowed = false;
 
     /***** --- TLS --- ****/
     // Enable TLS
@@ -484,6 +489,22 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     public void setNumWorkerThreadsForNonPersistentTopic(int numWorkerThreadsForNonPersistentTopic) {
         this.numWorkerThreadsForNonPersistentTopic = numWorkerThreadsForNonPersistentTopic;
+    }
+
+    public boolean isNonPersistentNamespaceAllowed() {
+        return nonPersistentNamespaceAllowed;
+    }
+
+    public void setNonPersistentNamespaceAllowed(boolean nonPersistentNamespaceAllowed) {
+        this.nonPersistentNamespaceAllowed = nonPersistentNamespaceAllowed;
+    }
+
+    public boolean isOnlyNonPersistentNamespaceAllowed() {
+        return onlyNonPersistentNamespaceAllowed;
+    }
+
+    public void setOnlyNonPersistentNamespaceAllowed(boolean onlyNonPersistentNamespaceAllowed) {
+        this.onlyNonPersistentNamespaceAllowed = onlyNonPersistentNamespaceAllowed;
     }
 
     public boolean isTlsEnabled() {

--- a/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
@@ -100,6 +100,10 @@ public class ServiceConfiguration implements PulsarConfiguration {
     // Max number of concurrent topic loading request broker allows to control number of zk-operations
     @FieldContext(dynamic = true)
     private int maxConcurrentTopicLoadRequest = 5000;
+    // Rate limit the number of messages can be published per second by each non-persistent topic
+    private int maxPublishMessageRatePerNonPersistentTopic = 1000;
+    // Number of worker threads to serve non-persistent topic 
+    private int numWorkerThreadsForNonPersistentTopic = 8;
 
     /***** --- TLS --- ****/
     // Enable TLS
@@ -464,6 +468,22 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     public void setMaxConcurrentTopicLoadRequest(int maxConcurrentTopicLoadRequest) {
         this.maxConcurrentTopicLoadRequest = maxConcurrentTopicLoadRequest;
+    }
+
+    public int getMaxPublishMessageRatePerNonPersistentTopic() {
+        return maxPublishMessageRatePerNonPersistentTopic;
+    }
+
+    public void setMaxPublishMessageRatePerNonPersistentTopic(int maxPublishMessageRatePerNonPersistentTopic) {
+        this.maxPublishMessageRatePerNonPersistentTopic = maxPublishMessageRatePerNonPersistentTopic;
+    }
+
+    public int getNumWorkerThreadsForNonPersistentTopic() {
+        return numWorkerThreadsForNonPersistentTopic;
+    }
+
+    public void setNumWorkerThreadsForNonPersistentTopic(int numWorkerThreadsForNonPersistentTopic) {
+        this.numWorkerThreadsForNonPersistentTopic = numWorkerThreadsForNonPersistentTopic;
     }
 
     public boolean isTlsEnabled() {

--- a/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
@@ -100,8 +100,8 @@ public class ServiceConfiguration implements PulsarConfiguration {
     // Max number of concurrent topic loading request broker allows to control number of zk-operations
     @FieldContext(dynamic = true)
     private int maxConcurrentTopicLoadRequest = 5000;
-    // Rate limit the number of messages can be published per second by each non-persistent topic
-    private int maxPublishMessageRatePerNonPersistentTopic = 1000;
+    // Max concurrent non-persistent message can be processed per connection
+    private int maxConcurrentNonPersistentMessagePerConnection = 1000;
     // Number of worker threads to serve non-persistent topic 
     private int numWorkerThreadsForNonPersistentTopic = 8;
 
@@ -470,12 +470,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
         this.maxConcurrentTopicLoadRequest = maxConcurrentTopicLoadRequest;
     }
 
-    public int getMaxPublishMessageRatePerNonPersistentTopic() {
-        return maxPublishMessageRatePerNonPersistentTopic;
+    public int getMaxConcurrentNonPersistentMessagePerConnection() {
+        return maxConcurrentNonPersistentMessagePerConnection;
     }
 
-    public void setMaxPublishMessageRatePerNonPersistentTopic(int maxPublishMessageRatePerNonPersistentTopic) {
-        this.maxPublishMessageRatePerNonPersistentTopic = maxPublishMessageRatePerNonPersistentTopic;
+    public void setMaxConcurrentNonPersistentMessagePerConnection(int maxConcurrentNonPersistentMessagePerConnection) {
+        this.maxConcurrentNonPersistentMessagePerConnection = maxConcurrentNonPersistentMessagePerConnection;
     }
 
     public int getNumWorkerThreadsForNonPersistentTopic() {

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/LocalBrokerData.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/LocalBrokerData.java
@@ -36,6 +36,8 @@ public class LocalBrokerData extends JSONWritable implements ServiceLookupData {
     private final String webServiceUrlTls;
     private final String pulsarServiceUrl;
     private final String pulsarServiceUrlTls;
+    private boolean nonPersistentNamespaceAllowed = true;
+    private boolean onlyNonPersistentNamespaceAllowed = false;
 
     // Most recently available system resource usage.
     private ResourceUsage cpu;
@@ -202,6 +204,22 @@ public class LocalBrokerData extends JSONWritable implements ServiceLookupData {
 
     public void setCpu(ResourceUsage cpu) {
         this.cpu = cpu;
+    }
+
+    public boolean isNonPersistentNamespaceAllowed() {
+        return nonPersistentNamespaceAllowed;
+    }
+
+    public void setNonPersistentNamespaceAllowed(boolean nonPersistentNamespaceAllowed) {
+        this.nonPersistentNamespaceAllowed = nonPersistentNamespaceAllowed;
+    }
+
+    public boolean isOnlyNonPersistentNamespaceAllowed() {
+        return onlyNonPersistentNamespaceAllowed;
+    }
+
+    public void setOnlyNonPersistentNamespaceAllowed(boolean onlyNonPersistentNamespaceAllowed) {
+        this.onlyNonPersistentNamespaceAllowed = onlyNonPersistentNamespaceAllowed;
     }
 
     public ResourceUsage getMemory() {

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/Namespaces.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/Namespaces.java
@@ -1049,11 +1049,55 @@ public class Namespaces extends AdminResource {
         validateAdminAccessOnProperty(property);
 
         Policies policies = getNamespacePolicies(property, cluster, namespace);
-        if (policies.persistence == null) {
+        if (!policies.nonPersistent && policies.persistence == null) {
             return new PersistencePolicies(config().getManagedLedgerDefaultEnsembleSize(),
                     config().getManagedLedgerDefaultWriteQuorum(), config().getManagedLedgerDefaultAckQuorum(), 0.0d);
         } else {
             return policies.persistence;
+        }
+    }
+
+    @POST
+    @Path("/{property}/{cluster}/{namespace}/non-persistent")
+    @ApiOperation(value = "Set namespace persistency.")
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Property or cluster or namespace doesn't exist") })
+    public void setNamespaceNonPersistency(@PathParam("property") String property,
+            @PathParam("cluster") String cluster, @PathParam("namespace") String namespace,
+            @QueryParam("nonPersistent") @DefaultValue("false") boolean isNonPersistent) {
+        validateAdminAccessOnProperty(property);
+        validatePoliciesReadOnlyAccess();
+
+        Entry<Policies, Stat> policiesNode = null;
+        NamespaceName nsName = new NamespaceName(property, cluster, namespace);
+
+        try {
+            // Force to read the data s.t. the watch to the cache content is setup.
+            policiesNode = policiesCache().getWithStat(path("policies", property, cluster, namespace))
+                    .orElseThrow(() -> new RestException(Status.NOT_FOUND, "Namespace " + nsName + " does not exist"));
+            policiesNode.getKey().nonPersistent = isNonPersistent;
+
+            // Write back the new policies into zookeeper
+            globalZk().setData(path("policies", property, cluster, namespace),
+                    jsonMapper().writeValueAsBytes(policiesNode.getKey()), policiesNode.getValue().getVersion());
+            policiesCache().invalidate(path("policies", property, cluster, namespace));
+
+            log.info("[{}] Successfully updated namespace persistency {}/{}/{}", clientAppId(), property, cluster,
+                    namespace);
+        } catch (KeeperException.NoNodeException e) {
+            log.warn("[{}] Failed to update namespace persistency, namespace {}/{}/{}: does not exist", clientAppId(),
+                    property, cluster, namespace);
+            throw new RestException(Status.NOT_FOUND, "Namespace does not exist");
+        } catch (KeeperException.BadVersionException e) {
+            log.warn(
+                    "[{}] Failed to update namespace persistency {}/{}/{} expected policy node version={} : concurrent modification",
+                    clientAppId(), property, cluster, namespace, policiesNode.getValue().getVersion());
+
+            throw new RestException(Status.CONFLICT, "Concurrent modification");
+        } catch (Exception e) {
+            log.error("[{}] Failed to update namespace persistency {}/{}/{}", clientAppId(), property, cluster,
+                    namespace, e);
+            throw new RestException(e);
         }
     }
 

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/NonPersistentTopics.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/admin/NonPersistentTopics.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright 2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.pulsar.broker.admin;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.yahoo.pulsar.common.util.Codec.decode;
+
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.Encoded;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response.Status;
+
+import org.apache.zookeeper.KeeperException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.yahoo.pulsar.broker.service.Topic;
+import com.yahoo.pulsar.broker.web.RestException;
+import com.yahoo.pulsar.common.naming.DestinationName;
+import com.yahoo.pulsar.common.partition.PartitionedTopicMetadata;
+import com.yahoo.pulsar.common.policies.data.PersistentTopicInternalStats;
+import com.yahoo.pulsar.common.policies.data.PersistentTopicStats;
+//import static com.yahoo.pulsar.broker.admin.PersistentTopics.PARTITIONED_TOPIC_WAIT_SYNC_TIME_MS;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
+/**
+ */
+@Path("/non-persistent")
+@Produces(MediaType.APPLICATION_JSON)
+@Api(value = "/non-persistent", description = "Non-Persistent topic admin apis", tags = "non-persistent topic")
+public class NonPersistentTopics extends PersistentTopics {
+    private static final Logger log = LoggerFactory.getLogger(NonPersistentTopics.class);
+    
+    public static final String PARTITIONED_NON_PERSISTENT_TOPIC_PATH_ZNODE = "partitioned-np-topics";
+
+    @GET
+    @Path("/{property}/{cluster}/{namespace}/{destination}/partitions")
+    @ApiOperation(value = "Get partitioned topic metadata.")
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission") })
+    public PartitionedTopicMetadata getPartitionedMetadata(@PathParam("property") String property,
+            @PathParam("cluster") String cluster, @PathParam("namespace") String namespace,
+            @PathParam("destination") @Encoded String destination,
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
+        destination = decode(destination);
+        return getPartitionedTopicMetadata(property, cluster, namespace, destination, authoritative);
+    }
+
+    @GET
+    @Path("{property}/{cluster}/{namespace}/{destination}/stats")
+    @ApiOperation(value = "Get the stats for the topic.")
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Topic does not exist") })
+    public PersistentTopicStats getStats(@PathParam("property") String property, @PathParam("cluster") String cluster,
+            @PathParam("namespace") String namespace, @PathParam("destination") @Encoded String destination,
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
+        destination = decode(destination);
+        DestinationName dn = DestinationName.get(domain(), property, cluster, namespace, destination);
+        validateAdminOperationOnDestination(dn, authoritative);
+        Topic topic = getTopicReference(dn);
+        return topic.getStats();
+    }
+
+    @GET
+    @Path("{property}/{cluster}/{namespace}/{destination}/internalStats")
+    @ApiOperation(value = "Get the internal stats for the topic.")
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Topic does not exist") })
+    public PersistentTopicInternalStats getInternalStats(@PathParam("property") String property,
+            @PathParam("cluster") String cluster, @PathParam("namespace") String namespace,
+            @PathParam("destination") @Encoded String destination,
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
+        destination = decode(destination);
+        DestinationName dn = DestinationName.get(domain(), property, cluster, namespace, destination);
+        validateAdminOperationOnDestination(dn, authoritative);
+        Topic topic = getTopicReference(dn);
+        return topic.getInternalStats();
+    }
+
+    @PUT
+    @Path("/{property}/{cluster}/{namespace}/{destination}/partitions")
+    @ApiOperation(value = "Create a partitioned topic.", notes = "It needs to be called before creating a producer on a partitioned topic.")
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 409, message = "Partitioned topic already exist") })
+    public void createPartitionedTopic(@PathParam("property") String property, @PathParam("cluster") String cluster,
+            @PathParam("namespace") String namespace, @PathParam("destination") @Encoded String destination, int numPartitions,
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
+        destination = decode(destination);
+        DestinationName dn = DestinationName.get(domain(), property, cluster, namespace, destination);
+        validateAdminAccessOnProperty(dn.getProperty());
+        if (numPartitions <= 1) {
+            throw new RestException(Status.NOT_ACCEPTABLE, "Number of partitions should be more than 1");
+        }
+        try {
+            String path = path(PARTITIONED_NON_PERSISTENT_TOPIC_PATH_ZNODE, property, cluster, namespace, domain(),
+                    dn.getEncodedLocalName());
+            byte[] data = jsonMapper().writeValueAsBytes(new PartitionedTopicMetadata(numPartitions));
+            zkCreateOptimistic(path, data);
+            // we wait for the data to be synced in all quorums and the observers
+            Thread.sleep(PARTITIONED_TOPIC_WAIT_SYNC_TIME_MS);
+            log.info("[{}] Successfully created partitioned topic {}", clientAppId(), dn);
+        } catch (KeeperException.NodeExistsException e) {
+            log.warn("[{}] Failed to create already existing partitioned topic {}", clientAppId(), dn);
+            throw new RestException(Status.CONFLICT, "Partitioned topic already exist");
+        } catch (Exception e) {
+            log.error("[{}] Failed to create partitioned topic {}", clientAppId(), dn, e);
+            throw new RestException(e);
+        }
+    }
+    
+    protected void validateAdminOperationOnDestination(DestinationName fqdn, boolean authoritative) {
+        validateAdminAccessOnProperty(fqdn.getProperty());
+        validateDestinationOwnership(fqdn, authoritative);
+    }
+
+    private Topic getTopicReference(DestinationName dn) {
+        try {
+            Topic topic = pulsar().getBrokerService().getTopicReference(dn.toString());
+            checkNotNull(topic);
+            return topic;
+        } catch (Exception e) {
+            throw new RestException(Status.NOT_FOUND, "Topic not found");
+        }
+    }
+}

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/ModularLoadManagerWrapper.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/ModularLoadManagerWrapper.java
@@ -15,7 +15,6 @@
  */
 package com.yahoo.pulsar.broker.loadbalance.impl;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -27,7 +26,6 @@ import com.yahoo.pulsar.broker.loadbalance.ResourceUnit;
 import com.yahoo.pulsar.common.naming.ServiceUnitId;
 import com.yahoo.pulsar.common.policies.data.loadbalancer.LoadReport;
 import com.yahoo.pulsar.common.policies.data.loadbalancer.ServiceLookupData;
-import com.yahoo.pulsar.common.policies.data.loadbalancer.SystemResourceUsage;
 import com.yahoo.pulsar.common.stats.Metrics;
 import com.yahoo.pulsar.zookeeper.ZooKeeperCache.Deserializer;
 
@@ -112,4 +110,5 @@ public class ModularLoadManagerWrapper implements LoadManager {
     public Deserializer<? extends ServiceLookupData> getLoadReportDeserializer() {
         return loadManager.getLoadReportDeserializer();
     }
+
 }

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/SimpleResourceAllocationPolicies.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/loadbalance/impl/SimpleResourceAllocationPolicies.java
@@ -33,6 +33,7 @@ import com.yahoo.pulsar.zookeeper.ZooKeeperDataCache;
 public class SimpleResourceAllocationPolicies {
     private static final Logger LOG = LoggerFactory.getLogger(SimpleResourceAllocationPolicies.class);
     private final ZooKeeperDataCache<NamespaceIsolationPolicies> namespaceIsolationPolicies;
+
     private final PulsarService pulsar;
 
     SimpleResourceAllocationPolicies(PulsarService pulsar) {
@@ -105,5 +106,9 @@ public class SimpleResourceAllocationPolicies {
     public boolean shouldFailoverToSecondaries(NamespaceName namespace, int totalPrimaryCandidates) {
 		NamespaceIsolationPolicy nsPolicy = getNamespaceIsolationPolicy(namespace);
 		return (nsPolicy != null) ? nsPolicy.shouldFailover(totalPrimaryCandidates) : false;
+    }
+
+    public boolean isNonPersistentNamespace(NamespaceName namespace) {
+        return pulsar.getBrokerService().isNonPersistentNamespace(namespace);
     }
 }

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/lookup/DestinationLookup.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/lookup/DestinationLookup.java
@@ -57,6 +57,15 @@ import io.netty.buffer.ByteBuf;
 public class DestinationLookup extends PulsarWebResource {
 
     @GET
+    @Path("non-persistent/{property}/{cluster}/{namespace}/{dest}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public void lookupNonPersistentDestinationAsync(@PathParam("property") String property, @PathParam("cluster") String cluster,
+            @PathParam("namespace") String namespace, @PathParam("dest") @Encoded String dest,
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
+            @Suspended AsyncResponse asyncResponse) {
+        lookupDestinationAsync(property, cluster, namespace, dest, authoritative, asyncResponse);
+    }
+    @GET
     @Path("persistent/{property}/{cluster}/{namespace}/{dest}")
     @Produces(MediaType.APPLICATION_JSON)
     public void lookupDestinationAsync(@PathParam("property") String property, @PathParam("cluster") String cluster,

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Consumer.java
@@ -142,21 +142,6 @@ public class Consumer {
      * @return a promise that can be use to track when all the data has been written into the socket
      */
     public Pair<ChannelPromise, Integer> sendMessages(final List<Entry> entries) {
-        return sendMessages(entries, true);
-    }
-    
-    /**
-     * 
-     * Dispatch a list of entries to the consumer. <br/>
-     * <b>It is also responsible to release entries data and recycle entries object.</b>
-     * 
-     * @param entries
-     * @param updatePermits
-     *            : if true then it updates consumer permits and adds messageId into pendingMessage list for redelivery
-     *            tracking
-     * @return a promise that can be use to track when all the data has been written into the socket
-     */
-    public Pair<ChannelPromise, Integer> sendMessages(final List<Entry> entries, boolean updatePermits) {
         final ChannelHandlerContext ctx = cnx.ctx();
         final MutablePair<ChannelPromise, Integer> sentMessages = new MutablePair<ChannelPromise, Integer>();
         final ChannelPromise writePromise = ctx.newPromise();
@@ -172,7 +157,7 @@ public class Consumer {
         }
 
         try {
-            sentMessages.setRight(updatePermits ? updatePermitsAndPendingAcks(entries) : 0);
+            sentMessages.setRight(updatePermitsAndPendingAcks(entries));
         } catch (PulsarServerException pe) {
             log.warn("[{}] [{}] consumer doesn't support batch-message {}", subscription, consumerId,
                     cnx.getRemoteEndpointProtocolVersion());

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Consumer.java
@@ -142,6 +142,21 @@ public class Consumer {
      * @return a promise that can be use to track when all the data has been written into the socket
      */
     public Pair<ChannelPromise, Integer> sendMessages(final List<Entry> entries) {
+        return sendMessages(entries, true);
+    }
+    
+    /**
+     * 
+     * Dispatch a list of entries to the consumer. <br/>
+     * <b>It is also responsible to release entries data and recycle entries object.</b>
+     * 
+     * @param entries
+     * @param updatePermits
+     *            : if true then it updates consumer permits and adds messageId into pendingMessage list for redelivery
+     *            tracking
+     * @return a promise that can be use to track when all the data has been written into the socket
+     */
+    public Pair<ChannelPromise, Integer> sendMessages(final List<Entry> entries, boolean updatePermits) {
         final ChannelHandlerContext ctx = cnx.ctx();
         final MutablePair<ChannelPromise, Integer> sentMessages = new MutablePair<ChannelPromise, Integer>();
         final ChannelPromise writePromise = ctx.newPromise();
@@ -157,7 +172,7 @@ public class Consumer {
         }
 
         try {
-            sentMessages.setRight(updatePermitsAndPendingAcks(entries));
+            sentMessages.setRight(updatePermits ? updatePermitsAndPendingAcks(entries) : 0);
         } catch (PulsarServerException pe) {
             log.warn("[{}] [{}] consumer doesn't support batch-message {}", subscription, consumerId,
                     cnx.getRemoteEndpointProtocolVersion());

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/PulsarStats.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/PulsarStats.java
@@ -80,7 +80,7 @@ public class PulsarStats implements Closeable {
     }
 
     public synchronized void updateStats(
-            ConcurrentOpenHashMap<String, ConcurrentOpenHashMap<String, ConcurrentOpenHashMap<String, PersistentTopic>>> topicsMap) {
+            ConcurrentOpenHashMap<String, ConcurrentOpenHashMap<String, ConcurrentOpenHashMap<String, Topic>>> topicsMap) {
 
         StatsOutputStream topicStatsStream = new StatsOutputStream(tempTopicStatsBuf);
 
@@ -119,7 +119,9 @@ public class PulsarStats implements Closeable {
                             }
                             // this task: helps to activate inactive-backlog-cursors which have caught up and
                             // connected, also deactivate active-backlog-cursors which has backlog
-                            topic.getManagedLedger().checkBackloggedCursors();
+                            if (topic instanceof PersistentTopic) {
+                                ((PersistentTopic) topic).getManagedLedger().checkBackloggedCursors();
+                            }
                         });
 
                         topicStatsStream.endObject();

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Replicator.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Replicator.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.pulsar.broker.service;
+
+import java.util.concurrent.CompletableFuture;
+
+import com.yahoo.pulsar.common.policies.data.ReplicatorStats;
+
+public interface Replicator {
+
+    void startProducer();
+    
+    ReplicatorStats getStats();
+
+    CompletableFuture<Void> disconnect();
+
+    CompletableFuture<Void> disconnect(boolean b);
+
+    void updateRates();
+
+    String getRemoteCluster();
+
+}

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Subscription.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Subscription.java
@@ -26,6 +26,8 @@ import com.yahoo.pulsar.common.api.proto.PulsarApi.CommandAck.AckType;
 import com.yahoo.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 
 public interface Subscription {
+    String getName();
+    
     void addConsumer(Consumer consumer) throws BrokerServiceException;
 
     void removeConsumer(Consumer consumer) throws BrokerServiceException;

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/Topic.java
@@ -17,13 +17,18 @@ package com.yahoo.pulsar.broker.service;
 
 import java.util.concurrent.CompletableFuture;
 
-import com.yahoo.pulsar.broker.service.persistent.PersistentSubscription;
+import com.yahoo.pulsar.broker.stats.ClusterReplicationMetrics;
+import com.yahoo.pulsar.broker.stats.NamespaceStats;
 import com.yahoo.pulsar.client.api.MessageId;
 import com.yahoo.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 import com.yahoo.pulsar.common.policies.data.BacklogQuota;
+import com.yahoo.pulsar.common.policies.data.PersistentTopicInternalStats;
+import com.yahoo.pulsar.common.policies.data.PersistentTopicStats;
 import com.yahoo.pulsar.common.policies.data.Policies;
+import com.yahoo.pulsar.common.policies.data.loadbalancer.NamespaceBundleStats;
 import com.yahoo.pulsar.common.util.collections.ConcurrentOpenHashMap;
 import com.yahoo.pulsar.common.util.collections.ConcurrentOpenHashSet;
+import com.yahoo.pulsar.utils.StatsOutputStream;
 
 import io.netty.buffer.ByteBuf;
 
@@ -42,11 +47,11 @@ public interface Topic {
     CompletableFuture<Consumer> subscribe(ServerCnx cnx, String subscriptionName, long consumerId, SubType subType,
             int priorityLevel, String consumerName, boolean isDurable, MessageId startMessageId);
     
-    CompletableFuture<PersistentSubscription> createSubscription(String subscriptionName);
+    CompletableFuture<Subscription> createSubscription(String subscriptionName);
 
     CompletableFuture<Void> unsubscribe(String subName);
 
-    ConcurrentOpenHashMap<String, PersistentSubscription> getSubscriptions();
+    ConcurrentOpenHashMap<String, ? extends Subscription> getSubscriptions();
 
     CompletableFuture<Void> delete();
 
@@ -65,6 +70,18 @@ public interface Topic {
     CompletableFuture<Void> onPoliciesUpdate(Policies data);
 
     boolean isBacklogQuotaExceeded(String producerName);
-
+    
     BacklogQuota getBacklogQuota();
+
+    void updateRates(NamespaceStats nsStats, NamespaceBundleStats currentBundleStats,
+            StatsOutputStream topicStatsStream, ClusterReplicationMetrics clusterReplicationMetrics,
+            String namespaceName);
+
+    Subscription getSubscription(String subscription);
+
+    ConcurrentOpenHashMap<String, Replicator> getReplicators();
+
+    PersistentTopicStats getStats();
+
+    PersistentTopicInternalStats getInternalStats();
 }

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/nonpersistent/NonPersistentDispatcher.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/nonpersistent/NonPersistentDispatcher.java
@@ -50,11 +50,8 @@ public interface NonPersistentDispatcher extends Dispatcher{
     
     void sendMessages(List<Entry> entries);
     
-    @Override
-    default void consumerFlow(Consumer consumer, int additionalNumberOfMessages) {
-        // No-op
-    }
-
+    boolean hasPermits();
+    
     @Override
     default void redeliverUnacknowledgedMessages(Consumer consumer) {
         // No-op

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/nonpersistent/NonPersistentDispatcher.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/nonpersistent/NonPersistentDispatcher.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.pulsar.broker.service.nonpersistent;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
+
+import com.yahoo.pulsar.broker.service.BrokerServiceException;
+import com.yahoo.pulsar.broker.service.Consumer;
+import com.yahoo.pulsar.broker.service.Dispatcher;
+import com.yahoo.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
+import com.yahoo.pulsar.utils.CopyOnWriteArrayList;
+
+
+public interface NonPersistentDispatcher extends Dispatcher{
+
+    void addConsumer(Consumer consumer) throws BrokerServiceException;
+
+    void removeConsumer(Consumer consumer) throws BrokerServiceException ;
+
+    boolean isConsumerConnected();
+    
+    CopyOnWriteArrayList<Consumer> getConsumers();
+
+    boolean canUnsubscribe(Consumer consumer);
+
+    CompletableFuture<Void> close() ;
+
+    CompletableFuture<Void> disconnectAllConsumers();
+
+    void reset();
+
+    SubType getType();
+    
+    void sendMessages(List<Entry> entries);
+    
+    @Override
+    default void consumerFlow(Consumer consumer, int additionalNumberOfMessages) {
+        // No-op
+    }
+
+    @Override
+    default void redeliverUnacknowledgedMessages(Consumer consumer) {
+        // No-op
+    }
+
+    @Override
+    default void redeliverUnacknowledgedMessages(Consumer consumer, List<PositionImpl> positions) {
+        // No-op
+    }
+
+    @Override
+    default void addUnAckedMessages(int unAckMessages) {
+        // No-op
+    }
+
+}

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/nonpersistent/NonPersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/nonpersistent/NonPersistentDispatcherMultipleConsumers.java
@@ -1,0 +1,167 @@
+/**
+ * Copyright 2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.pulsar.broker.service.nonpersistent;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
+import org.apache.bookkeeper.mledger.Entry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.carrotsearch.hppc.ObjectHashSet;
+import com.carrotsearch.hppc.ObjectSet;
+import com.yahoo.pulsar.broker.service.BrokerServiceException;
+import com.yahoo.pulsar.broker.service.Consumer;
+import com.yahoo.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
+import com.yahoo.pulsar.utils.CopyOnWriteArrayList;
+
+/**
+ */
+public class NonPersistentDispatcherMultipleConsumers implements NonPersistentDispatcher {
+
+    private final NonPersistentTopic topic;
+    private final CopyOnWriteArrayList<Consumer> consumerList = new CopyOnWriteArrayList<>();
+    private final ObjectSet<Consumer> consumerSet = new ObjectHashSet<>();
+    private int currentConsumerRoundRobinIndex = 0;
+
+    private CompletableFuture<Void> closeFuture = null;
+
+    private final String name;
+
+    private static final int FALSE = 0;
+    private static final int TRUE = 1;
+    private static final AtomicIntegerFieldUpdater<NonPersistentDispatcherMultipleConsumers> IS_CLOSED_UPDATER = AtomicIntegerFieldUpdater
+            .newUpdater(NonPersistentDispatcherMultipleConsumers.class, "isClosed");
+    private volatile int isClosed = FALSE;
+
+    public NonPersistentDispatcherMultipleConsumers(NonPersistentTopic topic, String dispatcherName) {
+        this.name = topic.getName() + " / " + dispatcherName;
+        this.topic = topic;
+    }
+
+    @Override
+    public synchronized void addConsumer(Consumer consumer) {
+        if (IS_CLOSED_UPDATER.get(this) == TRUE) {
+            log.warn("[{}] Dispatcher is already closed. Closing consumer ", name, consumer);
+            consumer.disconnect();
+            return;
+        }
+
+        consumerList.add(consumer);
+        consumerSet.add(consumer);
+    }
+
+    @Override
+    public synchronized void removeConsumer(Consumer consumer) throws BrokerServiceException {
+        if (consumerSet.removeAll(consumer) == 1) {
+            consumerList.remove(consumer);
+            log.info("Removed consumer {}", consumer);
+            if (consumerList.isEmpty()) {
+                if (closeFuture != null) {
+                    log.info("[{}] All consumers removed. Subscription is disconnected", name);
+                    closeFuture.complete(null);
+                }
+            }
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] Trying to remove a non-connected consumer: {}", name, consumer);
+            }
+        }
+    }
+
+    @Override
+    public boolean isConsumerConnected() {
+        return !consumerList.isEmpty();
+    }
+
+    @Override
+    public CopyOnWriteArrayList<Consumer> getConsumers() {
+        return consumerList;
+    }
+
+    @Override
+    public synchronized boolean canUnsubscribe(Consumer consumer) {
+        return consumerList.size() == 1 && consumerSet.contains(consumer);
+    }
+
+    @Override
+    public CompletableFuture<Void> close() {
+        IS_CLOSED_UPDATER.set(this, TRUE);
+        return disconnectAllConsumers();
+    }
+
+    @Override
+    public synchronized CompletableFuture<Void> disconnectAllConsumers() {
+        closeFuture = new CompletableFuture<>();
+        if (consumerList.isEmpty()) {
+            closeFuture.complete(null);
+        } else {
+            consumerList.forEach(Consumer::disconnect);
+        }
+        return closeFuture;
+    }
+
+    @Override
+    public void reset() {
+        IS_CLOSED_UPDATER.set(this, FALSE);
+    }
+
+    @Override
+    public SubType getType() {
+        return SubType.Shared;
+    }
+
+    @Override
+    public void sendMessages(List<Entry> entries) {
+        Consumer consumer = getNextConsumer();
+        if (consumer != null) {
+            consumer.sendMessages(entries, false);
+        } else {
+            entries.forEach(Entry::release);
+        }
+    }
+
+    private Consumer getNextConsumer() {
+        if (consumerList.isEmpty() || closeFuture != null) {
+            // abort read if no consumers are connected or if disconnect is initiated
+            return null;
+        }
+
+        if (currentConsumerRoundRobinIndex >= consumerList.size()) {
+            currentConsumerRoundRobinIndex = 0;
+        }
+
+        // find next available consumer
+        int availableConsumerIndex = currentConsumerRoundRobinIndex;
+        do {
+            if (consumerList.get(availableConsumerIndex).getAvailablePermits() > 0) {
+                currentConsumerRoundRobinIndex = availableConsumerIndex;
+                return consumerList.get(currentConsumerRoundRobinIndex++);
+            }
+            if (++availableConsumerIndex >= consumerList.size()) {
+                availableConsumerIndex = 0;
+            }
+        } while (availableConsumerIndex != currentConsumerRoundRobinIndex);
+
+        // not found any consumer
+        return null;
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(NonPersistentDispatcherMultipleConsumers.class);
+
+}

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/nonpersistent/NonPersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/nonpersistent/NonPersistentDispatcherSingleActiveConsumer.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright 2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.pulsar.broker.service.nonpersistent;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import org.apache.bookkeeper.mledger.Entry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.yahoo.pulsar.broker.service.BrokerServiceException;
+import com.yahoo.pulsar.broker.service.BrokerServiceException.ConsumerBusyException;
+import com.yahoo.pulsar.broker.service.BrokerServiceException.ServerMetadataException;
+import com.yahoo.pulsar.broker.service.Consumer;
+import com.yahoo.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
+import com.yahoo.pulsar.utils.CopyOnWriteArrayList;
+
+public final class NonPersistentDispatcherSingleActiveConsumer implements NonPersistentDispatcher {
+
+    private final NonPersistentTopic topic;
+    private static final AtomicReferenceFieldUpdater<NonPersistentDispatcherSingleActiveConsumer, Consumer> ACTIVE_CONSUMER_UPDATER = AtomicReferenceFieldUpdater
+            .newUpdater(NonPersistentDispatcherSingleActiveConsumer.class, Consumer.class, "activeConsumer");
+    private volatile Consumer activeConsumer = null;
+    private final CopyOnWriteArrayList<Consumer> consumers;
+    private CompletableFuture<Void> closeFuture = null;
+    private final int partitionIndex;
+
+    // This dispatcher supports both the Exclusive and Failover subscription types
+    private final SubType subscriptionType;
+
+    private static final int FALSE = 0;
+    private static final int TRUE = 1;
+    private static final AtomicIntegerFieldUpdater<NonPersistentDispatcherSingleActiveConsumer> IS_CLOSED_UPDATER = AtomicIntegerFieldUpdater
+            .newUpdater(NonPersistentDispatcherSingleActiveConsumer.class, "isClosed");
+    private volatile int isClosed = FALSE;
+
+    public NonPersistentDispatcherSingleActiveConsumer(SubType subscriptionType, int partitionIndex,
+            NonPersistentTopic topic) {
+        this.topic = topic;
+        this.consumers = new CopyOnWriteArrayList<>();
+        this.partitionIndex = partitionIndex;
+        this.subscriptionType = subscriptionType;
+        ACTIVE_CONSUMER_UPDATER.set(this, null);
+    }
+
+    private void pickAndScheduleActiveConsumer() {
+        checkArgument(!consumers.isEmpty());
+
+        consumers.sort((c1, c2) -> c1.consumerName().compareTo(c2.consumerName()));
+
+        int index = partitionIndex % consumers.size();
+        Consumer prevConsumer = ACTIVE_CONSUMER_UPDATER.getAndSet(this, consumers.get(index));
+
+        if (prevConsumer == ACTIVE_CONSUMER_UPDATER.get(this)) {
+            // Active consumer did not change. Do nothing at this point
+            return;
+        }
+
+    }
+
+    @Override
+    public synchronized void addConsumer(Consumer consumer) throws BrokerServiceException {
+        if (IS_CLOSED_UPDATER.get(this) == TRUE) {
+            log.warn("[{}] Dispatcher is already closed. Closing consumer ", this.topic.getName(), consumer);
+            consumer.disconnect();
+        }
+        if (subscriptionType == SubType.Exclusive && !consumers.isEmpty()) {
+            throw new ConsumerBusyException("Exclusive consumer is already connected");
+        }
+
+        consumers.add(consumer);
+
+        // Pick an active consumer and start it
+        pickAndScheduleActiveConsumer();
+
+    }
+
+    @Override
+    public synchronized void removeConsumer(Consumer consumer) throws BrokerServiceException {
+        log.info("Removing consumer {}", consumer);
+        if (!consumers.remove(consumer)) {
+            throw new ServerMetadataException("Consumer was not connected");
+        }
+
+        if (consumers.isEmpty()) {
+            ACTIVE_CONSUMER_UPDATER.set(this, null);
+        }
+
+        if (closeFuture == null && !consumers.isEmpty()) {
+            pickAndScheduleActiveConsumer();
+            return;
+        }
+
+        if (consumers.isEmpty() && closeFuture != null && !closeFuture.isDone()) {
+            // Control reaches here only when closeFuture is created
+            // and no more connected consumers left.
+            closeFuture.complete(null);
+        }
+    }
+
+    /**
+     * Handle unsubscribe command from the client API For failover subscription, if consumer is connected consumer, we
+     * can unsubscribe.
+     *
+     * @param consumer
+     *            Calling consumer object
+     */
+    @Override
+    public synchronized boolean canUnsubscribe(Consumer consumer) {
+        return (consumers.size() == 1) && Objects.equals(consumer, ACTIVE_CONSUMER_UPDATER.get(this));
+    }
+
+    @Override
+    public CompletableFuture<Void> close() {
+        IS_CLOSED_UPDATER.set(this, TRUE);
+        return disconnectAllConsumers();
+    }
+
+    /**
+     * Disconnect all consumers on this dispatcher (server side close). This triggers channelInactive on the inbound
+     * handler which calls dispatcher.removeConsumer(), where the closeFuture is completed
+     *
+     * @return
+     */
+    @Override
+    public synchronized CompletableFuture<Void> disconnectAllConsumers() {
+        closeFuture = new CompletableFuture<>();
+
+        if (!consumers.isEmpty()) {
+            consumers.forEach(Consumer::disconnect);
+        } else {
+            // no consumer connected, complete disconnect immediately
+            closeFuture.complete(null);
+        }
+        return closeFuture;
+    }
+
+    @Override
+    public void reset() {
+        IS_CLOSED_UPDATER.set(this, FALSE);
+    }
+
+    @Override
+    public boolean isConsumerConnected() {
+        return ACTIVE_CONSUMER_UPDATER.get(this) != null;
+    }
+
+    @Override
+    public CopyOnWriteArrayList<Consumer> getConsumers() {
+        return consumers;
+    }
+
+    @Override
+    public SubType getType() {
+        return subscriptionType;
+    }
+
+    public Consumer getActiveConsumer() {
+        return ACTIVE_CONSUMER_UPDATER.get(this);
+    }
+
+    @Override
+    public void sendMessages(List<Entry> entries) {
+        Consumer currentConsumer = ACTIVE_CONSUMER_UPDATER.get(this);
+        if (currentConsumer != null) {
+            currentConsumer.sendMessages(entries, false);
+        } else {
+            entries.forEach(Entry::release);
+        }
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(NonPersistentDispatcherSingleActiveConsumer.class);
+
+}

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/nonpersistent/NonPersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/nonpersistent/NonPersistentDispatcherSingleActiveConsumer.java
@@ -181,11 +181,21 @@ public final class NonPersistentDispatcherSingleActiveConsumer implements NonPer
     @Override
     public void sendMessages(List<Entry> entries) {
         Consumer currentConsumer = ACTIVE_CONSUMER_UPDATER.get(this);
-        if (currentConsumer != null) {
-            currentConsumer.sendMessages(entries, false);
+        if (currentConsumer != null && currentConsumer.getAvailablePermits() > 0) {
+            currentConsumer.sendMessages(entries);
         } else {
             entries.forEach(Entry::release);
         }
+    }
+
+    @Override
+    public boolean hasPermits() {
+        return ACTIVE_CONSUMER_UPDATER.get(this) != null && ACTIVE_CONSUMER_UPDATER.get(this).getAvailablePermits() > 0;
+    }
+
+    @Override
+    public void consumerFlow(Consumer consumer, int additionalNumberOfMessages) {
+        // No-op
     }
 
     private static final Logger log = LoggerFactory.getLogger(NonPersistentDispatcherSingleActiveConsumer.class);

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/nonpersistent/NonPersistentReplicator.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/nonpersistent/NonPersistentReplicator.java
@@ -1,0 +1,371 @@
+/**
+ * Copyright 2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.pulsar.broker.service.nonpersistent;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.util.Rate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.yahoo.pulsar.broker.service.BrokerService;
+import com.yahoo.pulsar.broker.service.Replicator;
+import com.yahoo.pulsar.broker.service.persistent.PersistentReplicator;
+import com.yahoo.pulsar.client.api.MessageId;
+import com.yahoo.pulsar.client.api.ProducerConfiguration;
+import com.yahoo.pulsar.client.impl.Backoff;
+import com.yahoo.pulsar.client.impl.MessageImpl;
+import com.yahoo.pulsar.client.impl.ProducerImpl;
+import com.yahoo.pulsar.client.impl.PulsarClientImpl;
+import com.yahoo.pulsar.client.impl.SendCallback;
+import com.yahoo.pulsar.common.policies.data.ReplicatorStats;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.Recycler;
+import io.netty.util.Recycler.Handle;
+
+public class NonPersistentReplicator implements Replicator {
+
+    private final BrokerService brokerService;
+    private final NonPersistentTopic topic;
+    private final String topicName;
+    private final String localCluster;
+    private final String remoteCluster;
+    private final PulsarClientImpl client;
+
+    private volatile ProducerImpl producer;
+
+    private final Rate msgOut = new Rate();
+    private final Rate msgExpired = new Rate();
+
+    private static final ProducerConfiguration producerConfiguration = new ProducerConfiguration().setSendTimeout(0,
+            TimeUnit.SECONDS);
+
+    private final Backoff backOff = new Backoff(100, TimeUnit.MILLISECONDS, 1, TimeUnit.MINUTES);
+
+    private final ReplicatorStats stats = new ReplicatorStats();
+
+    public NonPersistentReplicator(NonPersistentTopic topic, String localCluster, String remoteCluster,
+            BrokerService brokerService) {
+        this.brokerService = brokerService;
+        this.topic = topic;
+        this.topicName = topic.getName();
+        this.localCluster = localCluster;
+        this.remoteCluster = remoteCluster;
+        this.client = (PulsarClientImpl) brokerService.getReplicationClient(remoteCluster);
+        this.producer = null;
+        STATE_UPDATER.set(this, State.Stopped);
+
+        producerConfiguration
+                .setMaxPendingMessages(brokerService.pulsar().getConfiguration().getReplicationProducerQueueSize());
+        producerConfiguration.setBlockIfQueueFull(false);
+
+        startProducer();
+    }
+
+    public String getRemoteCluster() {
+        return remoteCluster;
+    }
+
+    enum State {
+        Stopped, Starting, Started, Stopping
+    }
+
+    private static final AtomicReferenceFieldUpdater<NonPersistentReplicator, State> STATE_UPDATER = AtomicReferenceFieldUpdater
+            .newUpdater(NonPersistentReplicator.class, State.class, "state");
+    private volatile State state = State.Stopped;
+
+    // This method needs to be synchronized with disconnects else if there is a disconnect followed by startProducer
+    // the end result can be disconnect.
+    public synchronized void startProducer() {
+        if (STATE_UPDATER.get(this) == State.Stopping) {
+            long waitTimeMs = backOff.next();
+            if (log.isDebugEnabled()) {
+                log.debug(
+                        "[{}][{} -> {}] waiting for producer to close before attempting to reconnect, retrying in {} s",
+                        topicName, localCluster, remoteCluster, waitTimeMs / 1000.0);
+            }
+            // BackOff before retrying
+            brokerService.executor().schedule(this::startProducer, waitTimeMs, TimeUnit.MILLISECONDS);
+            return;
+        }
+        State state = STATE_UPDATER.get(this);
+        if (!STATE_UPDATER.compareAndSet(this, State.Stopped, State.Starting)) {
+            if (state == State.Started) {
+                // Already running
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}][{} -> {}] Replicator was already running", topicName, localCluster, remoteCluster);
+                }
+            } else {
+                log.info("[{}][{} -> {}] Replicator already being started. Replicator state: {}", topicName,
+                        localCluster, remoteCluster, state);
+            }
+
+            return;
+        }
+
+        log.info("[{}][{} -> {}] Starting replicator", topicName, localCluster, remoteCluster);
+        client.createProducerAsync(topicName, producerConfiguration,
+                getReplicatorName(topic.replicatorPrefix, localCluster)).thenAccept(producer -> {
+
+                    this.producer = (ProducerImpl) producer;
+
+                    if (STATE_UPDATER.compareAndSet(this, State.Starting, State.Started)) {
+                        log.info("[{}][{} -> {}] Created replicator producer", topicName, localCluster, remoteCluster);
+                        backOff.reset();
+                    } else {
+                        log.info(
+                                "[{}][{} -> {}] Replicator was stopped while creating the producer. Closing it. Replicator state: {}",
+                                topicName, localCluster, remoteCluster, STATE_UPDATER.get(this));
+                        STATE_UPDATER.set(this, State.Stopping);
+                        closeProducerAsync();
+                        return;
+                    }
+                }).exceptionally(ex -> {
+                    if (STATE_UPDATER.compareAndSet(this, State.Starting, State.Stopped)) {
+                        long waitTimeMs = backOff.next();
+                        log.warn("[{}][{} -> {}] Failed to create remote producer ({}), retrying in {} s", topicName,
+                                localCluster, remoteCluster, ex.getMessage(), waitTimeMs / 1000.0);
+
+                        // BackOff before retrying
+                        brokerService.executor().schedule(this::startProducer, waitTimeMs, TimeUnit.MILLISECONDS);
+                    } else {
+                        log.warn("[{}][{} -> {}] Failed to create remote producer. Replicator state: {}", topicName,
+                                localCluster, remoteCluster, STATE_UPDATER.get(this), ex);
+                    }
+                    return null;
+                });
+
+    }
+
+    public void sendMessage(Entry entry) {
+        if ((STATE_UPDATER.get(this) == State.Started) && isWritable()) {
+
+            int length = entry.getLength();
+            ByteBuf headersAndPayload = entry.getDataBuffer();
+            MessageImpl msg;
+            try {
+                msg = MessageImpl.deserialize(headersAndPayload);
+            } catch (Throwable t) {
+                log.error("[{}][{} -> {}] Failed to deserialize message at {} (buffer size: {}): {}", topicName,
+                        localCluster, remoteCluster, entry.getPosition(), length, t.getMessage(), t);
+                entry.release();
+                return;
+            }
+
+            if (msg.isReplicated()) {
+                // Discard messages that were already replicated into this region
+                entry.release();
+                msg.recycle();
+                return;
+            }
+
+            if (msg.hasReplicateTo() && !msg.getReplicateTo().contains(remoteCluster)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}][{} -> {}] Skipping message at {} / msg-id: {}: replicateTo {}", topicName,
+                            localCluster, remoteCluster, entry.getPosition(), msg.getMessageId(), msg.getReplicateTo());
+                }
+                entry.release();
+                msg.recycle();
+                return;
+            }
+
+            msgOut.recordEvent(headersAndPayload.readableBytes());
+
+            msg.setReplicatedFrom(localCluster);
+
+            headersAndPayload.retain();
+
+            producer.sendAsync(msg, ProducerSendCallback.create(this, entry, msg));
+
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("[{}][{} -> {}] dropping message because replicator producer is not started/writable",
+                        topicName, localCluster, remoteCluster);
+            }
+            entry.release();
+        }
+    }
+
+    private synchronized CompletableFuture<Void> closeProducerAsync() {
+        if (producer == null) {
+            STATE_UPDATER.set(this, State.Stopped);
+            return CompletableFuture.completedFuture(null);
+        }
+        CompletableFuture<Void> future = producer.closeAsync();
+        future.thenRun(() -> {
+            STATE_UPDATER.set(this, State.Stopped);
+            this.producer = null;
+        }).exceptionally(ex -> {
+            long waitTimeMs = backOff.next();
+            log.warn(
+                    "[{}][{} -> {}] Exception: '{}' occured while trying to close the producer. retrying again in {} s",
+                    topicName, localCluster, remoteCluster, ex.getMessage(), waitTimeMs / 1000.0);
+            // BackOff before retrying
+            brokerService.executor().schedule(this::closeProducerAsync, waitTimeMs, TimeUnit.MILLISECONDS);
+            return null;
+        });
+        return future;
+    }
+
+    @Override
+    public CompletableFuture<Void> disconnect() {
+        return disconnect(false);
+    }
+
+    @Override
+    public CompletableFuture<Void> disconnect(boolean failIfHasBacklog) {
+
+        if (STATE_UPDATER.get(this) == State.Stopping) {
+            // Do nothing since the all "STATE_UPDATER.set(this, Stopping)" instructions are followed by
+            // closeProducerAsync()
+            // which will at some point change the state to stopped
+            return CompletableFuture.completedFuture(null);
+        }
+
+        if (producer != null && (STATE_UPDATER.compareAndSet(this, State.Starting, State.Stopping)
+                || STATE_UPDATER.compareAndSet(this, State.Started, State.Stopping))) {
+            log.info("[{}][{} -> {}] Disconnect replicator", topicName, localCluster, remoteCluster);
+            return closeProducerAsync();
+        }
+
+        STATE_UPDATER.set(this, State.Stopped);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public void updateRates() {
+        msgOut.calculateRate();
+        msgExpired.calculateRate();
+        stats.msgRateOut = msgOut.getRate();
+        stats.msgThroughputOut = msgOut.getValueRate();
+    }
+
+    @Override
+    public ReplicatorStats getStats() {
+        stats.connected = producer != null && producer.isConnected();
+        stats.replicationDelayInSeconds = getReplicationDelayInSeconds();
+
+        ProducerImpl producer = this.producer;
+        if (producer != null) {
+            stats.outboundConnection = producer.getConnectionId();
+            stats.outboundConnectedSince = producer.getConnectedSince();
+        } else {
+            stats.outboundConnection = null;
+            stats.outboundConnectedSince = null;
+        }
+
+        return stats;
+    }
+
+    private long getReplicationDelayInSeconds() {
+        if (producer != null) {
+            return TimeUnit.MILLISECONDS.toSeconds(producer.getDelayInMillis());
+        }
+        return 0L;
+    }
+
+    private boolean isWritable() {
+        return this.producer != null && this.producer.isWritable();
+    }
+
+    public static void setReplicatorQueueSize(int queueSize) {
+        producerConfiguration.setMaxPendingMessages(queueSize);
+    }
+
+    public static String getRemoteCluster(String remoteCursor) {
+        String[] split = remoteCursor.split("\\.");
+        return split[split.length - 1];
+    }
+
+    public static String getReplicatorName(String replicatorPrefix, String cluster) {
+        return String.format("%s.%s", replicatorPrefix, cluster);
+    }
+
+    private static final class ProducerSendCallback implements SendCallback {
+        private NonPersistentReplicator replicator;
+        private Entry entry;
+        private MessageImpl msg;
+
+        @Override
+        public void sendComplete(Exception exception) {
+            if (exception != null) {
+                log.error("[{}][{} -> {}] Error producing on remote broker", replicator.topicName,
+                        replicator.localCluster, replicator.remoteCluster, exception);
+            } else {
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}][{} -> {}] Message persisted on remote broker", replicator.topicName,
+                            replicator.localCluster, replicator.remoteCluster);
+                }
+            }
+            entry.release();
+
+            recycle();
+        }
+
+        private final Handle recyclerHandle;
+
+        private ProducerSendCallback(Handle recyclerHandle) {
+            this.recyclerHandle = recyclerHandle;
+        }
+
+        static ProducerSendCallback create(NonPersistentReplicator replicator, Entry entry, MessageImpl msg) {
+            ProducerSendCallback sendCallback = RECYCLER.get();
+            sendCallback.replicator = replicator;
+            sendCallback.entry = entry;
+            sendCallback.msg = msg;
+            return sendCallback;
+        }
+
+        private void recycle() {
+            replicator = null;
+            entry = null; // already released and recycled on sendComplete
+            if (msg != null) {
+                msg.recycle();
+                msg = null;
+            }
+            RECYCLER.recycle(this, recyclerHandle);
+        }
+
+        private static final Recycler<ProducerSendCallback> RECYCLER = new Recycler<ProducerSendCallback>() {
+            @Override
+            protected ProducerSendCallback newObject(Handle handle) {
+                return new ProducerSendCallback(handle);
+            }
+
+        };
+
+        @Override
+        public void addCallback(SendCallback scb) {
+            // noop
+        }
+
+        @Override
+        public SendCallback getNextSendCallback() {
+            return null;
+        }
+
+        @Override
+        public CompletableFuture<MessageId> getFuture() {
+            return null;
+        }
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(PersistentReplicator.class);
+}

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
@@ -60,6 +60,11 @@ public class NonPersistentSubscription implements Subscription {
     }
 
     @Override
+    public String getName() {
+        return this.subName;
+    }
+
+    @Override
     public synchronized void addConsumer(Consumer consumer) throws BrokerServiceException {
         if (IS_FENCED_UPDATER.get(this) == TRUE) {
             log.warn("Attempting to add consumer {} on a fenced subscription", consumer);
@@ -119,7 +124,7 @@ public class NonPersistentSubscription implements Subscription {
 
     @Override
     public void consumerFlow(Consumer consumer, int additionalNumberOfMessages) {
-        // No-op
+        dispatcher.consumerFlow(consumer, additionalNumberOfMessages);
     }
 
     @Override

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
@@ -1,0 +1,346 @@
+/**
+ * Copyright 2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.pulsar.broker.service.nonpersistent;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
+import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Objects;
+import com.yahoo.pulsar.broker.service.BrokerServiceException;
+import com.yahoo.pulsar.broker.service.BrokerServiceException.ServerMetadataException;
+import com.yahoo.pulsar.broker.service.BrokerServiceException.SubscriptionBusyException;
+import com.yahoo.pulsar.broker.service.BrokerServiceException.SubscriptionFencedException;
+import com.yahoo.pulsar.broker.service.Consumer;
+import com.yahoo.pulsar.broker.service.Dispatcher;
+import com.yahoo.pulsar.broker.service.Subscription;
+import com.yahoo.pulsar.common.api.proto.PulsarApi.CommandAck.AckType;
+import com.yahoo.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
+import com.yahoo.pulsar.common.naming.DestinationName;
+import com.yahoo.pulsar.common.policies.data.ConsumerStats;
+import com.yahoo.pulsar.common.policies.data.PersistentSubscriptionStats;
+import com.yahoo.pulsar.utils.CopyOnWriteArrayList;
+
+public class NonPersistentSubscription implements Subscription {
+    private final NonPersistentTopic topic;
+    private volatile NonPersistentDispatcher dispatcher;
+    private final String topicName;
+    private final String subName;
+
+    private static final int FALSE = 0;
+    private static final int TRUE = 1;
+    private static final AtomicIntegerFieldUpdater<NonPersistentSubscription> IS_FENCED_UPDATER = AtomicIntegerFieldUpdater
+            .newUpdater(NonPersistentSubscription.class, "isFenced");
+    private volatile int isFenced = FALSE;
+
+    public NonPersistentSubscription(NonPersistentTopic topic, String subscriptionName) {
+        this.topic = topic;
+        this.topicName = topic.getName();
+        this.subName = subscriptionName;
+        IS_FENCED_UPDATER.set(this, FALSE);
+    }
+
+    @Override
+    public synchronized void addConsumer(Consumer consumer) throws BrokerServiceException {
+        if (IS_FENCED_UPDATER.get(this) == TRUE) {
+            log.warn("Attempting to add consumer {} on a fenced subscription", consumer);
+            throw new SubscriptionFencedException("Subscription is fenced");
+        }
+
+        if (dispatcher == null || !dispatcher.isConsumerConnected()) {
+            switch (consumer.subType()) {
+            case Exclusive:
+                if (dispatcher == null || dispatcher.getType() != SubType.Exclusive) {
+                    dispatcher = new NonPersistentDispatcherSingleActiveConsumer(SubType.Exclusive, 0, topic);
+                }
+                break;
+            case Shared:
+                if (dispatcher == null || dispatcher.getType() != SubType.Shared) {
+                    dispatcher = new NonPersistentDispatcherMultipleConsumers(topic, this.subName);
+                }
+                break;
+            case Failover:
+                int partitionIndex = DestinationName.getPartitionIndex(topicName);
+                if (partitionIndex < 0) {
+                    // For non partition topics, assume index 0 to pick a predictable consumer
+                    partitionIndex = 0;
+                }
+
+                if (dispatcher == null || dispatcher.getType() != SubType.Failover) {
+                    dispatcher = new NonPersistentDispatcherSingleActiveConsumer(SubType.Failover, partitionIndex,
+                            topic);
+                }
+                break;
+            default:
+                throw new ServerMetadataException("Unsupported subscription type");
+            }
+        } else {
+            if (consumer.subType() != dispatcher.getType()) {
+                throw new SubscriptionBusyException("Subscription is of different type");
+            }
+        }
+
+        dispatcher.addConsumer(consumer);
+    }
+
+    @Override
+    public synchronized void removeConsumer(Consumer consumer) throws BrokerServiceException {
+        if (dispatcher != null) {
+            dispatcher.removeConsumer(consumer);
+        }
+
+        // invalid consumer remove will throw an exception
+        // decrement usage is triggered only for valid consumer close
+        NonPersistentTopic.USAGE_COUNT_UPDATER.decrementAndGet(topic);
+        if (log.isDebugEnabled()) {
+            log.debug("[{}] [{}] [{}] Removed consumer -- count: {}", topic.getName(), subName, consumer.consumerName(),
+                    NonPersistentTopic.USAGE_COUNT_UPDATER.get(topic));
+        }
+    }
+
+    @Override
+    public void consumerFlow(Consumer consumer, int additionalNumberOfMessages) {
+        // No-op
+    }
+
+    @Override
+    public void acknowledgeMessage(PositionImpl position, AckType ackType) {
+        // No-op
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this).add("topic", topicName).add("name", subName).toString();
+    }
+
+    @Override
+    public String getDestination() {
+        return this.topicName;
+    }
+
+    @Override
+    public SubType getType() {
+        return dispatcher != null ? dispatcher.getType() : null;
+    }
+
+    @Override
+    public String getTypeString() {
+        SubType type = getType();
+        if (type == null) {
+            return "None";
+        }
+
+        switch (type) {
+        case Exclusive:
+            return "Exclusive";
+        case Failover:
+            return "Failover";
+        case Shared:
+            return "Shared";
+        }
+
+        return "Null";
+    }
+
+    @Override
+    public CompletableFuture<Void> clearBacklog() {
+        // No-op
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> skipMessages(int numMessagesToSkip) {
+        // No-op
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> resetCursor(long timestamp) {
+        // No-op
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Entry> peekNthMessage(int messagePosition) {
+        // No-op
+        return CompletableFuture.completedFuture(null);// TODO: throw exception
+    }
+
+    @Override
+    public long getNumberOfEntriesInBacklog() {
+        // No-op
+        return 0;
+    }
+
+    @Override
+    public NonPersistentDispatcher getDispatcher() {
+        return this.dispatcher;
+    }
+
+    @Override
+    public CompletableFuture<Void> close() {
+        IS_FENCED_UPDATER.set(this, TRUE);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    /**
+     * Disconnect all consumers attached to the dispatcher and close this subscription
+     *
+     * @return CompletableFuture indicating the completion of disconnect operation
+     */
+    @Override
+    public synchronized CompletableFuture<Void> disconnect() {
+        CompletableFuture<Void> disconnectFuture = new CompletableFuture<>();
+
+        // block any further consumers on this subscription
+        IS_FENCED_UPDATER.set(this, TRUE);
+
+        (dispatcher != null ? dispatcher.close() : CompletableFuture.completedFuture(null)).thenCompose(v -> close())
+                .thenRun(() -> {
+                    log.info("[{}][{}] Successfully disconnected and closed subscription", topicName, subName);
+                    disconnectFuture.complete(null);
+                }).exceptionally(exception -> {
+                    IS_FENCED_UPDATER.set(this, FALSE);
+                    dispatcher.reset();
+                    log.error("[{}][{}] Error disconnecting consumers from subscription", topicName, subName,
+                            exception);
+                    disconnectFuture.completeExceptionally(exception);
+                    return null;
+                });
+
+        return disconnectFuture;
+    }
+
+    /**
+     * Delete the subscription by closing and deleting its managed cursor if no consumers are connected to it. Handle
+     * unsubscribe call from admin layer.
+     *
+     * @return CompletableFuture indicating the completion of delete operation
+     */
+    @Override
+    public CompletableFuture<Void> delete() {
+        CompletableFuture<Void> deleteFuture = new CompletableFuture<>();
+
+        log.info("[{}][{}] Unsubscribing", topicName, subName);
+
+        // cursor close handles pending delete (ack) operations
+        this.close().thenCompose(v -> topic.unsubscribe(subName)).thenAccept(v -> deleteFuture.complete(null))
+                .exceptionally(exception -> {
+                    IS_FENCED_UPDATER.set(this, FALSE);
+                    log.error("[{}][{}] Error deleting subscription", topicName, subName, exception);
+                    deleteFuture.completeExceptionally(exception);
+                    return null;
+                });
+
+        return deleteFuture;
+    }
+
+    /**
+     * Handle unsubscribe command from the client API Check with the dispatcher is this consumer can proceed with
+     * unsubscribe
+     *
+     * @param consumer
+     *            consumer object that is initiating the unsubscribe operation
+     * @return CompletableFuture indicating the completion of ubsubscribe operation
+     */
+    @Override
+    public CompletableFuture<Void> doUnsubscribe(Consumer consumer) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        try {
+            if (dispatcher.canUnsubscribe(consumer)) {
+                consumer.close();
+                return delete();
+            }
+            future.completeExceptionally(
+                    new ServerMetadataException("Unconnected or shared consumer attempting to unsubscribe"));
+        } catch (BrokerServiceException e) {
+            log.warn("Error removing consumer {}", consumer);
+            future.completeExceptionally(e);
+        }
+        return future;
+    }
+
+    @Override
+    public CopyOnWriteArrayList<Consumer> getConsumers() {
+        Dispatcher dispatcher = this.dispatcher;
+        if (dispatcher != null) {
+            return dispatcher.getConsumers();
+        } else {
+            return CopyOnWriteArrayList.empty();
+        }
+    }
+
+    @Override
+    public void expireMessages(int messageTTLInSeconds) {
+        // No-op
+    }
+
+
+    public PersistentSubscriptionStats getStats() {
+        PersistentSubscriptionStats subStats = new PersistentSubscriptionStats();
+
+        Dispatcher dispatcher = this.dispatcher;
+        if (dispatcher != null) {
+            dispatcher.getConsumers().forEach(consumer -> {
+                ConsumerStats consumerStats = consumer.getStats();
+                subStats.consumers.add(consumerStats);
+                subStats.msgRateOut += consumerStats.msgRateOut;
+                subStats.msgThroughputOut += consumerStats.msgThroughputOut;
+                subStats.msgRateRedeliver += consumerStats.msgRateRedeliver;
+                subStats.unackedMessages += consumerStats.unackedMessages;
+            });
+        }
+
+        subStats.type = getType();
+        subStats.msgBacklog = getNumberOfEntriesInBacklog();
+        return subStats;
+    }
+
+    @Override
+    public synchronized void redeliverUnacknowledgedMessages(Consumer consumer) {
+     // No-op
+    }
+
+    @Override
+    public synchronized void redeliverUnacknowledgedMessages(Consumer consumer, List<PositionImpl> positions) {
+        // No-op
+    }
+
+    @Override
+    public void addUnAckedMessages(int unAckMessages) {
+        // No-op
+    }
+
+    @Override
+    public double getExpiredMessageRate() {
+        // No-op
+        return 0;
+    }
+    
+    @Override
+    public void markTopicWithBatchMessagePublished() {
+        topic.markBatchMessagePublished();
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(NonPersistentSubscription.class);
+
+}

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -1,0 +1,886 @@
+/**
+ * Copyright 2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.pulsar.broker.service.nonpersistent;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.bookkeeper.mledger.impl.EntryCacheManager.create;
+
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.apache.bookkeeper.mledger.AsyncCallbacks.AddEntryCallback;
+import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.bookkeeper.mledger.ManagedLedgerException.ManagedLedgerFencedException;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.bookkeeper.mledger.util.SafeRun;
+import org.apache.bookkeeper.util.OrderedSafeExecutor;
+import org.apache.zookeeper.KeeperException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.beust.jcommander.internal.Lists;
+import com.carrotsearch.hppc.ObjectObjectHashMap;
+import com.google.common.base.Objects;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.RateLimiter;
+import com.yahoo.pulsar.broker.admin.AdminResource;
+import com.yahoo.pulsar.broker.service.BrokerService;
+import com.yahoo.pulsar.broker.service.BrokerServiceException;
+import com.yahoo.pulsar.broker.service.BrokerServiceException.ConsumerBusyException;
+import com.yahoo.pulsar.broker.service.BrokerServiceException.NamingException;
+import com.yahoo.pulsar.broker.service.BrokerServiceException.PersistenceException;
+import com.yahoo.pulsar.broker.service.BrokerServiceException.ServerMetadataException;
+import com.yahoo.pulsar.broker.service.BrokerServiceException.SubscriptionBusyException;
+import com.yahoo.pulsar.broker.service.BrokerServiceException.TooManyRequestsException;
+import com.yahoo.pulsar.broker.service.BrokerServiceException.TopicBusyException;
+import com.yahoo.pulsar.broker.service.BrokerServiceException.TopicFencedException;
+import com.yahoo.pulsar.broker.service.BrokerServiceException.UnsupportedVersionException;
+import com.yahoo.pulsar.broker.service.Consumer;
+import com.yahoo.pulsar.broker.service.Producer;
+import com.yahoo.pulsar.broker.service.Replicator;
+import com.yahoo.pulsar.broker.service.ServerCnx;
+import com.yahoo.pulsar.broker.service.Subscription;
+import com.yahoo.pulsar.broker.service.Topic;
+import com.yahoo.pulsar.broker.stats.ClusterReplicationMetrics;
+import com.yahoo.pulsar.broker.stats.NamespaceStats;
+import com.yahoo.pulsar.client.api.MessageId;
+import com.yahoo.pulsar.client.util.FutureUtil;
+import com.yahoo.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
+import com.yahoo.pulsar.common.naming.DestinationName;
+import com.yahoo.pulsar.common.policies.data.BacklogQuota;
+import com.yahoo.pulsar.common.policies.data.ConsumerStats;
+import com.yahoo.pulsar.common.policies.data.PersistentSubscriptionStats;
+import com.yahoo.pulsar.common.policies.data.PersistentTopicInternalStats;
+import com.yahoo.pulsar.common.policies.data.PersistentTopicInternalStats.CursorStats;
+import com.yahoo.pulsar.common.policies.data.PersistentTopicStats;
+import com.yahoo.pulsar.common.policies.data.Policies;
+import com.yahoo.pulsar.common.policies.data.PublisherStats;
+import com.yahoo.pulsar.common.policies.data.ReplicatorStats;
+import com.yahoo.pulsar.common.policies.data.loadbalancer.NamespaceBundleStats;
+import com.yahoo.pulsar.common.util.collections.ConcurrentOpenHashMap;
+import com.yahoo.pulsar.common.util.collections.ConcurrentOpenHashSet;
+import com.yahoo.pulsar.utils.StatsOutputStream;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.RecyclableDuplicateByteBuf;
+import io.netty.util.concurrent.FastThreadLocal;
+
+public class NonPersistentTopic implements Topic {
+    private final String topic;
+
+    // Producers currently connected to this topic
+    private final ConcurrentOpenHashSet<Producer> producers;
+
+    // Subscriptions to this topic
+    private final ConcurrentOpenHashMap<String, NonPersistentSubscription> subscriptions;
+
+    private final ConcurrentOpenHashMap<String, Replicator> replicators;
+
+    private final BrokerService brokerService;
+
+    private volatile boolean isFenced;
+
+    // Prefix for replication cursors
+    public final String replicatorPrefix;
+
+    private final RateLimiter messageDispatchLimiter;
+
+    protected static final AtomicLongFieldUpdater<NonPersistentTopic> USAGE_COUNT_UPDATER = AtomicLongFieldUpdater
+            .newUpdater(NonPersistentTopic.class, "usageCount");
+    private volatile long usageCount = 0;
+
+    private final int maxPublishMessagesRate;
+    private final OrderedSafeExecutor executor;
+    
+
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
+    public static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSZ")
+            .withZone(ZoneId.systemDefault());
+
+    // Timestamp of when this topic was last seen active
+    private volatile long lastActive;
+
+    // Flag to signal that producer of this topic has published batch-message so, broker should not allow consumer which
+    // doesn't support batch-message
+    private volatile boolean hasBatchMessagePublished = false;
+    // Ever increasing counter of entries added
+    static final AtomicLongFieldUpdater<NonPersistentTopic> ENTRIES_ADDED_COUNTER_UPDATER =
+            AtomicLongFieldUpdater.newUpdater(NonPersistentTopic.class, "entriesAddedCounter");
+    private volatile long entriesAddedCounter = 0;
+    private static final long POLICY_UPDATE_FAILURE_RETRY_TIME_SECONDS = 60;
+
+    private static final FastThreadLocal<TopicStats> threadLocalTopicStats = new FastThreadLocal<TopicStats>() {
+        @Override
+        protected TopicStats initialValue() {
+            return new TopicStats();
+        }
+    };
+
+    private static class TopicStats {
+        public double averageMsgSize;
+        public double aggMsgRateIn;
+        public double aggMsgThroughputIn;
+        public double aggMsgRateOut;
+        public double aggMsgThroughputOut;
+        public final ObjectObjectHashMap<String, PublisherStats> remotePublishersStats;
+
+        public TopicStats() {
+            remotePublishersStats = new ObjectObjectHashMap<String, PublisherStats>();
+            reset();
+        }
+
+        public void reset() {
+            averageMsgSize = 0;
+            aggMsgRateIn = 0;
+            aggMsgThroughputIn = 0;
+            aggMsgRateOut = 0;
+            aggMsgThroughputOut = 0;
+            remotePublishersStats.clear();
+        }
+    }
+
+    public NonPersistentTopic(String topic, BrokerService brokerService) {
+        this.topic = topic;
+        this.brokerService = brokerService;
+        this.producers = new ConcurrentOpenHashSet<Producer>();
+        this.subscriptions = new ConcurrentOpenHashMap<>();
+        this.replicators = new ConcurrentOpenHashMap<>();
+        this.isFenced = false;
+        this.replicatorPrefix = brokerService.pulsar().getConfiguration().getReplicatorPrefix();
+        this.maxPublishMessagesRate = brokerService.pulsar().getConfiguration()
+                .getMaxPublishMessageRatePerNonPersistentTopic();
+        this.messageDispatchLimiter = RateLimiter.create(maxPublishMessagesRate);
+        this.executor = brokerService.getTopicOrderedExecutor();
+        USAGE_COUNT_UPDATER.set(this, 0);
+
+        this.lastActive = System.nanoTime();
+    }
+
+    @Override
+    public void publishMessage(ByteBuf data, PublishCallback callback) {
+
+        if (messageDispatchLimiter.tryAcquire()) {
+           
+            data.retain();
+            this.executor.submitOrdered(topic, SafeRun.safeRun(() -> {
+                subscriptions.forEach((name, subscription) -> {
+                    Entry entry = create(0L, 0L, data);
+                    subscription.getDispatcher().sendMessages(Lists.newArrayList(entry));    
+                });
+                data.release();
+            }));
+            
+            data.retain();
+            this.executor.submitOrdered(topic, SafeRun.safeRun(() -> {
+                replicators.forEach((name, replicator) -> {
+                    // replicator modifies readerIndex while deserializing message-metadata so, create duplicateBuffer
+                    ByteBuf duplicateBuffer = RecyclableDuplicateByteBuf.create(data);
+                    Entry entry = create(0L, 0L, duplicateBuffer);
+                    // entry internally retains data so, duplicateBuffer should be release here
+                    duplicateBuffer.release();
+                    ((NonPersistentReplicator) replicator).sendMessage(entry);
+                });
+                data.release();
+            }));
+            callback.completed(null, 0L, 0L);
+            ENTRIES_ADDED_COUNTER_UPDATER.incrementAndGet(this);
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] Dropping published message due to max publish rate limit", topic);
+            }
+            callback.completed(new TooManyRequestsException("reached max publish rate " + maxPublishMessagesRate), 0L,
+                    0L);
+        }
+
+    }
+
+    @Override
+    public void addProducer(Producer producer) throws BrokerServiceException {
+        checkArgument(producer.getTopic() == this);
+
+        lock.readLock().lock();
+        try {
+            if (isFenced) {
+                log.warn("[{}] Attempting to add producer to a fenced topic", topic);
+                throw new TopicFencedException("Topic is temporarily unavailable");
+            }
+
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] {} Got request to create producer ", topic, producer.getProducerName());
+            }
+
+            if (!producers.add(producer)) {
+                throw new NamingException(
+                        "Producer with name '" + producer.getProducerName() + "' is already connected to topic");
+            }
+
+            USAGE_COUNT_UPDATER.incrementAndGet(this);
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] [{}] Added producer -- count: {}", topic, producer.getProducerName(),
+                        USAGE_COUNT_UPDATER.get(this));
+            }
+
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    private boolean hasLocalProducers() {
+        AtomicBoolean foundLocal = new AtomicBoolean(false);
+        producers.forEach(producer -> {
+            if (!producer.isRemote()) {
+                foundLocal.set(true);
+            }
+        });
+
+        return foundLocal.get();
+    }
+
+    private boolean hasRemoteProducers() {
+        AtomicBoolean foundRemote = new AtomicBoolean(false);
+        producers.forEach(producer -> {
+            if (producer.isRemote()) {
+                foundRemote.set(true);
+            }
+        });
+
+        return foundRemote.get();
+    }
+
+    @Override
+    public void removeProducer(Producer producer) {
+        checkArgument(producer.getTopic() == this);
+        if (producers.remove(producer)) {
+            // decrement usage only if this was a valid producer close
+            USAGE_COUNT_UPDATER.decrementAndGet(this);
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] [{}] Removed producer -- count: {}", topic, producer.getProducerName(),
+                        USAGE_COUNT_UPDATER.get(this));
+            }
+            lastActive = System.nanoTime();
+        }
+    }
+
+    @Override
+    public CompletableFuture<Consumer> subscribe(final ServerCnx cnx, String subscriptionName, long consumerId,
+            SubType subType, int priorityLevel, String consumerName, boolean isDurable, MessageId startMessageId) {
+
+        final CompletableFuture<Consumer> future = new CompletableFuture<>();
+
+        if (hasBatchMessagePublished && !cnx.isBatchMessageCompatibleVersion()) {
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] Consumer doesn't support batch-message {}", topic, subscriptionName);
+            }
+            future.completeExceptionally(new UnsupportedVersionException("Consumer doesn't support batch-message"));
+            return future;
+        }
+
+        if (subscriptionName.startsWith(replicatorPrefix)) {
+            log.warn("[{}] Failed to create subscription for {}", topic, subscriptionName);
+            future.completeExceptionally(new NamingException("Subscription with reserved subscription name attempted"));
+            return future;
+        }
+
+        lock.readLock().lock();
+        try {
+            if (isFenced) {
+                log.warn("[{}] Attempting to subscribe to a fenced topic", topic);
+                future.completeExceptionally(new TopicFencedException("Topic is temporarily unavailable"));
+                return future;
+            }
+            USAGE_COUNT_UPDATER.incrementAndGet(this);
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] [{}] [{}] Added consumer -- count: {}", topic, subscriptionName, consumerName,
+                        USAGE_COUNT_UPDATER.get(this));
+            }
+        } finally {
+            lock.readLock().unlock();
+        }
+
+        NonPersistentSubscription subscription = subscriptions.computeIfAbsent(subscriptionName,
+                name -> new NonPersistentSubscription(this, subscriptionName));
+
+        try {
+            Consumer consumer = new Consumer(subscription, subType, consumerId, priorityLevel, consumerName, 0, cnx,
+                    cnx.getRole());
+            subscription.addConsumer(consumer);
+            if (!cnx.isActive()) {
+                consumer.close();
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}] [{}] [{}] Subscribe failed -- count: {}", topic, subscriptionName,
+                            consumer.consumerName(), USAGE_COUNT_UPDATER.get(NonPersistentTopic.this));
+                }
+                future.completeExceptionally(
+                        new BrokerServiceException("Connection was closed while the opening the cursor "));
+            } else {
+                log.info("[{}][{}] Created new subscription for {}", topic, subscriptionName, consumerId);
+                future.complete(consumer);
+            }
+        } catch (BrokerServiceException e) {
+            if (e instanceof ConsumerBusyException) {
+                log.warn("[{}][{}] Consumer {} {} already connected", topic, subscriptionName, consumerId,
+                        consumerName);
+            } else if (e instanceof SubscriptionBusyException) {
+                log.warn("[{}][{}] {}", topic, subscriptionName, e.getMessage());
+            }
+
+            USAGE_COUNT_UPDATER.decrementAndGet(NonPersistentTopic.this);
+            future.completeExceptionally(e);
+        }
+
+        return future;
+    }
+
+    @Override
+    public CompletableFuture<Subscription> createSubscription(String subscriptionName) {
+        return CompletableFuture.completedFuture(new NonPersistentSubscription(this, subscriptionName));
+    }
+
+    void removeSubscription(String subscriptionName) {
+        subscriptions.remove(subscriptionName);
+    }
+
+    @Override
+    public CompletableFuture<Void> delete() {
+        return delete(false);
+    }
+
+    private CompletableFuture<Void> delete(boolean failIfHasSubscriptions) {
+        CompletableFuture<Void> deleteFuture = new CompletableFuture<>();
+
+        lock.writeLock().lock();
+        try {
+            if (isFenced) {
+                log.warn("[{}] Topic is already being closed or deleted", topic);
+                deleteFuture.completeExceptionally(new TopicFencedException("Topic is already fenced"));
+                return deleteFuture;
+            }
+            if (USAGE_COUNT_UPDATER.get(this) == 0) {
+                isFenced = true;
+
+                List<CompletableFuture<Void>> futures = Lists.newArrayList();
+
+                if (failIfHasSubscriptions) {
+                    if (!subscriptions.isEmpty()) {
+                        isFenced = false;
+                        deleteFuture.completeExceptionally(new TopicBusyException("Topic has subscriptions"));
+                        return deleteFuture;
+                    }
+                } else {
+                    subscriptions.forEach((s, sub) -> futures.add(sub.delete()));
+                }
+
+                FutureUtil.waitForAll(futures).whenComplete((v, ex) -> {
+                    if (ex != null) {
+                        log.error("[{}] Error deleting topic", topic, ex);
+                        isFenced = false;
+                        deleteFuture.completeExceptionally(ex);
+                    } else {
+                        brokerService.removeTopicFromCache(topic);
+                        log.info("[{}] Topic deleted", topic);
+                        deleteFuture.complete(null);
+                    }
+                });
+            } else {
+                deleteFuture.completeExceptionally(new TopicBusyException(
+                        "Topic has " + USAGE_COUNT_UPDATER.get(this) + " connected producers/consumers"));
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
+
+        return deleteFuture;
+    }
+
+    /**
+     * Close this topic - close all producers and subscriptions associated with this topic
+     *
+     * @return Completable future indicating completion of close operation
+     */
+    @Override
+    public CompletableFuture<Void> close() {
+        CompletableFuture<Void> closeFuture = new CompletableFuture<>();
+
+        lock.writeLock().lock();
+        try {
+            if (!isFenced) {
+                isFenced = true;
+            } else {
+                log.warn("[{}] Topic is already being closed or deleted", topic);
+                closeFuture.completeExceptionally(new TopicFencedException("Topic is already fenced"));
+                return closeFuture;
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
+
+        List<CompletableFuture<Void>> futures = Lists.newArrayList();
+
+        replicators.forEach((cluster, replicator) -> futures.add(replicator.disconnect()));
+        producers.forEach(producer -> futures.add(producer.disconnect()));
+        subscriptions.forEach((s, sub) -> futures.add(sub.disconnect()));
+
+        FutureUtil.waitForAll(futures).thenRun(() -> {
+            log.info("[{}] Topic closed", topic);
+            closeFuture.complete(null);
+        }).exceptionally(exception -> {
+            log.error("[{}] Error closing topic", topic, exception);
+            isFenced = false;
+            closeFuture.completeExceptionally(exception);
+            return null;
+        });
+
+        return closeFuture;
+    }
+
+    public CompletableFuture<Void> stopReplProducers() {
+        List<CompletableFuture<Void>> closeFutures = Lists.newArrayList();
+        replicators.forEach((region, replicator) -> closeFutures.add(replicator.disconnect()));
+        return FutureUtil.waitForAll(closeFutures);
+    }
+
+    @Override
+    public CompletableFuture<Void> checkReplication() {
+        DestinationName name = DestinationName.get(topic);
+        if (!name.isGlobal()) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("[{}] Checking replication status", name);
+        }
+
+        Policies policies = null;
+        try {
+            policies = brokerService.pulsar().getConfigurationCache().policiesCache()
+                    .get(AdminResource.path("policies", name.getNamespace()))
+                    .orElseThrow(() -> new KeeperException.NoNodeException());
+        } catch (Exception e) {
+            CompletableFuture<Void> future = new CompletableFuture<>();
+            future.completeExceptionally(new ServerMetadataException(e));
+            return future;
+        }
+
+        Set<String> configuredClusters;
+        if (policies.replication_clusters != null) {
+            configuredClusters = Sets.newTreeSet(policies.replication_clusters);
+        } else {
+            configuredClusters = Collections.emptySet();
+        }
+
+        String localCluster = brokerService.pulsar().getConfiguration().getClusterName();
+
+        List<CompletableFuture<Void>> futures = Lists.newArrayList();
+
+        // Check for missing replicators
+        for (String cluster : configuredClusters) {
+            if (cluster.equals(localCluster)) {
+                continue;
+            }
+
+            if (!replicators.containsKey(cluster)) {
+                startReplicator(cluster);
+            }
+        }
+
+        // Check for replicators to be stopped
+        replicators.forEach((cluster, replicator) -> {
+            if (!cluster.equals(localCluster)) {
+                if (!configuredClusters.contains(cluster)) {
+                    futures.add(removeReplicator(cluster));
+                }
+            }
+        });
+        return FutureUtil.waitForAll(futures);
+    }
+
+    void startReplicator(String remoteCluster) {
+        log.info("[{}] Starting replicator to remote: {}", topic, remoteCluster);
+        String localCluster = brokerService.pulsar().getConfiguration().getClusterName();
+        replicators.computeIfAbsent(remoteCluster,
+                r -> new NonPersistentReplicator(NonPersistentTopic.this, localCluster, remoteCluster, brokerService));
+    }
+
+    CompletableFuture<Void> removeReplicator(String remoteCluster) {
+        log.info("[{}] Removing replicator to {}", topic, remoteCluster);
+        final CompletableFuture<Void> future = new CompletableFuture<>();
+
+        String name = NonPersistentReplicator.getReplicatorName(replicatorPrefix, remoteCluster);
+
+        replicators.get(remoteCluster).disconnect().thenRun(() -> {
+            log.info("[{}] Successfully removed replicator {}", name, remoteCluster);
+
+        }).exceptionally(e -> {
+            log.error("[{}] Failed to close replication producer {} {}", topic, name, e.getMessage(), e);
+            future.completeExceptionally(e);
+            return null;
+        });
+
+        return future;
+    }
+
+    private CompletableFuture<Void> checkReplicationAndRetryOnFailure() {
+        CompletableFuture<Void> result = new CompletableFuture<Void>();
+        checkReplication().thenAccept(res -> {
+            log.info("[{}] Policies updated successfully", topic);
+            result.complete(null);
+        }).exceptionally(th -> {
+            log.error("[{}] Policies update failed {}, scheduled retry in {} seconds", topic, th.getMessage(),
+                    POLICY_UPDATE_FAILURE_RETRY_TIME_SECONDS, th);
+            brokerService.executor().schedule(this::checkReplicationAndRetryOnFailure,
+                    POLICY_UPDATE_FAILURE_RETRY_TIME_SECONDS, TimeUnit.SECONDS);
+            result.completeExceptionally(th);
+            return null;
+        });
+        return result;
+    }
+
+    @Override
+    public void checkMessageExpiry() {
+        // No-op
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this).add("topic", topic).toString();
+    }
+
+    @Override
+    public ConcurrentOpenHashSet<Producer> getProducers() {
+        return producers;
+    }
+
+    @Override
+    public ConcurrentOpenHashMap<String, NonPersistentSubscription> getSubscriptions() {
+        return subscriptions;
+    }
+
+    @Override
+    public ConcurrentOpenHashMap<String, Replicator> getReplicators() {
+        return replicators;
+    }
+
+    @Override
+    public Subscription getSubscription(String subscription) {
+        return subscriptions.get(subscription);
+    }
+
+    public Replicator getPersistentReplicator(String remoteCluster) {
+        return replicators.get(remoteCluster);
+    }
+
+    public BrokerService getBrokerService() {
+        return brokerService;
+    }
+
+    @Override
+    public String getName() {
+        return topic;
+    }
+
+    public void updateRates(NamespaceStats nsStats, NamespaceBundleStats bundleStats, StatsOutputStream destStatsStream,
+            ClusterReplicationMetrics replStats, String namespace) {
+
+        TopicStats topicStats = threadLocalTopicStats.get();
+        topicStats.reset();
+
+        replicators.forEach((region, replicator) -> replicator.updateRates());
+
+        nsStats.producerCount += producers.size();
+        bundleStats.producerCount += producers.size();
+        destStatsStream.startObject(topic);
+
+        producers.forEach(producer -> {
+            producer.updateRates();
+            PublisherStats publisherStats = producer.getStats();
+
+            topicStats.aggMsgRateIn += publisherStats.msgRateIn;
+            topicStats.aggMsgThroughputIn += publisherStats.msgThroughputIn;
+
+            if (producer.isRemote()) {
+                topicStats.remotePublishersStats.put(producer.getRemoteCluster(), publisherStats);
+            }
+        });
+
+        // Creating publishers object for backward compatibility
+        destStatsStream.startList("publishers");
+        destStatsStream.endList();
+
+        // Start replicator stats
+        destStatsStream.startObject("replication");
+        nsStats.replicatorCount += topicStats.remotePublishersStats.size();
+
+        // Close replication
+        destStatsStream.endObject();
+
+        // Start subscription stats
+        destStatsStream.startObject("subscriptions");
+        nsStats.subsCount += subscriptions.size();
+
+        subscriptions.forEach((subscriptionName, subscription) -> {
+            double subMsgRateOut = 0;
+            double subMsgThroughputOut = 0;
+            double subMsgRateRedeliver = 0;
+
+            // Start subscription name & consumers
+            try {
+                destStatsStream.startObject(subscriptionName);
+                Object[] consumers = subscription.getConsumers().array();
+                nsStats.consumerCount += consumers.length;
+                bundleStats.consumerCount += consumers.length;
+
+                destStatsStream.startList("consumers");
+
+                for (Object consumerObj : consumers) {
+                    Consumer consumer = (Consumer) consumerObj;
+                    consumer.updateRates();
+
+                    ConsumerStats consumerStats = consumer.getStats();
+                    subMsgRateOut += consumerStats.msgRateOut;
+                    subMsgThroughputOut += consumerStats.msgThroughputOut;
+                    subMsgRateRedeliver += consumerStats.msgRateRedeliver;
+
+                    // Populate consumer specific stats here
+                    destStatsStream.startObject();
+                    destStatsStream.writePair("address", consumerStats.address);
+                    destStatsStream.writePair("consumerName", consumerStats.consumerName);
+                    destStatsStream.writePair("availablePermits", consumerStats.availablePermits);
+                    destStatsStream.writePair("connectedSince", consumerStats.connectedSince);
+                    destStatsStream.writePair("msgRateOut", consumerStats.msgRateOut);
+                    destStatsStream.writePair("msgThroughputOut", consumerStats.msgThroughputOut);
+                    destStatsStream.writePair("msgRateRedeliver", consumerStats.msgRateRedeliver);
+
+                    if (SubType.Shared.equals(subscription.getType())) {
+                        destStatsStream.writePair("unackedMessages", consumerStats.unackedMessages);
+                        destStatsStream.writePair("blockedConsumerOnUnackedMsgs",
+                                consumerStats.blockedConsumerOnUnackedMsgs);
+                    }
+                    if (consumerStats.clientVersion != null) {
+                        destStatsStream.writePair("clientVersion", consumerStats.clientVersion);
+                    }
+                    destStatsStream.endObject();
+                }
+
+                // Close Consumer stats
+                destStatsStream.endList();
+
+                // Populate subscription specific stats here
+                destStatsStream.writePair("msgBacklog", subscription.getNumberOfEntriesInBacklog());
+                destStatsStream.writePair("msgRateExpired", subscription.getExpiredMessageRate());
+                destStatsStream.writePair("msgRateOut", subMsgRateOut);
+                destStatsStream.writePair("msgThroughputOut", subMsgThroughputOut);
+                destStatsStream.writePair("msgRateRedeliver", subMsgRateRedeliver);
+                destStatsStream.writePair("type", subscription.getTypeString());
+
+                // Close consumers
+                destStatsStream.endObject();
+
+                topicStats.aggMsgRateOut += subMsgRateOut;
+                topicStats.aggMsgThroughputOut += subMsgThroughputOut;
+                nsStats.msgBacklog += subscription.getNumberOfEntriesInBacklog();
+            } catch (Exception e) {
+                log.error("Got exception when creating consumer stats for subscription {}: {}", subscriptionName,
+                        e.getMessage(), e);
+            }
+        });
+
+        // Close subscription
+        destStatsStream.endObject();
+
+        // Remaining dest stats.
+        topicStats.averageMsgSize = topicStats.aggMsgRateIn == 0.0 ? 0.0
+                : (topicStats.aggMsgThroughputIn / topicStats.aggMsgRateIn);
+        destStatsStream.writePair("producerCount", producers.size());
+        destStatsStream.writePair("averageMsgSize", topicStats.averageMsgSize);
+        destStatsStream.writePair("msgRateIn", topicStats.aggMsgRateIn);
+        destStatsStream.writePair("msgRateOut", topicStats.aggMsgRateOut);
+        destStatsStream.writePair("msgThroughputIn", topicStats.aggMsgThroughputIn);
+        destStatsStream.writePair("msgThroughputOut", topicStats.aggMsgThroughputOut);
+
+        nsStats.msgRateIn += topicStats.aggMsgRateIn;
+        nsStats.msgRateOut += topicStats.aggMsgRateOut;
+        nsStats.msgThroughputIn += topicStats.aggMsgThroughputIn;
+        nsStats.msgThroughputOut += topicStats.aggMsgThroughputOut;
+
+        bundleStats.msgRateIn += topicStats.aggMsgRateIn;
+        bundleStats.msgRateOut += topicStats.aggMsgRateOut;
+        bundleStats.msgThroughputIn += topicStats.aggMsgThroughputIn;
+        bundleStats.msgThroughputOut += topicStats.aggMsgThroughputOut;
+
+        // Close topic object
+        destStatsStream.endObject();
+    }
+
+    public PersistentTopicStats getStats() {
+
+        PersistentTopicStats stats = new PersistentTopicStats();
+
+        ObjectObjectHashMap<String, PublisherStats> remotePublishersStats = new ObjectObjectHashMap<String, PublisherStats>();
+
+        producers.forEach(producer -> {
+            PublisherStats publisherStats = producer.getStats();
+            stats.msgRateIn += publisherStats.msgRateIn;
+            stats.msgThroughputIn += publisherStats.msgThroughputIn;
+
+            if (producer.isRemote()) {
+                remotePublishersStats.put(producer.getRemoteCluster(), publisherStats);
+            } else {
+                stats.publishers.add(publisherStats);
+            }
+        });
+
+        stats.averageMsgSize = stats.msgRateIn == 0.0 ? 0.0 : (stats.msgThroughputIn / stats.msgRateIn);
+
+        subscriptions.forEach((name, subscription) -> {
+            PersistentSubscriptionStats subStats = subscription.getStats();
+
+            stats.msgRateOut += subStats.msgRateOut;
+            stats.msgThroughputOut += subStats.msgThroughputOut;
+            stats.subscriptions.put(name, subStats);
+        });
+
+        replicators.forEach((cluster, replicator) -> {
+            ReplicatorStats replicatorStats = replicator.getStats();
+
+            // Add incoming msg rates
+            PublisherStats pubStats = remotePublishersStats.get(replicator.getRemoteCluster());
+            if (pubStats != null) {
+                replicatorStats.msgRateIn = pubStats.msgRateIn;
+                replicatorStats.msgThroughputIn = pubStats.msgThroughputIn;
+                replicatorStats.inboundConnection = pubStats.address;
+                replicatorStats.inboundConnectedSince = pubStats.connectedSince;
+            }
+
+            stats.msgRateOut += replicatorStats.msgRateOut;
+            stats.msgThroughputOut += replicatorStats.msgThroughputOut;
+
+            stats.replication.put(replicator.getRemoteCluster(), replicatorStats);
+        });
+
+        return stats;
+    }
+
+    public PersistentTopicInternalStats getInternalStats() {
+
+        PersistentTopicInternalStats stats = new PersistentTopicInternalStats();
+        stats.entriesAddedCounter = ENTRIES_ADDED_COUNTER_UPDATER.get(this);
+        
+        stats.cursors = Maps.newTreeMap();
+        subscriptions.forEach((name, subs) -> stats.cursors.put(name, new CursorStats()));
+        replicators.forEach((name, subs) -> stats.cursors.put(name, new CursorStats()));
+        
+        return stats;
+    }
+
+    public boolean isActive() {
+        if (DestinationName.get(topic).isGlobal()) {
+            // No local consumers and no local producers
+            return !subscriptions.isEmpty() || hasLocalProducers();
+        }
+        return USAGE_COUNT_UPDATER.get(this) != 0 || !subscriptions.isEmpty();
+    }
+
+    @Override
+    public void checkGC(int gcIntervalInSeconds) {
+        if (isActive()) {
+            lastActive = System.nanoTime();
+        } else {
+            if (System.nanoTime() - lastActive > TimeUnit.SECONDS.toNanos(gcIntervalInSeconds)) {
+
+                if (DestinationName.get(topic).isGlobal()) {
+                    // For global namespace, close repl producers first.
+                    // Once all repl producers are closed, we can delete the topic,
+                    // provided no remote producers connected to the broker.
+                    if (log.isDebugEnabled()) {
+                        log.debug("[{}] Global topic inactive for {} seconds, closing repl producers.", topic,
+                                gcIntervalInSeconds);
+                    }
+
+                    stopReplProducers().thenCompose(v -> delete(true))
+                            .thenRun(() -> log.info("[{}] Topic deleted successfully due to inactivity", topic))
+                            .exceptionally(e -> {
+                                if (e.getCause() instanceof TopicBusyException) {
+                                    // topic became active again
+                                    if (log.isDebugEnabled()) {
+                                        log.debug("[{}] Did not delete busy topic: {}", topic,
+                                                e.getCause().getMessage());
+                                    }
+                                    replicators.forEach((region, replicator) -> ((NonPersistentReplicator) replicator)
+                                            .startProducer());
+                                } else {
+                                    log.warn("[{}] Inactive topic deletion failed", topic, e);
+                                }
+                                return null;
+                            });
+
+                }
+            }
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> onPoliciesUpdate(Policies data) {
+        producers.forEach(Producer::checkPermissions);
+        subscriptions.forEach((subName, sub) -> sub.getConsumers().forEach(Consumer::checkPermissions));
+        return checkReplicationAndRetryOnFailure();
+    }
+
+    /**
+     *
+     * @return Backlog quota for topic
+     */
+    @Override
+    public BacklogQuota getBacklogQuota() {
+        // No-op
+        throw new UnsupportedOperationException("getBacklogQuota method is not supported on non-persistent topic");
+    }
+
+    /**
+     *
+     * @return quota exceeded status for blocking producer creation
+     */
+    @Override
+    public boolean isBacklogQuotaExceeded(String producerName) {
+        // No-op
+        return false;
+    }
+
+    @Override
+    public CompletableFuture<Void> unsubscribe(String subName) {
+        // No-op
+        return CompletableFuture.completedFuture(null);
+    }
+
+    public void markBatchMessagePublished() {
+        this.hasBatchMessagePublished = true;
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(NonPersistentTopic.class);
+}

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
 
 import com.yahoo.pulsar.broker.service.BrokerService;
 import com.yahoo.pulsar.broker.service.BrokerServiceException.TopicBusyException;
+import com.yahoo.pulsar.broker.service.Replicator;
 import com.yahoo.pulsar.client.api.MessageId;
 import com.yahoo.pulsar.client.api.ProducerConfiguration;
 import com.yahoo.pulsar.client.impl.Backoff;
@@ -52,7 +53,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
 
-public class PersistentReplicator implements ReadEntriesCallback, DeleteCallback {
+public class PersistentReplicator implements Replicator, ReadEntriesCallback, DeleteCallback {
 
     private final BrokerService brokerService;
     private final PersistentTopic topic;

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -80,6 +80,11 @@ public class PersistentSubscription implements Subscription {
     }
 
     @Override
+    public String getName() {
+        return this.subName;
+    }
+
+    @Override
     public synchronized void addConsumer(Consumer consumer) throws BrokerServiceException {
         if (IS_FENCED_UPDATER.get(this) == TRUE) {
             log.warn("Attempting to add consumer {} on a fenced subscription", consumer);

--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/broker/stats/prometheus/NamespaceStatsAggregator.java
@@ -18,6 +18,7 @@ package com.yahoo.pulsar.broker.stats.prometheus;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerMBeanImpl;
 
 import com.yahoo.pulsar.broker.PulsarService;
+import com.yahoo.pulsar.broker.service.Topic;
 import com.yahoo.pulsar.broker.service.persistent.PersistentTopic;
 import com.yahoo.pulsar.common.policies.data.ReplicatorStats;
 import com.yahoo.pulsar.utils.SimpleTextOutputStream;
@@ -50,16 +51,20 @@ public class NamespaceStatsAggregator {
         });
     }
 
-    private static void updateNamespaceStats(AggregatedNamespaceStats stats, PersistentTopic topic) {
-        // Managed Ledger stats
-        ManagedLedgerMBeanImpl mlStats = (ManagedLedgerMBeanImpl) topic.getManagedLedger().getStats();
+    private static void updateNamespaceStats(AggregatedNamespaceStats stats, Topic topic) {
+        
+        if(topic instanceof PersistentTopic) {
+         // Managed Ledger stats
+            ManagedLedgerMBeanImpl mlStats = (ManagedLedgerMBeanImpl) ((PersistentTopic)topic).getManagedLedger().getStats();
 
-        stats.storageSize += mlStats.getStoredMessagesSize();
-        stats.storageWriteLatencyBuckets.addAll(mlStats.getInternalAddEntryLatencyBuckets());
-        stats.entrySizeBuckets.addAll(mlStats.getInternalEntrySizeBuckets());
+            stats.storageSize += mlStats.getStoredMessagesSize();
+            stats.storageWriteLatencyBuckets.addAll(mlStats.getInternalAddEntryLatencyBuckets());
+            stats.entrySizeBuckets.addAll(mlStats.getInternalEntrySizeBuckets());
 
-        stats.storageWriteRate = mlStats.getAddEntryMessagesRate();
-        stats.storageReadRate = mlStats.getReadEntriesRate();
+            stats.storageWriteRate = mlStats.getAddEntryMessagesRate();
+            stats.storageReadRate = mlStats.getReadEntriesRate();    
+        }
+        
         stats.topicsCount++;
 
         topic.getProducers().forEach(producer -> {

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/admin/AdminApiTest.java
@@ -1796,4 +1796,50 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
 
     }
 
+    /**
+     * verifies admin api command for non-persistent topic.
+     * It verifies: partitioned-topic, stats
+     * @throws Exception
+     */
+    @Test
+    public void nonPersistentTopics() throws Exception {
+        final String topicName = "nonPersistentTopic";
+
+        final String persistentTopicName = "non-persistent://prop-xyz/use/ns1/" + topicName;
+        // Force to create a destination
+        publishMessagesOnPersistentTopic("non-persistent://prop-xyz/use/ns1/" + topicName, 0);
+
+        // create consumer and subscription
+        URL pulsarUrl = new URL("http://127.0.0.1" + ":" + BROKER_WEBSERVICE_PORT);
+        ClientConfiguration clientConf = new ClientConfiguration();
+        clientConf.setStatsInterval(0, TimeUnit.SECONDS);
+        PulsarClient client = PulsarClient.create(pulsarUrl.toString(), clientConf);
+        ConsumerConfiguration conf = new ConsumerConfiguration();
+        conf.setSubscriptionType(SubscriptionType.Exclusive);
+        Consumer consumer = client.subscribe(persistentTopicName, "my-sub", conf);
+
+        publishMessagesOnPersistentTopic("non-persistent://prop-xyz/use/ns1/" + topicName, 10);
+
+        PersistentTopicStats topicStats = admin.nonPersistentTopics().getStats(persistentTopicName);
+        assertEquals(topicStats.subscriptions.keySet(), Sets.newTreeSet(Lists.newArrayList("my-sub")));
+        assertEquals(topicStats.subscriptions.get("my-sub").consumers.size(), 1);
+        assertEquals(topicStats.publishers.size(), 0);
+
+        PersistentTopicInternalStats internalStats = admin.nonPersistentTopics().getInternalStats(persistentTopicName);
+        assertEquals(internalStats.cursors.keySet(), Sets.newTreeSet(Lists.newArrayList("my-sub")));
+
+        consumer.close();
+        client.close();
+
+        topicStats = admin.nonPersistentTopics().getStats(persistentTopicName);
+        assertTrue(topicStats.subscriptions.keySet().contains("my-sub"));
+        assertEquals(topicStats.publishers.size(), 0);
+
+        // test partitioned-topic
+        final String partitionedTopicName = "non-persistent://prop-xyz/use/ns1/paritioned";
+        assertEquals(admin.nonPersistentTopics().getPartitionedTopicMetadata(partitionedTopicName).partitions, 0);
+        admin.nonPersistentTopics().createPartitionedTopic(partitionedTopicName, 5);
+        assertEquals(admin.nonPersistentTopics().getPartitionedTopicMetadata(partitionedTopicName).partitions, 5);
+    }
+    
 }

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/namespace/NamespaceServiceTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/namespace/NamespaceServiceTest.java
@@ -42,7 +42,6 @@ import org.apache.bookkeeper.util.ZkUtils;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.zookeeper.CreateMode;
-import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.Stat;
 import org.mockito.invocation.InvocationOnMock;
@@ -54,15 +53,11 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.google.common.collect.Lists;
 import com.google.common.hash.Hashing;
 import com.yahoo.pulsar.broker.LocalBrokerData;
-import com.yahoo.pulsar.broker.PulsarServerException;
-import com.yahoo.pulsar.broker.PulsarService;
 import com.yahoo.pulsar.broker.loadbalance.LoadManager;
-import com.yahoo.pulsar.broker.loadbalance.ModularLoadManager;
 import com.yahoo.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl;
 import com.yahoo.pulsar.broker.loadbalance.impl.ModularLoadManagerWrapper;
 import com.yahoo.pulsar.broker.lookup.LookupResult;
@@ -76,13 +71,10 @@ import com.yahoo.pulsar.common.naming.NamespaceBundle;
 import com.yahoo.pulsar.common.naming.NamespaceBundleFactory;
 import com.yahoo.pulsar.common.naming.NamespaceBundles;
 import com.yahoo.pulsar.common.naming.NamespaceName;
-import com.yahoo.pulsar.common.naming.ServiceUnitId;
 import com.yahoo.pulsar.common.policies.data.Policies;
 import com.yahoo.pulsar.common.policies.data.loadbalancer.LoadReport;
-import com.yahoo.pulsar.common.policies.data.loadbalancer.ServiceLookupData;
 import com.yahoo.pulsar.common.util.ObjectMapperFactory;
 import com.yahoo.pulsar.common.util.collections.ConcurrentOpenHashMap;
-import com.yahoo.pulsar.zookeeper.ZooKeeperCache.Deserializer;
 
 public class NamespaceServiceTest extends BrokerTestBase {
 
@@ -184,11 +176,11 @@ public class NamespaceServiceTest extends BrokerTestBase {
 
         PersistentTopic topic = new PersistentTopic(dn.toString(), ledger, pulsar.getBrokerService());
         Method method = pulsar.getBrokerService().getClass().getDeclaredMethod("addTopicToStatsMaps",
-                DestinationName.class, PersistentTopic.class);
+                DestinationName.class, Topic.class);
         method.setAccessible(true);
         method.invoke(pulsar.getBrokerService(), dn, topic);
         String nspace = originalBundle.getNamespaceObject().toString();
-        List<PersistentTopic> list = this.pulsar.getBrokerService().getAllTopicsFromNamespaceBundle(nspace,
+        List<Topic> list = this.pulsar.getBrokerService().getAllTopicsFromNamespaceBundle(nspace,
                 originalBundle.toString());
         assertNotNull(list);
 

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/BatchMessageTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/BatchMessageTest.java
@@ -96,7 +96,7 @@ public class BatchMessageTest extends BrokerTestBase {
         assertTrue(topic.getProducers().values().iterator().next().getStats().msgRateIn > 0.0);
         // we expect 2 messages in the backlog since we sent 50 messages with the batch size set to 25. We have set the
         // batch time high enough for it to not affect the number of messages in the batch
-        assertEquals(topic.getPersistentSubscription(subscriptionName).getNumberOfEntriesInBacklog(), 2);
+        assertEquals(topic.getSubscription(subscriptionName).getNumberOfEntriesInBacklog(), 2);
         consumer = pulsarClient.subscribe(topicName, subscriptionName);
 
         for (int i = 0; i < numMsgs; i++) {
@@ -142,8 +142,8 @@ public class BatchMessageTest extends BrokerTestBase {
         rolloverPerIntervalStats();
         assertTrue(topic.getProducers().values().iterator().next().getStats().msgRateIn > 0.0);
         LOG.info("Sent {} messages, backlog is {} messages", numMsgs,
-                topic.getPersistentSubscription(subscriptionName).getNumberOfEntriesInBacklog());
-        assertTrue(topic.getPersistentSubscription(subscriptionName).getNumberOfEntriesInBacklog() < numMsgs);
+                topic.getSubscription(subscriptionName).getNumberOfEntriesInBacklog());
+        assertTrue(topic.getSubscription(subscriptionName).getNumberOfEntriesInBacklog() < numMsgs);
 
         producer.close();
     }
@@ -180,8 +180,8 @@ public class BatchMessageTest extends BrokerTestBase {
         rolloverPerIntervalStats();
         assertTrue(topic.getProducers().values().iterator().next().getStats().msgRateIn > 0.0);
         LOG.info("Sent {} messages, backlog is {} messages", numMsgs,
-                topic.getPersistentSubscription(subscriptionName).getNumberOfEntriesInBacklog());
-        assertTrue(topic.getPersistentSubscription(subscriptionName).getNumberOfEntriesInBacklog() < numMsgs);
+                topic.getSubscription(subscriptionName).getNumberOfEntriesInBacklog());
+        assertTrue(topic.getSubscription(subscriptionName).getNumberOfEntriesInBacklog() < numMsgs);
 
         producer.close();
     }
@@ -228,7 +228,7 @@ public class BatchMessageTest extends BrokerTestBase {
         assertTrue(topic.getProducers().values().iterator().next().getStats().msgRateIn > 0.0);
         // we expect 3 messages in the backlog since the large message in the middle should
         // close out the batch and be sent in a batch of its own
-        assertEquals(topic.getPersistentSubscription(subscriptionName).getNumberOfEntriesInBacklog(), 3);
+        assertEquals(topic.getSubscription(subscriptionName).getNumberOfEntriesInBacklog(), 3);
         consumer = pulsarClient.subscribe(topicName, subscriptionName);
 
         for (int i = 0; i <= numMsgs; i++) {
@@ -238,7 +238,7 @@ public class BatchMessageTest extends BrokerTestBase {
             consumer.acknowledge(msg);
         }
         Thread.sleep(100);
-        assertEquals(topic.getPersistentSubscription(subscriptionName).getNumberOfEntriesInBacklog(), 0);
+        assertEquals(topic.getSubscription(subscriptionName).getNumberOfEntriesInBacklog(), 0);
         consumer.close();
         producer.close();
     }
@@ -272,7 +272,7 @@ public class BatchMessageTest extends BrokerTestBase {
 
         rolloverPerIntervalStats();
         assertTrue(topic.getProducers().values().iterator().next().getStats().msgRateIn > 0.0);
-        assertEquals(topic.getPersistentSubscription(subscriptionName).getNumberOfEntriesInBacklog(),
+        assertEquals(topic.getSubscription(subscriptionName).getNumberOfEntriesInBacklog(),
                 numMsgs / numMsgsInBatch);
         consumer = pulsarClient.subscribe(topicName, subscriptionName);
 
@@ -290,7 +290,7 @@ public class BatchMessageTest extends BrokerTestBase {
             consumer.acknowledgeCumulative(lastunackedMsg);
         }
         Thread.sleep(100);
-        assertEquals(topic.getPersistentSubscription(subscriptionName).getNumberOfEntriesInBacklog(), 0);
+        assertEquals(topic.getSubscription(subscriptionName).getNumberOfEntriesInBacklog(), 0);
         consumer.close();
         producer.close();
     }
@@ -323,7 +323,7 @@ public class BatchMessageTest extends BrokerTestBase {
         assertTrue(topic.getProducers().values().iterator().next().getStats().msgRateIn > 0.0);
         // we expect 10 messages in the backlog since we sent 10 messages with the batch size set to 5.
         // However, we are using synchronous send and so each message will go as an individual message
-        assertEquals(topic.getPersistentSubscription(subscriptionName).getNumberOfEntriesInBacklog(), 10);
+        assertEquals(topic.getSubscription(subscriptionName).getNumberOfEntriesInBacklog(), 10);
         consumer = pulsarClient.subscribe(topicName, subscriptionName);
 
         for (int i = 0; i < numMsgs; i++) {
@@ -380,7 +380,7 @@ public class BatchMessageTest extends BrokerTestBase {
         Thread.sleep(5000);
         LOG.info("[{}] checking backlog stats..");
         rolloverPerIntervalStats();
-        assertEquals(topic.getPersistentSubscription(subscriptionName).getNumberOfEntriesInBacklog(),
+        assertEquals(topic.getSubscription(subscriptionName).getNumberOfEntriesInBacklog(),
                 numMsgs / numMsgsInBatch);
         consumer = pulsarClient.subscribe(topicName, subscriptionName);
 
@@ -394,7 +394,7 @@ public class BatchMessageTest extends BrokerTestBase {
             consumer.acknowledgeCumulative(lastunackedMsg);
         }
         Thread.sleep(100);
-        assertEquals(topic.getPersistentSubscription(subscriptionName).getNumberOfEntriesInBacklog(), 0);
+        assertEquals(topic.getSubscription(subscriptionName).getNumberOfEntriesInBacklog(), 0);
         consumer.close();
         producer.close();
     }
@@ -432,7 +432,7 @@ public class BatchMessageTest extends BrokerTestBase {
         PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
 
         rolloverPerIntervalStats();
-        assertEquals(topic.getPersistentSubscription(subscriptionName).getNumberOfEntriesInBacklog(),
+        assertEquals(topic.getSubscription(subscriptionName).getNumberOfEntriesInBacklog(),
                 numMsgs / numMsgsInBatch);
         consumer = pulsarClient.subscribe(topicName, subscriptionName);
         Set<Integer> individualAcks = new HashSet<>();
@@ -454,7 +454,7 @@ public class BatchMessageTest extends BrokerTestBase {
                 Thread.sleep(1000);
                 rolloverPerIntervalStats();
                 Thread.sleep(1000);
-                assertEquals(topic.getPersistentSubscription(subscriptionName).getNumberOfEntriesInBacklog(), 3);
+                assertEquals(topic.getSubscription(subscriptionName).getNumberOfEntriesInBacklog(), 3);
             } else if (individualAcks.contains(i)) {
                 consumer.acknowledge(msg);
             } else {
@@ -463,12 +463,12 @@ public class BatchMessageTest extends BrokerTestBase {
         }
         Thread.sleep(1000);
         rolloverPerIntervalStats();
-        assertEquals(topic.getPersistentSubscription(subscriptionName).getNumberOfEntriesInBacklog(), 2);
+        assertEquals(topic.getSubscription(subscriptionName).getNumberOfEntriesInBacklog(), 2);
         if (lastunackedMsg != null) {
             consumer.acknowledgeCumulative(lastunackedMsg);
         }
         Thread.sleep(100);
-        assertEquals(topic.getPersistentSubscription(subscriptionName).getNumberOfEntriesInBacklog(), 0);
+        assertEquals(topic.getSubscription(subscriptionName).getNumberOfEntriesInBacklog(), 0);
         consumer.close();
         producer.close();
     }
@@ -508,7 +508,7 @@ public class BatchMessageTest extends BrokerTestBase {
 
         rolloverPerIntervalStats();
         assertTrue(topic.getProducers().values().iterator().next().getStats().msgRateIn > 0.0);
-        assertEquals(topic.getPersistentSubscription(subscriptionName).getNumberOfEntriesInBacklog(), 2);
+        assertEquals(topic.getSubscription(subscriptionName).getNumberOfEntriesInBacklog(), 2);
         consumer = pulsarClient.subscribe(topicName, subscriptionName);
 
         Message lastunackedMsg = null;
@@ -522,7 +522,7 @@ public class BatchMessageTest extends BrokerTestBase {
         }
         Thread.sleep(100);
         rolloverPerIntervalStats();
-        assertEquals(topic.getPersistentSubscription(subscriptionName).getNumberOfEntriesInBacklog(), 0);
+        assertEquals(topic.getSubscription(subscriptionName).getNumberOfEntriesInBacklog(), 0);
         assertTrue(((ConsumerImpl) consumer).isBatchingAckTrackerEmpty());
         consumer.close();
         producer.close();
@@ -562,7 +562,7 @@ public class BatchMessageTest extends BrokerTestBase {
 
         rolloverPerIntervalStats();
         assertTrue(topic.getProducers().values().iterator().next().getStats().msgRateIn > 0.0);
-        assertEquals(topic.getPersistentSubscription(subscriptionName).getNumberOfEntriesInBacklog(),
+        assertEquals(topic.getSubscription(subscriptionName).getNumberOfEntriesInBacklog(),
                 (numMsgs / 2) / numMsgsInBatch + numMsgs / 2);
         consumer = pulsarClient.subscribe(topicName, subscriptionName);
 
@@ -583,7 +583,7 @@ public class BatchMessageTest extends BrokerTestBase {
             consumer.acknowledgeCumulative(lastunackedMsg);
         }
         Thread.sleep(100);
-        assertEquals(topic.getPersistentSubscription(subscriptionName).getNumberOfEntriesInBacklog(), 0);
+        assertEquals(topic.getSubscription(subscriptionName).getNumberOfEntriesInBacklog(), 0);
         assertTrue(((ConsumerImpl) consumer).isBatchingAckTrackerEmpty());
         consumer.close();
         producer.close();

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/PersistentFailoverE2ETest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/PersistentFailoverE2ETest.java
@@ -83,7 +83,7 @@ public class PersistentFailoverE2ETest extends BrokerTestBase {
         Consumer consumer2 = pulsarClient.subscribe(topicName, subName, consumerConf2);
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
-        PersistentSubscription subRef = topicRef.getPersistentSubscription(subName);
+        PersistentSubscription subRef = topicRef.getSubscription(subName);
 
         assertNotNull(topicRef);
         assertNotNull(subRef);
@@ -235,7 +235,7 @@ public class PersistentFailoverE2ETest extends BrokerTestBase {
         }
 
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
-        subRef = topicRef.getPersistentSubscription(subName);
+        subRef = topicRef.getSubscription(subName);
         assertNull(subRef);
 
         producer.close();
@@ -272,16 +272,16 @@ public class PersistentFailoverE2ETest extends BrokerTestBase {
         PersistentTopic topicRef;
         topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(destName.getPartition(0).toString());
         PersistentDispatcherSingleActiveConsumer disp0 = (PersistentDispatcherSingleActiveConsumer) topicRef
-                .getPersistentSubscription(subName).getDispatcher();
+                .getSubscription(subName).getDispatcher();
         topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(destName.getPartition(1).toString());
         PersistentDispatcherSingleActiveConsumer disp1 = (PersistentDispatcherSingleActiveConsumer) topicRef
-                .getPersistentSubscription(subName).getDispatcher();
+                .getSubscription(subName).getDispatcher();
         topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(destName.getPartition(2).toString());
         PersistentDispatcherSingleActiveConsumer disp2 = (PersistentDispatcherSingleActiveConsumer) topicRef
-                .getPersistentSubscription(subName).getDispatcher();
+                .getSubscription(subName).getDispatcher();
         topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(destName.getPartition(3).toString());
         PersistentDispatcherSingleActiveConsumer disp3 = (PersistentDispatcherSingleActiveConsumer) topicRef
-                .getPersistentSubscription(subName).getDispatcher();
+                .getSubscription(subName).getDispatcher();
 
         List<CompletableFuture<MessageId>> futures = Lists.newArrayListWithCapacity(numMsgs);
         Producer producer = pulsarClient.createProducer(topicName, producerConf);

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/PersistentQueueE2ETest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/PersistentQueueE2ETest.java
@@ -80,7 +80,7 @@ public class PersistentQueueE2ETest extends BrokerTestBase {
         Consumer consumer2 = pulsarClient.subscribe(topicName, subName, conf);
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
-        PersistentSubscription subRef = topicRef.getPersistentSubscription(subName);
+        PersistentSubscription subRef = topicRef.getSubscription(subName);
 
         assertNotNull(topicRef);
         assertNotNull(subRef);
@@ -152,7 +152,7 @@ public class PersistentQueueE2ETest extends BrokerTestBase {
         }
 
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
-        subRef = topicRef.getPersistentSubscription(subName);
+        subRef = topicRef.getSubscription(subName);
         assertNull(subRef);
 
         producer.close();

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/PersistentTopicE2ETest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/PersistentTopicE2ETest.java
@@ -127,7 +127,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         Consumer consumer = pulsarClient.subscribe(topicName, subName, conf);
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
-        PersistentSubscription subRef = topicRef.getPersistentSubscription(subName);
+        PersistentSubscription subRef = topicRef.getSubscription(subName);
 
         assertNotNull(topicRef);
         assertNotNull(subRef);
@@ -192,7 +192,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         }
 
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
-        subRef = topicRef.getPersistentSubscription(subName);
+        subRef = topicRef.getSubscription(subName);
         assertNull(subRef);
 
         producer.close();
@@ -217,7 +217,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
         assertNotNull(topicRef);
-        PersistentSubscription subRef = topicRef.getPersistentSubscription(subName);
+        PersistentSubscription subRef = topicRef.getSubscription(subName);
         assertNotNull(subRef);
 
         // 1. initial receive queue size recorded
@@ -344,7 +344,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
-        PersistentSubscription subRef = topicRef.getPersistentSubscription(subName);
+        PersistentSubscription subRef = topicRef.getSubscription(subName);
 
         // 1. cumulatively all threads drain the backlog
         assertEquals(subRef.getNumberOfEntriesInBacklog(), 0);
@@ -391,7 +391,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         conf.setSubscriptionType(SubscriptionType.Exclusive);
         Consumer consumer = pulsarClient.subscribe(topicName, subName, conf);
 
-        PersistentSubscription subRef = topicRef.getPersistentSubscription(subName);
+        PersistentSubscription subRef = topicRef.getSubscription(subName);
         assertNotNull(subRef);
 
         Message msg = null;
@@ -430,7 +430,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
         assertNotNull(topicRef);
-        PersistentSubscription subRef = topicRef.getPersistentSubscription(subName);
+        PersistentSubscription subRef = topicRef.getSubscription(subName);
         assertNotNull(subRef);
 
         Message msg;
@@ -505,7 +505,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         Consumer consumer = pulsarClient.subscribe(topicName, subName, conf);
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
-        PersistentSubscription subRef = topicRef.getPersistentSubscription(subName);
+        PersistentSubscription subRef = topicRef.getSubscription(subName);
 
         assertNotNull(topicRef);
         assertNotNull(subRef);
@@ -608,7 +608,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         Consumer consumer = pulsarClient.subscribe(topicName, subName, conf);
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
-        PersistentSubscription subRef = topicRef.getPersistentSubscription(subName);
+        PersistentSubscription subRef = topicRef.getSubscription(subName);
 
         consumer.close();
         assertFalse(subRef.getDispatcher().isConsumerConnected());
@@ -654,7 +654,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         pulsarClient.subscribe(topicName, subName, conf);
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
-        PersistentSubscription subRef = topicRef.getPersistentSubscription(subName);
+        PersistentSubscription subRef = topicRef.getSubscription(subName);
 
         assertTrue(subRef.getDispatcher().isConsumerConnected());
 
@@ -697,7 +697,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         Consumer consumer3 = null;
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
-        PersistentSubscription subRef = topicRef.getPersistentSubscription(subName);
+        PersistentSubscription subRef = topicRef.getSubscription(subName);
 
         // 1. shared consumer on an exclusive sub fails
         try {
@@ -1157,7 +1157,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
         assertNotNull(topicRef);
-        PersistentSubscription subRef = topicRef.getPersistentSubscription(subName);
+        PersistentSubscription subRef = topicRef.getSubscription(subName);
         PersistentDispatcherMultipleConsumers dispatcher = (PersistentDispatcherMultipleConsumers) subRef
                 .getDispatcher();
         Field replayMap = PersistentDispatcherMultipleConsumers.class.getDeclaredField("messagesToReplay");

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/PersistentTopicTest.java
@@ -368,7 +368,7 @@ public class PersistentTopicTest {
         Future<Void> f3 = topic.unsubscribe(successSubName);
         f3.get();
 
-        assertNull(topic.getPersistentSubscription(successSubName));
+        assertNull(topic.getSubscription(successSubName));
     }
 
     @Test
@@ -749,14 +749,14 @@ public class PersistentTopicTest {
         f3.get();
 
         assertEquals(
-                topic2.getPersistentSubscription(successSubName).getDispatcher().getConsumers().get(0).consumerId(), 1);
+                topic2.getSubscription(successSubName).getDispatcher().getConsumers().get(0).consumerId(), 1);
         assertEquals(
-                topic2.getPersistentSubscription(successSubName).getDispatcher().getConsumers().get(0).consumerName(),
+                topic2.getSubscription(successSubName).getDispatcher().getConsumers().get(0).consumerName(),
                 "C1");
         assertEquals(
-                topic2.getPersistentSubscription(successSubName).getDispatcher().getConsumers().get(1).consumerId(), 2);
+                topic2.getSubscription(successSubName).getDispatcher().getConsumers().get(1).consumerId(), 2);
         assertEquals(
-                topic2.getPersistentSubscription(successSubName).getDispatcher().getConsumers().get(1).consumerName(),
+                topic2.getSubscription(successSubName).getDispatcher().getConsumers().get(1).consumerName(),
                 "C2");
 
         // 4. Subscribe and create third duplicate consumer
@@ -769,19 +769,19 @@ public class PersistentTopicTest {
         f4.get();
 
         assertEquals(
-                topic2.getPersistentSubscription(successSubName).getDispatcher().getConsumers().get(0).consumerId(), 1);
+                topic2.getSubscription(successSubName).getDispatcher().getConsumers().get(0).consumerId(), 1);
         assertEquals(
-                topic2.getPersistentSubscription(successSubName).getDispatcher().getConsumers().get(0).consumerName(),
+                topic2.getSubscription(successSubName).getDispatcher().getConsumers().get(0).consumerName(),
                 "C1");
         assertEquals(
-                topic2.getPersistentSubscription(successSubName).getDispatcher().getConsumers().get(1).consumerId(), 3);
+                topic2.getSubscription(successSubName).getDispatcher().getConsumers().get(1).consumerId(), 3);
         assertEquals(
-                topic2.getPersistentSubscription(successSubName).getDispatcher().getConsumers().get(1).consumerName(),
+                topic2.getSubscription(successSubName).getDispatcher().getConsumers().get(1).consumerName(),
                 "C1");
         assertEquals(
-                topic2.getPersistentSubscription(successSubName).getDispatcher().getConsumers().get(2).consumerId(), 2);
+                topic2.getSubscription(successSubName).getDispatcher().getConsumers().get(2).consumerId(), 2);
         assertEquals(
-                topic2.getPersistentSubscription(successSubName).getDispatcher().getConsumers().get(2).consumerName(),
+                topic2.getSubscription(successSubName).getDispatcher().getConsumers().get(2).consumerName(),
                 "C2");
 
         // 5. Subscribe on partition topic with existing consumer id and different sub type
@@ -813,18 +813,18 @@ public class PersistentTopicTest {
         Future<Void> f7 = topic2.unsubscribe(successSubName2);
         f7.get();
 
-        assertNull(topic2.getPersistentSubscription(successSubName2));
+        assertNull(topic2.getSubscription(successSubName2));
 
         // 8. unsubscribe active consumer from shared sub.
-        PersistentSubscription sub = topic2.getPersistentSubscription(successSubName);
+        PersistentSubscription sub = topic2.getSubscription(successSubName);
         Consumer cons = sub.getDispatcher().getConsumers().get(0);
         sub.removeConsumer(cons);
 
         // Verify second consumer become active
         assertEquals(
-                topic2.getPersistentSubscription(successSubName).getDispatcher().getConsumers().get(0).consumerId(), 3);
+                topic2.getSubscription(successSubName).getDispatcher().getConsumers().get(0).consumerId(), 3);
         assertEquals(
-                topic2.getPersistentSubscription(successSubName).getDispatcher().getConsumers().get(0).consumerName(),
+                topic2.getSubscription(successSubName).getDispatcher().getConsumers().get(0).consumerName(),
                 "C1");
 
         // 9. unsubscribe active consumer from shared sub.
@@ -833,20 +833,20 @@ public class PersistentTopicTest {
 
         // Verify second consumer become active
         assertEquals(
-                topic2.getPersistentSubscription(successSubName).getDispatcher().getConsumers().get(0).consumerId(), 2);
+                topic2.getSubscription(successSubName).getDispatcher().getConsumers().get(0).consumerId(), 2);
         assertEquals(
-                topic2.getPersistentSubscription(successSubName).getDispatcher().getConsumers().get(0).consumerName(),
+                topic2.getSubscription(successSubName).getDispatcher().getConsumers().get(0).consumerName(),
                 "C2");
 
         // 10. unsubscribe shared sub
         Future<Void> f8 = topic2.unsubscribe(successSubName);
         f8.get();
 
-        assertNull(topic2.getPersistentSubscription(successSubName));
+        assertNull(topic2.getSubscription(successSubName));
     }
 
     /**
-     * {@link PersistentReplicator.removeReplicator} doesn't remove replicator in atomic way and does in multiple step:
+     * {@link NonPersistentReplicator.removeReplicator} doesn't remove replicator in atomic way and does in multiple step:
      * 1. disconnect replicator producer
      * <p>
      * 2. close cursor
@@ -869,7 +869,7 @@ public class PersistentTopicTest {
 
         PersistentTopic topic = new PersistentTopic(globalTopicName, ledgerMock, brokerService);
         String remoteReplicatorName = topic.replicatorPrefix + "." + remoteCluster;
-        ConcurrentOpenHashMap<String, PersistentReplicator> replicatorMap = topic.getReplicators();
+        ConcurrentOpenHashMap<String, Replicator> replicatorMap = topic.getReplicators();
         
         final URL brokerUrl = new URL(
                 "http://" + pulsar.getAdvertisedAddress() + ":" + pulsar.getConfiguration().getBrokerServicePort());

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/ReplicatorTest.java
@@ -468,7 +468,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
         producer1.produce(2);
         producer1.close();
         PersistentTopic topic = (PersistentTopic) pulsar1.getBrokerService().getTopicReference(dest.toString());
-        PersistentReplicator replicator = topic.getReplicators().get(topic.getReplicators().keys().get(0));
+        PersistentReplicator replicator = (PersistentReplicator) topic.getReplicators().get(topic.getReplicators().keys().get(0));
         replicator.skipMessages(2);
         CompletableFuture<Entry> result = replicator.peekNthMessage(1);
         Entry entry = result.get(50, TimeUnit.MILLISECONDS);
@@ -492,7 +492,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
         producer1.produce(2);
         producer1.close();
         PersistentTopic topic = (PersistentTopic) pulsar1.getBrokerService().getTopicReference(dest.toString());
-        PersistentReplicator replicator = spy(topic.getReplicators().get(topic.getReplicators().keys().get(0)));
+        PersistentReplicator replicator = (PersistentReplicator) spy(topic.getReplicators().get(topic.getReplicators().keys().get(0)));
         replicator.readEntriesFailed(new ManagedLedgerException.InvalidCursorPositionException("failed"), null);
         replicator.clearBacklog().get();
         Thread.sleep(100);
@@ -668,7 +668,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
         MessageProducer producer1 = new MessageProducer(url1, dest);
         PersistentTopic topic = (PersistentTopic) pulsar1.getBrokerService().getTopicReference(topicName);
         final String replicatorClusterName = topic.getReplicators().keys().get(0);
-        PersistentReplicator replicator = topic.getPersistentReplicator(replicatorClusterName);
+        Replicator replicator = topic.getPersistentReplicator(replicatorClusterName);
         pulsar2.close();
         pulsar3.close();
         replicator.disconnect(false);
@@ -710,7 +710,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
 
             // Replicator for r1 -> r2
             PersistentTopic topic = (PersistentTopic) pulsar1.getBrokerService().getTopicReference(dest.toString());
-            PersistentReplicator replicator = topic.getPersistentReplicator("r2");
+            Replicator replicator = topic.getPersistentReplicator("r2");
 
             // Restrict backlog quota limit to 1
             admin1.namespaces().setBacklogQuota("pulsar/global/ns1", new BacklogQuota(1, policy));
@@ -763,7 +763,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
 
         // Replicator for r1 -> r2
         PersistentTopic topic = (PersistentTopic) pulsar1.getBrokerService().getTopicReference(dest.toString());
-        PersistentReplicator replicator = topic.getPersistentReplicator("r2");
+        PersistentReplicator replicator = (PersistentReplicator) topic.getPersistentReplicator("r2");
 
         // close the cursor
         Field cursorField = PersistentReplicator.class.getDeclaredField("cursor");

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/broker/service/ServerCnxTest.java
@@ -510,7 +510,7 @@ public class ServerCnxTest {
         topicRef = (PersistentTopic) brokerService.getTopicReference(nonExistentTopicName);
         assertNotNull(topicRef);
         assertTrue(topicRef.getSubscriptions().containsKey(successSubName));
-        assertTrue(topicRef.getPersistentSubscription(successSubName).getDispatcher().isConsumerConnected());
+        assertTrue(topicRef.getSubscription(successSubName).getDispatcher().isConsumerConnected());
         assertTrue(getResponse() instanceof CommandSuccess);
     }
 
@@ -1042,7 +1042,7 @@ public class ServerCnxTest {
 
         assertNotNull(topicRef);
         assertTrue(topicRef.getSubscriptions().containsKey(successSubName));
-        assertTrue(topicRef.getPersistentSubscription(successSubName).getDispatcher().isConsumerConnected());
+        assertTrue(topicRef.getSubscription(successSubName).getDispatcher().isConsumerConnected());
 
         // test SUBSCRIBE on topic creation success and cursor failure
         clientCommand = Commands.newSubscribe(successTopicName, failSubName, 2, 2, SubType.Exclusive,

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/client/api/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/client/api/NonPersistentTopicTest.java
@@ -218,11 +218,11 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
     @Test
     public void testProducerRateLimit() throws Exception {
 
-        int defaultNonPersistentMessageRate = conf.getMaxPublishMessageRatePerNonPersistentTopic();
+        int defaultNonPersistentMessageRate = conf.getMaxConcurrentNonPersistentMessagePerConnection();
         try {
             final String topic = "non-persistent://my-property/use/my-ns/unacked-topic";
             // restart broker with lower publish rate limit
-            conf.setMaxPublishMessageRatePerNonPersistentTopic(1);
+            conf.setMaxConcurrentNonPersistentMessagePerConnection(1);
             stopBroker();
             startBroker();
             // produce message concurrently
@@ -248,7 +248,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             assertTrue(failed.get());
             producer.close();
         } finally {
-            conf.setMaxPublishMessageRatePerNonPersistentTopic(defaultNonPersistentMessageRate);
+            conf.setMaxConcurrentNonPersistentMessagePerConnection(defaultNonPersistentMessageRate);
         }
 
     }

--- a/pulsar-broker/src/test/java/com/yahoo/pulsar/client/api/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/com/yahoo/pulsar/client/api/NonPersistentTopicTest.java
@@ -1,0 +1,719 @@
+/**
+ * Copyright 2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.pulsar.client.api;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.net.URL;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.bookkeeper.test.PortManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.yahoo.pulsar.broker.PulsarService;
+import com.yahoo.pulsar.broker.ServiceConfiguration;
+import com.yahoo.pulsar.broker.service.BrokerService;
+import com.yahoo.pulsar.broker.service.nonpersistent.NonPersistentReplicator;
+import com.yahoo.pulsar.broker.service.nonpersistent.NonPersistentTopic;
+import com.yahoo.pulsar.client.admin.PulsarAdmin;
+import com.yahoo.pulsar.client.impl.ConsumerImpl;
+import com.yahoo.pulsar.common.naming.DestinationName;
+import com.yahoo.pulsar.common.policies.data.ClusterData;
+import com.yahoo.pulsar.common.policies.data.PersistentSubscriptionStats;
+import com.yahoo.pulsar.common.policies.data.PersistentTopicStats;
+import com.yahoo.pulsar.common.policies.data.PropertyAdmin;
+import com.yahoo.pulsar.zookeeper.LocalBookkeeperEnsemble;
+import com.yahoo.pulsar.zookeeper.ZookeeperServerTest;
+
+public class NonPersistentTopicTest extends ProducerConsumerBase {
+    private static final Logger log = LoggerFactory.getLogger(NonPersistentTopicTest.class);
+
+    @DataProvider(name = "subscriptionType")
+    public Object[][] getSubscriptionType() {
+        return new Object[][] { { SubscriptionType.Shared }, { SubscriptionType.Exclusive } };
+    }
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @AfterMethod
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test(dataProvider = "subscriptionType")
+    public void testNonPersistentTopic(SubscriptionType type) throws Exception {
+        log.info("-- Starting {} test --", methodName);
+
+        final String topic = "non-persistent://my-property/use/my-ns/unacked-topic";
+        ConsumerConfiguration conf = new ConsumerConfiguration();
+        conf.setSubscriptionType(type);
+
+        ProducerConfiguration producerConf = new ProducerConfiguration();
+
+        ConsumerImpl consumer = (ConsumerImpl) pulsarClient.subscribe(topic, "subscriber-1", conf);
+
+        Producer producer = pulsarClient.createProducer(topic, producerConf);
+
+        int totalProduceMsg = 500;
+        for (int i = 0; i < totalProduceMsg; i++) {
+            String message = "my-message-" + i;
+            producer.send(message.getBytes());
+            Thread.sleep(10);
+        }
+
+        Message msg = null;
+        Set<String> messageSet = Sets.newHashSet();
+        for (int i = 0; i < totalProduceMsg; i++) {
+            msg = consumer.receive(1, TimeUnit.SECONDS);
+            if (msg != null) {
+                consumer.acknowledge(msg);
+                String receivedMessage = new String(msg.getData());
+                log.debug("Received message: [{}]", receivedMessage);
+                String expectedMessage = "my-message-" + i;
+                testMessageOrderAndDuplicates(messageSet, receivedMessage, expectedMessage);
+            } else {
+                break;
+            }
+        }
+        assertEquals(messageSet.size(), totalProduceMsg);
+
+        producer.close();
+        consumer.close();
+        log.info("-- Exiting {} test --", methodName);
+
+    }
+
+    @Test(dataProvider = "subscriptionType")
+    public void testPartitionedNonPersistentTopic(SubscriptionType type) throws Exception {
+        log.info("-- Starting {} test --", methodName);
+
+        final String topic = "non-persistent://my-property/use/my-ns/unacked-topic";
+        admin.nonPersistentTopics().createPartitionedTopic(topic, 5);
+        ConsumerConfiguration conf = new ConsumerConfiguration();
+        conf.setSubscriptionType(type);
+
+        ProducerConfiguration producerConf = new ProducerConfiguration();
+
+        Consumer consumer = pulsarClient.subscribe(topic, "subscriber-1", conf);
+
+        Producer producer = pulsarClient.createProducer(topic, producerConf);
+
+        int totalProduceMsg = 500;
+        for (int i = 0; i < totalProduceMsg; i++) {
+            String message = "my-message-" + i;
+            producer.send(message.getBytes());
+            Thread.sleep(10);
+        }
+
+        Message msg = null;
+        Set<String> messageSet = Sets.newHashSet();
+        for (int i = 0; i < totalProduceMsg; i++) {
+            msg = consumer.receive(1, TimeUnit.SECONDS);
+            if (msg != null) {
+                consumer.acknowledge(msg);
+                String receivedMessage = new String(msg.getData());
+                log.debug("Received message: [{}]", receivedMessage);
+                String expectedMessage = "my-message-" + i;
+                testMessageOrderAndDuplicates(messageSet, receivedMessage, expectedMessage);
+            } else {
+                break;
+            }
+        }
+        assertEquals(messageSet.size(), totalProduceMsg);
+
+        producer.close();
+        consumer.close();
+        log.info("-- Exiting {} test --", methodName);
+
+    }
+
+    /**
+     * It verifies that consumer drops out messages if consumer is slow to consume message and once internal queue
+     * filled out with messages
+     */
+    @Test(dataProvider = "subscriptionType")
+    public void testConsumerInternalQueueMaxOut(SubscriptionType type) throws Exception {
+        log.info("-- Starting {} test --", methodName);
+
+        final String topic = "non-persistent://my-property/use/my-ns/unacked-topic";
+        final int queueSize = 10;
+        ConsumerConfiguration conf = new ConsumerConfiguration();
+        // conf.setSubscriptionType(type);
+        conf.setSubscriptionType(SubscriptionType.Shared);
+        conf.setReceiverQueueSize(queueSize);
+
+        ProducerConfiguration producerConf = new ProducerConfiguration();
+
+        ConsumerImpl consumer = (ConsumerImpl) pulsarClient.subscribe(topic, "subscriber-1", conf);
+
+        Producer producer = pulsarClient.createProducer(topic, producerConf);
+
+        int totalProduceMsg = 50;
+        for (int i = 0; i < totalProduceMsg; i++) {
+            String message = "my-message-" + i;
+            producer.send(message.getBytes());
+            Thread.sleep(10);
+        }
+
+        Message msg = null;
+        Set<String> messageSet = Sets.newHashSet();
+        for (int i = 0; i < totalProduceMsg; i++) {
+            msg = consumer.receive(1, TimeUnit.SECONDS);
+            if (msg != null) {
+                consumer.acknowledge(msg);
+                String receivedMessage = new String(msg.getData());
+                log.debug("Received message: [{}]", receivedMessage);
+                String expectedMessage = "my-message-" + i;
+                testMessageOrderAndDuplicates(messageSet, receivedMessage, expectedMessage);
+            } else {
+                break;
+            }
+        }
+        assertEquals(messageSet.size(), queueSize);
+
+        producer.close();
+        consumer.close();
+        log.info("-- Exiting {} test --", methodName);
+
+    }
+
+    /**
+     * Verifies that broker should failed to publish message if producer publishes messages more than rate limit
+     */
+    @Test
+    public void testProducerRateLimit() throws Exception {
+
+        int defaultNonPersistentMessageRate = conf.getMaxPublishMessageRatePerNonPersistentTopic();
+        try {
+            final String topic = "non-persistent://my-property/use/my-ns/unacked-topic";
+            // restart broker with lower publish rate limit
+            conf.setMaxPublishMessageRatePerNonPersistentTopic(1);
+            stopBroker();
+            startBroker();
+            // produce message concurrently
+            ExecutorService executor = Executors.newFixedThreadPool(10);
+            AtomicBoolean failed = new AtomicBoolean(false);
+            ProducerConfiguration producerConf = new ProducerConfiguration();
+            Producer producer = pulsarClient.createProducer(topic, producerConf);
+            byte[] msgData = "testData".getBytes();
+            final int totalProduceMessages = 10;
+            CountDownLatch latch = new CountDownLatch(totalProduceMessages);
+            for (int i = 0; i < totalProduceMessages; i++) {
+                executor.submit(() -> {
+                    try {
+                        producer.sendAsync(msgData).get(1, TimeUnit.SECONDS);
+                    } catch (Exception e) {
+                        failed.set(true);
+                    }
+                    latch.countDown();
+                });
+            }
+            latch.await();
+            executor.shutdown();
+            assertTrue(failed.get());
+            producer.close();
+        } finally {
+            conf.setMaxPublishMessageRatePerNonPersistentTopic(defaultNonPersistentMessageRate);
+        }
+
+    }
+
+    /**
+     * verifies message delivery with multiple consumers on shared and failover subscriptions
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testMultipleSubscription() throws Exception {
+        log.info("-- Starting {} test --", methodName);
+
+        final String topic = "non-persistent://my-property/use/my-ns/unacked-topic";
+        ConsumerConfiguration sharedConf = new ConsumerConfiguration();
+        sharedConf.setSubscriptionType(SubscriptionType.Shared);
+        ConsumerConfiguration excConf = new ConsumerConfiguration();
+        excConf.setSubscriptionType(SubscriptionType.Failover);
+
+        ProducerConfiguration producerConf = new ProducerConfiguration();
+
+        ConsumerImpl consumer1Shared = (ConsumerImpl) pulsarClient.subscribe(topic, "subscriber-shared", sharedConf);
+        ConsumerImpl consumer2Shared = (ConsumerImpl) pulsarClient.subscribe(topic, "subscriber-shared", sharedConf);
+        ConsumerImpl consumer1FailOver = (ConsumerImpl) pulsarClient.subscribe(topic, "subscriber-fo", excConf);
+        ConsumerImpl consumer2FailOver = (ConsumerImpl) pulsarClient.subscribe(topic, "subscriber-fo", excConf);
+
+        Producer producer = pulsarClient.createProducer(topic, producerConf);
+
+        int totalProduceMsg = 500;
+        for (int i = 0; i < totalProduceMsg; i++) {
+            String message = "my-message-" + i;
+            producer.send(message.getBytes());
+            Thread.sleep(10);
+        }
+
+        // consume from shared-subscriptions
+        Message msg = null;
+        Set<String> messageSet = Sets.newHashSet();
+        for (int i = 0; i < totalProduceMsg; i++) {
+            msg = consumer1Shared.receive(500, TimeUnit.MILLISECONDS);
+            if (msg != null) {
+                messageSet.add(new String(msg.getData()));
+            } else {
+                break;
+            }
+        }
+        for (int i = 0; i < totalProduceMsg; i++) {
+            msg = consumer2Shared.receive(500, TimeUnit.MILLISECONDS);
+            if (msg != null) {
+                messageSet.add(new String(msg.getData()));
+            } else {
+                break;
+            }
+        }
+        assertEquals(messageSet.size(), totalProduceMsg);
+
+        // consume from failover-subscriptions
+        messageSet.clear();
+        for (int i = 0; i < totalProduceMsg; i++) {
+            msg = consumer1FailOver.receive(500, TimeUnit.MILLISECONDS);
+            if (msg != null) {
+                messageSet.add(new String(msg.getData()));
+            } else {
+                break;
+            }
+        }
+        for (int i = 0; i < totalProduceMsg; i++) {
+            msg = consumer2FailOver.receive(500, TimeUnit.MILLISECONDS);
+            if (msg != null) {
+                messageSet.add(new String(msg.getData()));
+            } else {
+                break;
+            }
+        }
+        assertEquals(messageSet.size(), totalProduceMsg);
+
+        producer.close();
+        consumer1Shared.close();
+        consumer2Shared.close();
+        consumer1FailOver.close();
+        consumer2FailOver.close();
+        log.info("-- Exiting {} test --", methodName);
+
+    }
+
+    /**
+     * verifies that broker is capturing topic stats correctly
+     */
+    @Test
+    public void testTopicStats() throws Exception {
+
+        final String topicName = "non-persistent://my-property/use/my-ns/unacked-topic";
+        final String subName = "non-persistent";
+        final int timeWaitToSync = 100;
+
+        PersistentTopicStats stats;
+        PersistentSubscriptionStats subStats;
+
+        ConsumerConfiguration conf = new ConsumerConfiguration();
+        conf.setSubscriptionType(SubscriptionType.Shared);
+        Consumer consumer = pulsarClient.subscribe(topicName, subName, conf);
+        Thread.sleep(timeWaitToSync);
+
+        NonPersistentTopic topicRef = (NonPersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
+        assertNotNull(topicRef);
+
+        rolloverPerIntervalStats(pulsar);
+        stats = topicRef.getStats();
+        subStats = stats.subscriptions.values().iterator().next();
+
+        // subscription stats
+        assertEquals(stats.subscriptions.keySet().size(), 1);
+        assertEquals(subStats.consumers.size(), 1);
+
+        Producer producer = pulsarClient.createProducer(topicName);
+        Thread.sleep(timeWaitToSync);
+
+        int totalProducedMessages = 100;
+        for (int i = 0; i < totalProducedMessages; i++) {
+            String message = "my-message-" + i;
+            producer.send(message.getBytes());
+        }
+        Thread.sleep(timeWaitToSync);
+
+        rolloverPerIntervalStats(pulsar);
+        stats = topicRef.getStats();
+        subStats = stats.subscriptions.values().iterator().next();
+
+        assertTrue(subStats.msgRateOut > 0);
+        assertEquals(subStats.consumers.size(), 1);
+        assertTrue(subStats.msgThroughputOut > 0);
+
+        // consumer stats
+        assertTrue(subStats.consumers.get(0).msgRateOut > 0.0);
+        assertTrue(subStats.consumers.get(0).msgThroughputOut > 0.0);
+        assertEquals(subStats.msgRateRedeliver, 0.0);
+        producer.close();
+        consumer.close();
+
+    }
+
+    /**
+     * verifies that non-persistent topic replicates using replicator
+     */
+    @Test
+    public void testReplicator() throws Exception {
+
+        ReplicationClusterManager replication = new ReplicationClusterManager();
+        replication.setupReplicationCluster();
+        try {
+            final String globalTopicName = "non-persistent://pulsar/global/ns/nonPersistentTopic";
+            final int timeWaitToSync = 100;
+
+            PersistentTopicStats stats;
+            PersistentSubscriptionStats subStats;
+
+            DestinationName dest = DestinationName.get(globalTopicName);
+
+            PulsarClient client1 = PulsarClient.create(replication.url1.toString(), new ClientConfiguration());
+            PulsarClient client2 = PulsarClient.create(replication.url2.toString(), new ClientConfiguration());
+            PulsarClient client3 = PulsarClient.create(replication.url3.toString(), new ClientConfiguration());
+
+            ProducerConfiguration producerConf = new ProducerConfiguration();
+            ConsumerConfiguration consumerConf = new ConsumerConfiguration();
+            ConsumerImpl consumer1 = (ConsumerImpl) client1.subscribe(globalTopicName, "subscriber-1", consumerConf);
+            ConsumerImpl consumer2 = (ConsumerImpl) client1.subscribe(globalTopicName, "subscriber-2", consumerConf);
+            ConsumerImpl repl2Consumer = (ConsumerImpl) client2.subscribe(globalTopicName, "subscriber-1",
+                    consumerConf);
+            ConsumerImpl repl3Consumer = (ConsumerImpl) client3.subscribe(globalTopicName, "subscriber-1",
+                    consumerConf);
+            Producer producer = client1.createProducer(globalTopicName, producerConf);
+
+            Thread.sleep(timeWaitToSync);
+
+            PulsarService replicationPulasr = replication.pulsar1;
+
+            // Replicator for r1 -> r2,r3
+            NonPersistentTopic topicRef = (NonPersistentTopic) replication.pulsar1.getBrokerService()
+                    .getTopicReference(dest.toString());
+            NonPersistentReplicator replicatorR2 = (NonPersistentReplicator) topicRef.getPersistentReplicator("r2");
+            NonPersistentReplicator replicatorR3 = (NonPersistentReplicator) topicRef.getPersistentReplicator("r3");
+            assertNotNull(topicRef);
+            assertNotNull(replicatorR2);
+            assertNotNull(replicatorR3);
+
+            rolloverPerIntervalStats(replicationPulasr);
+            stats = topicRef.getStats();
+            subStats = stats.subscriptions.values().iterator().next();
+
+            // subscription stats
+            assertEquals(stats.subscriptions.keySet().size(), 2);
+            assertEquals(subStats.consumers.size(), 1);
+
+            Thread.sleep(timeWaitToSync);
+
+            int totalProducedMessages = 100;
+            for (int i = 0; i < totalProducedMessages; i++) {
+                String message = "my-message-" + i;
+                producer.send(message.getBytes());
+            }
+
+            // (1) consume by consumer1
+            Message msg = null;
+            Set<String> messageSet = Sets.newHashSet();
+            for (int i = 0; i < totalProducedMessages; i++) {
+                msg = consumer1.receive(300, TimeUnit.MILLISECONDS);
+                if (msg != null) {
+                    String receivedMessage = new String(msg.getData());
+                    testMessageOrderAndDuplicates(messageSet, receivedMessage, "my-message-" + i);
+                } else {
+                    break;
+                }
+            }
+            assertEquals(messageSet.size(), totalProducedMessages);
+
+            // (2) consume by consumer2
+            messageSet.clear();
+            for (int i = 0; i < totalProducedMessages; i++) {
+                msg = consumer2.receive(300, TimeUnit.MILLISECONDS);
+                if (msg != null) {
+                    String receivedMessage = new String(msg.getData());
+                    testMessageOrderAndDuplicates(messageSet, receivedMessage, "my-message-" + i);
+                } else {
+                    break;
+                }
+            }
+            assertEquals(messageSet.size(), totalProducedMessages);
+
+            // (3) consume by repl2consumer
+            messageSet.clear();
+            for (int i = 0; i < totalProducedMessages; i++) {
+                msg = repl2Consumer.receive(300, TimeUnit.MILLISECONDS);
+                if (msg != null) {
+                    String receivedMessage = new String(msg.getData());
+                    testMessageOrderAndDuplicates(messageSet, receivedMessage, "my-message-" + i);
+                } else {
+                    break;
+                }
+            }
+            assertEquals(messageSet.size(), totalProducedMessages);
+
+            // (4) consume by repl3consumer
+            messageSet.clear();
+            for (int i = 0; i < totalProducedMessages; i++) {
+                msg = repl3Consumer.receive(300, TimeUnit.MILLISECONDS);
+                if (msg != null) {
+                    String receivedMessage = new String(msg.getData());
+                    testMessageOrderAndDuplicates(messageSet, receivedMessage, "my-message-" + i);
+                } else {
+                    break;
+                }
+            }
+            assertEquals(messageSet.size(), totalProducedMessages);
+
+            Thread.sleep(timeWaitToSync);
+
+            System.out.println("done consuming");
+
+            rolloverPerIntervalStats(replicationPulasr);
+            stats = topicRef.getStats();
+            subStats = stats.subscriptions.values().iterator().next();
+
+            assertTrue(subStats.msgRateOut > 0);
+            assertEquals(subStats.consumers.size(), 1);
+            assertTrue(subStats.msgThroughputOut > 0);
+
+            // consumer stats
+            assertTrue(subStats.consumers.get(0).msgRateOut > 0.0);
+            assertTrue(subStats.consumers.get(0).msgThroughputOut > 0.0);
+            assertEquals(subStats.msgRateRedeliver, 0.0);
+
+            producer.close();
+            consumer1.close();
+            repl2Consumer.close();
+            repl3Consumer.close();
+            client1.close();
+            client2.close();
+            client3.close();
+
+        } finally {
+            replication.shutdownReplicationCluster();
+        }
+
+    }
+
+    class ReplicationClusterManager {
+        URL url1;
+        PulsarService pulsar1;
+        BrokerService ns1;
+
+        PulsarAdmin admin1;
+        LocalBookkeeperEnsemble bkEnsemble1;
+
+        URL url2;
+        ServiceConfiguration config2;
+        PulsarService pulsar2;
+        BrokerService ns2;
+        PulsarAdmin admin2;
+        LocalBookkeeperEnsemble bkEnsemble2;
+
+        URL url3;
+        ServiceConfiguration config3;
+        PulsarService pulsar3;
+        BrokerService ns3;
+        PulsarAdmin admin3;
+        LocalBookkeeperEnsemble bkEnsemble3;
+
+        ZookeeperServerTest globalZkS;
+
+        ExecutorService executor = new ThreadPoolExecutor(5, 20, 30, TimeUnit.SECONDS,
+                new LinkedBlockingQueue<Runnable>());
+
+        static final int TIME_TO_CHECK_BACKLOG_QUOTA = 5;
+
+        // Default frequency
+        public int getBrokerServicePurgeInactiveFrequency() {
+            return 60;
+        }
+
+        public boolean isBrokerServicePurgeInactiveDestination() {
+            return false;
+        }
+
+        void setupReplicationCluster() throws Exception {
+            log.info("--- Starting ReplicatorTestBase::setup ---");
+            int globalZKPort = PortManager.nextFreePort();
+            globalZkS = new ZookeeperServerTest(globalZKPort);
+            globalZkS.start();
+
+            // Start region 1
+            int zkPort1 = PortManager.nextFreePort();
+            bkEnsemble1 = new LocalBookkeeperEnsemble(3, zkPort1, PortManager.nextFreePort());
+            bkEnsemble1.start();
+
+            int webServicePort1 = PortManager.nextFreePort();
+
+            // NOTE: we have to instantiate a new copy of System.getProperties() to make sure pulsar1 and pulsar2 have
+            // completely
+            // independent config objects instead of referring to the same properties object
+            ServiceConfiguration config1 = new ServiceConfiguration();
+            config1.setClusterName("r1");
+            config1.setWebServicePort(webServicePort1);
+            config1.setZookeeperServers("127.0.0.1:" + zkPort1);
+            config1.setGlobalZookeeperServers("127.0.0.1:" + globalZKPort + "/foo");
+            config1.setBrokerDeleteInactiveTopicsEnabled(isBrokerServicePurgeInactiveDestination());
+            config1.setBrokerServicePurgeInactiveFrequencyInSeconds(
+                    inSec(getBrokerServicePurgeInactiveFrequency(), TimeUnit.SECONDS));
+            config1.setBrokerServicePort(PortManager.nextFreePort());
+            config1.setBacklogQuotaCheckIntervalInSeconds(TIME_TO_CHECK_BACKLOG_QUOTA);
+            pulsar1 = new PulsarService(config1);
+            pulsar1.start();
+            ns1 = pulsar1.getBrokerService();
+
+            url1 = new URL("http://127.0.0.1:" + webServicePort1);
+            admin1 = new PulsarAdmin(url1, (Authentication) null);
+
+            // Start region 2
+
+            // Start zk & bks
+            int zkPort2 = PortManager.nextFreePort();
+            bkEnsemble2 = new LocalBookkeeperEnsemble(3, zkPort2, PortManager.nextFreePort());
+            bkEnsemble2.start();
+
+            int webServicePort2 = PortManager.nextFreePort();
+            config2 = new ServiceConfiguration();
+            config2.setClusterName("r2");
+            config2.setWebServicePort(webServicePort2);
+            config2.setZookeeperServers("127.0.0.1:" + zkPort2);
+            config2.setGlobalZookeeperServers("127.0.0.1:" + globalZKPort + "/foo");
+            config2.setBrokerDeleteInactiveTopicsEnabled(isBrokerServicePurgeInactiveDestination());
+            config2.setBrokerServicePurgeInactiveFrequencyInSeconds(
+                    inSec(getBrokerServicePurgeInactiveFrequency(), TimeUnit.SECONDS));
+            config2.setBrokerServicePort(PortManager.nextFreePort());
+            config2.setBacklogQuotaCheckIntervalInSeconds(TIME_TO_CHECK_BACKLOG_QUOTA);
+            pulsar2 = new PulsarService(config2);
+            pulsar2.start();
+            ns2 = pulsar2.getBrokerService();
+
+            url2 = new URL("http://127.0.0.1:" + webServicePort2);
+            admin2 = new PulsarAdmin(url2, (Authentication) null);
+
+            // Start region 3
+
+            // Start zk & bks
+            int zkPort3 = PortManager.nextFreePort();
+            bkEnsemble3 = new LocalBookkeeperEnsemble(3, zkPort3, PortManager.nextFreePort());
+            bkEnsemble3.start();
+
+            int webServicePort3 = PortManager.nextFreePort();
+            config3 = new ServiceConfiguration();
+            config3.setClusterName("r3");
+            config3.setWebServicePort(webServicePort3);
+            config3.setZookeeperServers("127.0.0.1:" + zkPort3);
+            config3.setGlobalZookeeperServers("127.0.0.1:" + globalZKPort + "/foo");
+            config3.setBrokerDeleteInactiveTopicsEnabled(isBrokerServicePurgeInactiveDestination());
+            config3.setBrokerServicePurgeInactiveFrequencyInSeconds(
+                    inSec(getBrokerServicePurgeInactiveFrequency(), TimeUnit.SECONDS));
+            config3.setBrokerServicePort(PortManager.nextFreePort());
+            pulsar3 = new PulsarService(config3);
+            pulsar3.start();
+            ns3 = pulsar3.getBrokerService();
+
+            url3 = new URL("http://127.0.0.1:" + webServicePort3);
+            admin3 = new PulsarAdmin(url3, (Authentication) null);
+
+            // Provision the global namespace
+            admin1.clusters().createCluster("r1", new ClusterData(url1.toString(), null, pulsar1.getBrokerServiceUrl(),
+                    pulsar1.getBrokerServiceUrlTls()));
+            admin1.clusters().createCluster("r2", new ClusterData(url2.toString(), null, pulsar2.getBrokerServiceUrl(),
+                    pulsar1.getBrokerServiceUrlTls()));
+            admin1.clusters().createCluster("r3", new ClusterData(url3.toString(), null, pulsar3.getBrokerServiceUrl(),
+                    pulsar1.getBrokerServiceUrlTls()));
+
+            admin1.clusters().createCluster("global", new ClusterData("http://global:8080"));
+            admin1.properties().createProperty("pulsar", new PropertyAdmin(
+                    Lists.newArrayList("appid1", "appid2", "appid3"), Sets.newHashSet("r1", "r2", "r3")));
+            admin1.namespaces().createNamespace("pulsar/global/ns");
+            admin1.namespaces().setNamespaceReplicationClusters("pulsar/global/ns",
+                    Lists.newArrayList("r1", "r2", "r3"));
+
+            assertEquals(admin2.clusters().getCluster("r1").getServiceUrl(), url1.toString());
+            assertEquals(admin2.clusters().getCluster("r2").getServiceUrl(), url2.toString());
+            assertEquals(admin2.clusters().getCluster("r3").getServiceUrl(), url3.toString());
+            assertEquals(admin2.clusters().getCluster("r1").getBrokerServiceUrl(), pulsar1.getBrokerServiceUrl());
+            assertEquals(admin2.clusters().getCluster("r2").getBrokerServiceUrl(), pulsar2.getBrokerServiceUrl());
+            assertEquals(admin2.clusters().getCluster("r3").getBrokerServiceUrl(), pulsar3.getBrokerServiceUrl());
+            Thread.sleep(100);
+            log.info("--- ReplicatorTestBase::setup completed ---");
+
+        }
+
+        private int inSec(int time, TimeUnit unit) {
+            return (int) TimeUnit.SECONDS.convert(time, unit);
+        }
+
+        void shutdownReplicationCluster() throws Exception {
+            log.info("--- Shutting down ---");
+            executor.shutdown();
+
+            admin1.close();
+            admin2.close();
+            admin3.close();
+
+            pulsar3.close();
+            ns3.close();
+
+            pulsar2.close();
+            ns2.close();
+
+            pulsar1.close();
+            ns1.close();
+
+            bkEnsemble1.stop();
+            bkEnsemble2.stop();
+            bkEnsemble3.stop();
+            globalZkS.stop();
+        }
+
+    }
+
+    private void rolloverPerIntervalStats(PulsarService pulsar) {
+        try {
+            pulsar.getExecutor().submit(() -> pulsar.getBrokerService().updateRates()).get();
+        } catch (Exception e) {
+            log.error("Stats executor error", e);
+        }
+    }
+}

--- a/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/Namespaces.java
+++ b/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/Namespaces.java
@@ -593,6 +593,15 @@ public interface Namespaces {
     public PersistencePolicies getPersistence(String namespace) throws PulsarAdminException;
 
     /**
+     * Update namespace non-persistency. Non-persistent topic can be only created under non-persistent namespace. 
+     * 
+     * @param namespace
+     * @param isNonPersistent
+     * @throws PulsarAdminException 
+     */
+    public void setNamespaceNonPersistency(String namespace, boolean isNonPersistent) throws PulsarAdminException;
+    
+    /**
      * Set the retention configuration for all the destinations on a namespace.
      * <p/>
      * Set the retention configuration on a namespace. This operation requires Pulsar super-user access.

--- a/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/NonPersistentTopics.java
+++ b/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/NonPersistentTopics.java
@@ -1,0 +1,212 @@
+/**
+ * Copyright 2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.pulsar.client.admin;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import org.omg.CosNaming.NamingContextPackage.NotFound;
+
+import com.google.gson.JsonObject;
+import com.yahoo.pulsar.client.admin.PulsarAdminException.ConflictException;
+import com.yahoo.pulsar.client.admin.PulsarAdminException.NotAllowedException;
+import com.yahoo.pulsar.client.admin.PulsarAdminException.NotAuthorizedException;
+import com.yahoo.pulsar.client.admin.PulsarAdminException.NotFoundException;
+import com.yahoo.pulsar.client.admin.PulsarAdminException.PreconditionFailedException;
+import com.yahoo.pulsar.client.api.Message;
+import com.yahoo.pulsar.common.partition.PartitionedTopicMetadata;
+import com.yahoo.pulsar.common.policies.data.AuthAction;
+import com.yahoo.pulsar.common.policies.data.PartitionedTopicStats;
+import com.yahoo.pulsar.common.policies.data.PersistentTopicInternalStats;
+import com.yahoo.pulsar.common.policies.data.PersistentTopicStats;
+
+public interface NonPersistentTopics {
+
+
+
+    /**
+     * Get metadata of a partitioned topic.
+     * <p>
+     * Get metadata of a partitioned topic.
+     * <p>
+     *
+     * @param destination
+     *            Destination name
+     * @return Partitioned topic metadata
+     * @throws PulsarAdminException
+     */
+    PartitionedTopicMetadata getPartitionedTopicMetadata(String destination) throws PulsarAdminException;
+
+    /**
+     * Get metadata of a partitioned topic asynchronously.
+     * <p>
+     * Get metadata of a partitioned topic asynchronously.
+     * <p>
+     *
+     * @param destination
+     *            Destination name
+     * @return a future that can be used to track when the partitioned topic metadata is returned
+     */
+    CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadataAsync(String destination);
+
+    /**
+     * Get the stats for the topic.
+     * <p>
+     * Response Example:
+     *
+     * <pre>
+     * <code>
+     * {
+     *   "msgRateIn" : 100.0,                    // Total rate of messages published on the topic. msg/s
+     *   "msgThroughputIn" : 10240.0,            // Total throughput of messages published on the topic. byte/s
+     *   "msgRateOut" : 100.0,                   // Total rate of messages delivered on the topic. msg/s
+     *   "msgThroughputOut" : 10240.0,           // Total throughput of messages delivered on the topic. byte/s
+     *   "averageMsgSize" : 1024.0,              // Average size of published messages. bytes
+     *   "publishers" : [                        // List of publishes on this topic with their stats
+     *      {
+     *          "producerId" : 10                // producer id
+     *          "address"   : 10.4.1.23:3425     // IP and port for this producer
+     *          "connectedSince" : 2014-11-21 23:54:46 // Timestamp of this published connection
+     *          "msgRateIn" : 100.0,             // Total rate of messages published by this producer. msg/s
+     *          "msgThroughputIn" : 10240.0,     // Total throughput of messages published by this producer. byte/s
+     *          "averageMsgSize" : 1024.0,       // Average size of published messages by this producer. bytes
+     *      },
+     *   ],
+     *   "subscriptions" : {                     // Map of subscriptions on this topic
+     *     "sub1" : {
+     *       "msgRateOut" : 100.0,               // Total rate of messages delivered on this subscription. msg/s
+     *       "msgThroughputOut" : 10240.0,       // Total throughput delivered on this subscription. bytes/s
+     *       "msgBacklog" : 0,                   // Number of messages in the subscriotion backlog
+     *       "type" : Exclusive                  // Whether the subscription is exclusive or shared
+     *       "consumers" [                       // List of consumers on this subscription
+     *          {
+     *              "id" : 5                            // Consumer id
+     *              "address" : 10.4.1.23:3425          // IP and port for this consumer
+     *              "connectedSince" : 2014-11-21 23:54:46 // Timestamp of this consumer connection
+     *              "msgRateOut" : 100.0,               // Total rate of messages delivered to this consumer. msg/s
+     *              "msgThroughputOut" : 10240.0,       // Total throughput delivered to this consumer. bytes/s
+     *          }
+     *       ],
+     *   },
+     *   "replication" : {                    // Replication statistics
+     *     "cluster_1" : {                    // Cluster name in the context of from-cluster or to-cluster
+     *       "msgRateIn" : 100.0,             // Total rate of messages received from this remote cluster. msg/s
+     *       "msgThroughputIn" : 10240.0,     // Total throughput received from this remote cluster. bytes/s
+     *       "msgRateOut" : 100.0,            // Total rate of messages delivered to the replication-subscriber. msg/s
+     *       "msgThroughputOut" : 10240.0,    // Total throughput delivered to the replication-subscriber. bytes/s
+     *       "replicationBacklog" : 0,        // Number of messages pending to be replicated to this remote cluster
+     *       "connected" : true,              // Whether the replication-subscriber is currently connected locally
+     *     },
+     *     "cluster_2" : {
+     *       "msgRateIn" : 100.0,
+     *       "msgThroughputIn" : 10240.0,
+     *       "msgRateOut" : 100.0,
+     *       "msghroughputOut" : 10240.0,
+     *       "replicationBacklog" : 0,
+     *       "connected" : true,
+     *     }
+     *   },
+     * }
+     * </code>
+     * </pre>
+     *
+     * All the rates are computed over a 1 minute window and are relative the last completed 1 minute period.
+     *
+     * @param destination
+     *            Destination name
+     * @return the topic statistics
+     *
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws NotFoundException
+     *             Topic does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    PersistentTopicStats getStats(String destination) throws PulsarAdminException;
+
+    /**
+     * Get the stats for the topic asynchronously. All the rates are computed over a 1 minute window and are relative
+     * the last completed 1 minute period.
+     *
+     * @param destination
+     *            Destination name
+     *
+     * @return a future that can be used to track when the topic statistics are returned
+     *
+     */
+    CompletableFuture<PersistentTopicStats> getStatsAsync(String destination);
+
+    /**
+     * Get the internal stats for the topic.
+     * <p>
+     * Access the internal state of the topic
+     *
+     * @param destination
+     *            Destination name
+     * @return the topic statistics
+     *
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws NotFoundException
+     *             Topic does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    PersistentTopicInternalStats getInternalStats(String destination) throws PulsarAdminException;
+
+    /**
+     * Get the internal stats for the topic asynchronously.
+     *
+     * @param destination
+     *            Destination Name
+     *
+     * @return a future that can be used to track when the internal topic statistics are returned
+     */
+    CompletableFuture<PersistentTopicInternalStats> getInternalStatsAsync(String destination);
+
+    /**
+     * Create a partitioned topic.
+     * <p>
+     * Create a partitioned topic. It needs to be called before creating a producer for a partitioned topic.
+     * <p>
+     *
+     * @param destination
+     *            Destination name
+     * @param numPartitions
+     *            Number of partitions to create of the topic
+     * @throws PulsarAdminException
+     */
+    void createPartitionedTopic(String destination, int numPartitions) throws PulsarAdminException;
+
+    /**
+     * Create a partitioned topic asynchronously.
+     * <p>
+     * Create a partitioned topic asynchronously. It needs to be called before creating a producer for a partitioned
+     * topic.
+     * <p>
+     *
+     * @param destination
+     *            Destination name
+     * @param numPartitions
+     *            Number of partitions to create of the topic
+     * @return a future that can be used to track when the partitioned topic is created
+     */
+    CompletableFuture<Void> createPartitionedTopicAsync(String destination, int numPartitions);
+
+}

--- a/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/PulsarAdmin.java
+++ b/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/PulsarAdmin.java
@@ -39,6 +39,7 @@ import com.yahoo.pulsar.client.admin.internal.ClustersImpl;
 import com.yahoo.pulsar.client.admin.internal.JacksonConfigurator;
 import com.yahoo.pulsar.client.admin.internal.LookupImpl;
 import com.yahoo.pulsar.client.admin.internal.NamespacesImpl;
+import com.yahoo.pulsar.client.admin.internal.NonPersistentTopicsImpl;
 import com.yahoo.pulsar.client.admin.internal.PersistentTopicsImpl;
 import com.yahoo.pulsar.client.admin.internal.PropertiesImpl;
 import com.yahoo.pulsar.client.admin.internal.ResourceQuotasImpl;
@@ -62,6 +63,7 @@ public class PulsarAdmin implements Closeable {
     private final Properties properties;
     private final Namespaces namespaces;
     private final PersistentTopics persistentTopics;
+    private final NonPersistentTopics nonPersistentTopics;
     private final ResourceQuotas resourceQuotas;
 
     private final Client client;
@@ -156,6 +158,7 @@ public class PulsarAdmin implements Closeable {
         this.properties = new PropertiesImpl(web, auth);
         this.namespaces = new NamespacesImpl(web, auth);
         this.persistentTopics = new PersistentTopicsImpl(web, auth);
+        this.nonPersistentTopics = new NonPersistentTopicsImpl(web, auth);
         this.resourceQuotas = new ResourceQuotasImpl(web, auth);
         this.lookups = new LookupImpl(root, auth, pulsarConfig.isUseTls());
     }
@@ -244,6 +247,13 @@ public class PulsarAdmin implements Closeable {
      */
     public PersistentTopics persistentTopics() {
         return persistentTopics;
+    }
+
+    /**
+     * @return the persistentTopics management object
+     */
+    public NonPersistentTopics nonPersistentTopics() {
+        return nonPersistentTopics;
     }
 
     /**

--- a/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/internal/NamespacesImpl.java
+++ b/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/internal/NamespacesImpl.java
@@ -420,4 +420,16 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
             throw getApiException(e);
         }
     }
+
+    @Override
+    public void setNamespaceNonPersistency(String namespace, boolean isNonPersistent) throws PulsarAdminException {
+        try {
+            NamespaceName ns = new NamespaceName(namespace);
+            request(namespaces.path(ns.getProperty()).path(ns.getCluster()).path(ns.getLocalName())
+                    .path("non-persistent").queryParam("nonPersistent", isNonPersistent))
+                            .post(Entity.entity("", MediaType.APPLICATION_JSON), ErrorData.class);
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
 }

--- a/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/internal/NonPersistentTopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/com/yahoo/pulsar/client/admin/internal/NonPersistentTopicsImpl.java
@@ -1,0 +1,194 @@
+/**
+ * Copyright 2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.pulsar.client.admin.internal;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.ServerErrorException;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.InvocationCallback;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.yahoo.pulsar.client.admin.NonPersistentTopics;
+import com.yahoo.pulsar.client.admin.PulsarAdminException;
+import com.yahoo.pulsar.client.admin.PulsarAdminException.NotFoundException;
+import com.yahoo.pulsar.client.api.Authentication;
+import com.yahoo.pulsar.client.api.Message;
+import com.yahoo.pulsar.client.impl.MessageImpl;
+import com.yahoo.pulsar.common.naming.DestinationName;
+import com.yahoo.pulsar.common.naming.NamespaceName;
+import com.yahoo.pulsar.common.partition.PartitionedTopicMetadata;
+import com.yahoo.pulsar.common.policies.data.AuthAction;
+import com.yahoo.pulsar.common.policies.data.ErrorData;
+import com.yahoo.pulsar.common.policies.data.PartitionedTopicStats;
+import com.yahoo.pulsar.common.policies.data.PersistentTopicInternalStats;
+import com.yahoo.pulsar.common.policies.data.PersistentTopicStats;
+import com.yahoo.pulsar.common.util.Codec;
+
+public class NonPersistentTopicsImpl extends BaseResource implements NonPersistentTopics {
+
+    private final WebTarget persistentTopics;
+
+    public NonPersistentTopicsImpl(WebTarget web, Authentication auth) {
+        super(auth);
+        this.persistentTopics = web.path("/non-persistent");
+    }
+
+    @Override
+    public void createPartitionedTopic(String destination, int numPartitions) throws PulsarAdminException {
+        try {
+            createPartitionedTopicAsync(destination, numPartitions).get();
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e.getCause());
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> createPartitionedTopicAsync(String destination, int numPartitions) {
+        checkArgument(numPartitions > 1, "Number of partitions should be more than 1");
+        DestinationName ds = validateTopic(destination);
+        return asyncPutRequest(
+                persistentTopics.path(ds.getNamespace()).path(ds.getEncodedLocalName()).path("partitions"),
+                Entity.entity(numPartitions, MediaType.APPLICATION_JSON));
+    }
+
+    @Override
+    public PartitionedTopicMetadata getPartitionedTopicMetadata(String destination) throws PulsarAdminException {
+        try {
+            return getPartitionedTopicMetadataAsync(destination).get();
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e.getCause());
+        }
+    }
+
+    @Override
+    public CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadataAsync(String destination) {
+        DestinationName ds = validateTopic(destination);
+        final CompletableFuture<PartitionedTopicMetadata> future = new CompletableFuture<>();
+        asyncGetRequest(persistentTopics.path(ds.getNamespace()).path(ds.getEncodedLocalName()).path("partitions"),
+                new InvocationCallback<PartitionedTopicMetadata>() {
+
+                    @Override
+                    public void completed(PartitionedTopicMetadata response) {
+                        future.complete(response);
+                    }
+
+                    @Override
+                    public void failed(Throwable throwable) {
+                        future.completeExceptionally(getApiException(throwable.getCause()));
+                    }
+                });
+        return future;
+    }
+
+    @Override
+    public PersistentTopicStats getStats(String destination) throws PulsarAdminException {
+        try {
+            return getStatsAsync(destination).get();
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e.getCause());
+        }
+    }
+
+    @Override
+    public CompletableFuture<PersistentTopicStats> getStatsAsync(String destination) {
+        DestinationName ds = validateTopic(destination);
+        final CompletableFuture<PersistentTopicStats> future = new CompletableFuture<>();
+        asyncGetRequest(persistentTopics.path(ds.getNamespace()).path(ds.getEncodedLocalName()).path("stats"),
+                new InvocationCallback<PersistentTopicStats>() {
+
+                    @Override
+                    public void completed(PersistentTopicStats response) {
+                        future.complete(response);
+                    }
+
+                    @Override
+                    public void failed(Throwable throwable) {
+                        future.completeExceptionally(getApiException(throwable.getCause()));
+                    }
+                });
+        return future;
+    }
+
+    @Override
+    public PersistentTopicInternalStats getInternalStats(String destination) throws PulsarAdminException {
+        try {
+            return getInternalStatsAsync(destination).get();
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e.getCause());
+        }
+    }
+
+    @Override
+    public CompletableFuture<PersistentTopicInternalStats> getInternalStatsAsync(String destination) {
+        DestinationName ds = validateTopic(destination);
+        final CompletableFuture<PersistentTopicInternalStats> future = new CompletableFuture<>();
+        asyncGetRequest(persistentTopics.path(ds.getNamespace()).path(ds.getEncodedLocalName()).path("internalStats"),
+                new InvocationCallback<PersistentTopicInternalStats>() {
+
+                    @Override
+                    public void completed(PersistentTopicInternalStats response) {
+                        future.complete(response);
+                    }
+
+                    @Override
+                    public void failed(Throwable throwable) {
+                        future.completeExceptionally(getApiException(throwable.getCause()));
+                    }
+                });
+        return future;
+    }
+
+    /*
+     * returns destination name with encoded Local Name
+     */
+    private DestinationName validateTopic(String destination) {
+        // Parsing will throw exception if name is not valid
+        return DestinationName.get(destination);
+    }
+
+}

--- a/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdNamespaces.java
@@ -385,6 +385,22 @@ public class CmdNamespaces extends CmdBase {
         }
     }
 
+    @Parameters(commandDescription = "Set the namespace non-persistent to create non-persistent topics under the namespace")
+    private class SetNonPersistency extends CliCommand {
+        @Parameter(description = "property/cluster/namespace", required = true)
+        private java.util.List<String> params;
+
+        @Parameter(names = { "-np", "--non-persistent" }, description = "Whether namespace allow to create non-persistent topic")
+        private boolean nonPersistent;
+       
+
+        @Override
+        void run() throws PulsarAdminException {
+            String namespace = validateNamespace(params);
+            admin.namespaces().setNamespaceNonPersistency(namespace, nonPersistent);
+        }
+    }
+
     @Parameters(commandDescription = "Clear backlog for a namespace")
     private class ClearBacklog extends CliCommand {
         @Parameter(description = "property/cluster/namespace", required = true)
@@ -512,6 +528,7 @@ public class CmdNamespaces extends CmdBase {
 
         jcommander.addCommand("get-persistence", new GetPersistence());
         jcommander.addCommand("set-persistence", new SetPersistence());
+        jcommander.addCommand("set-non-persistency", new SetNonPersistency());
 
         jcommander.addCommand("get-message-ttl", new GetMessageTTL());
         jcommander.addCommand("set-message-ttl", new SetMessageTTL());

--- a/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdNonPersistentTopics.java
+++ b/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/CmdNonPersistentTopics.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2016 Yahoo Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.pulsar.admin.cli;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.yahoo.pulsar.client.admin.NonPersistentTopics;
+import com.yahoo.pulsar.client.admin.PulsarAdmin;
+import com.yahoo.pulsar.client.admin.PulsarAdminException;
+
+@Parameters(commandDescription = "Operations on non-persistent topics")
+public class CmdNonPersistentTopics extends CmdBase {
+    private final NonPersistentTopics nonPersistentTopics;
+
+    public CmdNonPersistentTopics(PulsarAdmin admin) {
+        super("non-persistent", admin);
+        nonPersistentTopics = admin.nonPersistentTopics();
+
+        jcommander.addCommand("create-partitioned-topic", new CreatePartitionedCmd());
+        jcommander.addCommand("lookup", new Lookup());
+        jcommander.addCommand("stats", new GetStats());
+        jcommander.addCommand("stats-internal", new GetInternalStats());
+        jcommander.addCommand("get-partitioned-topic-metadata", new GetPartitionedTopicMetadataCmd());
+    }
+
+    @Parameters(commandDescription = "Lookup a destination from the current serving broker")
+    private class Lookup extends CliCommand {
+        @Parameter(description = "non-persistent://property/cluster/namespace/topic\n", required = true)
+        private java.util.List<String> params;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String destination = validateDestination(params);
+            print(admin.lookups().lookupDestination(destination));
+        }
+    }
+
+    @Parameters(commandDescription = "Get the stats for the topic and its connected producers and consumers. \n"
+            + "\t       All the rates are computed over a 1 minute window and are relative the last completed 1 minute period.")
+    private class GetStats extends CliCommand {
+        @Parameter(description = "non-persistent://property/cluster/namespace/destination\n", required = true)
+        private java.util.List<String> params;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String persistentTopic = validatePersistentTopic(params);
+            print(nonPersistentTopics.getStats(persistentTopic));
+        }
+    }
+
+    @Parameters(commandDescription = "Get the internal stats for the topic")
+    private class GetInternalStats extends CliCommand {
+        @Parameter(description = "non-persistent://property/cluster/namespace/destination\n", required = true)
+        private java.util.List<String> params;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String persistentTopic = validatePersistentTopic(params);
+            print(nonPersistentTopics.getInternalStats(persistentTopic));
+        }
+    }
+
+    @Parameters(commandDescription = "Create a partitioned topic. \n"
+            + "\t\tThe partitioned topic has to be created before creating a producer on it.")
+    private class CreatePartitionedCmd extends CliCommand {
+
+        @Parameter(description = "non-persistent://property/cluster/namespace/destination\n", required = true)
+        private java.util.List<String> params;
+
+        @Parameter(names = { "-p",
+                "--partitions" }, description = "Number of partitions for the topic", required = true)
+        private int numPartitions;
+
+        @Override
+        void run() throws Exception {
+            String persistentTopic = validatePersistentTopic(params);
+            nonPersistentTopics.createPartitionedTopic(persistentTopic, numPartitions);
+        }
+    }
+
+    @Parameters(commandDescription = "Get the partitioned topic metadata. \n"
+            + "\t\tIf the topic is not created or is a non-partitioned topic, it returns empty topic with 0 partitions")
+    private class GetPartitionedTopicMetadataCmd extends CliCommand {
+
+        @Parameter(description = "non-persistent://property/cluster/namespace/destination\n", required = true)
+        private java.util.List<String> params;
+
+        @Override
+        void run() throws Exception {
+            String persistentTopic = validatePersistentTopic(params);
+            print(nonPersistentTopics.getPartitionedTopicMetadata(persistentTopic));
+        }
+    }
+}

--- a/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/PulsarAdminTool.java
+++ b/pulsar-client-tools/src/main/java/com/yahoo/pulsar/admin/cli/PulsarAdminTool.java
@@ -74,6 +74,7 @@ public class PulsarAdminTool {
         commandMap.put("properties", CmdProperties.class);
         commandMap.put("namespaces", CmdNamespaces.class);
         commandMap.put("persistent", CmdPersistentTopics.class);
+        commandMap.put("non-persistent", CmdNonPersistentTopics.class);
         commandMap.put("resource-quotas", CmdResourceQuotas.class);
     }
 

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/impl/ConsumerImpl.java
@@ -98,7 +98,6 @@ public class ConsumerImpl extends ConsumerBase {
     private final int priorityLevel;
     private final SubscriptionMode subscriptionMode;
     private final MessageId startMessageId;
-    private final boolean isNonPersistent;
 
     static enum SubscriptionMode {
         // Make the subscription to be backed by a durable cursor that will retain messages and persist the current
@@ -122,7 +121,6 @@ public class ConsumerImpl extends ConsumerBase {
         this.consumerId = client.newConsumerId();
         this.subscriptionMode = subscriptionMode;
         this.startMessageId = startMessageId;
-        this.isNonPersistent = topic.startsWith("non-persistent");
         AVAILABLE_PERMITS_UPDATER.set(this, 0);
         this.subscribeTimeout = System.currentTimeMillis() + client.getConfiguration().getOperationTimeoutMs();
         this.partitionIndex = partitionIndex;
@@ -668,14 +666,6 @@ public class ConsumerImpl extends ConsumerBase {
                     messageId.getEntryId());
         }
 
-        if (!canReceiveMessage()) {
-            if (log.isDebugEnabled()) {
-                log.debug("[{}][{}] Dropped received message: {}/{}", topic, subscription, messageId.getLedgerId(),
-                        messageId.getEntryId());
-            }
-            return;
-        }
-        
         MessageMetadata msgMetadata = null;
         ByteBuf payload = headersAndPayload;
 
@@ -775,10 +765,6 @@ public class ConsumerImpl extends ConsumerBase {
                 }
             });
         }
-    }
-
-    private boolean canReceiveMessage() {
-        return !(isNonPersistent && incomingMessages.size() >= conf.getReceiverQueueSize());
     }
 
     /**

--- a/pulsar-common/src/main/java/com/yahoo/pulsar/common/naming/DestinationDomain.java
+++ b/pulsar-common/src/main/java/com/yahoo/pulsar/common/naming/DestinationDomain.java
@@ -16,5 +16,29 @@
 package com.yahoo.pulsar.common.naming;
 
 public enum DestinationDomain {
-    persistent
+    persistent("persistent"), non_persistent("non-persistent");
+
+    private String value;
+
+    private DestinationDomain(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return this.value;
+    }
+    
+    public static DestinationDomain getEnum(String value) {
+        for (DestinationDomain e : values()) {
+            if (e.value.equalsIgnoreCase(value)) {
+                return e;
+            }
+        }
+        throw new IllegalArgumentException("Invalid enum value " + value);
+    }
+
+    @Override
+    public String toString() {
+        return this.value;
+    }
 }

--- a/pulsar-common/src/main/java/com/yahoo/pulsar/common/naming/DestinationName.java
+++ b/pulsar-common/src/main/java/com/yahoo/pulsar/common/naming/DestinationName.java
@@ -95,7 +95,7 @@ public class DestinationName implements ServiceUnitId {
             }
 
             List<String> parts = Splitter.on("://").limit(2).splitToList(destination);
-            this.domain = DestinationDomain.valueOf(parts.get(0));
+            this.domain = DestinationDomain.getEnum(parts.get(0));
 
             String rest = parts.get(1);
             // property/cluster/namespace/<localName>

--- a/pulsar-common/src/main/java/com/yahoo/pulsar/common/policies/data/Policies.java
+++ b/pulsar-common/src/main/java/com/yahoo/pulsar/common/policies/data/Policies.java
@@ -33,6 +33,7 @@ public class Policies {
     public int message_ttl_in_seconds;
     public RetentionPolicies retention_policies;
     public boolean deleted;
+    public boolean nonPersistent;
 
     public static final String FIRST_BOUNDARY = "0x00000000";
     public static final String LAST_BOUNDARY = "0xffffffff";
@@ -47,6 +48,7 @@ public class Policies {
         message_ttl_in_seconds = 0;
         retention_policies = null;
         deleted = false;
+        nonPersistent = false;
     }
 
     @Override
@@ -59,7 +61,8 @@ public class Policies {
                     && Objects.equal(persistence, other.persistence) && Objects.equal(bundles, other.bundles)
                     && Objects.equal(latency_stats_sample_rate, other.latency_stats_sample_rate)
                     && message_ttl_in_seconds == other.message_ttl_in_seconds
-                    && Objects.equal(retention_policies, other.retention_policies);
+                    && Objects.equal(retention_policies, other.retention_policies)
+                    && Objects.equal(nonPersistent, other.nonPersistent);
         }
 
         return false;
@@ -81,7 +84,7 @@ public class Policies {
                 .add("backlog_quota_map", backlog_quota_map).add("persistence", persistence)
                 .add("latency_stats_sample_rate", latency_stats_sample_rate)
                 .add("message_ttl_in_seconds", message_ttl_in_seconds).add("retention_policies", retention_policies)
-                .add("deleted", deleted).toString();
+                .add("deleted", deleted).add("nonPersistent", nonPersistent).toString();
     }
     
 }

--- a/pulsar-common/src/main/java/com/yahoo/pulsar/common/policies/data/loadbalancer/LoadReport.java
+++ b/pulsar-common/src/main/java/com/yahoo/pulsar/common/policies/data/loadbalancer/LoadReport.java
@@ -39,6 +39,8 @@ public class LoadReport implements ServiceLookupData {
     private final String webServiceUrlTls;
     private final String pulsarServiceUrl;
     private final String pulsarServiceUrlTls;
+    private boolean nonPersistentNamespaceAllowed = true;
+    private boolean onlyNonPersistentNamespaceAllowed = false;
     private boolean isUnderLoaded;
     private boolean isOverLoaded;
     private long timestamp;
@@ -118,6 +120,22 @@ public class LoadReport implements ServiceLookupData {
 
     public void setSystemResourceUsage(SystemResourceUsage systemResourceUsage) {
         this.systemResourceUsage = systemResourceUsage;
+    }
+
+    public boolean isNonPersistentNamespaceAllowed() {
+        return nonPersistentNamespaceAllowed;
+    }
+
+    public void setNonPersistentNamespaceAllowed(boolean nonPersistentNamespaceAllowed) {
+        this.nonPersistentNamespaceAllowed = nonPersistentNamespaceAllowed;
+    }
+
+    public boolean isOnlyNonPersistentNamespaceAllowed() {
+        return onlyNonPersistentNamespaceAllowed;
+    }
+
+    public void setOnlyNonPersistentNamespaceAllowed(boolean onlyNonPersistentNamespaceAllowed) {
+        this.onlyNonPersistentNamespaceAllowed = onlyNonPersistentNamespaceAllowed;
     }
 
     public boolean isUnderLoaded() {


### PR DESCRIPTION
### Motivation

As discussed at #451 : In cluster we may need a way to isolate few of the brokers which only own non-persistent topics or we want to configure broker which doesn't own non-persistent topics (by default broker can own both kinds of topics). So, load-manager should have a way to identify namespace which has non-persistent characteristics and based on broker mode it assigns non-persistent bundles to appropriate brokers.
- Therefore, namespace should be configured such a way that only non-persistent topics can be assigned under it.
- Broker can be configured to  not own non-persistent topics
- Broker can be configured to only own non-persistent topics

### Modifications

- namespace can be configured with non-persistency
- broker can be configured to not own non-persistent topic 
- broker can be configured to only own non-persistent topics 

### Result

We can isolate few of the brokers which can only serve non-persistent topics in case if we don't want to serve both kind of topics in the same broker.

Note: 
- this PR is based on #452  I will rebase this PR once we rebase #452 
- I will document non-peristent topic once we are fine with both the PRs.