### PR TITLE
Support wildcard in permitted role name

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -129,6 +129,10 @@ authenticationProviders=
 # Enforce authorization
 authorizationEnabled=false
 
+# Actions that can be authorized by using permitted role name which contains wildcard
+# e.g. pulsar.service.*
+# wildcardRoleNamePermittedActions=produce,consume
+
 # Role names that are treated as "super-user", meaning they will be able to do all admin
 # operations and publish/consume from all topics
 superUserRoles=

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -92,6 +92,10 @@ authenticationProviders=false
 # Enforce authorization
 authorizationEnabled=false
 
+# Actions that can be authorized by using permitted role name which contains wildcard
+# e.g. pulsar.service.*
+# wildcardRoleNamePermittedActions=produce,consume
+
 # Role names that are treated as "super-user", meaning they will be able to do all admin
 # operations and publish/consume from all topics
 superUserRoles=

--- a/conf/websocket.conf
+++ b/conf/websocket.conf
@@ -50,6 +50,10 @@ authenticationProviders=
 # Enforce authorization
 authorizationEnabled=false
 
+# Actions that can be authorized by using permitted role name which contains wildcard
+# e.g. pulsar.service.*
+# wildcardRoleNamePermittedActions=produce,consume
+
 # Role names that are treated as "super-user", meaning they will be able to do all admin
 # operations and publish/consume from all topics
 superUserRoles=

--- a/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/ServiceConfiguration.java
@@ -24,11 +24,10 @@ import com.google.common.collect.Sets;
 import com.yahoo.pulsar.client.impl.auth.AuthenticationDisabled;
 import com.yahoo.pulsar.common.configuration.FieldContext;
 import com.yahoo.pulsar.common.configuration.PulsarConfiguration;
