### PR TITLE
Enable Apache rat in CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ install:
 
 script:
     # Build Java and C++
-    - mvn license:check test package && sudo bash -x $TRAVIS_BUILD_DIR/pulsar-client-cpp/travis-build.sh $HOME/pulsar-dep $TRAVIS_BUILD_DIR compile
+    - mvn license:check apache-rat:check test package && sudo bash -x $TRAVIS_BUILD_DIR/pulsar-client-cpp/travis-build.sh $HOME/pulsar-dep $TRAVIS_BUILD_DIR compile
     # Build docker images
     - docker/build.sh
     # Generate website

--- a/pom.xml
+++ b/pom.xml
@@ -640,6 +640,13 @@ flexible messaging model and an intuitive client API.</description>
             <exclude>**/*.hgrm</exclude>
             <exclude>**/*.test</exclude>
 
+            <!-- Other license files -->
+            <exclude>licenses/LICENSE-*.txt</exclude>
+            <exclude>src/assemble/README.bin.txt</exclude>
+
+            <!-- Exclude site since it's not released -->
+            <exclude>**/site/**</exclude>
+
             <exclude>**/*.patch</exclude>
             <exclude>**/*.md</exclude>
 

--- a/pulsar-client-cpp/Doxyfile
+++ b/pulsar-client-cpp/Doxyfile
@@ -1,3 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 # Doxyfile 1.8.14
 
 # This file describes the settings to be used by the documentation system


### PR DESCRIPTION
### Motivation

Enable Apache RAT check in CI builds to check for license compliance.

