### PR TITLE
Only deploy releases and website from apache/incubator-pulsar repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ deploy:
     skip_cleanup: true
     script: mvn install deploy -Prelease -DskipTests --settings .travis/settings.xml
     on:
+      repo: apache/incubator-pulsar
       tags: true
   -
     provider: releases
@@ -71,11 +72,12 @@ deploy:
     file_glob: true
     file: "all/target/pulsar-*.tar.gz"
     on:
-      repo: yahoo/pulsar
+      repo: apache/incubator-pulsar
       tags: true
   -
     provider: script
     skip_cleanup: true
     script: (cd site && make travis_publish)
     on:
+        repo: apache/incubator-pulsar
         branch: master


### PR DESCRIPTION
### Motivation

We should not attempt to publish the release binaries from any other fork of the original `apache/incubator-pulsar` repo.
