### PR TITLE
Reduce memory usage in producer and subscriptions maps

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -160,9 +160,9 @@ public class NonPersistentTopic implements Topic {
     public NonPersistentTopic(String topic, BrokerService brokerService) {
         this.topic = topic;
         this.brokerService = brokerService;
-        this.producers = new ConcurrentOpenHashSet<Producer>();
-        this.subscriptions = new ConcurrentOpenHashMap<>();
-        this.replicators = new ConcurrentOpenHashMap<>();
+        this.producers = new ConcurrentOpenHashSet<Producer>(16, 1);
+        this.subscriptions = new ConcurrentOpenHashMap<>(16, 1);
+        this.replicators = new ConcurrentOpenHashMap<>(16, 1);
         this.isFenced = false;
         this.replicatorPrefix = brokerService.pulsar().getConfiguration().getReplicatorPrefix();
         this.executor = brokerService.getTopicOrderedExecutor();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -180,9 +180,9 @@ public class PersistentTopic implements Topic, AddEntryCallback {
         this.topic = topic;
         this.ledger = ledger;
         this.brokerService = brokerService;
-        this.producers = new ConcurrentOpenHashSet<Producer>();
-        this.subscriptions = new ConcurrentOpenHashMap<>();
-        this.replicators = new ConcurrentOpenHashMap<>();
+        this.producers = new ConcurrentOpenHashSet<Producer>(16, 1);
+        this.subscriptions = new ConcurrentOpenHashMap<>(16, 1);
+        this.replicators = new ConcurrentOpenHashMap<>(16, 1);
         this.isFenced = false;
         this.replicatorPrefix = brokerService.pulsar().getConfiguration().getReplicatorPrefix();
         USAGE_COUNT_UPDATER.set(this, 0);


### PR DESCRIPTION
### Motivation

In the topic object, we're creating a map to reference producers, subscriptions and replicators. This map is not heavily contented and in most cases it would have far less than 256 items on it. 

### Modifications

Reduce the expected items from the default of 256 to 16 and use a single hash-table section instead of default of 16.