### PR TITLE
Add narSystemPackage to avoid maven-warning with nar plugin

### DIFF
--- a/pulsar-checksum/pom.xml
+++ b/pulsar-checksum/pom.xml
@@ -117,6 +117,7 @@
               <libraries>
                 <library>
                   <type>jni</type>
+                  <narSystemPackage>org.apache.pulsar.checksum</narSystemPackage>
                 </library>
               </libraries>
               <cpp>
@@ -150,6 +151,7 @@
               <libraries>
                 <library>
                   <type>jni</type>
+                  <narSystemPackage>org.apache.pulsar.checksum</narSystemPackage>
                 </library>
               </libraries>
               <cpp>


### PR DESCRIPTION
### Motivation

As mentioned at #681 
Nar-plugin requires `narSystemPackage` to auto-generate `NarSystem.java` which can load generated `pulsar-checksum.jni`  library. But `pulsar-checksum` loads the library using [custom-NativeUtils](https://github.com/apache/incubator-pulsar/blob/master/pulsar-checksum/src/main/java/com/scurrilous/circe/crc/Sse42Crc32C.java#L36) because of different library-path compare to default one.
However, if we don't provide system-package name then plugin [logs warn msg](https://github.com/maven-nar/nar-maven-plugin/blob/288bfd1c0e0a114a584de56856f9986d385db81b/src/main/java/com/github/maven_nar/NarSystemMojo.java#L174) which can be fixed by adding `narSystemPackage` though it will not be used by the library.

### Result

Nar plugin will not log the warning : `no system package specified; unable to generate NarSystem class`
