### PR TITLE
Run unit tests in isolated processes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -604,8 +604,10 @@ flexible messaging model and an intuitive client API.</description>
             -Dorg.slf4j.simpleLogger.log.org.apache.bookkeeper=off
             -Dorg.slf4j.simpleLogger.log.org.apache.bookkeeper.mledger=info
           </argLine>
-          <reuseForks>true</reuseForks>
+          <reuseForks>false</reuseForks>
           <forkCount>1</forkCount>
+          <shutdown>kill</shutdown>
+          <forkedProcessExitTimeoutInSeconds>30</forkedProcessExitTimeoutInSeconds>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
         </configuration>
       </plugin>


### PR DESCRIPTION
### Motivation

Use different JVM forks to execute the unit tests. This prevent resource leaks from some tests (which are very difficult to track down) to lead to failures in subsequent tests.

Next step would be to run multiple forks in parallel, to speed up the execution.