### PR TITLE
Fix reconnection error in C++ client

### DIFF
--- a/pulsar-client-cpp/lib/HandlerBase.cc
+++ b/pulsar-client-cpp/lib/HandlerBase.cc
@@ -99,9 +99,7 @@ void HandlerBase::handleDisconnection(Result result, ClientConnectionWeakPtr con
         return;
     }
 
-    if (currentConnection) {
-        currentConnection.reset();
-    }
+    handler->connection_.reset();
 
     switch (state) {
         case Pending:


### PR DESCRIPTION
### Problem
In case of nongraceful shutdown, if the ClientConnection object is not destroyed within first backoff time (0.1 seconds) then the consumer/producer will no longer attempt to reconnect to the broker - which may lead to Timeouts and queue full in case of producer and backlog in case of consumer.

### Explanation
In _HandlerBase.grabCnx()_ we check if the ClientConnect object exists (i.e .lock() is not null), and if it exists we stop the reconnection loop for that entity (Producer/Consumer).
 
The problem is that in _HandlerBase.handleDisconnection()_ we reset the shared pointer but some other pointer (including the _ClientConnect's shared_from_this_) could be holding a reference to ClientConnection hence the condition _HandlerBase.grabCnx()_ will stop the loop if ClientConnect is not destroyed by the time the function is called. 

For better understanding of this behavior refer:-
https://gist.github.com/jai1/6356c3067d2599c26d77f44e1797d3af

### Way to Reproduce the problem in testing environment
a. In https://github.com/apache/incubator-pulsar/blob/master/pulsar-client-cpp/lib/HandlerBase.cc#L38 set backoff to 1 millisecond.
b. Create approximately 6000 topics (each having one consumer and producer)
c. Kill -9 the Broker
You should see a lot of diconnected Producers and Consumers.

### Modifications
In _HandlerBase.handleDisconnection()_ reset the weak pointer instead of the shared pointer like in _ProducerImpl::disconnectProducer()_

### Result
Consumers and Producers will always be able to reconnect incase the brokers gets killed.