### PR TITLE
Validate msg size after compressing the msg while sending msg

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -902,10 +902,11 @@ public class ConsumerImpl extends ConsumerBase {
         CompressionType compressionType = msgMetadata.getCompression();
         CompressionCodec codec = codecProvider.getCodec(compressionType);
         int uncompressedSize = msgMetadata.getUncompressedSize();
-        if (uncompressedSize > PulsarDecoder.MaxMessageSize) {
-            // Uncompressed size is itself corrupted since it cannot be bigger than the MaxMessageSize
-            log.error("[{}][{}] Got corrupted uncompressed message size {} at {}", topic, subscription,
-                uncompressedSize, messageId);
+        int payloadSize = payload.readableBytes();
+        if (payloadSize > PulsarDecoder.MaxMessageSize) {
+            // payload size is itself corrupted since it cannot be bigger than the MaxMessageSize
+            log.error("[{}][{}] Got corrupted payload message size {} at {}", topic, subscription, payloadSize,
+                    messageId);
             discardCorruptedMessage(messageId, currentCnx, ValidationError.UncompressedSizeCorruption);
             return null;
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageBuilderImpl.java
@@ -24,7 +24,6 @@ import java.util.Map;
 
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageBuilder;
-import org.apache.pulsar.common.api.PulsarDecoder;
 import org.apache.pulsar.common.api.proto.PulsarApi.KeyValue;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
 
@@ -37,10 +36,6 @@ public class MessageBuilderImpl implements MessageBuilder {
 
     @Override
     public Message build() {
-        if (content.remaining() > PulsarDecoder.MaxMessageSize) {
-            throw new IllegalArgumentException(
-                    "Message payload cannot exceed " + PulsarDecoder.MaxMessageSize + " bytes");
-        }
         return MessageImpl.create(msgMetadataBuilder, content);
     }
 


### PR DESCRIPTION
### Motivation

As per discussion at #523 : add msg-size validation after compressing the message for non-batch message.  

### Modifications

- check msg-size after compressing the message.
- for batch-msg : compression happens on a container-msg so, it requires to check msg-size upfront rather checking later on when we try to compress container-msg.

### Result

- if msg is larger than max_msg_size (eg. 5 MB) but compression makes in less than it then producer will publish the message successfully.
