### PR TITLE
Added missing copyright notice for Circe library

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -4,3 +4,8 @@ Copyright 2017 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+----------------------------------------------------------------------------------------------------
+
+Circe CRC library
+Copyright 2014 Trevor Robinson


### PR DESCRIPTION
### Motivation

As it was pointed out in ASF incubator mailing list, we are missing to mention the copyright notice for the Circe library that we bundle in our source tree.