### PR TITLE
CPP Client - Reducing number of duplicate lookups

### DIFF
--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -885,6 +885,7 @@ void ClientConnection::handleIncomingCommand() {
                     ConsumersMap::iterator it = consumers_.find(consumerId);
                     if (it != consumers_.end()) {
                         ConsumerImplPtr consumer = it->second.lock();
+                        consumers_.erase(it);
                         lock.unlock();
 
                         if (consumer) {
@@ -1124,6 +1125,10 @@ void ClientConnection::close() {
     state_ = Disconnected;
     boost::system::error_code err;
     socket_->close(err);
+    ConsumersMap consumers;
+    consumers.swap(consumers_);
+    ProducersMap producers;
+    producers.swap(producers_);
     lock.unlock();
 
     LOG_INFO(cnxString_ << "Connection closed");
@@ -1135,11 +1140,11 @@ void ClientConnection::close() {
     if (consumerStatsRequestTimer_) {
         consumerStatsRequestTimer_->cancel();
     }
-    for (ProducersMap::iterator it = producers_.begin(); it != producers_.end(); ++it) {
+    for (ProducersMap::iterator it = producers.begin(); it != producers.end(); ++it) {
         HandlerBase::handleDisconnection(ResultConnectError, shared_from_this(), it->second);
     }
 
-    for (ConsumersMap::iterator it = consumers_.begin(); it != consumers_.end(); ++it) {
+    for (ConsumersMap::iterator it = consumers.begin(); it != consumers.end(); ++it) {
         HandlerBase::handleDisconnection(ResultConnectError, shared_from_this(), it->second);
     }
 

--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -607,7 +607,6 @@ void ClientConnection::handleIncomingCommand() {
                     ProducersMap::iterator it = producers_.find(producerId);
                     if (it != producers_.end()) {
                         ProducerImplPtr producer = it->second.lock();
-                        producers_.erase(it);
                         lock.unlock();
 
                         if (producer) {
@@ -863,6 +862,7 @@ void ClientConnection::handleIncomingCommand() {
                     ProducersMap::iterator it = producers_.find(producerId);
                     if (it != producers_.end()) {
                         ProducerImplPtr producer = it->second.lock();
+                        producers_.erase(it);
                         lock.unlock();
 
                         if (producer) {

--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -607,6 +607,7 @@ void ClientConnection::handleIncomingCommand() {
                     ProducersMap::iterator it = producers_.find(producerId);
                     if (it != producers_.end()) {
                         ProducerImplPtr producer = it->second.lock();
+                        producers_.erase(it);
                         lock.unlock();
 
                         if (producer) {


### PR DESCRIPTION
### Motivation
(A) During a graceful shutdown, the broker sends CLOSE_PRODUCER / CLOSE_CONSUMER command to the client, which triggers the reconnection logic.
(B) After the connection is closed the ClientConnection.close() also triggers the reconnection logic for all registered consumers/producers.
If (A) doesn't complete before (B) then lookups and CREATE_PRODUCER / CREATE_CONSUMER commands are sent twice - this is not a functional issue because the broker returns success for the duplicate command but this leads a twice the required number of lookups.

### Modifications

Put all operation on the producers and consumers map (in ClientConnection) inside a lock.
Remove the consumer/producer from producers/consumers map if CLOSE_PRODUCER / CLOSE_CONSUMER command is received.

### Result

No functional change, lesser lookups.