### PR TITLE
add msgAck and redelivery debug-logs And add topic-name in debug-logs

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -625,7 +625,12 @@ public class ServerCnx extends PulsarHandler {
         CompletableFuture<Consumer> consumerFuture = consumers.get(flow.getConsumerId());
 
         if (consumerFuture != null && consumerFuture.isDone() && !consumerFuture.isCompletedExceptionally()) {
-            consumerFuture.getNow(null).flowPermits(flow.getMessagePermits());
+            Consumer consumer = consumerFuture.getNow(null);
+            if (consumer != null) {
+                consumer.flowPermits(flow.getMessagePermits());
+            } else {
+                log.info("[{}] Couldn't find consumer {}", remoteAddress, flow.getConsumerId());
+            }
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -321,7 +321,7 @@ public class NonPersistentTopic implements Topic {
                 name -> new NonPersistentSubscription(this, subscriptionName));
 
         try {
-            Consumer consumer = new Consumer(subscription, subType, consumerId, priorityLevel, consumerName, 0, cnx,
+            Consumer consumer = new Consumer(subscription, subType, topic, consumerId, priorityLevel, consumerName, 0, cnx,
                     cnx.getRole());
             subscription.addConsumer(consumer);
             if (!cnx.isActive()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -163,7 +163,8 @@ public class PersistentDispatcherMultipleConsumers  extends AbstractDispatcherMu
 
         totalAvailablePermits += additionalNumberOfMessages;
         if (log.isDebugEnabled()) {
-            log.debug("[{}] Trigger new read after receiving flow control message", consumer);
+            log.debug("[{}-{}] Trigger new read after receiving flow control message with permits {}", name, consumer,
+                    totalAvailablePermits);
         }
         readMoreEntries();
     }
@@ -331,6 +332,7 @@ public class PersistentDispatcherMultipleConsumers  extends AbstractDispatcherMu
             Consumer c = getNextConsumer();
             if (c == null) {
                 // Do nothing, cursor will be rewind at reconnection
+                log.info("[{}] rewind because no available consumer found from total {}", name, consumerList.size());
                 entries.subList(start, entries.size()).forEach(Entry::release);
                 cursor.rewind();
                 return;
@@ -460,7 +462,7 @@ public class PersistentDispatcherMultipleConsumers  extends AbstractDispatcherMu
             messagesToReplay.add(ledgerId, entryId);
         });
         if (log.isDebugEnabled()) {
-            log.debug("[{}] Redelivering unacknowledged messages for consumer {}", consumer, messagesToReplay);
+            log.debug("[{}-{}] Redelivering unacknowledged messages for consumer {}", name, consumer, messagesToReplay);
         }
         readMoreEntries();
     }
@@ -469,7 +471,7 @@ public class PersistentDispatcherMultipleConsumers  extends AbstractDispatcherMu
     public synchronized void redeliverUnacknowledgedMessages(Consumer consumer, List<PositionImpl> positions) {
         positions.forEach(position -> messagesToReplay.add(position.getLedgerId(), position.getEntryId()));
         if (log.isDebugEnabled()) {
-            log.debug("[{}] Redelivering unacknowledged messages for consumer {}", consumer, positions);
+            log.debug("[{}-{}] Redelivering unacknowledged messages for consumer {}", name, consumer, positions);
         }
         readMoreEntries();
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -57,7 +57,8 @@ public final class PersistentDispatcherSingleActiveConsumer extends AbstractDisp
             PersistentTopic topic) {
         super(subscriptionType, partitionIndex, topic.getName());
         this.topic = topic;
-        this.name = topic.getName() + " / " + Codec.decode(cursor.getName());
+        this.name = topic.getName() + " / " + (cursor.getName() != null ? Codec.decode(cursor.getName())
+                : ""/* NonDurableCursor doesn't have name */);
         this.cursor = cursor;
         this.readBatchSize = MaxReadBatchSize;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -423,7 +423,7 @@ public class PersistentReplicator extends AbstractReplicator implements Replicat
         } else {
             if (log.isDebugEnabled()) {
                 log.debug("[{}][{} -> {}] Throttled by bookies while reading at {}. Retrying to read in {}s. ({})",
-                        topic, localCluster, remoteCluster, ctx, waitTimeMillis / 1000.0, exception.getMessage(),
+                        topicName, localCluster, remoteCluster, ctx, waitTimeMillis / 1000.0, exception.getMessage(),
                         exception);
             }
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -404,7 +404,7 @@ public class PersistentTopic implements Topic, AddEntryCallback {
 
         subscriptionFuture.thenAccept(subscription -> {
             try {
-                Consumer consumer = new Consumer(subscription, subType, consumerId, priorityLevel, consumerName,
+                Consumer consumer = new Consumer(subscription, subType, topic, consumerId, priorityLevel, consumerName,
                         maxUnackedMessages, cnx, cnx.getRole());
                 subscription.addConsumer(consumer);
                 if (!cnx.isActive()) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
@@ -207,8 +207,8 @@ public class PersistentDispatcherFailoverConsumerTest {
         assertFalse(pdfc.isConsumerConnected());
 
         // 2. Add consumer
-        Consumer consumer1 = new Consumer(sub, SubType.Exclusive, 1 /* consumer id */, 0, "Cons1"/* consumer name */,
-                50000, serverCnx, "myrole-1");
+        Consumer consumer1 = new Consumer(sub, SubType.Exclusive, topic.getName(), 1 /* consumer id */, 0,
+                "Cons1"/* consumer name */, 50000, serverCnx, "myrole-1");
         pdfc.addConsumer(consumer1);
         List<Consumer> consumers = pdfc.getConsumers();
         assertTrue(consumers.get(0).consumerName() == consumer1.consumerName());
@@ -224,7 +224,7 @@ public class PersistentDispatcherFailoverConsumerTest {
         assertTrue(pdfc.getActiveConsumer().consumerName() == consumer1.consumerName());
 
         // 5. Add another consumer which does not change active consumer
-        Consumer consumer2 = new Consumer(sub, SubType.Exclusive, 2 /* consumer id */, 0, "Cons2"/* consumer name */,
+        Consumer consumer2 = new Consumer(sub, SubType.Exclusive, topic.getName(), 2 /* consumer id */, 0, "Cons2"/* consumer name */,
                 50000, serverCnx, "myrole-1");
         pdfc.addConsumer(consumer2);
         consumers = pdfc.getConsumers();
@@ -232,8 +232,8 @@ public class PersistentDispatcherFailoverConsumerTest {
         assertEquals(3, consumers.size());
 
         // 6. Add a consumer which changes active consumer
-        Consumer consumer0 = new Consumer(sub, SubType.Exclusive, 0 /* consumer id */, 0, "Cons0"/* consumer name */,
-                50000, serverCnx, "myrole-1");
+        Consumer consumer0 = new Consumer(sub, SubType.Exclusive, topic.getName(), 0 /* consumer id */, 0,
+                "Cons0"/* consumer name */, 50000, serverCnx, "myrole-1");
         pdfc.addConsumer(consumer0);
         consumers = pdfc.getConsumers();
         assertTrue(pdfc.getActiveConsumer().consumerName() == consumer0.consumerName());
@@ -440,7 +440,7 @@ public class PersistentDispatcherFailoverConsumerTest {
     }
 
     private Consumer createConsumer(int priority, int permit, boolean blocked, int id) throws Exception {
-        Consumer consumer = new Consumer(null, SubType.Shared, id, priority, ""+id, 5000, serverCnx, "appId");
+        Consumer consumer = new Consumer(null, SubType.Shared, null, id, priority, ""+id, 5000, serverCnx, "appId");
         try {
             consumer.flowPermits(permit);
         } catch (Exception e) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -409,7 +409,7 @@ public class PersistentTopicTest {
         PersistentSubscription sub = new PersistentSubscription(topic, "sub-1", cursorMock);
 
         // 1. simple add consumer
-        Consumer consumer = new Consumer(sub, SubType.Exclusive, 1 /* consumer id */, 0, "Cons1"/* consumer name */,
+        Consumer consumer = new Consumer(sub, SubType.Exclusive, topic.getName(), 1 /* consumer id */, 0, "Cons1"/* consumer name */,
                 50000, serverCnx, "myrole-1");
         sub.addConsumer(consumer);
         assertTrue(sub.getDispatcher().isConsumerConnected());
@@ -439,7 +439,7 @@ public class PersistentTopicTest {
     public void testUbsubscribeRaceConditions() throws Exception {
         PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
         PersistentSubscription sub = new PersistentSubscription(topic, "sub-1", cursorMock);
-        Consumer consumer1 = new Consumer(sub, SubType.Exclusive, 1 /* consumer id */, 0, "Cons1"/* consumer name */,
+        Consumer consumer1 = new Consumer(sub, SubType.Exclusive, topic.getName(), 1 /* consumer id */, 0, "Cons1"/* consumer name */,
                 50000, serverCnx, "myrole-1");
         sub.addConsumer(consumer1);
 
@@ -461,7 +461,7 @@ public class PersistentTopicTest {
 
         try {
             Thread.sleep(10); /* delay to ensure that the ubsubscribe gets executed first */
-            Consumer consumer2 = new Consumer(sub, SubType.Exclusive, 2 /* consumer id */, 0, "Cons2"/* consumer name */,
+            Consumer consumer2 = new Consumer(sub, SubType.Exclusive, topic.getName(), 2 /* consumer id */, 0, "Cons2"/* consumer name */,
                     50000, serverCnx, "myrole-1");
         } catch (BrokerServiceException e) {
             assertTrue(e instanceof BrokerServiceException.SubscriptionFencedException);


### PR DESCRIPTION
### Motivation

- Purpose of #680 to provide a way to enable debug log for specific topic using which we can debug end2end execution flow for a specific topic at broker-side. For that, we have to do debug-logging with topic-name. 
- Also, added some more debug-logging for msgAck and msgRedelivery flow to help in debugging when client is seeing unexpected msg-redelivery behavior.

### Modifications

- add more debug logs for msgAck and msgRedelivery
- add topicName in debug logs

### Result

No functional change.
