### PR TITLE
Add empty check for subscription name

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.service.persistent;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.time.Instant;
 import java.time.ZoneId;
@@ -348,6 +349,14 @@ public class PersistentTopic implements Topic, AddEntryCallback {
             SubType subType, int priorityLevel, String consumerName, boolean isDurable, MessageId startMessageId) {
 
         final CompletableFuture<Consumer> future = new CompletableFuture<>();
+
+        if (isBlank(subscriptionName)) {
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] Empty subscription name", topic);
+            }
+            future.completeExceptionally(new NamingException("Empty subscription name"));
+            return future;
+        }
 
         if (hasBatchMessagePublished && !cnx.isBatchMessageCompatibleVersion()) {
             if (log.isDebugEnabled()) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -354,6 +354,25 @@ public class PersistentTopicTest {
     }
 
     @Test
+    public void testSubscribeFail() throws Exception {
+        PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
+
+        // Empty subscription name
+        CommandSubscribe cmd = CommandSubscribe.newBuilder().setConsumerId(1).setTopic(successTopicName)
+                .setSubscription("").setRequestId(1).setSubType(SubType.Exclusive).build();
+
+        Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
+                0, cmd.getConsumerName(), cmd.getDurable(), null);
+        try {
+            f1.get();
+            fail("should fail with exception");
+        } catch (ExecutionException ee) {
+            // Expected
+            assertTrue(ee.getCause() instanceof BrokerServiceException.NamingException);
+        }
+    }
+
+    @Test
     public void testSubscribeUnsubscribe() throws Exception {
         PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -449,6 +449,14 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         }
 
         try {
+            Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic7", "",
+                    consumerConf);
+            Assert.fail("Should fail");
+        } catch (PulsarClientException e) {
+            Assert.assertTrue(e instanceof PulsarClientException.InvalidConfigurationException);
+        }
+
+        try {
             Consumer consumer = pulsarClient.subscribe("invalid://topic7", "my-subscriber-name", consumerConf);
             Assert.fail("Should fail");
         } catch (PulsarClientException e) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -56,6 +56,8 @@ import io.netty.util.HashedWheelTimer;
 import io.netty.util.Timer;
 import io.netty.util.concurrent.DefaultThreadFactory;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
 public class PulsarClientImpl implements PulsarClient {
 
     private static final Logger log = LoggerFactory.getLogger(PulsarClientImpl.class);
@@ -233,9 +235,9 @@ public class PulsarClientImpl implements PulsarClient {
         if (!DestinationName.isValid(topic)) {
             return FutureUtil.failedFuture(new PulsarClientException.InvalidTopicNameException("Invalid topic name"));
         }
-        if (subscription == null) {
+        if (isBlank(subscription)) {
             return FutureUtil
-                    .failedFuture(new PulsarClientException.InvalidConfigurationException("Invalid subscription name"));
+                    .failedFuture(new PulsarClientException.InvalidConfigurationException("Empty subscription name"));
         }
         if (conf == null) {
             return FutureUtil.failedFuture(

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
@@ -267,6 +267,7 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
         checkArgument(parts.size() == 9, "Invalid topic name format");
         checkArgument(parts.get(1).equals("ws"));
         checkArgument(parts.get(3).equals("persistent"));
+        checkArgument(parts.get(8).length() > 0, "Empty subscription name");
 
         return parts.get(8);
     }


### PR DESCRIPTION
### Motivation
Subscription name can be empty for now.
It causes some problems.

(Indeed, recently we encountered sudden Broker stopping caused by large number of requests 　whose subscription name is empty through WebSocketProxy)

### Modifications
* Add empty check for subscription name to `PersistentTopic`, `PulsarClientImpl` and `ConsumerHandler`
* Add test cases for empty subscription name

### Result
* Subscription name can not be empty.
