### PR TITLE
Removed required maven version from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,10 +72,6 @@ flexible messaging model and an intuitive client API.</description>
     <url>https://travis-ci.org/apache/incubator-pulsar</url>
   </ciManagement>
 
-  <prerequisites>
-    <maven>3.3</maven>
-  </prerequisites>
-
   <modules>
     <module>managed-ledger</module>
     <module>pulsar-common</module>


### PR DESCRIPTION
### Motivation

There is a warning in the maven build about the required maven version which only applies to maven plugins and not to general maven applications.

```
[WARNING] The project org.apache.pulsar:pulsar:pom:1.20.0-incubating-SNAPSHOT uses 
prerequisites which is only intended for maven-plugin projects but not for non maven-plugin 
projects. For such purposes you should use the maven-enforcer-plugin. See 
https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html
```