### PR TITLE
C++ Client - Changed compiler to default version (4.8.4)

### DIFF
--- a/pulsar-client-cpp/travis-build.sh
+++ b/pulsar-client-cpp/travis-build.sh
@@ -58,10 +58,10 @@ exec_cmd() {
 
 if [ "$3" = "all" -o "$3" = "dep" ]; then
   # Install dependant packages
-  exec_cmd "apt-get update && apt-get install -y cmake gcc-4.4 cpp-4.4 gcc-4.4-base libssl-dev libcurl4-openssl-dev liblog4cxx10-dev libprotobuf-dev libboost1.55-all-dev libgtest-dev libxml2-utils g++-4.4 libjsoncpp-dev";
+  exec_cmd "apt-get update && apt-get install -y cmake libssl-dev libcurl4-openssl-dev liblog4cxx10-dev libprotobuf-dev libboost1.55-all-dev libgtest-dev libxml2-utils libjsoncpp-dev";
   if [ ! -f "$1/libgtest.a" ]; then
     echo "Not Found: $1/libgtest.a"
-    exec_cmd "pushd /usr/src/gtest && CC=gcc-4.4 CXX=g++-4.4 cmake . && make && cp libgtest.a $1/ && popd";
+    exec_cmd "pushd /usr/src/gtest && cmake . && make && cp libgtest.a $1/ && popd";
   fi
   if [ ! -d "$1/protobuf-2.6.1/" ]; then
     echo "Not Found: $1/protobuf-2.6.1/"
@@ -77,7 +77,7 @@ if [ "$3" = "all" -o "$3" = "compile" ]; then
   export PATH=$PATH:$1/
   # Compile and run unit tests
   pushd $2/pulsar-client-cpp
-  CC=gcc-4.4 CXX=g++-4.4 cmake . && make
+  cmake . && make
   if [ $? -ne 0 ]; then
     echo "Failed to compile CPP client library"
     exit 1


### PR DESCRIPTION
Looks like there is some issue with g++4.4 Ubuntu compiler - it crashes while compiling the CPP Client - https://travis-ci.org/apache/incubator-pulsar/builds/245891752

As per @msb-at-yahoo sugesstions, I spent a day on trying to make the code work with g++4.4 by making changes to headers and re coding one line at a time to see if reordering the code may fix it - but no success.

@merlimat @saandrews - if you have any other suggestions I can try it - else I don't see any other option but to upgrade the compiler.

@saandrews - I tried to compile the code in Yahoo environment with legacy compiler, the code compiles - this change is required only to get the travis build to pass.