### PR TITLE
Message size validation on post compression

### DIFF
--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -324,9 +324,10 @@ bool ConsumerImpl::uncompressMessageIfNeeded(const ClientConnectionPtr& cnx,
     CompressionType compressionType = CompressionCodecProvider::convertType(metadata.compression());
 
     uint32_t uncompressedSize = metadata.uncompressed_size();
-    if (uncompressedSize > Commands::MaxMessageSize) {
+    uint32_t payloadSize = payload.readableBytes();
+    if (payloadSize > Commands::MaxMessageSize) {
         // Uncompressed size is itself corrupted since it cannot be bigger than the MaxMessageSize
-        LOG_ERROR(getName() << "Got corrupted uncompressed message size " << uncompressedSize  //
+        LOG_ERROR(getName() << "Got corrupted payload message size " << payloadSize  //
                 << " at  " << msg.message_id().ledgerid() << ":" << msg.message_id().entryid());
         discardCorruptedMessage(cnx, msg.message_id(),
                                 proto::CommandAck::UncompressedSizeCorruption);

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -247,10 +247,6 @@ void ProducerImpl::statsCallBackHandler(Result res, const Message& msg, SendCall
 void ProducerImpl::sendAsync(const Message& msg, SendCallback callback) {
     producerStatsBasePtr_->messageSent(msg);
     SendCallback cb = boost::bind(&ProducerImpl::statsCallBackHandler, this, _1, _2, callback, boost::posix_time::microsec_clock::universal_time());
-    if (msg.getLength() > Commands::MaxMessageSize) {
-        callback(ResultMessageTooBig, msg);
-        return;
-    }
 
     // Reserve a spot in the messages queue before acquiring the ProducerImpl
     // mutex. When the queue is full, this call will block until a spot is
@@ -267,6 +263,14 @@ void ProducerImpl::sendAsync(const Message& msg, SendCallback callback) {
     if (! batchMessageContainer) {
         // If batching is enabled we compress all the payloads together before sending the batch
         payload = CompressionCodecProvider::getCodec(conf_.getCompressionType()).encode(payload);
+    }
+    uint32_t compressedSize = payload.readableBytes();
+    if (compressedSize > Commands::MaxMessageSize) {
+        if (conf_.getBlockIfQueueFull()) {
+            pendingMessagesQueue_.release(1);
+        }
+        cb(ResultMessageTooBig, msg);
+        return;
     }
 
     Lock lock(mutex_);

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -1003,8 +1003,21 @@ TEST(BasicEndToEndTest, testProduceMessageSize) {
     result = producer2.send(msg);
     ASSERT_EQ(ResultOk, result);
 
+    Consumer consumer;
+    Promise<Result, Consumer> consumerPromise;
+    client.subscribeAsync(topicName, subName, WaitForCallbackValue<Consumer>(consumerPromise));
+    Future<Result, Consumer> consumerFuture = consumerPromise.getFuture();
+    result = consumerFuture.get(consumer);
+    ASSERT_EQ(ResultOk, result);
+
+    Message receivedMsg;
+    consumer.receive(receivedMsg);
+    ASSERT_EQ(size, receivedMsg.getDataAsString().length());
+
+    consumer.close();
     producer1.closeAsync(0);
     producer2.closeAsync(0);
+    client.close();
 
     delete[] content;
 }

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -974,7 +974,7 @@ TEST(BasicEndToEndTest, testMessageListenerPause)
 TEST(BasicEndToEndTest, testProduceMessageSize) {
     ClientConfiguration config;
     Client client(lookupUrl);
-    std::string topicName = "persistent://prop/unit/ns1/my-topic";
+    std::string topicName = "persistent://prop/unit/ns1/maxMsgSize";
     std::string subName = "my-sub-name";
     Producer producer1;
     Producer producer2;
@@ -999,10 +999,6 @@ TEST(BasicEndToEndTest, testProduceMessageSize) {
     result = producer1.send(msg);
     ASSERT_EQ(ResultMessageTooBig, result);
 
-    msg = MessageBuilder().setAllocatedContent(content, size).build();
-    result = producer2.send(msg);
-    ASSERT_EQ(ResultOk, result);
-
     Consumer consumer;
     Promise<Result, Consumer> consumerPromise;
     client.subscribeAsync(topicName, subName, WaitForCallbackValue<Consumer>(consumerPromise));
@@ -1010,13 +1006,17 @@ TEST(BasicEndToEndTest, testProduceMessageSize) {
     result = consumerFuture.get(consumer);
     ASSERT_EQ(ResultOk, result);
 
+    msg = MessageBuilder().setAllocatedContent(content, size).build();
+    result = producer2.send(msg);
+    ASSERT_EQ(ResultOk, result);
+
     Message receivedMsg;
     consumer.receive(receivedMsg);
     ASSERT_EQ(size, receivedMsg.getDataAsString().length());
 
-    consumer.close();
     producer1.closeAsync(0);
     producer2.closeAsync(0);
+    consumer.close();
     client.close();
 
     delete[] content;


### PR DESCRIPTION
### Motivation

CPP changes for #534 


### Result

if msg is larger than max_msg_size (eg. 5 MB) but compression makes in less than it then producer will publish the message successfully.
