### PR TITLE
Succeed when unloading namespace bundles not owned by any broker

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/Namespaces.java
@@ -769,9 +769,15 @@ public class Namespaces extends AdminResource {
 
         NamespaceName fqnn = new NamespaceName(property, cluster, namespace);
         validatePoliciesReadOnlyAccess();
+
+        if (!isBundleOwnedByAnyBroker(fqnn, policies.bundles, bundleRange)) {
+            log.info("[{}] Namespace bundle is not owned by any broker {}/{}/{}/{}", clientAppId(), property, cluster,
+                    namespace, bundleRange);
+            return;
+        }
+
         NamespaceBundle nsBundle = validateNamespaceBundleOwnership(fqnn, policies.bundles, bundleRange, authoritative,
                 true);
-
         try {
             pulsar().getNamespaceService().unloadNamespaceBundle(nsBundle);
             log.info("[{}] Successfully unloaded namespace bundle {}", clientAppId(), nsBundle.toString());
@@ -1346,13 +1352,13 @@ public class Namespaces extends AdminResource {
                 }
                 for (Topic topic : topicList) {
                     if(topic instanceof PersistentTopic) {
-                        futures.add(((PersistentTopic)topic).clearBacklog(subscription));    
+                        futures.add(((PersistentTopic)topic).clearBacklog(subscription));
                     }
                 }
             } else {
                 for (Topic topic : topicList) {
                     if(topic instanceof PersistentTopic) {
-                        futures.add(((PersistentTopic)topic).clearBacklog());    
+                        futures.add(((PersistentTopic)topic).clearBacklog());
                     }
                 }
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/DestinationLookup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/DestinationLookup.java
@@ -18,11 +18,13 @@
  */
 package org.apache.pulsar.broker.lookup;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.pulsar.common.api.Commands.newLookupErrorResponse;
 import static org.apache.pulsar.common.api.Commands.newLookupResponse;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import javax.ws.rs.DefaultValue;
@@ -37,18 +39,15 @@ import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
 
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.web.NoSwaggerDocumentation;
 import org.apache.pulsar.broker.web.PulsarWebResource;
 import org.apache.pulsar.broker.web.RestException;
-import org.apache.pulsar.client.api.PulsarClientException;
-import org.apache.pulsar.common.api.proto.PulsarApi.ServerError;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandLookupTopicResponse.LookupType;
+import org.apache.pulsar.common.api.proto.PulsarApi.ServerError;
 import org.apache.pulsar.common.lookup.data.LookupData;
 import org.apache.pulsar.common.naming.DestinationName;
-import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.util.Codec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -100,16 +99,17 @@ public class DestinationLookup extends PulsarWebResource {
             return;
         }
 
-        CompletableFuture<LookupResult> lookupFuture = pulsar().getNamespaceService().getBrokerServiceUrlAsync(topic,
+        CompletableFuture<Optional<LookupResult>> lookupFuture = pulsar().getNamespaceService().getBrokerServiceUrlAsync(topic,
                 authoritative);
 
-        lookupFuture.thenAccept(result -> {
-            if (result == null) {
+        lookupFuture.thenAccept(optionalResult -> {
+            if (optionalResult == null || !optionalResult.isPresent()) {
                 log.warn("No broker was found available for topic {}", topic);
                 completeLookupResponseExceptionally(asyncResponse, new WebApplicationException(Response.Status.SERVICE_UNAVAILABLE));
                 return;
             }
 
+            LookupResult result = optionalResult.get();
             // We have found either a broker that owns the topic, or a broker to which we should redirect the client to
             if (result.isRedirect()) {
                 boolean newAuthoritative = this.isLeaderBroker();
@@ -223,8 +223,9 @@ public class DestinationLookup extends PulsarWebResource {
                                 log.debug("[{}] Lookup result {}", fqdn.toString(), lookupResult);
                             }
 
-                            LookupData lookupData = lookupResult.getLookupData();
-                            if (lookupResult.isRedirect()) {
+                            checkArgument(lookupResult.isPresent());
+                            LookupData lookupData = lookupResult.get().getLookupData();
+                            if (lookupResult.get().isRedirect()) {
                                 boolean newAuthoritative = isLeaderBroker(pulsarService);
                                 lookupfuture.complete(
                                         newLookupResponse(lookupData.getBrokerUrl(), lookupData.getBrokerUrlTls(),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/DestinationLookup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/DestinationLookup.java
@@ -223,7 +223,11 @@ public class DestinationLookup extends PulsarWebResource {
                                 log.debug("[{}] Lookup result {}", fqdn.toString(), lookupResult);
                             }
 
-                            checkArgument(lookupResult.isPresent());
+                            if (!lookupResult.isPresent()) {
+                                lookupfuture.complete(newLookupErrorResponse(ServerError.ServiceNotReady, "Namespace bundle is not owned by any broker", requestId));
+                                return;
+                            }
+
                             LookupData lookupData = lookupResult.get().getLookupData();
                             if (lookupResult.get().isRedirect()) {
                                 boolean newAuthoritative = isLeaderBroker(pulsarService);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -542,7 +542,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         doReturn(uri).when(uriInfo).getRequestUri();
 
         // setup to redirect to another broker in the same cluster
-        doReturn(new URL("http://otherhost" + ":" + BROKER_WEBSERVICE_PORT)).when(nsSvc)
+        doReturn(Optional.of(new URL("http://otherhost" + ":" + BROKER_WEBSERVICE_PORT))).when(nsSvc)
                 .getWebServiceUrl(Mockito.argThat(new Matcher<NamespaceName>() {
 
                     @Override
@@ -602,7 +602,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
 
         // setup ownership to localhost
         URL localWebServiceUrl = new URL(pulsar.getWebServiceAddress());
-        doReturn(localWebServiceUrl).when(nsSvc).getWebServiceUrl(testNs, false, false, false);
+        doReturn(Optional.of(localWebServiceUrl)).when(nsSvc).getWebServiceUrl(testNs, false, false, false);
         doReturn(true).when(nsSvc).isServiceUnitOwned(testNs);
         try {
             namespaces.deleteNamespace(testNs.getProperty(), testNs.getCluster(), testNs.getLocalName(), false);
@@ -614,13 +614,13 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
 
         testNs = this.testGlobalNamespaces.get(0);
         // setup ownership to localhost
-        doReturn(localWebServiceUrl).when(nsSvc).getWebServiceUrl(testNs, false, false, false);
+        doReturn(Optional.of(localWebServiceUrl)).when(nsSvc).getWebServiceUrl(testNs, false, false, false);
         doReturn(true).when(nsSvc).isServiceUnitOwned(testNs);
         namespaces.deleteNamespace(testNs.getProperty(), testNs.getCluster(), testNs.getLocalName(), false);
 
         testNs = this.testLocalNamespaces.get(0);
         // setup ownership to localhost
-        doReturn(localWebServiceUrl).when(nsSvc).getWebServiceUrl(testNs, false, false, false);
+        doReturn(Optional.of(localWebServiceUrl)).when(nsSvc).getWebServiceUrl(testNs, false, false, false);
         doReturn(true).when(nsSvc).isServiceUnitOwned(testNs);
         namespaces.deleteNamespace(testNs.getProperty(), testNs.getCluster(), testNs.getLocalName(), false);
         List<String> nsList = Lists.newArrayList(this.testLocalNamespaces.get(1).toString(),
@@ -641,7 +641,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         // ensure refreshed destination list in the cache
         pulsar.getLocalZkCacheService().managedLedgerListCache().clearTree();
         // setup ownership to localhost
-        doReturn(localWebServiceUrl).when(nsSvc).getWebServiceUrl(testNs, false, false, false);
+        doReturn(Optional.of(localWebServiceUrl)).when(nsSvc).getWebServiceUrl(testNs, false, false, false);
         doReturn(true).when(nsSvc).isServiceUnitOwned(testNs);
         namespaces.deleteNamespace(testNs.getProperty(), testNs.getCluster(), testNs.getLocalName(), false);
     }
@@ -739,7 +739,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
 
         NamespaceBundles nsBundles = nsSvc.getNamespaceBundleFactory().getBundles(testNs, bundleData);
         // make one bundle owned
-        doReturn(localWebServiceUrl).when(nsSvc).getWebServiceUrl(nsBundles.getBundles().get(0), false, true, false);
+        doReturn(Optional.of(localWebServiceUrl)).when(nsSvc).getWebServiceUrl(nsBundles.getBundles().get(0), false, true, false);
         doReturn(true).when(nsSvc).isServiceUnitOwned(nsBundles.getBundles().get(0));
         doNothing().when(namespacesAdmin).deleteNamespaceBundle(
                 testProperty + "/" + testLocalCluster + "/" + bundledNsLocal, "0x00000000_0x80000000");
@@ -761,7 +761,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
 
         // ensure all three bundles are owned by the local broker
         for (NamespaceBundle bundle : nsBundles.getBundles()) {
-            doReturn(localWebServiceUrl).when(nsSvc).getWebServiceUrl(bundle, false, true, false);
+            doReturn(Optional.of(localWebServiceUrl)).when(nsSvc).getWebServiceUrl(bundle, false, true, false);
             doReturn(true).when(nsSvc).isServiceUnitOwned(bundle);
         }
         doNothing().when(namespacesAdmin).deleteNamespaceBundle(Mockito.anyString(), Mockito.anyString());
@@ -771,30 +771,31 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
     public void testUnloadNamespaces() throws Exception {
         final NamespaceName testNs = this.testLocalNamespaces.get(1);
         URL localWebServiceUrl = new URL(pulsar.getWebServiceAddress());
-        doReturn(localWebServiceUrl).when(nsSvc).getWebServiceUrl(Mockito.argThat(new Matcher<NamespaceBundle>() {
+        doReturn(Optional.of(localWebServiceUrl)).when(nsSvc)
+                .getWebServiceUrl(Mockito.argThat(new Matcher<NamespaceBundle>() {
 
-            @Override
-            public void describeTo(Description description) {
-                // TODO Auto-generated method stub
+                    @Override
+                    public void describeTo(Description description) {
+                        // TODO Auto-generated method stub
 
-            }
+                    }
 
-            @Override
-            public boolean matches(Object item) {
-                if (item instanceof NamespaceName) {
-                    NamespaceName ns = (NamespaceName) item;
-                    return ns.equals(testNs);
-                }
-                return false;
-            }
+                    @Override
+                    public boolean matches(Object item) {
+                        if (item instanceof NamespaceName) {
+                            NamespaceName ns = (NamespaceName) item;
+                            return ns.equals(testNs);
+                        }
+                        return false;
+                    }
 
-            @Override
-            public void _dont_implement_Matcher___instead_extend_BaseMatcher_() {
-                // TODO Auto-generated method stub
+                    @Override
+                    public void _dont_implement_Matcher___instead_extend_BaseMatcher_() {
+                        // TODO Auto-generated method stub
 
-            }
+                    }
 
-        }), Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyBoolean());
+                }), Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyBoolean());
         doReturn(true).when(nsSvc).isServiceUnitOwned(Mockito.argThat(new Matcher<NamespaceBundle>() {
 
             @Override
@@ -824,14 +825,8 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         NamespaceBundle bundle = nsSvc.getNamespaceBundleFactory().getFullBundle(testNs);
         doNothing().when(namespaces).validateBundleOwnership(bundle, false, true);
 
-        try {
-            namespaces.unloadNamespace(testNs.getProperty(), testNs.getCluster(), testNs.getLocalName());
-            fail("should have failed as bydefault bundle is activated and can't be unloaded");
-        } catch (RestException re) {
-            // ok
-        }
-
-        verify(nsSvc, times(0)).unloadNamespace(testNs);
+        // The namespace unload should succeed on all the bundles
+        namespaces.unloadNamespace(testNs.getProperty(), testNs.getCluster(), testNs.getLocalName());
     }
 
     @Test
@@ -873,30 +868,31 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         createBundledTestNamespaces(this.testProperty, this.testLocalCluster, bundledNsLocal, bundleData);
         final NamespaceName testNs = new NamespaceName(this.testProperty, this.testLocalCluster, bundledNsLocal);
 
-        doReturn(localWebServiceUrl).when(nsSvc).getWebServiceUrl(Mockito.argThat(new Matcher<NamespaceBundle>() {
+        doReturn(Optional.of(localWebServiceUrl)).when(nsSvc)
+                .getWebServiceUrl(Mockito.argThat(new Matcher<NamespaceBundle>() {
 
-            @Override
-            public void describeTo(Description description) {
-                // TODO Auto-generated method stub
+                    @Override
+                    public void describeTo(Description description) {
+                        // TODO Auto-generated method stub
 
-            }
+                    }
 
-            @Override
-            public boolean matches(Object item) {
-                if (item instanceof NamespaceBundle) {
-                    NamespaceBundle bundle = (NamespaceBundle) item;
-                    return bundle.getNamespaceObject().equals(testNs);
-                }
-                return false;
-            }
+                    @Override
+                    public boolean matches(Object item) {
+                        if (item instanceof NamespaceBundle) {
+                            NamespaceBundle bundle = (NamespaceBundle) item;
+                            return bundle.getNamespaceObject().equals(testNs);
+                        }
+                        return false;
+                    }
 
-            @Override
-            public void _dont_implement_Matcher___instead_extend_BaseMatcher_() {
-                // TODO Auto-generated method stub
+                    @Override
+                    public void _dont_implement_Matcher___instead_extend_BaseMatcher_() {
+                        // TODO Auto-generated method stub
 
-            }
+                    }
 
-        }), Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyBoolean());
+                }), Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyBoolean());
         doReturn(true).when(nsSvc).isServiceUnitOwned(Mockito.argThat(new Matcher<NamespaceBundle>() {
 
             @Override
@@ -925,7 +921,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         NamespaceBundles nsBundles = nsSvc.getNamespaceBundleFactory().getBundles(testNs, bundleData);
         NamespaceBundle testBundle = nsBundles.getBundles().get(0);
         // make one bundle owned
-        doReturn(localWebServiceUrl).when(nsSvc).getWebServiceUrl(testBundle, false, true, false);
+        doReturn(Optional.of(localWebServiceUrl)).when(nsSvc).getWebServiceUrl(testBundle, false, true, false);
         doReturn(true).when(nsSvc).isServiceUnitOwned(testBundle);
         doNothing().when(nsSvc).unloadNamespaceBundle(testBundle);
         namespaces.unloadNamespaceBundle(testProperty, testLocalCluster, bundledNsLocal, "0x00000000_0x80000000",
@@ -1070,7 +1066,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
 
     /**
      * Verifies that deleteNamespace cleans up policies(global,local), bundle cache and bundle ownership
-     * 
+     *
      * @throws Exception
      */
     @Test
@@ -1094,30 +1090,31 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         // (4) check bundle
         NamespaceBundle bundle2 = pulsar.getNamespaceService().getBundle(destination);
         assertNotEquals(bundle1.getBundleRange(), bundle2.getBundleRange());
-        // returns full bundle if policies not present 
+        // returns full bundle if policies not present
         assertEquals("0x00000000_0xffffffff", bundle2.getBundleRange());
 
     }
 
     private void mockWebUrl(URL localWebServiceUrl, NamespaceName namespace) throws Exception {
-        doReturn(localWebServiceUrl).when(nsSvc).getWebServiceUrl(Mockito.argThat(new Matcher<NamespaceBundle>() {
-            @Override
-            public void describeTo(Description description) {
-            }
+        doReturn(Optional.of(localWebServiceUrl)).when(nsSvc)
+                .getWebServiceUrl(Mockito.argThat(new Matcher<NamespaceBundle>() {
+                    @Override
+                    public void describeTo(Description description) {
+                    }
 
-            @Override
-            public boolean matches(Object item) {
-                if (item instanceof NamespaceBundle) {
-                    NamespaceBundle bundle = (NamespaceBundle) item;
-                    return bundle.getNamespaceObject().equals(namespace);
-                }
-                return false;
-            }
+                    @Override
+                    public boolean matches(Object item) {
+                        if (item instanceof NamespaceBundle) {
+                            NamespaceBundle bundle = (NamespaceBundle) item;
+                            return bundle.getNamespaceObject().equals(namespace);
+                        }
+                        return false;
+                    }
 
-            @Override
-            public void _dont_implement_Matcher___instead_extend_BaseMatcher_() {
-            }
-        }), Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyBoolean());
+                    @Override
+                    public void _dont_implement_Matcher___instead_extend_BaseMatcher_() {
+                    }
+                }), Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.anyBoolean());
         doReturn(true).when(nsSvc).isServiceUnitOwned(Mockito.argThat(new Matcher<NamespaceBundle>() {
             @Override
             public void describeTo(Description description) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceUnloadingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceUnloadingTest.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.namespace;
+
+import static org.testng.Assert.assertTrue;
+
+import org.apache.pulsar.broker.service.BrokerTestBase;
+import org.apache.pulsar.client.api.Producer;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class NamespaceUnloadingTest extends BrokerTestBase {
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        super.baseSetup();
+    }
+
+    @AfterMethod
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testUnloadNotLoadedNamespace() throws Exception {
+        admin.namespaces().createNamespace("prop/use/ns-test-1");
+
+        assertTrue(admin.namespaces().getNamespaces("prop", "use").contains("prop/use/ns-test-1"));
+
+        admin.namespaces().unload("prop/use/ns-test-1");
+    }
+
+    @Test
+    public void testUnloadPartiallyLoadedNamespace() throws Exception {
+        admin.namespaces().createNamespace("prop/use/ns-test-2", 16);
+
+        Producer producer = pulsarClient.createProducer("persistent://prop/use/ns-test-2/my-topic");
+
+        assertTrue(admin.namespaces().getNamespaces("prop", "use").contains("prop/use/ns-test-2"));
+
+        admin.namespaces().unload("prop/use/ns-test-2");
+
+        producer.close();
+    }
+
+}


### PR DESCRIPTION
### Motivation

As explained in #707, there are currently `500 Server Error` reported when unloading a namespace bundle which is not owned by any broker.

The correct behavior should be to ignore bundles which are not loaded.