### PR TITLE
Fix mobile navbar issue

### DIFF
--- a/site/_includes/navbar.html
+++ b/site/_includes/navbar.html
@@ -112,7 +112,7 @@
       </li>
     </ul>
   </div>
-  <a href="http://www.apache.org/">
-    <img class="asf-logo hidden-md-down" title="Apache Software Foundation" src="/img/feather.png" />
+  <a class="hidden-md-down" href="http://www.apache.org/">
+    <img class="asf-logo" title="Apache Software Foundation" src="/img/feather.png" />
   </a>
 </nav>

--- a/site/_includes/navbar.html
+++ b/site/_includes/navbar.html
@@ -113,6 +113,6 @@
     </ul>
   </div>
   <a href="http://www.apache.org/">
-    <img class="asf-logo" title="Apache Software Foundation" src="/img/feather.png" />
+    <img class="asf-logo hidden-md-down" title="Apache Software Foundation" src="/img/feather.png" />
   </a>
 </nav>


### PR DESCRIPTION
### Motivation

At the moment, the Apache feather logo causes a variety problems on smaller screens.

### Modifications

I've removed the logo for smaller screens by adding a Bootstrap `hidden-md-down` class to the image.

### Result

The logo will not appear on smaller screens.
