### PR TITLE
remove topicName-dataProvider from testIncrementPartitionsOfTopic test

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -1707,8 +1707,9 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
      * @param topicName
      * @throws Exception
      */
-    @Test(dataProvider = "topicName")
-    public void testIncrementPartitionsOfTopic(String topicName) throws Exception {
+    @Test
+    public void testIncrementPartitionsOfTopic() throws Exception {
+        final String topicName = "increment-partitionedTopic";
         final String subName1 = topicName + "-my-sub 1";
         final String subName2 = topicName + "-my-sub 2";
         final int startPartitions = 4;


### PR DESCRIPTION
### Motivation

as discussed in #635, removing multiple test-invocation in `AdminApiTest` that creates multiple pulsar instance and cleans it up which may affects subsequent test invocation. 

