### PR TITLE
Use PrometheusMetricsProvider by default in bookies

### DIFF
--- a/conf/bookkeeper.conf
+++ b/conf/bookkeeper.conf
@@ -298,9 +298,9 @@ writeBufferSizeBytes=65536
 useHostNameAsBookieID=false
 
 # Stats Provider Class
-statsProviderClass=org.apache.bokkeeper.stats.datasketches.DataSketchesMetricsProvider
-dataSketchesMetricsJsonFileReporter=data/bookie-stats.json
-dataSketchesMetricsUpdateIntervalSeconds=60
+statsProviderClass=org.apache.bokkeeper.stats.PrometheusMetricsProvider
+# Default port for Prometheus metrics exporter
+prometheusStatsHttpPort=8000
 
 
 ## DB Ledger storage configuration

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
@@ -148,7 +148,7 @@ public class PulsarStandaloneStarter {
 
         if (!onlyBroker) {
             // Start LocalBookKeeper
-            bkEnsemble = new LocalBookkeeperEnsemble(numOfBk, zkPort, bkPort, zkDir, bkDir, true, wipeData);
+            bkEnsemble = new LocalBookkeeperEnsemble(numOfBk, zkPort, bkPort, zkDir, bkDir, wipeData);
             bkEnsemble.start();
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
@@ -148,7 +148,7 @@ public class PulsarStandaloneStarter {
 
         if (!onlyBroker) {
             // Start LocalBookKeeper
-            bkEnsemble = new LocalBookkeeperEnsemble(numOfBk, zkPort, bkPort, zkDir, bkDir, wipeData);
+            bkEnsemble = new LocalBookkeeperEnsemble(numOfBk, zkPort, bkPort, zkDir, bkDir, true, wipeData);
             bkEnsemble.start();
         }
 
@@ -158,7 +158,7 @@ public class PulsarStandaloneStarter {
 
         // load aspectj-weaver agent for instrumentation
         AgentLoader.loadAgentClass(Agent.class.getName(), null);
-        
+
         // Start Broker
         broker = new PulsarService(config);
         broker.start();

--- a/pulsar-zookeeper-utils/pom.xml
+++ b/pulsar-zookeeper-utils/pom.xml
@@ -46,12 +46,7 @@
 
     <dependency>
       <groupId>org.apache.bookkeeper.stats</groupId>
-      <artifactId>datasketches-metrics-provider</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-common</artifactId></exclusion>
-      </exclusions>
+      <artifactId>prometheus-metrics-provider</artifactId>
     </dependency>
 
     <dependency>

--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
@@ -85,14 +85,16 @@ public class LocalBookkeeperEnsemble {
 
     int numberOfBookies;
     private boolean clearOldData = false;
+    private boolean isStandaloneMode = false;
 
     public LocalBookkeeperEnsemble(int numberOfBookies, int zkPort, int bkBasePort) {
-        this(numberOfBookies, zkPort, bkBasePort, null, null, true);
+        this(numberOfBookies, zkPort, bkBasePort, null, null, false, true);
     }
 
     public LocalBookkeeperEnsemble(int numberOfBookies, int zkPort, int bkBasePort, String zkDataDirName,
-            String bkDataDirName, boolean clearOldData) {
+            String bkDataDirName, boolean isStandaloneMode, boolean clearOldData) {
         this.numberOfBookies = numberOfBookies;
+        this.isStandaloneMode = isStandaloneMode;
         this.HOSTPORT = "127.0.0.1:" + zkPort;
         this.ZooKeeperDefaultPort = zkPort;
         this.initialPort = bkBasePort;
@@ -203,7 +205,7 @@ public class LocalBookkeeperEnsemble {
             // Initialize Stats Provider only if we're running with 1 single bookie
             // to avoid port conflicts
             StatsLogger statsLogger;
-            if (numberOfBookies == 1) {
+            if (isStandaloneMode && numberOfBookies == 1) {
                 statsProviders[i] = new PrometheusMetricsProvider();
                 statsProviders[i].start(bsConfs[i]);
                 statsLogger = statsProviders[i].getStatsLogger("");

--- a/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsembleTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsembleTest.java
@@ -83,7 +83,7 @@ public class LocalBookkeeperEnsembleTest {
 
         // Start local Bookies/ZooKeepers and confirm that specified data directories are created
         LocalBookkeeperEnsemble ensemble1 = new LocalBookkeeperEnsemble(numBk, zkPort, bkPort, zkDirName, bkDirName,
-                true);
+                false, true);
         ensemble1.start();
         assertTrue(zkDir.exists());
         assertTrue(bkDir.exists());
@@ -91,7 +91,7 @@ public class LocalBookkeeperEnsembleTest {
 
         // Restart local Bookies/ZooKeepers without refreshing data
         LocalBookkeeperEnsemble ensemble2 = new LocalBookkeeperEnsemble(numBk, zkPort, bkPort, zkDirName, bkDirName,
-                false);
+                false, false);
         ensemble2.start();
         assertTrue(ensemble2.getZkServer().isRunning());
         assertEquals(ensemble2.getZkServer().getClientPort(), zkPort);

--- a/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsembleTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsembleTest.java
@@ -83,7 +83,7 @@ public class LocalBookkeeperEnsembleTest {
 
         // Start local Bookies/ZooKeepers and confirm that specified data directories are created
         LocalBookkeeperEnsemble ensemble1 = new LocalBookkeeperEnsemble(numBk, zkPort, bkPort, zkDirName, bkDirName,
-                false, true);
+                true);
         ensemble1.start();
         assertTrue(zkDir.exists());
         assertTrue(bkDir.exists());
@@ -91,7 +91,7 @@ public class LocalBookkeeperEnsembleTest {
 
         // Restart local Bookies/ZooKeepers without refreshing data
         LocalBookkeeperEnsemble ensemble2 = new LocalBookkeeperEnsemble(numBk, zkPort, bkPort, zkDirName, bkDirName,
-                false, false);
+                false);
         ensemble2.start();
         assertTrue(ensemble2.getZkServer().isRunning());
         assertEquals(ensemble2.getZkServer().getClientPort(), zkPort);

--- a/site/_data/config/bookkeeper.yaml
+++ b/site/_data/config/bookkeeper.yaml
@@ -198,11 +198,9 @@ configs:
   description: |
     Whether the bookie should use its hostname to register with the coordination service (e.g.: zookeeper service). When `false`, bookie will use its ipaddress for the registration.
 - name: statsProviderClass
-  default: org.apache.bokkeeper.stats.datasketches.DataSketchesMetricsProvider
-- name: dataSketchesMetricsJsonFileReporter
-  default: data/bookie-stats.json
-- name: dataSketchesMetricsUpdateIntervalSeconds
-  default: '60'
+  default: org.apache.bokkeeper.stats.PrometheusMetricsProvider
+- name: prometheusStatsHttpPort
+  default: 8000
 - name: dbStorage_writeCacheMaxSizeMb
   default: '512'
   description: |


### PR DESCRIPTION
### Motivation

Since we're already exposing the metrics with Prometheus for broker and ZK, we should do the same thing by default also for bookies.