### PR TITLE
Revert back to default ZookeeperClientFactoryImpl

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -64,7 +64,7 @@ import org.apache.pulsar.zookeeper.LocalZooKeeperCache;
 import org.apache.pulsar.zookeeper.LocalZooKeeperConnectionService;
 import org.apache.pulsar.zookeeper.ZooKeeperCache;
 import org.apache.pulsar.zookeeper.ZooKeeperClientFactory;
-import org.apache.pulsar.zookeeper.ZookeeperBkClientFactoryImpl;
+import org.apache.pulsar.zookeeper.ZookeeperClientFactoryImpl;
 import org.apache.zookeeper.ZooKeeper;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.slf4j.Logger;
@@ -561,7 +561,7 @@ public class PulsarService implements AutoCloseable {
 
     public ZooKeeperClientFactory getZooKeeperClientFactory() {
         if (zkClientFactory == null) {
-            zkClientFactory = new ZookeeperBkClientFactoryImpl();
+            zkClientFactory = new ZookeeperClientFactoryImpl();
         }
         // Return default factory
         return zkClientFactory;


### PR DESCRIPTION
### Motivation

Reverting back to default `ZookeeperClientFactoryImpl` to create ZkClient instead BK-ZkClient, until we fix #568 

### Result

It should not crash the jvm while running tests.
