### PR TITLE
Local-policies cache should copy global-policy data and return combin…

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.service;
 
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
+import static org.apache.pulsar.broker.web.PulsarWebResource.joinPath;
 import static org.mockito.Mockito.anyObject;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -32,6 +33,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -48,7 +50,6 @@ import org.apache.pulsar.broker.service.BrokerServiceException;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.BrokerStats;
-import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.ClientConfiguration;
 import org.apache.pulsar.client.api.Consumer;
@@ -60,6 +61,8 @@ import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.auth.AuthenticationTls;
 import org.apache.pulsar.common.naming.DestinationName;
 import org.apache.pulsar.common.naming.NamespaceBundle;
+import org.apache.pulsar.common.policies.data.BundlesData;
+import org.apache.pulsar.common.policies.data.LocalPolicies;
 import org.apache.pulsar.common.policies.data.PersistentSubscriptionStats;
 import org.apache.pulsar.common.policies.data.PersistentTopicStats;
 import org.testng.annotations.AfterClass;
@@ -69,6 +72,7 @@ import org.testng.annotations.Test;
 import com.google.common.collect.Lists;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import static org.apache.pulsar.broker.cache.LocalZooKeeperCacheService.LOCAL_POLICIES_ROOT;
 
 /**
  */
@@ -823,5 +827,21 @@ public class BrokerServiceTest extends BrokerTestBase {
             executor.shutdownNow();
         }
     }
-    
+
+    /**
+     * It verifies that policiesCache() copies global-policy data into local-policy data and returns combined result
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testCreateNamespacePolicy() throws Exception {
+        final String namespace = "prop/use/testPolicy";
+        final int totalBundle = 3;
+        admin.namespaces().createNamespace(namespace, new BundlesData(totalBundle));
+        String globalPath = joinPath(LOCAL_POLICIES_ROOT, namespace);
+        pulsar.getLocalZkCacheService().policiesCache().clear();
+        Optional<LocalPolicies> policy = pulsar.getLocalZkCacheService().policiesCache().get(globalPath);
+        assertTrue(policy.isPresent());
+        assertEquals(policy.get().bundles.numBundles, totalBundle);
+    }
 }

--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZooKeeperDataCache.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZooKeeperDataCache.java
@@ -83,7 +83,7 @@ public abstract class ZooKeeperDataCache<T> implements Deserializer<T>, CacheUpd
      * @throws Exception
      */
     public Optional<T> get(final String path) throws Exception {
-        return getWithStat(path).map(Entry::getKey);
+        return getAsync(path).get();
     }
 
     public Optional<Entry<T, Stat>> getWithStat(final String path) throws Exception {


### PR DESCRIPTION
…ed result

### Motivation

after creating namespace, if we try to get `LocalZooKeeperCacheService.localPolicy()` then it gives below exception and doesn't create local-policy and doesn't give correct bundle-data

- `LocalZooKeeperCacheService.policyCache()` overrides `getAsync()` to combine global-policy + local-policy data. So, `ZookeeperDataCache` should use `getAsync()` in internal sync method such as `get()`


```
java.util.NoSuchElementException: No value present
	at java.util.Optional.get(Optional.java:135)
	at org.apache.pulsar.broker.cache.LocalZooKeeperCacheService.lambda$2(LocalZooKeeperCacheService.java:194)
	at java.util.concurrent.CompletableFuture.uniAccept(CompletableFuture.java:656)
	at java.util.concurrent.CompletableFuture.uniAcceptStage(CompletableFuture.java:669)
	at java.util.concurrent.CompletableFuture.thenAccept(CompletableFuture.java:1997)
	at org.apache.pulsar.broker.cache.LocalZooKeeperCacheService.createPolicies(LocalZooKeeperCacheService.java:186)
	at org.apache.pulsar.broker.cache.LocalZooKeeperCacheService$2.lambda$0(LocalZooKeeperCacheService.java:91)
	at java.util.concurrent.CompletableFuture.uniAccept(CompletableFuture.java:656)
	at java.util.concurrent.CompletableFuture.uniAcceptStage(CompletableFuture.java:669)
	at java.util.concurrent.CompletableFuture.thenAccept(CompletableFuture.java:1997)
	at org.apache.pulsar.broker.cache.LocalZooKeeperCacheService$2.getAsync(LocalZooKeeperCacheService.java:86)
	at org.apache.pulsar.common.naming.NamespaceBundleFactory.lambda$0(NamespaceBundleFactory.java:80)
	at com.github.benmanes.caffeine.cache.LocalAsyncLoadingCache.lambda$get$2(LocalAsyncLoadingCache.java:126)
```

### Result

`LocalZooKeeperCacheService.localPolicy()` should returns correct result and create `local-policy` znode.
