### PR TITLE
Upgrdate JNA library to 4.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -340,6 +340,12 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
+        <groupId>net.java.dev.jna</groupId>
+        <artifactId>jna</artifactId>
+        <version>4.2.0</version>
+      </dependency>
+
+      <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
         <artifactId>jackson-jaxrs-json-provider</artifactId>
         <version>2.4.3</version>


### PR DESCRIPTION
### Motivation

BookKeeper is depending on JNA library and it's pulling in version 3.2.7. 

According to https://github.com/java-native-access/jna/blob/master/LICENSE versions before 4.0 are licensed through LGPL, while starting from 4.0 is double licensed Apache License 2.0 and LGPL.

### Modifications

Force to pick up latest version with Apache License.
