### PR TITLE
Don't attach pulsar-*-{src,bin}.tar.gz to maven artifacts

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -100,7 +100,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.6</version>
         <executions>
           <execution>
             <id>distro-assembly</id>
@@ -109,6 +108,7 @@
               <goal>single</goal>
             </goals>
             <configuration>
+              <attach>false</attach>
               <tarLongFileMode>posix</tarLongFileMode>
               <finalName>apache-pulsar-${project.version}</finalName>
               <descriptors>


### PR DESCRIPTION
### Motivation

Currently, the src and bin distribution archives are getting attached as maven artifacts and thus deployed and uploaded on the maven repo. That is not necessary, since these archives are not meant to be download from maven.

Setting `attach=false` should fix this and avoid copying the 40Mb file multiple times.