### PR TITLE
Fixed misspelled PrometheusMetricsProvider class name in conf file

### DIFF
--- a/conf/bookkeeper.conf
+++ b/conf/bookkeeper.conf
@@ -298,7 +298,7 @@ writeBufferSizeBytes=65536
 useHostNameAsBookieID=false
 
 # Stats Provider Class
-statsProviderClass=org.apache.bokkeeper.stats.PrometheusMetricsProvider
+statsProviderClass=org.apache.bookkeeper.stats.PrometheusMetricsProvider
 # Default port for Prometheus metrics exporter
 prometheusStatsHttpPort=8000
 


### PR DESCRIPTION
### Motivation

Default configuration for bookies has a typo in class name. That prevents bookie from 
starting with default config.