### PR TITLE
remove redundant dependencies from modules

### DIFF
--- a/pulsar-broker-common/pom.xml
+++ b/pulsar-broker-common/pom.xml
@@ -35,12 +35,6 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>pulsar-client</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>pulsar-zookeeper-utils</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
-import org.apache.pulsar.client.impl.auth.AuthenticationDisabled;
 import org.apache.pulsar.common.configuration.FieldContext;
 import org.apache.pulsar.common.configuration.PulsarConfiguration;
 
@@ -159,8 +158,8 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private boolean authorizationAllowWildcardsMatching = false;
 
     // Authentication settings of the broker itself. Used when the broker connects
-    // to other brokers, either in same or other clusters
-    private String brokerClientAuthenticationPlugin = AuthenticationDisabled.class.getName();
+    // to other brokers, either in same or other clusters. Default uses plugin which disables authentication
+    private String brokerClientAuthenticationPlugin = "org.apache.pulsar.client.impl.auth.AuthenticationDisabled";
     private String brokerClientAuthenticationParameters = "";
 
     /**** --- BookKeeper Client --- ****/

--- a/pulsar-proxy/pom.xml
+++ b/pulsar-proxy/pom.xml
@@ -39,6 +39,12 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-client</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>pulsar-zookeeper-utils</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/pulsar-websocket/pom.xml
+++ b/pulsar-websocket/pom.xml
@@ -75,11 +75,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.beust</groupId>
-      <artifactId>jcommander</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
     </dependency>


### PR DESCRIPTION
### Motivation

Remove unnecessary dependencies to avoid pulling transitive dependencies. `Pulsar-broker-common.ServiceConfiguration` should not require artifact dependencies to get classname for the config-property.

### Result

`Pulsar-broker-common` will not depend on `Pulsar-client` and will remain thin artifact.
