### PR TITLE
Use redirectTestOutputToFile in unit tests to reduce build output size

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -486,7 +486,7 @@ flexible messaging model and an intuitive client API.</description>
         <artifactId>aspectjweaver</artifactId>
         <version>${aspectj.version}</version>
       </dependency>
-      
+
       <dependency>
         <groupId>com.ea.agentloader</groupId>
         <artifactId>ea-agent-loader</artifactId>
@@ -544,10 +544,11 @@ flexible messaging model and an intuitive client API.</description>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.19.1</version>
+        <version>2.20</version>
         <configuration>
           <argLine> -Xmx2G -XX:MaxDirectMemorySize=8G
             -Dio.netty.leakDetectionLevel=advanced</argLine>
+          <redirectTestOutputToFile>true</redirectTestOutputToFile>
         </configuration>
       </plugin>
 

--- a/pulsar-broker/src/test/resources/log4j.properties
+++ b/pulsar-broker/src/test/resources/log4j.properties
@@ -28,7 +28,7 @@ log4j.rootLogger=OFF, CONSOLE
 log4j.logger.org.apache.zookeeper=OFF
 log4j.logger.org.apache.bookkeeper=OFF
 
-log4j.logger.org.apache.pulsar=OFF
+log4j.logger.org.apache.pulsar=INFO
 
 log4j.logger.org.testng.listener.TestListener=INFO
 


### PR DESCRIPTION
### Motivation

In several cases the console output on the Travis build is truncated because we exceed the max size.

We should redirect the tests output to files to reduce the text output. Also it gives the advantage of separating each test output into a separate file.