### PR TITLE
Make athenzConf and athenzPrincipalHeader configurable

### DIFF
--- a/pulsar-client-auth-athenz/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationAthenz.java
+++ b/pulsar-client-auth-athenz/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationAthenz.java
@@ -90,6 +90,12 @@ public class AuthenticationAthenz implements Authentication {
         this.providerDomain = authParams.get("providerDomain");
         this.privateKeyPath = authParams.get("privateKeyPath");
         this.keyId = authParams.getOrDefault("keyId", "0");
+        if (authParams.containsKey("athenzConfPath")) {
+            System.setProperty("athenz.athenz_conf", authParams.get("athenzConfPath"));
+        }
+        if (authParams.containsKey("principalHeader")) {
+            System.setProperty("athenz.auth.principal.header", authParams.get("principalHeader"));
+        }
     }
 
     @Override


### PR DESCRIPTION
### Motivation

When using Athenz plugin for the java client, we have to set some params (e.g. principal header) as a system properties like `-Dathenz.athenz.auth.principal.header`.

### Modifications

Make athenzConf and athenzPrincipalHeader configurable.