### PR TITLE
Fix test : avoid multiple registration of zkClient-aspect in test

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ZooKeeperClientAspectJTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ZooKeeperClientAspectJTest.java
@@ -73,7 +73,9 @@ public class ZooKeeperClientAspectJTest {
     
     static {
         // load agent with aspectjweaver-Agent for testing
-        AgentLoader.loadAgentClass(Agent.class.getName(), null);
+        // maven-test waves advice on build-goal so, maven doesn't need explicit loading
+        // uncomment it while testing on eclipse: 
+        //AgentLoader.loadAgentClass(Agent.class.getName(), null);
     }
 
     @Test


### PR DESCRIPTION
### Motivation

we can close: #565 to avoid disabling test.

It seems ZKCleint aspect-advice (org.apache.pulsar.broker.zookeeper.aspectj.ClientCnxnAspect) gets registered multiple times: 
1. maven project-build 
2. test loads aspectj-agent 
and somewhere test is crashing due to that. 

**Fix:** avoid loading aspect-agent multiple times.

### Modifications

Avoid apsectj-agent loading in test.

### Result

prevents build failure.
