### PR TITLE
Ensure the Python client works with Python-3

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -83,9 +83,24 @@ else()
     find_path(LOG4CXX_INCLUDE_PATH log4cxx/logger.h)
 endif (LINK_STATIC)
 
-find_package(Boost REQUIRED COMPONENTS program_options filesystem regex
-                                        thread system python)
+
 find_package(PythonLibs REQUIRED)
+
+
+MESSAGE(STATUS "PYTHON: " ${PYTHONLIBS_VERSION_STRING})
+
+if (PYTHONLIBS_VERSION_STRING MATCHES "^3.+$")
+    MESSAGE(STATUS "DETECTED Python 3")
+    # For python3 the lib name is boost_python3
+    set(BOOST_PYTHON_NAME python3)
+else ()
+    # Regular boost_python
+    set(BOOST_PYTHON_NAME python)
+endif ()
+
+find_package(Boost REQUIRED COMPONENTS program_options filesystem regex
+                    thread system ${BOOST_PYTHON_NAME})
+
 
 
 find_package(OpenSSL REQUIRED)

--- a/pulsar-client-cpp/lib/stats/ProducerStatsImpl.h
+++ b/pulsar-client-cpp/lib/stats/ProducerStatsImpl.h
@@ -23,6 +23,8 @@
 #include <pulsar/Message.h>
 #include <map>
 #include <lib/ExecutorService.h>
+
+#include <boost/serialization/array_wrapper.hpp>
 #include <boost/accumulators/framework/features.hpp>
 
 #include <boost/accumulators/accumulators.hpp>

--- a/pulsar-client-cpp/lib/stats/ProducerStatsImpl.h
+++ b/pulsar-client-cpp/lib/stats/ProducerStatsImpl.h
@@ -24,7 +24,9 @@
 #include <map>
 #include <lib/ExecutorService.h>
 
-#include <boost/serialization/array_wrapper.hpp>
+#if BOOST_VERSION >= 106400
+  #include <boost/serialization/array_wrapper.hpp>
+#endif
 #include <boost/accumulators/framework/features.hpp>
 
 #include <boost/accumulators/accumulators.hpp>

--- a/pulsar-client-cpp/python/CMakeLists.txt
+++ b/pulsar-client-cpp/python/CMakeLists.txt
@@ -6,9 +6,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -30,8 +30,8 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 endif()
 
 if (APPLE)
-    target_link_libraries(_pulsar -Wl,-all_load pulsarStatic ${Boost_PYTHON_LIBRARY})
+    target_link_libraries(_pulsar -Wl,-all_load pulsarStatic ${Boost_PYTHON_LIBRARY} ${Boost_PYTHON3_LIBRARY})
 else ()
     set (CMAKE_SHARED_LINKER_FLAGS " -static-libgcc  -static-libstdc++")
-    target_link_libraries(_pulsar pulsarStatic ${Boost_PYTHON_LIBRARY})
+    target_link_libraries(_pulsar pulsarStatic ${Boost_PYTHON_LIBRARY} ${Boost_PYTHON3_LIBRARY})
 endif ()

--- a/pulsar-client-cpp/python/pulsar.py
+++ b/pulsar-client-cpp/python/pulsar.py
@@ -234,7 +234,7 @@ class Client:
 
     def create_producer(self, topic,
                         send_timeout_millis=30000,
-                        compression_type=CompressionType.None,
+                        compression_type=CompressionType.NONE,
                         max_pending_messages=1000,
                         block_if_queue_full=False,
                         batching_enabled=False,
@@ -414,7 +414,7 @@ class Producer:
 
             #!python
             def callback(res, msg):
-                print 'Message published:', res
+                print('Message published: %s' % res)
 
             producer.send_async(msg, callback)
 

--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -33,7 +33,7 @@ class PulsarTest(TestCase):
         conf.send_timeout_millis(12)
         self.assertEqual(conf.send_timeout_millis(), 12)
 
-        self.assertEqual(conf.compression_type(), CompressionType.None)
+        self.assertEqual(conf.compression_type(), CompressionType.NONE)
         conf.compression_type(CompressionType.LZ4)
         self.assertEqual(conf.compression_type(), CompressionType.LZ4)
 
@@ -100,7 +100,7 @@ class PulsarTest(TestCase):
         received_messages = []
 
         def listener(consumer, msg):
-            print "Got message", msg
+            print("Got message: %s" % msg)
             received_messages.append(msg)
             consumer.acknowledge(msg)
 

--- a/pulsar-client-cpp/python/setup.py
+++ b/pulsar-client-cpp/python/setup.py
@@ -34,7 +34,7 @@ def get_version():
     if error:
         raise 'Failed to get version: ' + error
 
-    return str(output.strip())
+    return output.strip().decode('utf-8', 'strict')
 
 
 VERSION = get_version()

--- a/pulsar-client-cpp/python/src/enums.cc
+++ b/pulsar-client-cpp/python/src/enums.cc
@@ -29,7 +29,7 @@ void export_enums() {
             ;
 
     enum_<CompressionType>("CompressionType")
-            .value("None", CompressionNone)
+            .value("NONE", CompressionNone) // Don't use 'None' since it's a keyword in py3
             .value("LZ4", CompressionLZ4)
             .value("ZLib", CompressionZLib)
             ;


### PR DESCRIPTION
### Motivation

In 1.19, we've added support for Python client library (based on wrapping the C++ Pulsar client lib). 

The initial version was only working on Python-2.7. We need to do some small adjustments to make it working for Python3 as well. 

