### PR TITLE
remove duplicate dynamic-config listener call

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1035,17 +1035,6 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
      */
     public <T> void registerConfigurationListener(String configKey, Consumer<T> listener) {
         configRegisteredListeners.put(configKey, listener);
-        dynamicConfigurationCache.registerListener(new ZooKeeperCacheListener<Map<String, String>>() {
-            @SuppressWarnings("unchecked")
-            @Override
-            public void onUpdate(String path, Map<String, String> data, Stat stat) {
-                if (BROKER_SERVICE_CONFIGURATION_PATH.equalsIgnoreCase(path) && data != null
-                        && data.containsKey(configKey)) {
-                    log.info("Updating configuration {}/{}", configKey, data.get(configKey));
-                    listener.accept((T) FieldParser.value(data.get(configKey), dynamicConfigurationMap.get(configKey)));
-                }
-            }
-        });
     }
 
     private void updateDynamicServiceConfiguration() {


### PR DESCRIPTION
### Motivation

right now, dynamic-config listener was being registered twice  in `configRegisteredListeners-map` and `ZooKeeperDataCache(dynamicConfigurationCache)` therefore, every listener was being called twice which can create issue if config-change is not idempotent.

### Modifications

Remove multiple listener registration.

### Result

Dynamic-config listener will be called only once.
