### PR TITLE
Support wildcard in permitted role name

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -142,7 +142,7 @@ authorizationEnabled=false
 
 # Actions that can be authorized by using permitted role name which contains wildcard
 # e.g. pulsar.service.*
-# wildcardRoleNamePermittedActions=produce,consume
+wildcardInPermittedRoleNameEnabled=false
 
 # Role names that are treated as "super-user", meaning they will be able to do all admin
 # operations and publish/consume from all topics

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -142,7 +142,7 @@ authorizationEnabled=false
 
 # Actions that can be authorized by using permitted role name which contains wildcard
 # e.g. pulsar.service.*
-wildcardInPermittedRoleNameEnabled=false
+authorizationAllowWildcardsMatching=false
 
 # Role names that are treated as "super-user", meaning they will be able to do all admin
 # operations and publish/consume from all topics

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -140,6 +140,10 @@ authenticationProviders=
 # Enforce authorization
 authorizationEnabled=false
 
+# Actions that can be authorized by using permitted role name which contains wildcard
+# e.g. pulsar.service.*
+# wildcardRoleNamePermittedActions=produce,consume
+
 # Role names that are treated as "super-user", meaning they will be able to do all admin
 # operations and publish/consume from all topics
 superUserRoles=

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -106,6 +106,10 @@ authenticationProviders=false
 # Enforce authorization
 authorizationEnabled=false
 
+# Actions that can be authorized by using permitted role name which contains wildcard
+# e.g. pulsar.service.*
+# wildcardRoleNamePermittedActions=produce,consume
+
 # Role names that are treated as "super-user", meaning they will be able to do all admin
 # operations and publish/consume from all topics
 superUserRoles=

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -108,7 +108,7 @@ authorizationEnabled=false
 
 # Actions that can be authorized by using permitted role name which contains wildcard
 # e.g. pulsar.service.*
-wildcardInPermittedRoleNameEnabled=false
+authorizationAllowWildcardsMatching=false
 
 # Role names that are treated as "super-user", meaning they will be able to do all admin
 # operations and publish/consume from all topics

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -108,7 +108,7 @@ authorizationEnabled=false
 
 # Actions that can be authorized by using permitted role name which contains wildcard
 # e.g. pulsar.service.*
-# wildcardRoleNamePermittedActions=produce,consume
+wildcardInPermittedRoleNameEnabled=false
 
 # Role names that are treated as "super-user", meaning they will be able to do all admin
 # operations and publish/consume from all topics

--- a/conf/websocket.conf
+++ b/conf/websocket.conf
@@ -59,6 +59,10 @@ authenticationProviders=
 # Enforce authorization
 authorizationEnabled=false
 
+# Actions that can be authorized by using permitted role name which contains wildcard
+# e.g. pulsar.service.*
+# wildcardRoleNamePermittedActions=produce,consume
+
 # Role names that are treated as "super-user", meaning they will be able to do all admin
 # operations and publish/consume from all topics
 superUserRoles=

--- a/conf/websocket.conf
+++ b/conf/websocket.conf
@@ -61,7 +61,7 @@ authorizationEnabled=false
 
 # Actions that can be authorized by using permitted role name which contains wildcard
 # e.g. pulsar.service.*
-# wildcardRoleNamePermittedActions=produce,consume
+wildcardInPermittedRoleNameEnabled=false
 
 # Role names that are treated as "super-user", meaning they will be able to do all admin
 # operations and publish/consume from all topics

--- a/conf/websocket.conf
+++ b/conf/websocket.conf
@@ -61,7 +61,7 @@ authorizationEnabled=false
 
 # Actions that can be authorized by using permitted role name which contains wildcard
 # e.g. pulsar.service.*
