### PR TITLE
Add subscription-type argument into test

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -34,6 +34,8 @@ import org.apache.pulsar.client.api.ConsumerConfiguration;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageListener;
 import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.SubscriptionType;
+
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.common.naming.DestinationName;
 import org.slf4j.Logger;
@@ -71,6 +73,9 @@ public class PerformanceConsumer {
 
         @Parameter(names = { "-s", "--subscriber-name" }, description = "Subscriber name prefix")
         public String subscriberName = "sub";
+        
+        @Parameter(names = { "-st", "--subscription-type" }, description = "Subscriber name prefix")
+        public SubscriptionType subscriptionType = SubscriptionType.Exclusive;
 
         @Parameter(names = { "-r", "--rate" }, description = "Simulate a slow message consumer (rate in msg/s)")
         public double rate = 0;
@@ -182,6 +187,7 @@ public class PerformanceConsumer {
         ConsumerConfiguration consumerConfig = new ConsumerConfiguration();
         consumerConfig.setMessageListener(listener);
         consumerConfig.setReceiverQueueSize(arguments.receiverQueueSize);
+        consumerConfig.setSubscriptionType(arguments.subscriptionType);
 
         for (int i = 0; i < arguments.numDestinations; i++) {
             final DestinationName destinationName = (arguments.numDestinations == 1) ? prefixDestinationName


### PR DESCRIPTION
### Motivation

Many times, there is a need to test perf-consumer with different subscription other than `Exclusive` as broker has two different code-base for `Exclusive` and `Shared`. Right now, perf-consumer can be started only with Exclusive sub-type.
### Modifications

Subscription-type can be passed as an argument.

### Result

Perf-consumer can support multiple subscription type.
