### PR TITLE
Added links to the Slack channel in website

### DIFF
--- a/site/_includes/navbar.html
+++ b/site/_includes/navbar.html
@@ -75,7 +75,7 @@
         </a>
         <div class="dropdown-menu" aria-labelledby="versionsDropdown">
           <h3 class="dropdown-header">Get in touch</h3>
-          <a class="dropdown-item" href="{{ site.baseurl }}mailing-lists">Mailing Lists</a>
+          <a class="dropdown-item" href="{{ site.baseurl }}contact">Contact</a>
           <a class="dropdown-item" href="https://twitter.com/Apache_Pulsar">Twitter</a>
           <a class="dropdown-item" href="https://github.com/apache/incubator-pulsar/wiki">Wiki</a>
           <a class="dropdown-item" href="https://github.com/apache/incubator-pulsar/issues">Issue tracking</a>

--- a/site/contact.md
+++ b/site/contact.md
@@ -1,5 +1,5 @@
 ---
-title: Mailing lists
+title: Contact
 layout: content
 ---
 
@@ -7,8 +7,18 @@ layout: content
 There are many ways to get help from the Apache Pulsar community. The mailing lists are the primary place where all Pulsar committers are present. Bugs and feature requests can either be discussed
 on the dev mailing list or by opening an issue on [GitHub]({{ site.pulsar_repo }}).
 
+## Mailing Lists
+
 Name | Scope |  |  |  |
 :----|:------|:-|:-|:-|
 **users@pulsar.incubator.apache.org**   | User-related discussions        |  [Subscribe](mailto:users-subscribe@pulsar.incubator.apache.org)  |  [Unsubscribe](mailto:users-unsubscribe@pulsar.incubator.apache.org)  |  [Archives](http://mail-archives.apache.org/mod_mbox/incubator-pulsar-users/)  |
 **dev@pulsar.incubator.apache.org**     | Development-related discussions |   [Subscribe](mailto:dev-subscribe@pulsar.incubator.apache.org)   |   [Unsubscribe](mailto:dev-unsubscribe@pulsar.incubator.apache.org)   |   [Archives](http://mail-archives.apache.org/mod_mbox/incubator-pulsar-dev/)   |
 **commits@pulsar.incubator.apache.org** | All commits to the Pulsar repository   | [Subscribe](mailto:commits-subscribe@pulsar.incubator.apache.org) | [Unsubscribe](mailto:commits-unsubscribe@pulsar.incubator.apache.org) | [Archives](http://mail-archives.apache.org/mod_mbox/incubator-pulsar-commits/) |
+
+## Slack
+
+There is a Pulsar slack channel that is used for informal discussions for devs and users.
+
+The Slack instance is at https://apache-pulsar.slack.com/
+
+You can self-register at https://apache-pulsar.herokuapp.com/


### PR DESCRIPTION
### Motivation

Renamed "mailing list" into "contact" page and added Slack channel info. 
cc/ @lucperkins 