-wildcardInPermittedRoleNameEnabled=false
+authorizationAllowWildcardsMatching=false
 
 # Role names that are treated as "super-user", meaning they will be able to do all admin
 # operations and publish/consume from all topics

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -26,13 +26,12 @@ import java.util.Set;
 import org.apache.pulsar.client.impl.auth.AuthenticationDisabled;
 import org.apache.pulsar.common.configuration.FieldContext;
 import org.apache.pulsar.common.configuration.PulsarConfiguration;
+import org.apache.pulsar.common.policies.data.AuthAction;
 
 import com.google.common.collect.Sets;
 
 /**
- *
  * Pulsar service configuration object.
- *
  */
 public class ServiceConfiguration implements PulsarConfiguration {
 
@@ -138,6 +137,9 @@ public class ServiceConfiguration implements PulsarConfiguration {
     // Role names that are treated as "super-user", meaning they will be able to
     // do all admin operations and publish/consume from all topics
     private Set<String> superUserRoles = Sets.newTreeSet();
+
+    // Actions that can be authorized by using permitted role name which contains wildcard
+    private Set<AuthAction> wildcardRoleNamePermittedActions = Sets.newTreeSet();
 
     // Authentication settings of the broker itself. Used when the broker connects
     // to other brokers, either in same or other clusters
@@ -279,7 +281,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     // Name of load manager to use
     @FieldContext(dynamic = true)
     private String loadManagerClassName = "org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl";
-    // If true, (and ModularLoadManagerImpl is being used), the load manager will attempt to 
+    // If true, (and ModularLoadManagerImpl is being used), the load manager will attempt to
     // use only brokers running the latest software version (to minimize impact to bundles)
     @FieldContext(dynamic = true)
     private boolean preferLaterVersions = false;
@@ -570,6 +572,14 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     public Set<String> getSuperUserRoles() {
         return superUserRoles;
+    }
+
+    public Set<AuthAction> getWildcardRoleNamePermittedActions() {
+        return wildcardRoleNamePermittedActions;
+    }
+
+    public void setWildcardRoleNamePermittedActions(Set<AuthAction> wildcardRoleNamePermittedActions) {
+        this.wildcardRoleNamePermittedActions = wildcardRoleNamePermittedActions;
     }
 
     public void setSuperUserRoles(Set<String> superUserRoles) {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -26,7 +26,6 @@ import java.util.Set;
 import org.apache.pulsar.client.impl.auth.AuthenticationDisabled;
 import org.apache.pulsar.common.configuration.FieldContext;
 import org.apache.pulsar.common.configuration.PulsarConfiguration;
-import org.apache.pulsar.common.policies.data.AuthAction;
 
 import com.google.common.collect.Sets;
 
@@ -104,7 +103,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private int maxUnackedMessagesPerBroker = 0;
     // Once broker reaches maxUnackedMessagesPerBroker limit, it blocks subscriptions which has higher unacked messages
     // than this percentage limit and subscription will not receive any new messages until that subscription acks back
-    // limit/2 messages 
+    // limit/2 messages
     private double maxUnackedMessagesPerSubscriptionOnBrokerBlocked = 0.16;
     // Max number of concurrent lookup request broker allows to throttle heavy incoming lookup traffic
     @FieldContext(dynamic = true)
@@ -139,7 +138,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private Set<String> superUserRoles = Sets.newTreeSet();
 
     // Actions that can be authorized by using permitted role name which contains wildcard
-    private Set<AuthAction> wildcardRoleNamePermittedActions = Sets.newTreeSet();
+    private boolean wildcardInPermittedRoleNameEnabled = false;
 
     // Authentication settings of the broker itself. Used when the broker connects
     // to other brokers, either in same or other clusters
@@ -574,12 +573,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
         return superUserRoles;
     }
 
-    public Set<AuthAction> getWildcardRoleNamePermittedActions() {
-        return wildcardRoleNamePermittedActions;
+    public boolean getWildcardInPermittedRoleNameEnabled() {
+        return wildcardInPermittedRoleNameEnabled;
     }
 
-    public void setWildcardRoleNamePermittedActions(Set<AuthAction> wildcardRoleNamePermittedActions) {
-        this.wildcardRoleNamePermittedActions = wildcardRoleNamePermittedActions;
+    public void setWildcardInPermittedRoleNameEnabled(boolean wildcardInPermittedRoleNameEnabled) {
+        this.wildcardInPermittedRoleNameEnabled = wildcardInPermittedRoleNameEnabled;
     }
 
     public void setSuperUserRoles(Set<String> superUserRoles) {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -138,7 +138,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private Set<String> superUserRoles = Sets.newTreeSet();
 
     // Actions that can be authorized by using permitted role name which contains wildcard
-    private boolean wildcardInPermittedRoleNameEnabled = false;
+    private boolean authorizationAllowWildcardsMatching = false;
 
     // Authentication settings of the broker itself. Used when the broker connects
     // to other brokers, either in same or other clusters
@@ -573,12 +573,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
         return superUserRoles;
     }
 
-    public boolean getWildcardInPermittedRoleNameEnabled() {
-        return wildcardInPermittedRoleNameEnabled;
+    public boolean getAuthorizationAllowWildcardsMatching() {
+        return authorizationAllowWildcardsMatching;
     }
 
-    public void setWildcardInPermittedRoleNameEnabled(boolean wildcardInPermittedRoleNameEnabled) {
-        this.wildcardInPermittedRoleNameEnabled = wildcardInPermittedRoleNameEnabled;
+    public void setAuthorizationAllowWildcardsMatching(boolean authorizationAllowWildcardsMatching) {
+        this.authorizationAllowWildcardsMatching = authorizationAllowWildcardsMatching;
     }
 
     public void setSuperUserRoles(Set<String> superUserRoles) {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationManager.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationManager.java
@@ -162,7 +162,7 @@ public class AuthorizationManager {
                     }
 
                     // Using wildcard
-                    if (conf.getWildcardRoleNamePermittedActions().contains(action)) {
+                    if (conf.getWildcardInPermittedRoleNameEnabled()) {
                         if (checkWildcardPermission(role, action, namespaceRoles)) {
                             // The role has namespace level permission by wildcard match
                             permissionFuture.complete(true);
@@ -190,7 +190,7 @@ public class AuthorizationManager {
         return permissionFuture;
     }
 
-    private Boolean checkWildcardPermission(String checkedRole, AuthAction checkedAction,
+    private boolean checkWildcardPermission(String checkedRole, AuthAction checkedAction,
             Map<String, Set<AuthAction>> permissionMap) {
         for (Map.Entry<String, Set<AuthAction>> permissionData : permissionMap.entrySet()) {
             String permittedRole = permissionData.getKey();

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationManager.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationManager.java
@@ -162,7 +162,7 @@ public class AuthorizationManager {
                     }
 
                     // Using wildcard
-                    if (conf.getWildcardInPermittedRoleNameEnabled()) {
+                    if (conf.getAuthorizationAllowWildcardsMatching()) {
                         if (checkWildcardPermission(role, action, namespaceRoles)) {
                             // The role has namespace level permission by wildcard match
                             permissionFuture.complete(true);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
@@ -48,7 +48,7 @@ public class AuthorizationTest extends MockedPulsarServiceBaseTest {
     protected void setup() throws Exception {
         conf.setClusterName("c1");
         conf.setAuthorizationEnabled(true);
-        conf.setWildcardRoleNamePermittedActions(EnumSet.of(AuthAction.produce, AuthAction.consume));
+        conf.setWildcardInPermittedRoleNameEnabled(true);
         internalSetup();
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
@@ -28,6 +28,7 @@ import org.apache.pulsar.common.naming.DestinationName;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.PropertyAdmin;
+import org.apache.pulsar.broker.authorization.AuthorizationManager;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -47,6 +48,7 @@ public class AuthorizationTest extends MockedPulsarServiceBaseTest {
     protected void setup() throws Exception {
         conf.setClusterName("c1");
         conf.setAuthorizationEnabled(true);
+        conf.setWildcardRoleNamePermittedActions(EnumSet.of(AuthAction.produce, AuthAction.consume));
         internalSetup();
     }
 
@@ -93,6 +95,46 @@ public class AuthorizationTest extends MockedPulsarServiceBaseTest {
 
         assertEquals(auth.canProduce(DestinationName.get("persistent://p1/c1/ns1/ds1"), "my-role"), true);
         assertEquals(auth.canConsume(DestinationName.get("persistent://p1/c1/ns1/ds1"), "my-role"), true);
+
+        // test for wildcard
+        assertEquals(auth.canLookup(DestinationName.get("persistent://p1/c1/ns1/ds1"), "my.role.1"), false);
+        assertEquals(auth.canLookup(DestinationName.get("persistent://p1/c1/ns1/ds1"), "my.role.2"), false);
+        assertEquals(auth.canProduce(DestinationName.get("persistent://p1/c1/ns1/ds1"), "my.role.1"), false);
+        assertEquals(auth.canConsume(DestinationName.get("persistent://p1/c1/ns1/ds1"), "my.role.1"), false);
+        assertEquals(auth.canLookup(DestinationName.get("persistent://p1/c1/ns1/ds1"), "other.role.1"), false);
+        assertEquals(auth.canLookup(DestinationName.get("persistent://p1/c1/ns1/ds1"), "other.role.2"), false);
+
+        admin.namespaces().grantPermissionOnNamespace("p1/c1/ns1", "my.role.*", EnumSet.of(AuthAction.produce));
+        waitForChange();
+
+        assertEquals(auth.canLookup(DestinationName.get("persistent://p1/c1/ns1/ds1"), "my.role.1"), true);
+        assertEquals(auth.canLookup(DestinationName.get("persistent://p1/c1/ns1/ds1"), "my.role.2"), true);
+        assertEquals(auth.canProduce(DestinationName.get("persistent://p1/c1/ns1/ds1"), "my.role.1"), true);
+        assertEquals(auth.canConsume(DestinationName.get("persistent://p1/c1/ns1/ds1"), "my.role.1"), false);
+        assertEquals(auth.canLookup(DestinationName.get("persistent://p1/c1/ns1/ds1"), "other.role.1"), false);
+        assertEquals(auth.canLookup(DestinationName.get("persistent://p1/c1/ns1/ds1"), "other.role.2"), false);
+
+        assertEquals(auth.canLookup(DestinationName.get("persistent://p1/c1/ns1/ds1"), "1.role.my"), false);
+        assertEquals(auth.canLookup(DestinationName.get("persistent://p1/c1/ns1/ds1"), "2.role.my"), false);
+        assertEquals(auth.canProduce(DestinationName.get("persistent://p1/c1/ns1/ds1"), "1.role.my"), false);
+        assertEquals(auth.canConsume(DestinationName.get("persistent://p1/c1/ns1/ds1"), "1.role.my"), false);
+        assertEquals(auth.canLookup(DestinationName.get("persistent://p1/c1/ns1/ds1"), "2.role.other"), false);
+        assertEquals(auth.canLookup(DestinationName.get("persistent://p1/c1/ns1/ds1"), "2.role.other"), false);
+        assertEquals(auth.canLookup(DestinationName.get("persistent://p1/c1/ns1/ds2"), "1.role.my"), false);
+        assertEquals(auth.canLookup(DestinationName.get("persistent://p1/c1/ns1/ds2"), "2.role.my"), false);
+
+        admin.persistentTopics().grantPermission("persistent://p1/c1/ns1/ds1", "*.my",
+                EnumSet.of(AuthAction.consume));
+        waitForChange();
+
+        assertEquals(auth.canLookup(DestinationName.get("persistent://p1/c1/ns1/ds1"), "1.role.my"), true);
+        assertEquals(auth.canLookup(DestinationName.get("persistent://p1/c1/ns1/ds1"), "2.role.my"), true);
+        assertEquals(auth.canProduce(DestinationName.get("persistent://p1/c1/ns1/ds1"), "1.role.my"), false);
+        assertEquals(auth.canConsume(DestinationName.get("persistent://p1/c1/ns1/ds1"), "1.role.my"), true);
+        assertEquals(auth.canLookup(DestinationName.get("persistent://p1/c1/ns1/ds1"), "2.role.other"), false);
+        assertEquals(auth.canLookup(DestinationName.get("persistent://p1/c1/ns1/ds1"), "2.role.other"), false);
+        assertEquals(auth.canLookup(DestinationName.get("persistent://p1/c1/ns1/ds2"), "1.role.my"), false);
+        assertEquals(auth.canLookup(DestinationName.get("persistent://p1/c1/ns1/ds2"), "2.role.my"), false);
 
         admin.namespaces().deleteNamespace("p1/c1/ns1");
         admin.properties().deleteProperty("p1");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
@@ -48,7 +48,7 @@ public class AuthorizationTest extends MockedPulsarServiceBaseTest {
     protected void setup() throws Exception {
         conf.setClusterName("c1");
         conf.setAuthorizationEnabled(true);
-        conf.setWildcardInPermittedRoleNameEnabled(true);
+        conf.setAuthorizationAllowWildcardsMatching(true);
         internalSetup();
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FieldParser.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FieldParser.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.common.util;
 
+import org.apache.pulsar.common.policies.data.AuthAction;
+
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
 
@@ -33,19 +35,19 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * 
+ *
  * Generic value converter.
  * <p>
  * <h3>Use examples</h3>
- * 
+ *
  * <pre>
  * String o1 = String.valueOf(1);
  * ;
  * Integer i = FieldParser.convert(o1, Integer.class);
  * System.out.println(i); // 1
- * 
+ *
  * </pre>
- * 
+ *
  */
 public final class FieldParser {
 
@@ -60,7 +62,7 @@ public final class FieldParser {
 
     /**
      * Convert the given object value to the given class.
-     * 
+     *
      * @param from
      *            The object value to be converted.
      * @param to
@@ -106,7 +108,7 @@ public final class FieldParser {
 
     /**
      * Update given Object attribute by reading it from provided map properties.
-     * 
+     *
      * @param properties
      *            which key-value pair of properties to assign those values to given object
      * @param obj
@@ -131,7 +133,7 @@ public final class FieldParser {
 
     /**
      * Converts value as per appropriate DataType of the field.
-     * 
+     *
      * @param strValue
      *            : string value of the object
      * @param field
@@ -185,7 +187,7 @@ public final class FieldParser {
 
     /**
      * Converts String to Integer.
-     * 
+     *
      * @param value
      *            The String to be converted.
      * @return The converted Integer value.
@@ -196,7 +198,7 @@ public final class FieldParser {
 
     /**
      * Converts String to Long.
-     * 
+     *
      * @param value
      *            The String to be converted.
      * @return The converted Long value.
@@ -207,7 +209,7 @@ public final class FieldParser {
 
     /**
      * Converts String to Double.
-     * 
+     *
      * @param value
      *            The String to be converted.
      * @return The converted Double value.
@@ -218,7 +220,7 @@ public final class FieldParser {
 
     /**
      * Converts String to float.
-     * 
+     *
      * @param value
      *            The String to be converted.
      * @return The converted Double value.
@@ -229,7 +231,7 @@ public final class FieldParser {
 
     /**
      * Converts comma separated string to List
-     * 
+     *
      * @param <T>
      *            type of list
      * @param value
@@ -245,7 +247,7 @@ public final class FieldParser {
 
     /**
      * Converts comma separated string to Set
-     * 
+     *
      * @param <T>
      *            type of set
      * @param value
@@ -266,7 +268,7 @@ public final class FieldParser {
 
     /**
      * Converts Integer to String.
-     * 
+     *
      * @param value
      *            The Integer to be converted.
      * @return The converted String value.
@@ -277,7 +279,7 @@ public final class FieldParser {
 
     /**
      * Converts Boolean to String.
-     * 
+     *
      * @param value
      *            The Boolean to be converted.
      * @return The converted String value.
@@ -289,13 +291,24 @@ public final class FieldParser {
 
     /**
      * Converts String to Boolean.
-     * 
+     *
      * @param value
      *            The String to be converted.
      * @return The converted Boolean value.
      */
     public static Boolean stringToBoolean(String value) {
         return Boolean.valueOf(value);
+    }
+
+    /**
+     * Converts String to AuthAction.
+     *
+     * @param value
+     *            The String to be converted.
+     * @return The converted AuthAction value.
+     */
+    public static AuthAction stringToAuthAction(String value) {
+        return AuthAction.valueOf(value);
     }
 
     // implement more converter methods here.

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FieldParser.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FieldParser.java
@@ -26,7 +26,6 @@ import static java.lang.String.format;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
-import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -298,17 +297,6 @@ public final class FieldParser {
      */
     public static Boolean stringToBoolean(String value) {
         return Boolean.valueOf(value);
-    }
-
-    /**
-     * Converts String to AuthAction.
-     *
-     * @param value
-     *            The String to be converted.
-     * @return The converted AuthAction value.
-     */
-    public static AuthAction stringToAuthAction(String value) {
-        return AuthAction.valueOf(value);
     }
 
     // implement more converter methods here.

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/FieldParserTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/FieldParserTest.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pulsar.common.util.collections;
 
-import org.apache.pulsar.common.policies.data.AuthAction;
-
 import static org.apache.pulsar.common.util.FieldParser.booleanToString;
 import static org.apache.pulsar.common.util.FieldParser.convert;
 import static org.apache.pulsar.common.util.FieldParser.integerToString;
@@ -29,7 +27,6 @@ import static org.apache.pulsar.common.util.FieldParser.stringToList;
 import static org.apache.pulsar.common.util.FieldParser.stringToLong;
 import static org.apache.pulsar.common.util.FieldParser.stringToSet;
 import static org.apache.pulsar.common.util.FieldParser.update;
-import static org.apache.pulsar.common.util.FieldParser.stringToAuthAction;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -62,7 +59,6 @@ public class FieldParserTest {
         assertEquals(stringToDouble("2.2"), Double.valueOf(2.2));
         assertEquals(stringToLong("2"), Long.valueOf(2));
         assertEquals(booleanToString(Boolean.TRUE), String.valueOf(true));
-        assertEquals(stringToAuthAction("produce"), AuthAction.produce);
 
         // test invalid value type
         try {

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/FieldParserTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/util/collections/FieldParserTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.common.util.collections;
 
+import org.apache.pulsar.common.policies.data.AuthAction;
+
 import static org.apache.pulsar.common.util.FieldParser.booleanToString;
 import static org.apache.pulsar.common.util.FieldParser.convert;
 import static org.apache.pulsar.common.util.FieldParser.integerToString;
@@ -27,6 +29,7 @@ import static org.apache.pulsar.common.util.FieldParser.stringToList;
 import static org.apache.pulsar.common.util.FieldParser.stringToLong;
 import static org.apache.pulsar.common.util.FieldParser.stringToSet;
 import static org.apache.pulsar.common.util.FieldParser.update;
+import static org.apache.pulsar.common.util.FieldParser.stringToAuthAction;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -42,7 +45,7 @@ public class FieldParserTest {
 
     /**
      * test all conversion scenarios.
-     * 
+     *
      * @throws Exception
      */
     @Test
@@ -59,6 +62,7 @@ public class FieldParserTest {
         assertEquals(stringToDouble("2.2"), Double.valueOf(2.2));
         assertEquals(stringToLong("2"), Long.valueOf(2));
         assertEquals(booleanToString(Boolean.TRUE), String.valueOf(true));
+        assertEquals(stringToAuthAction("produce"), AuthAction.produce);
 
         // test invalid value type
         try {

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketService.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketService.java
@@ -220,6 +220,7 @@ public class WebSocketService implements Closeable {
         serviceConfig.setBrokerClientAuthenticationPlugin(config.getBrokerClientAuthenticationPlugin());
         serviceConfig.setBrokerClientAuthenticationParameters(config.getBrokerClientAuthenticationParameters());
         serviceConfig.setAuthorizationEnabled(config.isAuthorizationEnabled());
+        serviceConfig.setWildcardRoleNamePermittedActions(config.getWildcardRoleNamePermittedActions());
         serviceConfig.setSuperUserRoles(config.getSuperUserRoles());
         serviceConfig.setGlobalZookeeperServers(config.getGlobalZookeeperServers());
         serviceConfig.setZooKeeperSessionTimeoutMillis(config.getZooKeeperSessionTimeoutMillis());

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketService.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketService.java
@@ -220,7 +220,7 @@ public class WebSocketService implements Closeable {
         serviceConfig.setBrokerClientAuthenticationPlugin(config.getBrokerClientAuthenticationPlugin());
         serviceConfig.setBrokerClientAuthenticationParameters(config.getBrokerClientAuthenticationParameters());
         serviceConfig.setAuthorizationEnabled(config.isAuthorizationEnabled());
-        serviceConfig.setWildcardInPermittedRoleNameEnabled(config.getWildcardInPermittedRoleNameEnabled());
+        serviceConfig.setAuthorizationAllowWildcardsMatching(config.getAuthorizationAllowWildcardsMatching());
         serviceConfig.setSuperUserRoles(config.getSuperUserRoles());
         serviceConfig.setGlobalZookeeperServers(config.getGlobalZookeeperServers());
         serviceConfig.setZooKeeperSessionTimeoutMillis(config.getZooKeeperSessionTimeoutMillis());

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketService.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketService.java
@@ -220,7 +220,7 @@ public class WebSocketService implements Closeable {
         serviceConfig.setBrokerClientAuthenticationPlugin(config.getBrokerClientAuthenticationPlugin());
         serviceConfig.setBrokerClientAuthenticationParameters(config.getBrokerClientAuthenticationParameters());
         serviceConfig.setAuthorizationEnabled(config.isAuthorizationEnabled());
-        serviceConfig.setWildcardRoleNamePermittedActions(config.getWildcardRoleNamePermittedActions());
+        serviceConfig.setWildcardInPermittedRoleNameEnabled(config.getWildcardInPermittedRoleNameEnabled());
         serviceConfig.setSuperUserRoles(config.getSuperUserRoles());
         serviceConfig.setGlobalZookeeperServers(config.getGlobalZookeeperServers());
         serviceConfig.setZooKeeperSessionTimeoutMillis(config.getZooKeeperSessionTimeoutMillis());

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
@@ -23,7 +23,6 @@ import java.util.Set;
 
 import org.apache.pulsar.common.configuration.FieldContext;
 import org.apache.pulsar.common.configuration.PulsarConfiguration;
-import org.apache.pulsar.common.policies.data.AuthAction;
 
 import com.google.common.collect.Sets;
 
@@ -69,7 +68,7 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     private Set<String> superUserRoles = Sets.newTreeSet();
 
     // Actions that can be authorized by using permitted role name which contains wildcard
-    private Set<AuthAction> wildcardRoleNamePermittedActions = Sets.newTreeSet();
+    private boolean wildcardInPermittedRoleNameEnabled = false;
 
     // Authentication settings of the proxy itself. Used to connect to brokers
     private String brokerClientAuthenticationPlugin;
@@ -198,12 +197,12 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
         this.authorizationEnabled = authorizationEnabled;
     }
 
-    public Set<AuthAction> getWildcardRoleNamePermittedActions() {
-        return wildcardRoleNamePermittedActions;
+    public boolean getWildcardInPermittedRoleNameEnabled() {
+        return wildcardInPermittedRoleNameEnabled;
     }
 
-    public void setWildcardRoleNamePermittedActions(Set<AuthAction> wildcardRoleNamePermittedActions) {
-        this.wildcardRoleNamePermittedActions = wildcardRoleNamePermittedActions;
+    public void setWildcardInPermittedRoleNameEnabled(boolean wildcardInPermittedRoleNameEnabled) {
+        this.wildcardInPermittedRoleNameEnabled = wildcardInPermittedRoleNameEnabled;
     }
 
     public Set<String> getSuperUserRoles() {

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
@@ -68,7 +68,7 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     private Set<String> superUserRoles = Sets.newTreeSet();
 
     // Actions that can be authorized by using permitted role name which contains wildcard
-    private boolean wildcardInPermittedRoleNameEnabled = false;
+    private boolean authorizationAllowWildcardsMatching = false;
 
     // Authentication settings of the proxy itself. Used to connect to brokers
     private String brokerClientAuthenticationPlugin;
@@ -197,12 +197,12 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
         this.authorizationEnabled = authorizationEnabled;
     }
 
-    public boolean getWildcardInPermittedRoleNameEnabled() {
-        return wildcardInPermittedRoleNameEnabled;
+    public boolean getAuthorizationAllowWildcardsMatching() {
+        return authorizationAllowWildcardsMatching;
     }
 
-    public void setWildcardInPermittedRoleNameEnabled(boolean wildcardInPermittedRoleNameEnabled) {
-        this.wildcardInPermittedRoleNameEnabled = wildcardInPermittedRoleNameEnabled;
+    public void setAuthorizationAllowWildcardsMatching(boolean authorizationAllowWildcardsMatching) {
+        this.authorizationAllowWildcardsMatching = authorizationAllowWildcardsMatching;
     }
 
     public Set<String> getSuperUserRoles() {

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import org.apache.pulsar.common.configuration.FieldContext;
 import org.apache.pulsar.common.configuration.PulsarConfiguration;
+import org.apache.pulsar.common.policies.data.AuthAction;
 
 import com.google.common.collect.Sets;
 
@@ -66,6 +67,9 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     // Role names that are treated as "super-user", meaning they will be able to
     // do all admin operations and publish/consume from all topics
     private Set<String> superUserRoles = Sets.newTreeSet();
+
+    // Actions that can be authorized by using permitted role name which contains wildcard
+    private Set<AuthAction> wildcardRoleNamePermittedActions = Sets.newTreeSet();
 
     // Authentication settings of the proxy itself. Used to connect to brokers
     private String brokerClientAuthenticationPlugin;
@@ -192,6 +196,14 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
 
     public void setAuthorizationEnabled(boolean authorizationEnabled) {
         this.authorizationEnabled = authorizationEnabled;
+    }
+
+    public Set<AuthAction> getWildcardRoleNamePermittedActions() {
+        return wildcardRoleNamePermittedActions;
+    }
+
+    public void setWildcardRoleNamePermittedActions(Set<AuthAction> wildcardRoleNamePermittedActions) {
+        this.wildcardRoleNamePermittedActions = wildcardRoleNamePermittedActions;
     }
 
     public Set<String> getSuperUserRoles() {


### PR DESCRIPTION
This PR is resolving conflicts of #494 as I commented when closing it.

### Motivation

Please refer to #469.

### Modifications

Fix AuthorizationManger to check by wildcard matching after normal authorization check.
This process is executed when ~~`wildcardRoleNamePermittedActions`~~`authorizationAllowWildcardsMatching` in `ServiceConfiguration` is true.

### Result

Wildcard is valid in heads or tails of permission's role names.
I'm going to add document after this  PR is merged.