### PR TITLE
Publish website after commits on master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,4 +78,4 @@ deploy:
     skip_cleanup: true
     script: (cd site && make travis_publish)
     on:
-        branch: docs
+        branch: master


### PR DESCRIPTION
### Motivation

The travis configuration is still set to publish the generated website on the `docs` branch. This should be now changed to `master` 

### Result

Every commit on master, that creates a change in the website, will trigger the publishing of the new generated content.