### PR TITLE
Websocket Client - Making ServiceConfiguration extendable

### DIFF
--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketService.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketService.java
@@ -212,6 +212,7 @@ public class WebSocketService implements Closeable {
 
     private static ServiceConfiguration createServiceConfiguration(WebSocketProxyConfiguration config) {
         ServiceConfiguration serviceConfig = new ServiceConfiguration();
+        serviceConfig.setProperties(config.getProperties());
         serviceConfig.setClusterName(config.getClusterName());
         serviceConfig.setWebServicePort(config.getWebServicePort());
         serviceConfig.setWebServicePortTls(config.getWebServicePortTls());


### PR DESCRIPTION
This change will allow us to add more parameters to websocket.conf file and customize it to set parameters required by authentication plugins.

For example, we need `athensDomainNames` for athens plugin used in yahoo.