### PR TITLE
CPP Client: Fix for sendTimer_ being dereferenced after reset

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -70,6 +70,7 @@ if (LINK_STATIC)
 else()
     # Link to shared libraries
     find_package(ZLIB REQUIRED)
+    set(ZLIB_LIBRARY_PATH ${ZLIB_LIBRARIES})
     if (NOT PROTOBUF_LIBRARIES)
       find_package(ProtoBuf QUIET)
       if (NOT ProtoBuf_FOUND)

--- a/pulsar-client-cpp/lib/ProducerImpl.cc
+++ b/pulsar-client-cpp/lib/ProducerImpl.cc
@@ -561,10 +561,11 @@ const std::string& ProducerImpl::getName() const{
 void ProducerImpl::start() {
     HandlerBase::start();
 }
+
 void ProducerImpl::shutdown() {
     Lock lock(mutex_);
     state_ = Closed;
-    sendTimer_.reset();
+    sendTimer_->cancel();
     producerCreatedPromise_.setFailed(ResultAlreadyClosed);
 }
 


### PR DESCRIPTION
Fix for #618 

### Explanation
When Client is destructed it shuts down the Producers and Consumers, which currently resets the sendTimer_. If `handleSendTimeout` is called during client shut down or after client shut down the application crashes since it tries to dereference the sendTimer_ in these functions.