### PR TITLE
CPP Client - Accessing connection_ pointer under a lock

### DIFF
--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -155,9 +155,9 @@ void ConsumerImpl::handleCreateConsumer(const ClientConnectionPtr& cnx, Result r
             firstTime = false;
         }
         LOG_INFO(getName() << "Created consumer on broker " << cnx->cnxString());
-        connection_ = cnx;
         {
             Lock lock(mutex_);
+            connection_ = cnx;
             incomingMessages_.clear();
             cnx->registerConsumer(consumerId_, shared_from_this());
             state_ = Ready;
@@ -581,7 +581,9 @@ void ConsumerImpl::doAcknowledge(const BatchMessageId& messageId, proto::Command
 
 void ConsumerImpl::disconnectConsumer() {
     LOG_DEBUG("Broker notification of Closed consumer: " << consumerId_);
+    Lock lock(mutex_);
     connection_.reset();
+    lock.unlock();
     scheduleReconnection(shared_from_this());
 }
 

--- a/pulsar-client-cpp/lib/HandlerBase.cc
+++ b/pulsar-client-cpp/lib/HandlerBase.cc
@@ -101,7 +101,9 @@ void HandlerBase::handleDisconnection(Result result, ClientConnectionWeakPtr con
         return;
     }
 
-    handler->connection_.reset();
+    if (currentConnection) {
+        currentConnection.reset();
+    }
 
     switch (state) {
         case Pending:

--- a/pulsar-client-cpp/lib/HandlerBase.cc
+++ b/pulsar-client-cpp/lib/HandlerBase.cc
@@ -99,9 +99,7 @@ void HandlerBase::handleDisconnection(Result result, ClientConnectionWeakPtr con
         return;
     }
 
-    if (currentConnection) {
-        currentConnection.reset();
-    }
+    handler->connection_.reset();
 
     switch (state) {
         case Pending:

--- a/pulsar-client-cpp/lib/HandlerBase.cc
+++ b/pulsar-client-cpp/lib/HandlerBase.cc
@@ -48,11 +48,13 @@ void HandlerBase::start() {
 }
 
 void HandlerBase::grabCnx() {
+    Lock lock(mutex_);
     if (connection_.lock()) {
+        lock.unlock();
         LOG_INFO(getName() << "Ignoring reconnection request since we're already connected");
         return;
     }
-
+    lock.unlock();
     LOG_INFO(getName() << "Getting connection from pool");
     ClientImplPtr client = client_.lock();
     Future<Result, ClientConnectionWeakPtr> future = client->getConnection(topic_);

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -548,9 +548,10 @@ bool ProducerImpl::ackReceived(uint64_t sequenceId) {
 
 void ProducerImpl::disconnectProducer() {
 	LOG_DEBUG("Broker notification of Closed producer: " << producerId_);
+	Lock lock(mutex_);
 	connection_.reset();
+	lock.unlock();
 	scheduleReconnection(shared_from_this());
-
 }
 
 const std::string& ProducerImpl::getName() const{


### PR DESCRIPTION
### Motivation

There are locking inconsistencies wrt HandlerBase.connection_

### Modifications

Added a lock to the following methods, to check/change the connection_  pointer
- ProducerImpl.disconnectProducer()
- ConsumerImpl.disconnectConsumer()
- HandlerBase.grabCnx()
- ConsumerImpl.handleCreateConsumer()

### Result

No functional changes, but will help in reducing the number of race conditions.