### PR TITLE
CPP Client - removed log statement from ClientImpl Destructor

### DIFF
--- a/pulsar-client-cpp/lib/ClientImpl.cc
+++ b/pulsar-client-cpp/lib/ClientImpl.cc
@@ -83,7 +83,6 @@ namespace pulsar {
     }
 
     ClientImpl::~ClientImpl() {
-        LOG_DEBUG("~ClientImpl");
         shutdown();
     }
 


### PR DESCRIPTION
As a part of #485 I had added this log statement in the destructor of ClientImpl, this causes core dump due to heap corruption in few environments during destruction.

@merlimat @msb-at-yahoo - Any idea why this behavior is so erratic? - works in some environments and doesn't work else where. 
Is there some concept I am unable to understand???