### PR TITLE
Enable TLS Client Authentication  on WebSocketProxy and DiscoveryService

### DIFF
--- a/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/server/ServerManager.java
+++ b/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/server/ServerManager.java
@@ -73,14 +73,14 @@ public class ServerManager {
         if (config.isTlsEnabled()) {
             SslContextFactory sslCtxFactory = new SslContextFactory();
             try {
-                SSLContext sslCtx = SecurityUtility.createSslContext(false, null, config.getTlsCertificateFilePath(),
+                SSLContext sslCtx = SecurityUtility.createSslContext(config.isTlsAllowInsecureConnection(), config.getTlsTrustCertsFilePath(), config.getTlsCertificateFilePath(),
                         config.getTlsKeyFilePath());
                 sslCtxFactory.setSslContext(sslCtx);
             } catch (GeneralSecurityException e) {
                 throw new RestException(e);
             }
 
-            sslCtxFactory.setWantClientAuth(false);
+            sslCtxFactory.setWantClientAuth(true);
             ServerConnector tlsConnector = new ServerConnector(server, 1, 1, sslCtxFactory);
             tlsConnector.setPort(config.getWebServicePortTls());
             connectors.add(tlsConnector);

--- a/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/server/ServiceConfig.java
+++ b/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/server/ServiceConfig.java
@@ -70,6 +70,10 @@ public class ServiceConfig implements PulsarConfiguration {
     private String tlsCertificateFilePath;
     // Path for the TLS private key file
     private String tlsKeyFilePath;
+    // Path for the trusted TLS certificate file
+    private String tlsTrustCertsFilePath = "";
+    // Accept untrusted TLS certificate from client
+    private boolean tlsAllowInsecureConnection = false;
 
     private Properties properties = new Properties();
 
@@ -151,6 +155,22 @@ public class ServiceConfig implements PulsarConfiguration {
 
     public void setTlsKeyFilePath(String tlsKeyFilePath) {
         this.tlsKeyFilePath = tlsKeyFilePath;
+    }
+
+    public String getTlsTrustCertsFilePath() {
+        return tlsTrustCertsFilePath;
+    }
+
+    public void setTlsTrustCertsFilePath(String tlsTrustCertsFilePath) {
+        this.tlsTrustCertsFilePath = tlsTrustCertsFilePath;
+    }
+
+    public boolean isTlsAllowInsecureConnection() {
+        return tlsAllowInsecureConnection;
+    }
+
+    public void setTlsAllowInsecureConnection(boolean tlsAllowInsecureConnection) {
+        this.tlsAllowInsecureConnection = tlsAllowInsecureConnection;
     }
 
     public boolean isBindOnLocalhost() {

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/ProxyServer.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/ProxyServer.java
@@ -82,7 +82,7 @@ public class ProxyServer {
         if (config.isTlsEnabled()) {
             SslContextFactory sslCtxFactory = new SslContextFactory(true);
             try {
-                SSLContext sslCtx = SecurityUtility.createSslContext(false, null, config.getTlsCertificateFilePath(),
+                SSLContext sslCtx = SecurityUtility.createSslContext(false, config.getTlsTrustCertsFilePath(), config.getTlsCertificateFilePath(),
                         config.getTlsKeyFilePath());
                 sslCtxFactory.setSslContext(sslCtx);
 


### PR DESCRIPTION
### Motivation

* `tlsTrustCertsFilePath` in `ProxyServer` is not configurable
* `tlsTrustCertsFilePath` and `tlsAllowInsecureConnection` in `ServerManager` and `ServiceChannelInitializer` is not configurable

To use TLS Client Authentication on WebSocketProxy and DiscoveryService, they should be configurable.

### Modifications

* Enable `ProxyServer` to set `tlsTrustCertsFilePath`
* Enable `ServerManager` and `ServiceChannelInitializer` to set `tlsTrustCertsFilePath` and `tlsAllowInsecureConnection`

### Result

We can use TLS Client Authentication on WebSocketProxy and DiscoveryService.

Note:
I'm going to add test codes for TLS client authentication as another Pull-Request.