### PR TITLE
Add wildcard matching setting for DiscoveryService

### DIFF
--- a/conf/discovery.conf
+++ b/conf/discovery.conf
@@ -56,6 +56,11 @@ authorizationEnabled=false
 # operations and publish/consume from all topics (comma-separated)
 superUserRoles=
 
+# Allow wildcard matching in authorization
+# (wildcard matching only applicable if wildcard-char:
+# * presents at first or last position eg: *.pulsar.service, pulsar.service.*)
+authorizationAllowWildcardsMatching=false
+
 ##### --- TLS --- #####
 # Enable TLS
 tlsEnabled=false

--- a/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/DiscoveryService.java
+++ b/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/DiscoveryService.java
@@ -51,7 +51,6 @@ import io.netty.util.concurrent.DefaultThreadFactory;
 /**
  * Main discovery-service which starts component to serve incoming discovery-request over binary-proto channel and
  * redirects to one of the active broker
- *
  */
 public class DiscoveryService implements Closeable {
 
@@ -93,12 +92,12 @@ public class DiscoveryService implements Closeable {
 
     /**
      * Starts discovery service by initializing zookkeeper and server
+     *
      * @throws Exception
      */
     public void start() throws Exception {
         discoveryProvider = new BrokerDiscoveryProvider(this.config, getZooKeeperClientFactory());
-        this.configurationCacheService = new ConfigurationCacheService(
-                discoveryProvider.globalZkCache);
+        this.configurationCacheService = new ConfigurationCacheService(discoveryProvider.globalZkCache);
         ServiceConfiguration serviceConfiguration = createServiceConfiguration(config);
         authenticationService = new AuthenticationService(serviceConfiguration);
         authorizationManager = new AuthorizationManager(serviceConfiguration, configurationCacheService);
@@ -107,7 +106,7 @@ public class DiscoveryService implements Closeable {
 
     /**
      * starts server to handle discovery-request from client-channel
-     * 
+     *
      * @throws Exception
      */
     public void startServer() throws Exception {
@@ -158,14 +157,15 @@ public class DiscoveryService implements Closeable {
     }
 
     private ServiceConfiguration createServiceConfiguration(ServiceConfig config) {
-    	ServiceConfiguration serviceConfiguration = new ServiceConfiguration();
-    	serviceConfiguration.setAuthenticationEnabled(config.isAuthenticationEnabled());
-    	serviceConfiguration.setAuthorizationEnabled(config.isAuthorizationEnabled());
-    	serviceConfiguration.setAuthenticationProviders(config.getAuthenticationProviders());
-    	serviceConfiguration.setProperties(config.getProperties());
-		return serviceConfiguration;
-	}
-    
+        ServiceConfiguration serviceConfiguration = new ServiceConfiguration();
+        serviceConfiguration.setAuthenticationEnabled(config.isAuthenticationEnabled());
+        serviceConfiguration.setAuthorizationEnabled(config.isAuthorizationEnabled());
+        serviceConfiguration.setAuthenticationProviders(config.getAuthenticationProviders());
+        serviceConfiguration.setAuthorizationAllowWildcardsMatching(config.getAuthorizationAllowWildcardsMatching());
+        serviceConfiguration.setProperties(config.getProperties());
+        return serviceConfiguration;
+    }
+
     /**
      * Derive the host
      *
@@ -207,9 +207,9 @@ public class DiscoveryService implements Closeable {
     }
 
     public ServiceConfig getConfiguration() {
-    	return config;
+        return config;
     }
-    
+
     public AuthenticationService getAuthenticationService() {
         return authenticationService;
     }
@@ -225,6 +225,6 @@ public class DiscoveryService implements Closeable {
     public void setConfigurationCacheService(ConfigurationCacheService configurationCacheService) {
         this.configurationCacheService = configurationCacheService;
     }
-	
-	private static final Logger LOG = LoggerFactory.getLogger(DiscoveryService.class);
+
+    private static final Logger LOG = LoggerFactory.getLogger(DiscoveryService.class);
 }

--- a/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/server/ServiceConfig.java
+++ b/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/server/ServiceConfig.java
@@ -56,6 +56,11 @@ public class ServiceConfig implements PulsarConfiguration {
     // do all admin operations and publish/consume from all topics
     private Set<String> superUserRoles = Sets.newTreeSet();
 
+    // Allow wildcard matching in authorization
+    // (wildcard matching only applicable if wildcard-char:
+    // * presents at first or last position eg: *.pulsar.service, pulsar.service.*)
+    private boolean authorizationAllowWildcardsMatching = false;
+
     // Enable authentication
     private boolean authenticationEnabled = false;
     // Authentication provider name list, which is a list of class names
@@ -211,6 +216,14 @@ public class ServiceConfig implements PulsarConfiguration {
 
     public void setSuperUserRoles(Set<String> superUserRoles) {
         this.superUserRoles = superUserRoles;
+    }
+
+    public boolean getAuthorizationAllowWildcardsMatching() {
+        return authorizationAllowWildcardsMatching;
+    }
+
+    public void setAuthorizationAllowWildcardsMatching(boolean authorizationAllowWildcardsMatching) {
+        this.authorizationAllowWildcardsMatching = authorizationAllowWildcardsMatching;
     }
 
     public Properties getProperties() {


### PR DESCRIPTION
### Motivation

Wildcard matching is available in `AuthorizationManager` but its setting is not added to `ServiceConfig` (configuration for DiscoveryService).

### Modifications

- Added `authorizationAllowWildcardsMatching` to `ServiceConfig`
- Fix `createServiceConfiguration()` in `DiscoveryService`
- Fix conf

### Result

Wildcard matching is available in discovery service.