### PR TITLE
Enable to configure webSocketServiceEnabled on Standalone

### DIFF
--- a/pulsar-broker/src/main/java/com/yahoo/pulsar/PulsarStandaloneStarter.java
+++ b/pulsar-broker/src/main/java/com/yahoo/pulsar/PulsarStandaloneStarter.java
@@ -106,7 +106,6 @@ public class PulsarStandaloneStarter {
         // Set ZK server's host to localhost
         config.setZookeeperServers("127.0.0.1:" + zkPort);
         config.setGlobalZookeeperServers("127.0.0.1:" + zkPort);
-        config.setWebSocketServiceEnabled(true);
 
         if (advertisedAddress != null) {
             // Use advertised address from command line


### PR DESCRIPTION
### Motivation

When standalone mode, WebSocket service is always enabled.
I think it should be configured by `standalone.conf`.

### Modifications

Delete the line where WebSocket service is directly enabled.

### Result

Whether to run WebSocket service can be configure by `standalone.conf` even when standalone mode.