### PR TITLE
Use $UID instead of $USER in docker build

### DIFF
--- a/site/scripts/docker-build.sh
+++ b/site/scripts/docker-build.sh
@@ -35,6 +35,9 @@ echo "---- Build Pulsar website using image $IMAGE"
 
 docker pull $IMAGE
 
-DOCKER_CMD="docker run --user $USER -i -v $ROOT_DIR:/pulsar $IMAGE"
+CI_USER=$(id -u)
+CI_GROUP=$(id -g)
 
-$DOCKER_CMD bash -l -c 'cd /pulsar/site && rvm use . && make setup && make protobuf_doc_gen && make build'
+DOCKER_CMD="docker run -i -e CI_USER=$CI_USER -e CI_GROUP=$CI_GROUP -v $ROOT_DIR:/pulsar $IMAGE"
+
+$DOCKER_CMD bash -l -c 'cd /pulsar/site && rvm use . && make setup && make protobuf_doc_gen && make build && chown -R $CI_USER:$CI_GROUP /pulsar/generated-site'


### PR DESCRIPTION
### Motivation

In #652, there was an attempt to fix the website build by using current user in Docker. It doesn't work in Jenkins and the (verified) solution here is to keep using "root" inside the container, but change the owner of these files after the build, so that Jenkins can read and write from outside the container.
