### PR TITLE
Build website using the current user rather than root

### DIFF
--- a/site/scripts/docker-build.sh
+++ b/site/scripts/docker-build.sh
@@ -35,6 +35,6 @@ echo "---- Build Pulsar website using image $IMAGE"
 
 docker pull $IMAGE
 
-DOCKER_CMD="docker run -i -v $ROOT_DIR:/pulsar $IMAGE"
+DOCKER_CMD="docker run --user $USER -i -v $ROOT_DIR:/pulsar $IMAGE"
 
 $DOCKER_CMD bash -l -c 'cd /pulsar/site && rvm use . && make setup && make protobuf_doc_gen && make build'


### PR DESCRIPTION
### Motivation

Trying to publish the website after the build on Jenkins, it appears that there are some permissions related issue regarding the generated files.

This should be solved by forcing Docker to use the current user to run the container for the website build.