### PR TITLE
Fix: intermittent test failure for BrokerClientIntegrationTest.testCloseBrokerService

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
@@ -256,7 +256,15 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
         // [1] OwnershipCache should not contain any more namespaces
         OwnershipCache ownershipCache = pulsar.getNamespaceService().getOwnershipCache();
         assertTrue(ownershipCache.getOwnedBundles().keySet().isEmpty());
-
+        // Strategical retry
+        for (int i = 0; i < 5; i++) {
+            if (producer1.getClientCnx() != null || consumer1.getClientCnx() != null
+                    || producer2.getClientCnx() != null) {
+                Thread.sleep(100);
+            } else {
+                break;
+            }
+        }
         // [2] All clients must be disconnected and in connecting state
         // producer1 must not be able to connect again
         assertTrue(producer1.getClientCnx() == null);


### PR DESCRIPTION
### Motivation

As mentioned at #544 
Fixed intermittent test failure of `BrokerClientIntegrationTest.testCloseBrokerService` by adding strategical retry.
