### PR TITLE
exclude license for athenz-test-conf file

### DIFF
--- a/pulsar-broker-auth-athenz/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderAthenzTest.java
+++ b/pulsar-broker-auth-athenz/src/test/java/org/apache/pulsar/broker/authentication/AuthenticationProviderAthenzTest.java
@@ -60,7 +60,7 @@ public class AuthenticationProviderAthenzTest {
         provider.initialize(config);
 
         // Specify Athenz configuration file for AuthZpeClient which is used in AuthenticationProviderAthenz
-        System.setProperty(ZpeConsts.ZPE_PROP_ATHENZ_CONF, "./src/test/resources/athenz.conf");
+        System.setProperty(ZpeConsts.ZPE_PROP_ATHENZ_CONF, "./src/test/resources/athenz.conf.test");
     }
 
     @Test

--- a/pulsar-broker-auth-athenz/src/test/resources/athenz.conf.test
+++ b/pulsar-broker-auth-athenz/src/test/resources/athenz.conf.test
@@ -1,22 +1,3 @@
-#
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-#
-
 {
  "zmsUrl": "https://server-zms.athenzcompany.com:4443/",
  "ztsUrl": "https://server-zts.athenzcompany.com:4443/",


### PR DESCRIPTION
### Motivation

Athenz-test was failing due to invalid test-conf file under test-resource. Adding license was making file invalid for parsing.

```
Running org.apache.pulsar.broker.authentication.AuthenticationProviderAthenzTest
com.fasterxml.jackson.core.JsonParseException: Unexpected character ('#' (code 35)): expected a valid value (number, String, array, object, 'true', 'false' or 'null')
 at [Source: [B@7c1e2a9e; line: 1, column: 2]
	at com.fasterxml.jackson.core.JsonParser._constructError(JsonParser.java:1419)
	at com.fasterxml.jackson.core.base.ParserMinimalBase._reportError(ParserMinimalBase.java:508)
	at com.fasterxml.jackson.core.base.ParserMinimalBase._reportUnexpectedChar(ParserMinimalBase.java:437)
	at com.fasterxml.jackson.core.json.UTF8StreamJsonParser._handleUnexpectedValue(UTF8StreamJsonParser.java:2363)
	at com.fasterxml.jackson.core.json.UTF8StreamJsonParser._nextTokenNotInObject(UTF8StreamJsonParser.java:794)
	at com.fasterxml.jackson.core.json.UTF8StreamJsonParser.nextToken(UTF8StreamJsonParser.java:690)
	at com.fasterxml.jackson.databind.ObjectReader._initForReading(ObjectReader.java:1346)
	at com.fasterxml.jackson.databind.ObjectReader._bindAndClose(ObjectReader.java:1252)
	at com.fasterxml.jackson.databind.ObjectReader.readValue(ObjectReader.java:912)
	at com.yahoo.rdl.JSON.fromBytes(JSON.java:56)
	at com.yahoo.athenz.zpe.pkey.file.FilePublicKeyStore.init(FilePublicKeyStore.java:56)
	at com.yahoo.athenz.zpe.pkey.file.FilePublicKeyStoreFactory.create(FilePublicKeyStoreFactory.java:26)
	at com.yahoo.athenz.zpe.AuthZpeClient.<clinit>(AuthZpeClient.java:147)
	at org.apache.pulsar.broker.authentication.AuthenticationProviderAthenz.authenticate(AuthenticationProviderAthenz.java:97)
	at org.apache.pulsar.broker.authentication.AuthenticationProviderAthenzTest.testAuthenticateSignedToken(AuthenticationProviderAthenzTest.java:79)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:84)
	at org.testng.internal.Invoker.invokeMethod(Invoker.java:714)
	at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:901)
	at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1231)
	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:127)
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:111)
	at org.testng.TestRunner.privateRun(TestRunner.java:767)
	at org.testng.TestRunner.run(TestRunner.java:617)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:334)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:329)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:291)
	at org.testng.SuiteRunner.run(SuiteRunner.java:240)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1224)
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1149)
	at org.testng.TestNG.run(TestNG.java:1057)
	at org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:132)
	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.executeSingleClass(TestNGDirectoryTestSuite.java:112)
	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.execute(TestNGDirectoryTestSuite.java:99)
	at org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:147)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:290)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:242)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:121)
Tests run: 3, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.564 sec <<< FAILURE! - in org.apache.pulsar.broker.authentication.AuthenticationProviderAthenzTest
testAuthenticateSignedToken(org.apache.pulsar.broker.authentication.AuthenticationProviderAthenzTest)  Time elapsed: 0.939 sec  <<< FAILURE!
javax.naming.AuthenticationException: Unable to retrieve ZTS Public Key
	at org.apache.pulsar.broker.authentication.AuthenticationProviderAthenzTest.testAuthenticateSignedToken(AuthenticationProviderAthenzTest.java:79)


Results :

Failed tests: 
  AuthenticationProviderAthenzTest.testAuthenticateSignedToken:79 Â» Authentication
```

### Modifications

- Exclude license headers for athenz resource file.
- rename file because file extension ".conf" [must requires a header](https://github.com/apache/incubator-pulsar/blob/master/pom.xml#L580) and we can't exclude them.