### PR TITLE
Allow to compile C++ client lib in debug mode

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -23,13 +23,24 @@ project (pulsar-cpp)
 option(LINK_STATIC "Link against static libraries" OFF)
 MESSAGE(STATUS "LINK_STATIC:  " ${LINK_STATIC})
 
+option(DEBUG_MODE "Enable debug mode" OFF)
+MESSAGE(STATUS "DEBUG_MODE:  " ${DEBUG_MODE})
+
 set(Boost_NO_BOOST_CMAKE ON)
 
 if (NOT CXX_STANDARD)
     set(CXX_STANDARD "-std=c++11")
 endif(NOT CXX_STANDARD)
 
-set(CMAKE_CXX_FLAGS "-O3 -g -Wno-deprecated-declarations ${CXX_STANDARD} ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS " -msse4.2 -mpclmul -Wno-deprecated-declarations ${CXX_STANDARD} ${CMAKE_CXX_FLAGS}")
+
+if (DEBUG_MODE)
+    set(CMAKE_CXX_FLAGS "-O0 -g3 ${CMAKE_CXX_FLAGS}")
+else ()
+    set(CMAKE_CXX_FLAGS "-O3 -g ${CMAKE_CXX_FLAGS}")
+endif (DEBUG_MODE)
+
+
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 set(PROTOBUF_LIBRARIES $ENV{PROTOBUF_LIBRARIES})

--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -23,8 +23,11 @@ project (pulsar-cpp)
 option(LINK_STATIC "Link against static libraries" OFF)
 MESSAGE(STATUS "LINK_STATIC:  " ${LINK_STATIC})
 
-option(DEBUG_MODE "Enable debug mode" OFF)
-MESSAGE(STATUS "DEBUG_MODE:  " ${DEBUG_MODE})
+IF (CMAKE_BUILD_TYPE STREQUAL "")
+    set(CMAKE_BUILD_TYPE RelWithDebInfo)
+ENDIF ()
+
+MESSAGE(STATUS "CMAKE_BUILD_TYPE:  " ${CMAKE_BUILD_TYPE})
 
 set(Boost_NO_BOOST_CMAKE ON)
 
@@ -33,13 +36,6 @@ if (NOT CXX_STANDARD)
 endif(NOT CXX_STANDARD)
 
 set(CMAKE_CXX_FLAGS " -msse4.2 -mpclmul -Wno-deprecated-declarations ${CXX_STANDARD} ${CMAKE_CXX_FLAGS}")
-
-if (DEBUG_MODE)
-    set(CMAKE_CXX_FLAGS "-O0 -g3 ${CMAKE_CXX_FLAGS}")
-else ()
-    set(CMAKE_CXX_FLAGS "-O3 -g ${CMAKE_CXX_FLAGS}")
-endif (DEBUG_MODE)
-
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 

--- a/pulsar-client-cpp/docker-build.sh
+++ b/pulsar-client-cpp/docker-build.sh
@@ -20,8 +20,6 @@
 
 # Build Pulsar C++ client within a Docker container
 
-ARGS=$*
-
 # Fail script in case of errors
 set -e
 
@@ -43,4 +41,4 @@ DOCKER_CMD="docker run -i -v $ROOT_DIR:/pulsar $IMAGE"
 find . -name CMakeCache.txt | xargs rm -f
 find . -name CMakeFiles | xargs rm -rf
 
-$DOCKER_CMD bash -c "cd /pulsar/pulsar-client-cpp && cmake . $ARGS && make"
+$DOCKER_CMD bash -c "cd /pulsar/pulsar-client-cpp && cmake . $CMAKE_ARGS && make"

--- a/pulsar-client-cpp/docker-build.sh
+++ b/pulsar-client-cpp/docker-build.sh
@@ -20,6 +20,8 @@
 
 # Build Pulsar C++ client within a Docker container
 
+ARGS=$*
+
 # Fail script in case of errors
 set -e
 
@@ -41,4 +43,4 @@ DOCKER_CMD="docker run -i -v $ROOT_DIR:/pulsar $IMAGE"
 find . -name CMakeCache.txt | xargs rm -f
 find . -name CMakeFiles | xargs rm -rf
 
-$DOCKER_CMD bash -c 'cd /pulsar/pulsar-client-cpp && cmake . && make'
+$DOCKER_CMD bash -c "cd /pulsar/pulsar-client-cpp && cmake . $ARGS && make"

--- a/pulsar-client-cpp/lib/CMakeLists.txt
+++ b/pulsar-client-cpp/lib/CMakeLists.txt
@@ -6,9 +6,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -20,7 +20,7 @@
 file(GLOB PULSAR_SOURCES *.cc lz4/*.c checksum/*.cc stats/*.cc)
 
 execute_process(COMMAND cat ../pom.xml COMMAND xmllint --format - COMMAND sed "s/xmlns=\".*\"//g" COMMAND xmllint --stream --pattern /project/version --debug - COMMAND grep -A 2 "matches pattern" COMMAND grep text COMMAND sed "s/.* [0-9] //g" OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE PV)
-set (CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -msse4.2 -mpclmul -D_PULSAR_VERSION_=\\\"${PV}\\\"")
+set (CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -D_PULSAR_VERSION_=\\\"${PV}\\\"")
 
 # Protobuf generation is only supported natively starting from CMake 3.8
 # Using custom command for now


### PR DESCRIPTION
### Motivation

Allow to compile C++ code in debug mode by adding `-DDEBUG_MODE=ON` when invoking CMake.

Additionally, when compiling in CI for PRs validation, we can use debug mode to reduce compilation time, since `-O3` can be very slow.