### PR TITLE
centralize policies znode name

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/cache/ConfigurationCacheService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/cache/ConfigurationCacheService.java
@@ -55,6 +55,7 @@ public class ConfigurationCacheService {
     private ZooKeeperChildrenCache clustersListCache;
     private ZooKeeperDataCache<NamespaceIsolationPolicies> namespaceIsolationPoliciesCache;
 
+    public static final String POLICIES = "policies";
     protected static final String POLICIES_ROOT = "/admin/policies";
     private static final String CLUSTERS_ROOT = "/admin/clusters";
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -73,6 +73,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.Lists;
 
 import io.netty.util.concurrent.DefaultThreadFactory;
+import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
 
 /**
  * Main class for Pulsar broker service
@@ -346,7 +347,7 @@ public class PulsarService implements AutoCloseable {
         try {
             // Namespace not created hence no need to unload it
             if (!this.globalZkCache.exists(
-                    AdminResource.path("policies") + "/" + NamespaceService.getSLAMonitorNamespace(getAdvertisedAddress(), config))) {
+                    AdminResource.path(POLICIES) + "/" + NamespaceService.getSLAMonitorNamespace(getAdvertisedAddress(), config))) {
                 return;
             }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -64,6 +64,7 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
+import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
 
 public abstract class AdminResource extends PulsarWebResource {
     private static final Logger log = LoggerFactory.getLogger(AdminResource.class);
@@ -187,13 +188,13 @@ public abstract class AdminResource extends PulsarWebResource {
     protected List<String> getListOfNamespaces(String property) throws Exception {
         List<String> namespaces = Lists.newArrayList();
         // First get the list of cluster nodes
-        log.info("Children of {} : {}", path("policies", property),
-                globalZk().getChildren(path("policies", property), null));
+        log.info("Children of {} : {}", path(POLICIES, property),
+                globalZk().getChildren(path(POLICIES, property), null));
 
-        for (String cluster : globalZk().getChildren(path("policies", property), false)) {
+        for (String cluster : globalZk().getChildren(path(POLICIES, property), false)) {
             // Then get the list of namespaces
             try {
-                for (String namespace : globalZk().getChildren(path("policies", property, cluster), false)) {
+                for (String namespace : globalZk().getChildren(path(POLICIES, property, cluster), false)) {
                     namespaces.add(String.format("%s/%s/%s", property, cluster, namespace));
                 }
             } catch (KeeperException.NoNodeException e) {
@@ -229,7 +230,7 @@ public abstract class AdminResource extends PulsarWebResource {
 
     protected Policies getNamespacePolicies(String property, String cluster, String namespace) {
         try {
-            Policies policies = policiesCache().get(AdminResource.path("policies", property, cluster, namespace))
+            Policies policies = policiesCache().get(AdminResource.path(POLICIES, property, cluster, namespace))
                     .orElseThrow(() -> new RestException(Status.NOT_FOUND, "Namespace does not exist"));
             // fetch bundles from LocalZK-policies
             NamespaceBundles bundles = pulsar().getNamespaceService().getNamespaceBundleFactory()

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/Clusters.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/Clusters.java
@@ -54,6 +54,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
 
 @Path("/clusters")
 @Api(value = "/clusters", description = "Cluster admin apis", tags = "clusters")
@@ -158,12 +159,12 @@ public class Clusters extends AdminResource {
         // Check that the cluster is not used by any property (eg: no namespaces provisioned there)
         boolean isClusterUsed = false;
         try {
-            for (String property : globalZk().getChildren(path("policies"), false)) {
-                if (globalZk().exists(path("policies", property, cluster), false) == null) {
+            for (String property : globalZk().getChildren(path(POLICIES), false)) {
+                if (globalZk().exists(path(POLICIES, property, cluster), false) == null) {
                     continue;
                 }
 
-                if (!globalZk().getChildren(path("policies", property, cluster), false).isEmpty()) {
+                if (!globalZk().getChildren(path(POLICIES, property, cluster), false).isEmpty()) {
                     // We found a property that has at least a namespace in this cluster
                     isClusterUsed = true;
                     break;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
@@ -40,6 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Lists;
+import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
 
 public class BacklogQuotaManager {
     private static final Logger log = LoggerFactory.getLogger(BacklogQuotaManager.class);
@@ -74,7 +75,7 @@ public class BacklogQuotaManager {
     }
 
     public long getBacklogQuotaLimit(String namespace) {
-        String policyPath = AdminResource.path("policies", namespace);
+        String policyPath = AdminResource.path(POLICIES, namespace);
         return getBacklogQuota(namespace, policyPath).getLimit();
     }
 
@@ -87,7 +88,7 @@ public class BacklogQuotaManager {
     public void handleExceededBacklogQuota(PersistentTopic persistentTopic) {
         DestinationName destination = DestinationName.get(persistentTopic.getName());
         String namespace = destination.getNamespace();
-        String policyPath = AdminResource.path("policies", namespace);
+        String policyPath = AdminResource.path(POLICIES, namespace);
 
         BacklogQuota quota = getBacklogQuota(namespace, policyPath);
         log.info("Backlog quota exceeded for topic [{}]. Applying [{}] policy", persistentTopic.getName(),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -120,6 +120,7 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import org.apache.pulsar.broker.service.BrokerServiceException.NotAllowedException;
+import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
 
 public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies> {
     private static final Logger log = LoggerFactory.getLogger(BrokerService.class);
@@ -618,7 +619,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             Policies policies;
             try {
                 policies = pulsar
-                        .getConfigurationCache().policiesCache().get(AdminResource.path("policies",
+                        .getConfigurationCache().policiesCache().get(AdminResource.path(POLICIES,
                                 namespace.getProperty(), namespace.getCluster(), namespace.getLocalName()))
                         .orElse(null);
             } catch (Throwable t) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -85,6 +85,7 @@ import com.google.common.collect.Sets;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.RecyclableDuplicateByteBuf;
 import io.netty.util.concurrent.FastThreadLocal;
+import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
 
 public class NonPersistentTopic implements Topic {
     private final String topic;
@@ -472,7 +473,7 @@ public class NonPersistentTopic implements Topic {
         Policies policies = null;
         try {
             policies = brokerService.pulsar().getConfigurationCache().policiesCache()
-                    .get(AdminResource.path("policies", name.getNamespace()))
+                    .get(AdminResource.path(POLICIES, name.getNamespace()))
                     .orElseThrow(() -> new KeeperException.NoNodeException());
         } catch (Exception e) {
             CompletableFuture<Void> future = new CompletableFuture<>();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -106,6 +106,7 @@ import com.google.common.collect.Sets;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.util.concurrent.FastThreadLocal;
+import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
 
 public class PersistentTopic implements Topic, AddEntryCallback {
     private final String topic;
@@ -303,7 +304,7 @@ public class PersistentTopic implements Topic, AddEntryCallback {
         // read repl-cluster from policies to avoid restart of replicator which are in process of disconnect and close
         try {
             Policies policies = brokerService.pulsar().getConfigurationCache().policiesCache()
-                    .get(AdminResource.path("policies", DestinationName.get(topic).getNamespace()))
+                    .get(AdminResource.path(POLICIES, DestinationName.get(topic).getNamespace()))
                     .orElseThrow(() -> new KeeperException.NoNodeException());
             if (policies.replication_clusters != null) {
                 Set<String> configuredClusters = Sets.newTreeSet(policies.replication_clusters);
@@ -700,7 +701,7 @@ public class PersistentTopic implements Topic, AddEntryCallback {
         Policies policies = null;
         try {
             policies = brokerService.pulsar().getConfigurationCache().policiesCache()
-                    .get(AdminResource.path("policies", name.getNamespace()))
+                    .get(AdminResource.path(POLICIES, name.getNamespace()))
                     .orElseThrow(() -> new KeeperException.NoNodeException());
         } catch (Exception e) {
             CompletableFuture<Void> future = new CompletableFuture<>();
@@ -753,7 +754,7 @@ public class PersistentTopic implements Topic, AddEntryCallback {
         Policies policies;
         try {
             policies = brokerService.pulsar().getConfigurationCache().policiesCache()
-                    .get(AdminResource.path("policies", name.getNamespace()))
+                    .get(AdminResource.path(POLICIES, name.getNamespace()))
                     .orElseThrow(() -> new KeeperException.NoNodeException());
             if (policies.message_ttl_in_seconds != 0) {
                 subscriptions.forEach((subName, sub) -> sub.expireMessages(policies.message_ttl_in_seconds));
@@ -1243,7 +1244,7 @@ public class PersistentTopic implements Topic, AddEntryCallback {
         DestinationName name = DestinationName.get(topic);
         try {
             Optional<Policies> policies = brokerService.pulsar().getConfigurationCache().policiesCache()
-                    .get(AdminResource.path("policies", name.getNamespace()));
+                    .get(AdminResource.path(POLICIES, name.getNamespace()));
             if (!policies.isPresent()) {
                 // If no policies, the default is to have no retention and delete the inactive topic
                 return false;
@@ -1282,7 +1283,7 @@ public class PersistentTopic implements Topic, AddEntryCallback {
     public BacklogQuota getBacklogQuota() {
         DestinationName destination = DestinationName.get(this.getName());
         String namespace = destination.getNamespace();
-        String policyPath = AdminResource.path("policies", namespace);
+        String policyPath = AdminResource.path(POLICIES, namespace);
 
         BacklogQuota backlogQuota = brokerService.getBacklogQuotaManager().getBacklogQuota(namespace, policyPath);
         return backlogQuota;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -20,14 +20,13 @@ package org.apache.pulsar.broker.web;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.apache.pulsar.common.api.Commands.newLookupResponse;
+import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
 import static org.apache.pulsar.zookeeper.ZooKeeperCache.cacheTimeOutInSec;
 
 import java.net.URI;
 import java.net.URL;
 import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
@@ -43,7 +42,6 @@ import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.admin.AdminResource;
 import org.apache.pulsar.broker.admin.Namespaces;
 import org.apache.pulsar.broker.namespace.NamespaceService;
-import org.apache.pulsar.common.api.proto.PulsarApi.CommandLookupTopicResponse.LookupType;
 import org.apache.pulsar.common.naming.DestinationName;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.NamespaceBundles;
@@ -185,7 +183,7 @@ public abstract class PulsarWebResource {
                 PropertyAdmin propertyAdmin;
 
                 try {
-                    propertyAdmin = pulsar.getConfigurationCache().propertiesCache().get(path("policies", property))
+                    propertyAdmin = pulsar.getConfigurationCache().propertiesCache().get(path(POLICIES, property))
                             .orElseThrow(() -> new RestException(Status.UNAUTHORIZED, "Property does not exist"));
                 } catch (KeeperException.NoNodeException e) {
                     log.warn("Failed to get property admin data for non existing property {}", property);
@@ -205,7 +203,7 @@ public abstract class PulsarWebResource {
     protected void validateClusterForProperty(String property, String cluster) {
         PropertyAdmin propertyAdmin;
         try {
-            propertyAdmin = pulsar().getConfigurationCache().propertiesCache().get(path("policies", property))
+            propertyAdmin = pulsar().getConfigurationCache().propertiesCache().get(path(POLICIES, property))
                     .orElseThrow(() -> new RestException(Status.NOT_FOUND, "Property does not exist"));
         } catch (Exception e) {
             log.error("Failed to get property admin data for property");
@@ -525,7 +523,7 @@ public abstract class PulsarWebResource {
         if (namespace.isGlobal()) {
             String localCluster = pulsarService.getConfiguration().getClusterName();
 
-            String path = AdminResource.path("policies", namespace.getProperty(), namespace.getCluster(),
+            String path = AdminResource.path(POLICIES, namespace.getProperty(), namespace.getCluster(),
                     namespace.getLocalName());
 
             pulsarService.getConfigurationCache().policiesCache().getAsync(path).thenAccept(policiesResult -> {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
@@ -82,6 +82,7 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
 
 @Test
 public class AdminTest extends MockedPulsarServiceBaseTest {
@@ -535,7 +536,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         // create policies
         PropertyAdmin admin = new PropertyAdmin();
         admin.getAllowedClusters().add(cluster);
-        mockZookKeeper.create(PulsarWebResource.path("policies", property),
+        mockZookKeeper.create(PulsarWebResource.path(POLICIES, property),
                 ObjectMapperFactory.getThreadLocal().writeValueAsBytes(admin), Ids.OPEN_ACL_UNSAFE,
                 CreateMode.PERSISTENT);
 
@@ -592,7 +593,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         PropertyAdmin admin = new PropertyAdmin();
         admin.getAllowedClusters().add(cluster);
         ZkUtils.createFullPathOptimistic(mockZookKeeper,
-                PulsarWebResource.path("policies", property, cluster, namespace),
+                PulsarWebResource.path(POLICIES, property, cluster, namespace),
                 ObjectMapperFactory.getThreadLocal().writeValueAsBytes(new Policies()), ZooDefs.Ids.OPEN_ACL_UNSAFE,
                 CreateMode.PERSISTENT);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.admin;
 
+import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -35,7 +36,6 @@ import static org.testng.Assert.fail;
 import java.lang.reflect.Field;
 import java.net.URI;
 import java.net.URL;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
@@ -47,9 +47,6 @@ import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
 import org.apache.bookkeeper.util.ZkUtils;
-import org.apache.pulsar.broker.admin.AdminResource;
-import org.apache.pulsar.broker.admin.Namespaces;
-import org.apache.pulsar.broker.admin.PersistentTopics;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.namespace.NamespaceEphemeralData;
 import org.apache.pulsar.broker.namespace.NamespaceService;
@@ -425,7 +422,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         // Sometimes watcher event consumes scheduled exception, so set to always fail to ensure exception is
         // thrown for api call.
         mockZookKeeper.setAlwaysFail(Code.SESSIONEXPIRED);
-        pulsar.getConfigurationCache().policiesCache().invalidate(AdminResource.path("policies", this.testProperty,
+        pulsar.getConfigurationCache().policiesCache().invalidate(AdminResource.path(POLICIES, this.testProperty,
                 "global", this.testGlobalNamespaces.get(0).getLocalName()));
         try {
             namespaces.setNamespaceReplicationClusters(this.testProperty, "global",
@@ -966,7 +963,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
             final String property = "prop";
             pulsar.getConfiguration().setAuthenticationEnabled(true);
             pulsar.getConfiguration().setAuthorizationEnabled(true);
-            final String path = PulsarWebResource.path("policies", property);
+            final String path = PulsarWebResource.path(POLICIES, property);
             final String data = ObjectMapperFactory.getThreadLocal().writeValueAsString(
                     new PropertyAdmin(Lists.newArrayList(namespaces.clientAppId()), Sets.newHashSet("use")));
             ZkUtils.createFullPathOptimistic(pulsar.getConfigurationCache().getZooKeeper(), path, data.getBytes(),

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadBalancerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadBalancerTest.java
@@ -18,13 +18,13 @@
  */
 package org.apache.pulsar.broker.loadbalance;
 
+import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -41,7 +41,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -50,11 +49,6 @@ import org.apache.bookkeeper.util.ZkUtils;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.admin.AdminResource;
-import org.apache.pulsar.broker.loadbalance.LeaderBroker;
-import org.apache.pulsar.broker.loadbalance.LeaderElectionService;
-import org.apache.pulsar.broker.loadbalance.LoadManager;
-import org.apache.pulsar.broker.loadbalance.LoadRanker;
-import org.apache.pulsar.broker.loadbalance.ResourceUnit;
 import org.apache.pulsar.broker.loadbalance.impl.PulsarResourceDescription;
 import org.apache.pulsar.broker.loadbalance.impl.ResourceAvailabilityRanker;
 import org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl;
@@ -604,7 +598,7 @@ public class LoadBalancerTest {
 
         ObjectMapper jsonMapper = ObjectMapperFactory.create();
         ZooKeeper globalZk = pulsar.getGlobalZkCache().getZooKeeper();
-        String zpath = AdminResource.path("policies", namespace);
+        String zpath = AdminResource.path(POLICIES, namespace);
         ZkUtils.createFullPathOptimistic(globalZk, zpath, jsonMapper.writeValueAsBytes(policies),
                 ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpDestinationLookupv2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/lookup/http/HttpDestinationLookupv2Test.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.lookup.http;
 
+import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -31,7 +32,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.atomic.AtomicReference;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.AsyncResponse;
@@ -55,7 +55,6 @@ import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.zookeeper.ZooKeeperChildrenCache;
 import org.apache.pulsar.zookeeper.ZooKeeperDataCache;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -179,11 +178,11 @@ public class HttpDestinationLookupv2Test {
         final String ns2 = "ns2";
         Policies policies1 = new Policies();
         doReturn(Optional.of(policies1)).when(policiesCache)
-                .get(AdminResource.path("policies", property, cluster, ns1));
+                .get(AdminResource.path(POLICIES, property, cluster, ns1));
         Policies policies2 = new Policies();
         policies2.replication_clusters = Lists.newArrayList("invalid-localCluster");
         doReturn(Optional.of(policies2)).when(policiesCache)
-                .get(AdminResource.path("policies", property, cluster, ns2));
+                .get(AdminResource.path(POLICIES, property, cluster, ns2));
 
         DestinationLookup destLookup = spy(new DestinationLookup());
         doReturn(false).when(destLookup).isRequestHttps();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -19,14 +19,15 @@
 package org.apache.pulsar.broker.service;
 
 import static org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.createMockZooKeeper;
+import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.matches;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -72,12 +73,7 @@ import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.admin.AdminResource;
 import org.apache.pulsar.broker.cache.ConfigurationCacheService;
 import org.apache.pulsar.broker.namespace.NamespaceService;
-import org.apache.pulsar.broker.service.BrokerService;
-import org.apache.pulsar.broker.service.BrokerServiceException;
-import org.apache.pulsar.broker.service.Consumer;
-import org.apache.pulsar.broker.service.Producer;
-import org.apache.pulsar.broker.service.ServerCnx;
-import org.apache.pulsar.broker.service.Topic;
+import org.apache.pulsar.broker.service.nonpersistent.NonPersistentReplicator;
 import org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers;
 import org.apache.pulsar.broker.service.persistent.PersistentDispatcherSingleActiveConsumer;
 import org.apache.pulsar.broker.service.persistent.PersistentReplicator;
@@ -87,8 +83,8 @@ import org.apache.pulsar.client.api.ProducerConfiguration;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe;
-import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
+import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
 import org.apache.pulsar.common.naming.DestinationName;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.policies.data.Policies;
@@ -99,11 +95,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.mockito.verification.VerificationMode;
-import org.powermock.api.mockito.PowerMockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -921,7 +914,7 @@ public class PersistentTopicTest {
         // step-2 now, policies doesn't have removed replication cluster so, it should not invoke "startProducer" of the
         // replicator
         when(pulsar.getConfigurationCache().policiesCache()
-                .get(AdminResource.path("policies", DestinationName.get(globalTopicName).getNamespace())))
+                .get(AdminResource.path(POLICIES, DestinationName.get(globalTopicName).getNamespace())))
                         .thenReturn(Optional.of(new Policies()));
         // try to start replicator again
         topic.startReplProducers();

--- a/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/BrokerDiscoveryProvider.java
+++ b/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/BrokerDiscoveryProvider.java
@@ -45,6 +45,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Joiner;
 
 import io.netty.util.concurrent.DefaultThreadFactory;
+import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
 
 /**
  * Maintains available active broker list and returns next active broker in round-robin for discovery service.
@@ -138,7 +139,7 @@ public class BrokerDiscoveryProvider implements Closeable {
             PropertyAdmin propertyAdmin;
             try {
                 propertyAdmin = service.getConfigurationCacheService().propertiesCache()
-                        .get(path("policies", destination.getProperty()))
+                        .get(path(POLICIES, destination.getProperty()))
                         .orElseThrow(() -> new IllegalAccessException("Property does not exist"));
             } catch (KeeperException.NoNodeException e) {
                 LOG.warn("Failed to get property admin data for non existing property {}", destination.getProperty());

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/BrokerDiscoveryProvider.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/BrokerDiscoveryProvider.java
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Joiner;
 
 import io.netty.util.concurrent.DefaultThreadFactory;
+import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
 
 /**
  * Maintains available active broker list and returns next active broker in round-robin for discovery service.
@@ -139,7 +140,7 @@ public class BrokerDiscoveryProvider implements Closeable {
             PropertyAdmin propertyAdmin;
             try {
                 propertyAdmin = service.getConfigurationCacheService().propertiesCache()
-                        .get(path("policies", destination.getProperty()))
+                        .get(path(POLICIES, destination.getProperty()))
                         .orElseThrow(() -> new IllegalAccessException("Property does not exist"));
             } catch (KeeperException.NoNodeException e) {
                 LOG.warn("Failed to get property admin data for non existing property {}", destination.getProperty());


### PR DESCRIPTION
### Motivation

Right now, znode name of `policies` is not centralized and every class uses it's own reference. making it centralized help to create a single literal of `policies` znode and useful for future refactoring or readability. 

### Result

No functional change.
