### PR TITLE
Reduce memory settings for LocalBookieEsemble in tests mode

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
@@ -149,7 +149,7 @@ public class PulsarStandaloneStarter {
         if (!onlyBroker) {
             // Start LocalBookKeeper
             bkEnsemble = new LocalBookkeeperEnsemble(numOfBk, zkPort, bkPort, zkDir, bkDir, wipeData);
-            bkEnsemble.start();
+            bkEnsemble.startStandalone();
         }
 
         if (noBroker) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -85,6 +85,7 @@ public abstract class MockedPulsarServiceBaseTest {
         this.conf.setWebServicePortTls(BROKER_WEBSERVICE_PORT_TLS);
         this.conf.setClusterName("test");
         this.conf.setAdvertisedAddress("localhost"); // there are TLS tests in here, they need to use localhost because of the certificate
+        this.conf.setManagedLedgerCacheSizeMB(8);
     }
 
     protected final void internalSetup() throws Exception {

--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
@@ -206,8 +206,25 @@ public class LocalBookkeeperEnsemble {
         LOG.debug("Local ZK/BK starting ...");
         ServerConfiguration conf = new ServerConfiguration();
         conf.setLedgerManagerFactoryClassName("org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory");
+        // Use minimal configuration requiring less memory for unit tests
         conf.setLedgerStorageClass(DbLedgerStorage.class.getName());
-        conf.setProperty("dbStorage_rocksDBEnabled", true);
+        conf.setProperty("dbStorage_writeCacheMaxSizeMb", 2);
+        conf.setProperty("dbStorage_readAheadCacheMaxSizeMb", 1);
+        conf.setProperty("dbStorage_rocksDB_writeBufferSizeMB", 1);
+        conf.setProperty("dbStorage_rocksDB_blockCacheSize", 1024 * 1024);
+        conf.setFlushInterval(60000);
+        conf.setProperty("journalMaxGroupWaitMSec", 0L);
+
+        runZookeeper(1000);
+        initializeZookeper();
+        runBookies(conf);
+    }
+
+    public void startStandalone() throws Exception {
+        LOG.debug("Local ZK/BK starting ...");
+        ServerConfiguration conf = new ServerConfiguration();
+        conf.setLedgerManagerFactoryClassName("org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory");
+        conf.setLedgerStorageClass(DbLedgerStorage.class.getName());
         conf.setProperty("dbStorage_writeCacheMaxSizeMb", 256);
         conf.setProperty("dbStorage_readAheadCacheMaxSizeMb", 64);
         conf.setFlushInterval(60000);


### PR DESCRIPTION
### Motivation

Reduce the amount of memory used for cache during the unit tests execution.