### PR TITLE
Disabled deployment of SNAPSHOT jars to Sonatype repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,12 +46,15 @@ script:
     - mvn license:check test && sudo bash -x $TRAVIS_BUILD_DIR/pulsar-client-cpp/travis-build.sh $HOME/pulsar-dep $TRAVIS_BUILD_DIR compile
 
 deploy:
-  -
-    provider: script
-    skip_cleanup: true
-    script: mvn deploy -DskipTests --settings .travis/settings.xml
-    on:
-      tags: false
+  # Disabled the deployment of snapshots jars to Maven central for now
+  # until we figure out a way to deploy them through the proper Apache
+  # route.
+  # -
+  #   provider: script
+  #   skip_cleanup: true
+  #   script: mvn deploy -DskipTests --settings .travis/settings.xml
+  #   on:
+  #     tags: false
   -
     provider: script
     skip_cleanup: true


### PR DESCRIPTION
### Motivation

We used to push `com.yahoo..` packages for SNAPSHOT versions to OSS Sonatype repository. Now that we change the groupId to `org.apache.pulsar`, the deploy phase is not working anymore and the build on master is failing.

Disable deployment for now and later we need to decide what we want to do for SNAPSHOT jars.