### PR TITLE
add get bundle api for a given topic-name

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/DestinationLookup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/DestinationLookup.java
@@ -50,10 +50,10 @@ import org.apache.pulsar.common.lookup.data.LookupData;
 import org.apache.pulsar.common.naming.DestinationDomain;
 import org.apache.pulsar.common.naming.DestinationName;
 import org.apache.pulsar.common.naming.NamespaceBundle;
-import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.util.Codec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import javax.ws.rs.core.Response.Status;
 
 import io.netty.buffer.ByteBuf;
 import io.swagger.annotations.ApiResponse;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/DestinationLookup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/DestinationLookup.java
@@ -47,13 +47,17 @@ import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.api.proto.PulsarApi.ServerError;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandLookupTopicResponse.LookupType;
 import org.apache.pulsar.common.lookup.data.LookupData;
+import org.apache.pulsar.common.naming.DestinationDomain;
 import org.apache.pulsar.common.naming.DestinationName;
+import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.util.Codec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.netty.buffer.ByteBuf;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 @Path("/v2/destination/")
 @NoSwaggerDocumentation
@@ -76,7 +80,7 @@ public class DestinationLookup extends PulsarWebResource {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
             @Suspended AsyncResponse asyncResponse) {
         dest = Codec.decode(dest);
-        DestinationName topic = DestinationName.get("persistent", property, cluster, namespace, dest);
+        DestinationName topic = DestinationName.get(DestinationDomain.persistent.value(), property, cluster, namespace, dest);
 
         if (!pulsar().getBrokerService().getLookupRequestSemaphore().tryAcquire()) {
             log.warn("No broker was found available for topic {}", topic);
@@ -144,6 +148,33 @@ public class DestinationLookup extends PulsarWebResource {
 
     }
 
+    @GET
+    @Path("{destination-domain}/{property}/{cluster}/{namespace}/{dest}/bundle")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 405, message = "Invalid destination domain type") })
+    public String getNamespaceBundle(@PathParam("destination-domain") String destinationDomain,
+            @PathParam("property") String property, @PathParam("cluster") String cluster,
+            @PathParam("namespace") String namespace, @PathParam("dest") @Encoded String dest) {
+        dest = Codec.decode(dest);
+        DestinationDomain domain = null;
+        try {
+            domain = DestinationDomain.getEnum(destinationDomain);
+        } catch (IllegalArgumentException e) {
+            log.error("[{}] Invalid destination-domain {}", clientAppId(), destinationDomain, e);
+            throw new RestException(Status.METHOD_NOT_ALLOWED,
+                    "Bundle lookup can not be done on destination domain " + destinationDomain);
+        }
+        DestinationName topic = DestinationName.get(domain.value(), property, cluster, namespace, dest);
+        validateSuperUserAccess();
+        try {
+            NamespaceBundle bundle = pulsar().getNamespaceService().getBundle(topic);
+            return bundle.getBundleRange();
+        } catch (Exception e) {
+            log.error("[{}] Failed to get namespace bundle for {}", clientAppId(), topic, e);
+            throw new RestException(e);
+        }
+    }
 
     /**
      *

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Lookup.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Lookup.java
@@ -31,4 +31,13 @@ public interface Lookup {
      * @return the broker URL that serves the destination
      */
     public String lookupDestination(String destination) throws PulsarAdminException;
+    
+    /**
+     * Get a bundle range of a destination
+     * 
+     * @param destination
+     * @return
+     * @throws PulsarAdminException
+     */
+    public String getBundleRange(String destination) throws PulsarAdminException;
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/LookupImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/LookupImpl.java
@@ -56,6 +56,16 @@ public class LookupImpl extends BaseResource implements Lookup {
         }
     }
 
+    @Override
+    public String getBundleRange(String destination) throws PulsarAdminException {
+        try {
+            DestinationName destName = DestinationName.get(destination);
+            return request(v2lookup.path("/destination").path(destName.getLookupName()).path("bundle")).get(String.class);
+        } catch (Exception e) {
+            throw getLookupApiException(e);
+        }
+    }
+
     private String doDestinationLookup(WebTarget lookupResource, DestinationName destName) throws PulsarAdminException {
         LookupData lookupData = request(lookupResource.path(destName.getLookupName())).get(LookupData.class);
         if (useTls) {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPersistentTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPersistentTopics.java
@@ -54,6 +54,7 @@ public class CmdPersistentTopics extends CmdBase {
         jcommander.addCommand("grant-permission", new GrantPermissions());
         jcommander.addCommand("revoke-permission", new RevokePermissions());
         jcommander.addCommand("lookup", new Lookup());
+        jcommander.addCommand("bundle-range", new GetBundleRange());
         jcommander.addCommand("delete", new DeleteCmd());
         jcommander.addCommand("subscriptions", new ListSubscriptions());
         jcommander.addCommand("unsubscribe", new DeleteSubscription());
@@ -158,6 +159,18 @@ public class CmdPersistentTopics extends CmdBase {
         void run() throws PulsarAdminException {
             String destination = validateDestination(params);
             print(admin.lookups().lookupDestination(destination));
+        }
+    }
+
+    @Parameters(commandDescription = "Get Namespace bundle range of a topic")
+    private class GetBundleRange extends CliCommand {
+        @Parameter(description = "persistent://property/cluster/namespace/topic\n", required = true)
+        private java.util.List<String> params;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String destination = validateDestination(params);
+            print(admin.lookups().getBundleRange(destination));
         }
     }
 

--- a/site/_data/cli/pulsar-admin.yaml
+++ b/site/_data/cli/pulsar-admin.yaml
@@ -291,6 +291,9 @@ commands:
   - name: lookup
     description: Look up a topic from the current serving broker
     argument: persistent://property/cluster/namespace/topic
+  - name: bundle-range
+    description: Get the namespace bundle which contains the given topic  
+    argument: persistent://property/cluster/namespace/topic
   - name: delete
     description: Delete a topic. The topic cannot be deleted if there are any active subscriptions or producers connected to the topic.
     argument: persistent://property/cluster/namespace/topic

--- a/site/docs/latest/admin-api/persistent-topics.md
+++ b/site/docs/latest/admin-api/persistent-topics.md
@@ -496,6 +496,32 @@ String destination = "persistent://my-property/my-cluster-my-namespace/my-topic"
 admin.lookup().lookupDestination(destination);
 ```
 
+### Get bundle 
+
+It gives range of the bundle which contains given topic
+
+#### pulsar-admin
+
+
+```shell
+$ pulsar-admin persistent bundle-range \
+  persistent://test-property/cl1/ns1/tp1 \
+
+ "0x00000000_0xffffffff"
+```
+
+#### REST API
+
+{% endpoint GET /lookup/v2/destination/:destination_domain/:property/:cluster/:namespace/:destination/bundle %}
+
+#### Java
+
+```java
+String destination = "persistent://my-property/my-cluster-my-namespace/my-topic";
+admin.lookup().getBundleRange(destination);
+```
+
+
 ### Get subscriptions
 
 It shows all subscription names for a given topic.


### PR DESCRIPTION
### Motivation

When broker is serving large number of topics, sometimes we may want to unload specific topics for multiple reasons. and that topic belongs to namespace which has N bundles and we want to unload specific namespace-bundle. Therefore, we want to know which namespace-bundle contains that topic so, we can unload specific namespace bundle.

### Modifications

add api to get namespace bundle for a topic.

### Result

No functional change, but now admin-user can find out namespace-bundle for a specific topic.
