### PR TITLE
Fix: CPP release baseCommand after serializing it

### DIFF
--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -934,7 +934,7 @@ ClientConnection::newConsumerStats(uint64_t consumerId, uint64_t requestId) {
     }
     pendingConsumerStatsMap_.insert(std::make_pair(requestId, promise));
     lock.unlock();
-    sendCommand(Commands::newConsumerStats(outgoingCmd_, consumerId, requestId));
+    sendCommand(Commands::newConsumerStats(consumerId, requestId));
     return promise.getFuture();
 }
 
@@ -948,8 +948,8 @@ void ClientConnection::newTopicLookup(const std::string& destinationName, bool a
 void ClientConnection::newPartitionedMetadataLookup(const std::string& destinationName,
                                                     const uint64_t requestId,
                                                     LookupDataResultPromisePtr promise) {
-    newLookup(Commands::newPartitionMetadataRequest(destinationName, requestId), requestId,
-              promise);
+    newLookup(Commands::newPartitionMetadataRequest(destinationName, requestId),
+              requestId, promise);
 }
 
 void ClientConnection::newLookup(const SharedBuffer& cmd, const uint64_t requestId,

--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -941,14 +941,14 @@ ClientConnection::newConsumerStats(uint64_t consumerId, uint64_t requestId) {
 void ClientConnection::newTopicLookup(const std::string& destinationName, bool authoritative,
                                       const uint64_t requestId,
                                       LookupDataResultPromisePtr promise) {
-    newLookup(Commands::newLookup(outgoingCmd_, destinationName, authoritative, requestId),
+    newLookup(Commands::newLookup(destinationName, authoritative, requestId),
               requestId, promise);
 }
 
 void ClientConnection::newPartitionedMetadataLookup(const std::string& destinationName,
                                                     const uint64_t requestId,
                                                     LookupDataResultPromisePtr promise) {
-    newLookup(Commands::newPartitionMetadataRequest(outgoingCmd_, destinationName, requestId), requestId,
+    newLookup(Commands::newPartitionMetadataRequest(destinationName, requestId), requestId,
               promise);
 }
 

--- a/pulsar-client-cpp/lib/Commands.cc
+++ b/pulsar-client-cpp/lib/Commands.cc
@@ -29,9 +29,6 @@ namespace pulsar {
 
 using namespace pulsar::proto;
 
-static BaseCommand cmd;
-static boost::mutex mutex;
-
 DECLARE_LOG_OBJECT();
 
 SharedBuffer Commands::writeMessageWithSize(const BaseCommand& cmd) {
@@ -49,6 +46,8 @@ SharedBuffer Commands::writeMessageWithSize(const BaseCommand& cmd) {
 }
 
 SharedBuffer Commands::newPartitionMetadataRequest(const std::string& topic, uint64_t requestId) {
+    static BaseCommand cmd;
+    static boost::mutex mutex;
     mutex.lock();
     cmd.set_type(BaseCommand::PARTITIONED_METADATA);
     CommandPartitionedTopicMetadata* partitionMetadata = cmd.mutable_partitionmetadata();
@@ -62,6 +61,8 @@ SharedBuffer Commands::newPartitionMetadataRequest(const std::string& topic, uin
 
 SharedBuffer Commands::newLookup(const std::string& topic, const bool authoritative,
                                  uint64_t requestId) {
+    static BaseCommand cmd;
+    static boost::mutex mutex;
     mutex.lock();
     cmd.set_type(BaseCommand::LOOKUP);
     CommandLookupTopic* lookup = cmd.mutable_lookuptopic();
@@ -75,6 +76,8 @@ SharedBuffer Commands::newLookup(const std::string& topic, const bool authoritat
 }
 
 SharedBuffer Commands::newConsumerStats(uint64_t consumerId, uint64_t requestId) {
+    static BaseCommand cmd;
+    static boost::mutex mutex;
     mutex.lock();
     cmd.set_type(BaseCommand::CONSUMER_STATS);
     CommandConsumerStats* consumerStats = cmd.mutable_consumerstats();

--- a/pulsar-client-cpp/lib/Commands.cc
+++ b/pulsar-client-cpp/lib/Commands.cc
@@ -43,7 +43,8 @@ SharedBuffer Commands::writeMessageWithSize(const BaseCommand& cmd) {
     return buffer;
 }
 
-SharedBuffer Commands::newPartitionMetadataRequest(BaseCommand& cmd, const std::string& topic, uint64_t requestId) {
+SharedBuffer Commands::newPartitionMetadataRequest(const std::string& topic, uint64_t requestId) {
+    BaseCommand cmd;
     cmd.set_type(BaseCommand::PARTITIONED_METADATA);
     CommandPartitionedTopicMetadata* partitionMetadata = cmd.mutable_partitionmetadata();
     partitionMetadata->set_topic(topic);
@@ -51,8 +52,9 @@ SharedBuffer Commands::newPartitionMetadataRequest(BaseCommand& cmd, const std::
     return writeMessageWithSize(cmd);
 }
 
-SharedBuffer Commands::newLookup(BaseCommand& cmd, const std::string& topic, const bool authoritative,
+SharedBuffer Commands::newLookup(const std::string& topic, const bool authoritative,
                                  uint64_t requestId) {
+    BaseCommand cmd;
     cmd.set_type(BaseCommand::LOOKUP);
     CommandLookupTopic* lookup = cmd.mutable_lookuptopic();
     lookup->set_topic(topic);
@@ -66,7 +68,9 @@ SharedBuffer Commands::newConsumerStats(BaseCommand& cmd, uint64_t consumerId, u
     CommandConsumerStats* consumerStats = cmd.mutable_consumerstats();
     consumerStats->set_consumer_id(consumerId);
     consumerStats->set_request_id(requestId);
-    return writeMessageWithSize(cmd);
+    const SharedBuffer& buffer = writeMessageWithSize(cmd);
+    cmd.release_consumerstats();
+    return buffer;
 }
 
 PairSharedBuffer Commands::newSend(SharedBuffer& headers, BaseCommand& cmd,
@@ -137,6 +141,7 @@ PairSharedBuffer Commands::newSend(SharedBuffer& headers, BaseCommand& cmd,
         headers.setWriterIndex(writeIndex);
     }
 
+    cmd.release_send();
     return composite;
 }
 

--- a/pulsar-client-cpp/lib/Commands.h
+++ b/pulsar-client-cpp/lib/Commands.h
@@ -53,9 +53,9 @@ class Commands {
 
     static SharedBuffer newConnect(const AuthenticationPtr& authentication);
 
-    static SharedBuffer newPartitionMetadataRequest(proto::BaseCommand& cmd, const std::string& topic, uint64_t requestId);
+    static SharedBuffer newPartitionMetadataRequest(const std::string& topic, uint64_t requestId);
 
-    static SharedBuffer newLookup(proto::BaseCommand& cmd, const std::string& topic, const bool authoritative,
+    static SharedBuffer newLookup(const std::string& topic, const bool authoritative,
                                   uint64_t requestId);
 
     static PairSharedBuffer newSend(SharedBuffer& headers, proto::BaseCommand& cmd,

--- a/pulsar-client-cpp/lib/Commands.h
+++ b/pulsar-client-cpp/lib/Commands.h
@@ -93,7 +93,7 @@ class Commands {
 
     static Message deSerializeSingleMessageInBatch(Message& batchedMessage);
 
-    static SharedBuffer newConsumerStats(proto::BaseCommand& cmd, uint64_t consumerId, uint64_t requestId);
+    static SharedBuffer newConsumerStats(uint64_t consumerId, uint64_t requestId);
 
  private:
     Commands();


### PR DESCRIPTION
### Motivation

if `CmsClient` has created producers for batch and non-batch topics  then client shows invalid `msgRateIn` for non-batch topic.
**root cause:**
client-lib uses singleton `proto-BaseCommand` to get `send (cmd.mutable_send())` cmd. If application uses batch and non-batch producers then batch-producer sets `num_message` into the command and same command used by non-batch producer which picks up this stale invalid value and sends invalid `num_batch_msg` to broker for monitoring. 


### Modifications

- release command after serializing send-command to reset its value.
- for concurrent lookup requests : use new BaseCommand to create lookup-command.

### Result

- client sends correct num_batch_msg to broker
- make binary lookup threadsafe.
