### PR TITLE
Fix API doc generation issue

### DIFF
--- a/site/Makefile
+++ b/site/Makefile
@@ -52,7 +52,7 @@ serve: clean_local
 		--config _config.yml,_config.local.yml
 
 javadoc:
-	rm -rf api
+	rm -rf api/{admin,client}
 	scripts/javadoc-gen.sh
 
 python_doc_gen:


### PR DESCRIPTION
### Motivation

At the moment, API docs for Java are showing up at pulsar.incubator.apache.org but API docs for Python and C++ are not. That seems to be because the `make javadoc` script is deleting the *whole* `site/api` directory rather than just the Java-specific subdirectories.

### Modifications

The `Makefile` in the `site` folder has been updated to fix the issue.

### Result

Generated API docs for C++ and Python should end up in `generated-site/content/api` (as part of the Jekyll build process) and then automatically committed to the `asf-site` branch.
