### PR TITLE
Use Docker images from apachepulsar hub org

### DIFF
--- a/kubernetes/generic/bookie.yaml
+++ b/kubernetes/generic/bookie.yaml
@@ -57,7 +57,7 @@ spec:
         spec:
             containers:
               - name: bookie
-                image: streamlio/pulsar:latest
+                image: apachepulsar/pulsar:latest
                 command: ["sh", "-c"]
                 args:
                   - >
@@ -82,7 +82,7 @@ spec:
                 # The first time, initialize BK metadata in zookeeper
                  # Otherwise ignore error if it's already there
               - name: bookie-metaformat
-                image: streamlio/pulsar:latest
+                image: apachepulsar/pulsar:latest
                 command: ["sh", "-c"]
                 args:
                   - >
@@ -144,7 +144,7 @@ spec:
         spec:
             containers:
               - name: replication-worker
-                image: streamlio/pulsar:latest
+                image: apachepulsar/pulsar:latest
                 command: ["sh", "-c"]
                 args:
                   - >

--- a/kubernetes/generic/broker.yaml
+++ b/kubernetes/generic/broker.yaml
@@ -50,7 +50,7 @@ spec:
         spec:
             containers:
               - name: broker
-                image: streamlio/pulsar:latest
+                image: apachepulsar/pulsar:latest
                 command: ["sh", "-c"]
                 args:
                   - >
@@ -105,7 +105,7 @@ metadata:
 spec:
     containers:
       - name: pulsar-admin
-        image: streamlio/pulsar:latest
+        image: apachepulsar/pulsar:latest
         command: ["sh", "-c"]
         args:
           - >

--- a/kubernetes/generic/monitoring.yaml
+++ b/kubernetes/generic/monitoring.yaml
@@ -127,7 +127,7 @@ spec:
         spec:
             containers:
               - name: grafana
-                image: streamlio/pulsar-grafana:latest
+                image: apachepulsar/pulsar-grafana:latest
                 ports:
                   - containerPort: 9090
                 env:
@@ -171,7 +171,7 @@ spec:
         spec:
             containers:
               - name: grafana
-                image: streamlio/pulsar-dashboard:latest
+                image: apachepulsar/pulsar-dashboard:latest
                 ports:
                   - containerPort: 80
                 env:

--- a/kubernetes/generic/zookeeper.yaml
+++ b/kubernetes/generic/zookeeper.yaml
@@ -79,7 +79,7 @@ spec:
                             topologyKey: "kubernetes.io/hostname"
             containers:
               - name: zookeeper
-                image: streamlio/pulsar:latest
+                image: apachepulsar/pulsar:latest
                 command: ["sh", "-c"]
                 args:
                   - >

--- a/kubernetes/google-container-engine/bookie.yaml
+++ b/kubernetes/google-container-engine/bookie.yaml
@@ -58,7 +58,7 @@ spec:
         spec:
             containers:
               - name: bookie
-                image: streamlio/pulsar:latest
+                image: apachepulsar/pulsar:latest
                 command: ["sh", "-c"]
                 args:
                   - >
@@ -83,7 +83,7 @@ spec:
                 # The first time, initialize BK metadata in zookeeper
                  # Otherwise ignore error if it's already there
               - name: bookie-metaformat
-                image: streamlio/pulsar:latest
+                image: apachepulsar/pulsar:latest
                 command: ["sh", "-c"]
                 args:
                   - >
@@ -145,7 +145,7 @@ spec:
         spec:
             containers:
               - name: replication-worker
-                image: streamlio/pulsar:latest
+                image: apachepulsar/pulsar:latest
                 command: ["sh", "-c"]
                 args:
                   - >

--- a/kubernetes/google-container-engine/broker.yaml
+++ b/kubernetes/google-container-engine/broker.yaml
@@ -49,7 +49,7 @@ spec:
         spec:
             containers:
               - name: broker
-                image: streamlio/pulsar:latest
+                image: apachepulsar/pulsar:latest
                 command: ["sh", "-c"]
                 args:
                   - >
@@ -104,7 +104,7 @@ metadata:
 spec:
     containers:
       - name: pulsar-admin
-        image: streamlio/pulsar:latest
+        image: apachepulsar/pulsar:latest
         command: ["sh", "-c"]
         args:
           - >

--- a/kubernetes/google-container-engine/monitoring.yaml
+++ b/kubernetes/google-container-engine/monitoring.yaml
@@ -145,7 +145,7 @@ spec:
         spec:
             containers:
               - name: grafana
-                image: streamlio/pulsar-grafana:latest
+                image: apachepulsar/pulsar-grafana:latest
                 ports:
                   - containerPort: 9090
                 env:
@@ -189,7 +189,7 @@ spec:
         spec:
             containers:
               - name: grafana
-                image: streamlio/pulsar-dashboard:latest
+                image: apachepulsar/pulsar-dashboard:latest
                 ports:
                   - containerPort: 80
                 env:

--- a/kubernetes/google-container-engine/zookeeper.yaml
+++ b/kubernetes/google-container-engine/zookeeper.yaml
@@ -90,7 +90,7 @@ spec:
                             topologyKey: "kubernetes.io/hostname"
             containers:
               - name: zookeeper
-                image: streamlio/pulsar:latest
+                image: apachepulsar/pulsar:latest
                 command: ["sh", "-c"]
                 args:
                   - >

--- a/site/docs/latest/deployment/Monitoring.md
+++ b/site/docs/latest/deployment/Monitoring.md
@@ -92,5 +92,5 @@ To use the dashboard manually:
 ```shell
 docker run -p3000:3000 \
         -e PROMETHEUS_URL=http://$PROMETHEUS_HOST:9090/ \
-        streamlio/pulsar-grafana:latest
+        apachepulsar/pulsar-grafana:latest
 ```


### PR DESCRIPTION
### Motivation

Right now we are using the `streamlio/pulsar` image. We should use the `apachepulsar/pulsar` image.