+import com.yahoo.pulsar.common.policies.data.AuthAction;
 
 /**
- *
  * Pulsar service configuration object.
- *
  */
 public class ServiceConfiguration implements PulsarConfiguration {
 
@@ -125,6 +124,9 @@ public class ServiceConfiguration implements PulsarConfiguration {
     // Role names that are treated as "super-user", meaning they will be able to
     // do all admin operations and publish/consume from all topics
     private Set<String> superUserRoles = Sets.newTreeSet();
+
+    // Actions that can be authorized by using permitted role name which contains wildcard
+    private Set<AuthAction> wildcardRoleNamePermittedActions = Sets.newTreeSet();
 
     // Authentication settings of the broker itself. Used when the broker connects
     // to other brokers, either in same or other clusters
@@ -266,7 +268,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     // Name of load manager to use
     @FieldContext(dynamic = true)
     private String loadManagerClassName = "com.yahoo.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl";
-    // If true, (and ModularLoadManagerImpl is being used), the load manager will attempt to 
+    // If true, (and ModularLoadManagerImpl is being used), the load manager will attempt to
     // use only brokers running the latest software version (to minimize impact to bundles)
     @FieldContext(dynamic = true)
     private boolean preferLaterVersions = false;
@@ -534,6 +536,14 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     public Set<String> getSuperUserRoles() {
         return superUserRoles;
+    }
+
+    public Set<AuthAction> getWildcardRoleNamePermittedActions() {
+        return wildcardRoleNamePermittedActions;
+    }
+
+    public void setWildcardRoleNamePermittedActions(Set<AuthAction> wildcardRoleNamePermittedActions) {
+        this.wildcardRoleNamePermittedActions = wildcardRoleNamePermittedActions;
     }
 
     public void setSuperUserRoles(Set<String> superUserRoles) {

--- a/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/authorization/AuthorizationManager.java
+++ b/pulsar-broker-common/src/main/java/com/yahoo/pulsar/broker/authorization/AuthorizationManager.java
@@ -54,7 +54,7 @@ public class AuthorizationManager {
     public CompletableFuture<Boolean> canProduceAsync(DestinationName destination, String role) {
         return checkAuthorization(destination, role, AuthAction.produce);
     }
-    
+
     public boolean canProduce(DestinationName destination, String role) throws Exception {
         try {
             return canProduceAsync(destination, role).get(cacheTimeOutInSec, SECONDS);
@@ -80,7 +80,7 @@ public class AuthorizationManager {
     public CompletableFuture<Boolean> canConsumeAsync(DestinationName destination, String role) {
         return checkAuthorization(destination, role, AuthAction.consume);
     }
-    
+
     public boolean canConsume(DestinationName destination, String role) throws Exception {
         try {
             return canConsumeAsync(destination, role).get(cacheTimeOutInSec, SECONDS);
@@ -102,7 +102,7 @@ public class AuthorizationManager {
      * @param destination
      * @param role
      * @return
-     * @throws Exception 
+     * @throws Exception
      */
     public boolean canLookup(DestinationName destination, String role) throws Exception {
         return canProduce(destination, role) || canConsume(destination, role);
@@ -130,8 +130,7 @@ public class AuthorizationManager {
         }
     }
 
-    public CompletableFuture<Boolean> checkPermission(DestinationName destination, String role,
-            AuthAction action) {
+    public CompletableFuture<Boolean> checkPermission(DestinationName destination, String role, AuthAction action) {
         CompletableFuture<Boolean> permissionFuture = new CompletableFuture<>();
         try {
             configCache.policiesCache().getAsync(POLICY_ROOT + destination.getNamespace()).thenAccept(policies -> {
@@ -139,29 +138,43 @@ public class AuthorizationManager {
                     if (log.isDebugEnabled()) {
                         log.debug("Policies node couldn't be found for destination : {}", destination);
                     }
-                    permissionFuture.complete(false);
                 } else {
-                    Set<AuthAction> namespaceActions = policies.get().auth_policies.namespace_auth.get(role);
+                    Map<String, Set<AuthAction>> namespaceRoles = policies.get().auth_policies.namespace_auth;
+                    Set<AuthAction> namespaceActions = namespaceRoles.get(role);
                     if (namespaceActions != null && namespaceActions.contains(action)) {
                         // The role has namespace level permission
                         permissionFuture.complete(true);
-                    } else {
-                        Map<String, Set<AuthAction>> roles = policies.get().auth_policies.destination_auth
-                                .get(destination.toString());
-                        if (roles == null) {
-                            // Destination has no custom policy
-                            permissionFuture.complete(false);
-                        } else {
-                            Set<AuthAction> resourceActions = roles.get(role);
-                            if (resourceActions != null && resourceActions.contains(action)) {
-                                // The role has destination level permission
-                                permissionFuture.complete(true);
-                            } else {
-                                permissionFuture.complete(false);
-                            }
+                        return;
+                    }
+
+                    Map<String, Set<AuthAction>> destinationRoles = policies.get().auth_policies.destination_auth
+                            .get(destination.toString());
+                    if (destinationRoles != null) {
+                        // Destination has custom policy
+                        Set<AuthAction> destinationActions = destinationRoles.get(role);
+                        if (destinationActions != null && destinationActions.contains(action)) {
+                            // The role has destination level permission
+                            permissionFuture.complete(true);
+                            return;
+                        }
+                    }
+
+                    // Using wildcard
+                    if (conf.getWildcardRoleNamePermittedActions().contains(action)) {
+                        if (checkWildcardPermission(role, action, namespaceRoles)) {
+                            // The role has namespace level permission by wildcard match
+                            permissionFuture.complete(true);
+                            return;
+                        }
+
+                        if (destinationRoles != null && checkWildcardPermission(role, action, destinationRoles)) {
+                            // The role has destination level permission by wildcard match
+                            permissionFuture.complete(true);
+                            return;
                         }
                     }
                 }
+                permissionFuture.complete(false);
             }).exceptionally(ex -> {
                 log.warn("Client  with Role - {} failed to get permissions for destination - {}", role, destination,
                         ex);
@@ -173,6 +186,29 @@ public class AuthorizationManager {
             permissionFuture.completeExceptionally(e);
         }
         return permissionFuture;
+    }
+
+    private Boolean checkWildcardPermission(String checkedRole, AuthAction checkedAction,
+            Map<String, Set<AuthAction>> permissionMap) {
+        for (Map.Entry<String, Set<AuthAction>> permissionData : permissionMap.entrySet()) {
+            String permittedRole = permissionData.getKey();
+            Set<AuthAction> permittedActions = permissionData.getValue();
+
+            // Prefix match
+            if (permittedRole.charAt(permittedRole.length() - 1) == '*'
+                    && checkedRole.startsWith(permittedRole.substring(0, permittedRole.length() - 1))
+                    && permittedActions.contains(checkedAction)) {
+                return true;
+            }
+
+            // Suffix match
+            if (permittedRole.charAt(0) == '*'
+                    && checkedRole.endsWith(permittedRole.substring(1))
+                    && permittedActions.contains(checkedAction)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/pulsar-common/src/main/java/com/yahoo/pulsar/common/util/FieldParser.java
+++ b/pulsar-common/src/main/java/com/yahoo/pulsar/common/util/FieldParser.java
@@ -15,6 +15,8 @@
  */
 package com.yahoo.pulsar.common.util;
 
+import com.yahoo.pulsar.common.policies.data.AuthAction;
+
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
 
@@ -30,19 +32,19 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * 
+ *
  * Generic value converter.
  * <p>
  * <h3>Use examples</h3>
- * 
+ *
  * <pre>
  * String o1 = String.valueOf(1);
  * ;
  * Integer i = FieldParser.convert(o1, Integer.class);
  * System.out.println(i); // 1
- * 
+ *
  * </pre>
- * 
+ *
  */
 public final class FieldParser {
 
@@ -57,7 +59,7 @@ public final class FieldParser {
 
     /**
      * Convert the given object value to the given class.
-     * 
+     *
      * @param from
      *            The object value to be converted.
      * @param to
@@ -103,7 +105,7 @@ public final class FieldParser {
 
     /**
      * Update given Object attribute by reading it from provided map properties.
-     * 
+     *
      * @param properties
      *            which key-value pair of properties to assign those values to given object
      * @param obj
@@ -128,7 +130,7 @@ public final class FieldParser {
 
     /**
      * Converts value as per appropriate DataType of the field.
-     * 
+     *
      * @param strValue
      *            : string value of the object
      * @param field
@@ -182,7 +184,7 @@ public final class FieldParser {
 
     /**
      * Converts String to Integer.
-     * 
+     *
      * @param value
      *            The String to be converted.
      * @return The converted Integer value.
@@ -193,7 +195,7 @@ public final class FieldParser {
 
     /**
      * Converts String to Long.
-     * 
+     *
      * @param value
      *            The String to be converted.
      * @return The converted Long value.
@@ -204,7 +206,7 @@ public final class FieldParser {
 
     /**
      * Converts String to Double.
-     * 
+     *
      * @param value
      *            The String to be converted.
      * @return The converted Double value.
@@ -215,7 +217,7 @@ public final class FieldParser {
 
     /**
      * Converts String to float.
-     * 
+     *
      * @param value
      *            The String to be converted.
      * @return The converted Double value.
@@ -226,7 +228,7 @@ public final class FieldParser {
 
     /**
      * Converts comma separated string to List
-     * 
+     *
      * @param <T>
      *            type of list
      * @param value
@@ -242,7 +244,7 @@ public final class FieldParser {
 
     /**
      * Converts comma separated string to Set
-     * 
+     *
      * @param <T>
      *            type of set
      * @param value
@@ -263,7 +265,7 @@ public final class FieldParser {
 
     /**
      * Converts Integer to String.
-     * 
+     *
      * @param value
      *            The Integer to be converted.
      * @return The converted String value.
@@ -274,7 +276,7 @@ public final class FieldParser {
 
     /**
      * Converts Boolean to String.
-     * 
+     *
      * @param value
      *            The Boolean to be converted.
      * @return The converted String value.
@@ -286,13 +288,24 @@ public final class FieldParser {
 
     /**
      * Converts String to Boolean.
-     * 
+     *
      * @param value
      *            The String to be converted.
      * @return The converted Boolean value.
      */
     public static Boolean stringToBoolean(String value) {
         return Boolean.valueOf(value);
+    }
+
+    /**
+     * Converts String to AuthAction.
+     *
+     * @param value
+     *            The String to be converted.
+     * @return The converted AuthAction value.
+     */
+    public static AuthAction stringToAuthAction(String value) {
+        return AuthAction.valueOf(value);
     }
 
     // implement more converter methods here.

--- a/pulsar-common/src/test/java/com/yahoo/pulsar/common/util/collections/FieldParserTest.java
+++ b/pulsar-common/src/test/java/com/yahoo/pulsar/common/util/collections/FieldParserTest.java
@@ -15,6 +15,8 @@
  */
 package com.yahoo.pulsar.common.util.collections;
 
+import com.yahoo.pulsar.common.policies.data.AuthAction;
+
 import static com.yahoo.pulsar.common.util.FieldParser.booleanToString;
 import static com.yahoo.pulsar.common.util.FieldParser.convert;
 import static com.yahoo.pulsar.common.util.FieldParser.integerToString;
@@ -23,6 +25,7 @@ import static com.yahoo.pulsar.common.util.FieldParser.stringToDouble;
 import static com.yahoo.pulsar.common.util.FieldParser.stringToList;
 import static com.yahoo.pulsar.common.util.FieldParser.stringToLong;
 import static com.yahoo.pulsar.common.util.FieldParser.stringToSet;
+import static com.yahoo.pulsar.common.util.FieldParser.stringToAuthAction;
 import static com.yahoo.pulsar.common.util.FieldParser.update;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -39,7 +42,7 @@ public class FieldParserTest {
 
     /**
      * test all conversion scenarios.
-     * 
+     *
      * @throws Exception
      */
     @Test
@@ -56,6 +59,7 @@ public class FieldParserTest {
         assertEquals(stringToDouble("2.2"), Double.valueOf(2.2));
         assertEquals(stringToLong("2"), Long.valueOf(2));
         assertEquals(booleanToString(Boolean.TRUE), String.valueOf(true));
+        assertEquals(stringToAuthAction("produce"), AuthAction.produce);
 
         // test invalid value type
         try {

--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/WebSocketService.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/WebSocketService.java
@@ -215,6 +215,7 @@ public class WebSocketService implements Closeable {
         serviceConfig.setBrokerClientAuthenticationPlugin(config.getBrokerClientAuthenticationPlugin());
         serviceConfig.setBrokerClientAuthenticationParameters(config.getBrokerClientAuthenticationParameters());
         serviceConfig.setAuthorizationEnabled(config.isAuthorizationEnabled());
+        serviceConfig.setWildcardRoleNamePermittedActions(config.getWildcardRoleNamePermittedActions());
         serviceConfig.setSuperUserRoles(config.getSuperUserRoles());
         serviceConfig.setGlobalZookeeperServers(config.getGlobalZookeeperServers());
         serviceConfig.setZooKeeperSessionTimeoutMillis(config.getZooKeeperSessionTimeoutMillis());

--- a/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/service/WebSocketProxyConfiguration.java
+++ b/pulsar-websocket/src/main/java/com/yahoo/pulsar/websocket/service/WebSocketProxyConfiguration.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import com.google.common.collect.Sets;
 import com.yahoo.pulsar.common.configuration.FieldContext;
 import com.yahoo.pulsar.common.configuration.PulsarConfiguration;
+import com.yahoo.pulsar.common.policies.data.AuthAction;
 
 public class WebSocketProxyConfiguration implements PulsarConfiguration {
 
@@ -64,6 +65,9 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     // Role names that are treated as "super-user", meaning they will be able to
     // do all admin operations and publish/consume from all topics
     private Set<String> superUserRoles = Sets.newTreeSet();
+
+    // Actions that can be authorized by using permitted role name which contains wildcard
+    private Set<AuthAction> wildcardRoleNamePermittedActions = Sets.newTreeSet();
 
     // Authentication settings of the proxy itself. Used to connect to brokers
     private String brokerClientAuthenticationPlugin;
@@ -185,6 +189,14 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
 
     public void setAuthorizationEnabled(boolean authorizationEnabled) {
         this.authorizationEnabled = authorizationEnabled;
+    }
+
+    public Set<AuthAction> getWildcardRoleNamePermittedActions() {
+        return wildcardRoleNamePermittedActions;
+    }
+
+    public void setWildcardRoleNamePermittedActions(Set<AuthAction> wildcardRoleNamePermittedActions) {
+        this.wildcardRoleNamePermittedActions = wildcardRoleNamePermittedActions;
     }
 
     public Set<String> getSuperUserRoles() {


### PR DESCRIPTION
### Motivation

Please refer to #469.

### Modifications

Fix AuthorizationManger to check by wildcard matching after normal authorization check.
This process is executed when `wildcardRoleNamePermittedActions` in `ServiceConfiguration` is set.

### Result

Wildcard is valid in heads or tails of permission's role names.
I'm going to add document after this  PR is merged.