### PR TITLE
Fix #657: Use exceptions instead of assert() to do runtime parameter …

### DIFF
--- a/pulsar-client-cpp/lib/ProducerConfiguration.cc
+++ b/pulsar-client-cpp/lib/ProducerConfiguration.cc
@@ -55,7 +55,9 @@ CompressionType ProducerConfiguration::getCompressionType() const {
 }
 
 ProducerConfiguration& ProducerConfiguration::setMaxPendingMessages(int maxPendingMessages) {
-    assert(maxPendingMessages > 0);
+    if (maxPendingMessages <= 0) {
+        throw "maxPendingMessages needs to be greater than 0";
+    }
     impl_->maxPendingMessages = maxPendingMessages;
     return *this;
 }
@@ -104,7 +106,9 @@ const bool& ProducerConfiguration::getBatchingEnabled() const {
 
 ProducerConfiguration& ProducerConfiguration::setBatchingMaxMessages(
         const unsigned int& batchingMaxMessages) {
-    assert(batchingMaxMessages > 1);
+    if (batchingMaxMessages <= 1) {
+        throw "batchingMaxMessages needs to be greater than 1";
+    }
     impl_->batchingMaxMessages = batchingMaxMessages;
     return *this;
 }

--- a/pulsar-client-cpp/tests/BatchMessageTest.cc
+++ b/pulsar-client-cpp/tests/BatchMessageTest.cc
@@ -72,7 +72,12 @@ static void sendCallBackExpectingErrors(Result r, const Message& msg) {
 
 TEST(BatchMessageTest, testProducerConfig) {
     ProducerConfiguration conf;
-    ASSERT_DEATH(conf.setBatchingMaxMessages(1), "");
+    try {
+        conf.setBatchingMaxMessages(1);
+        FAIL();
+    } catch (const char* ex) {
+        // Ok
+    }
 }
 
 TEST(BatchMessageTest, testProducerTimeout) {
@@ -301,7 +306,7 @@ TEST(BatchMessageTest, testSmallReceiverQueueSize) {
         LOG_DEBUG("Received Message with [ content - " << receivedMsg.getDataAsString() << "] [ messageID = " << receivedMsg.getMessageId() << "]");
         ASSERT_EQ(receivedMsg.getProperty("msgIndex"), boost::lexical_cast<std::string>(i));
         ASSERT_EQ(expectedMessageContent, receivedMsg.getDataAsString());
-        ASSERT_EQ(ResultOk, consumer.acknowledge(receivedMsg));   
+        ASSERT_EQ(ResultOk, consumer.acknowledge(receivedMsg));
     }
 
     ConsumerStatsImplPtr consumerStatsImplPtr = PulsarFriend::getConsumerStatsPtr(consumer);


### PR DESCRIPTION
…validations

### Motivation

Since we use the Release profile to compile in the `pulsar-master` Jenkins build, CMake is passing the `-DNDEBUG` macro which remove the assertions.

The ProducerConfiguration test was failing because it was excepting the process to be aborted because of the assertion failure, but that is no longer the case in release build. 

This is causing the master builds to fail.

### Modifications

As in other places, throw an exception when some configuration parameters are not valid.