### PR TITLE
Fix variable name in Authentication Class in pulsar.py

### DIFF
--- a/pulsar-client-cpp/python/pulsar.py
+++ b/pulsar-client-cpp/python/pulsar.py
@@ -158,7 +158,7 @@ class Authentication:
         * `authParamsString`: Comma-separated list of provider-specific
           configuration params
         """
-        self._auth = _pulsar.Authentication(dynamicLibPath, authParamsString)
+        self.auth = _pulsar.Authentication(dynamicLibPath, authParamsString)
 
 
 class Client:


### PR DESCRIPTION
### Motivation

I got an error like following when using authentication on python client.
```
Traceback (most recent call last):
  File "test_producer.py", line 27, in <module>
    authentication = athenz)
  File "/path/to/pulsar-client-cpp/python/pulsar.py", line 221, in __init__
    conf.authentication(authentication.auth)
AttributeError: Authentication instance has no attribute 'auth'
```

### Modifications

Replaced _auth with auth in Authentication class in pulsar.py

### Result
The error is resolved.
