### PR TITLE
Reduce default producer queue size from 30K to 1K also for Python

### DIFF
--- a/docs/Python.md
+++ b/docs/Python.md
@@ -142,7 +142,7 @@ CLASSES
      |      Close the client and all the associated producers and consumers
      |  
      |  create_producer(self, topic, send_timeout_millis=30000,
-     |                  compression_type=_pulsar.CompressionType.None, max_pending_messages=30000,
+     |                  compression_type=_pulsar.CompressionType.None, max_pending_messages=1000,
      |                  block_if_queue_full=False, batching_enabled=False, batching_max_messages=1000,
      |                  batching_max_allowed_size_in_bytes=131072, batching_max_publish_delay_ms=10)
      |      Create a new producer on a given topic

--- a/pulsar-client-cpp/python/pulsar.py
+++ b/pulsar-client-cpp/python/pulsar.py
@@ -227,7 +227,7 @@ class Client:
     def create_producer(self, topic,
                         send_timeout_millis=30000,
                         compression_type=CompressionType.None,
-                        max_pending_messages=30000,
+                        max_pending_messages=1000,
                         block_if_queue_full=False,
                         batching_enabled=False,
                         batching_max_messages=1000,


### PR DESCRIPTION
### Motivation

Since it the producer queue size was reduced for C++ and Java producer, we should keep it the same also in Python client lib.
