### PR TITLE
Reverting  commit d990b1 - changing producer queue size back to 1000

### DIFF
--- a/pulsar-client-cpp/lib/ProducerConfigurationImpl.h
+++ b/pulsar-client-cpp/lib/ProducerConfigurationImpl.h
@@ -36,7 +36,7 @@ struct ProducerConfigurationImpl {
     ProducerConfigurationImpl()
             : sendTimeoutMs(30000),
               compressionType(CompressionNone),
-              maxPendingMessages(30000),
+              maxPendingMessages(1000),
               routingMode(ProducerConfiguration::UseSinglePartition),
               blockIfQueueFull(false),
               batchingEnabled(false),

--- a/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/ProducerConfiguration.java
+++ b/pulsar-client/src/main/java/com/yahoo/pulsar/client/api/ProducerConfiguration.java
@@ -37,7 +37,7 @@ public class ProducerConfiguration implements Serializable {
     private static final long serialVersionUID = 1L;
     private long sendTimeoutMs = 30000;
     private boolean blockIfQueueFull = false;
-    private int maxPendingMessages = 30000;
+    private int maxPendingMessages = 1000;
     private MessageRoutingMode messageRouteMode = MessageRoutingMode.SinglePartition;
     private MessageRouter customMessageRouter = null;
     private long batchingMaxPublishDelayMs = 10;


### PR DESCRIPTION
### Motivation

There was a concern that the client will end up using 30x the memory if there is a GC pause or N/W issue. Hence changing the queue size back to 1K.

### Modifications

Reverted commit d990b171f5d3f14a2a196363fb315594c46afab6

### Result

Expect to see more ProducerQueueFull error/exceptions in case of GC pauses.