### PR TITLE
CPP Client - Fixed MAC build errors, due to undefined ZLIB_LIBRARY_PATH

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -70,6 +70,7 @@ if (LINK_STATIC)
 else()
     # Link to shared libraries
     find_package(ZLIB REQUIRED)
+    set(ZLIB_LIBRARY_PATH ${ZLIB_LIBRARIES})
     if (NOT PROTOBUF_LIBRARIES)
       find_package(ProtoBuf QUIET)
       if (NOT ProtoBuf_FOUND)


### PR DESCRIPTION
### Problem
After merging https://github.com/apache/incubator-pulsar/commit/666e73f496b98c9685205aadae7f9eebe74c2c9e, we were unable to build the CPP Client on macOS.

```
Undefined symbols for architecture x86_64:
  "_compress", referenced from:
      pulsar::CompressionCodecZLib::encode(pulsar::SharedBuffer const&) in CompressionCodecZLib.cc.o
     (maybe you meant: _LZ4_compress_continue, _LZ4_compress , _LZ4_compress_limitedOutput , _LZ4_compress_fast_continue , _LZ4_compress_forceExtDict , _LZ4_compress_fast_extState , _LZ4_compress_default , _LZ4_compressBound , _LZ4_compress_destSize , __ZN5boost9algorithm5splitINSt3__16vectorINS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEENS7_IS9_EEEEKS9_NS0_6detail10is_any_ofFIcEEEERT_SH_RT0_T1_NS0_24token_compress_mode_typeE , _LZ4_compress_limitedOutput_continue , _LZ4_compress_fast , _LZ4_compress_limitedOutput_withState , _LZ4_compress_fast_force , _LZ4_compress_withState , __ZN5boost9algorithm5splitINSt3__16vectorINS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEENS7_IS9_EEEES9_NS0_6detail10is_any_ofFIcEEEERT_SG_RT0_T1_NS0_24token_compress_mode_typeE )
  "_compressBound", referenced from:
      pulsar::CompressionCodecZLib::encode(pulsar::SharedBuffer const&) in CompressionCodecZLib.cc.o
     (maybe you meant: _LZ4_compressBound)
  "_uncompress", referenced from:
      pulsar::CompressionCodecZLib::decode(pulsar::SharedBuffer const&, unsigned int, pulsar::SharedBuffer&) in CompressionCodecZLib.cc.o
     (maybe you meant: _LZ4_uncompress_unknownOutputSize, _LZ4_uncompress )
ld: symbol(s) not found for architecture x86_64
```
### Fix
Defined ZLIB_LIBRARY_PATH in case LINK_STATIC is OFF.
