### PR TITLE
Fix: msg rate acquire permit for msg/bytes

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -354,8 +354,8 @@ public class PersistentDispatcherMultipleConsumers  extends AbstractDispatcherMu
                 start += messagesForC;
                 entriesToDispatch -= messagesForC;
                 totalAvailablePermits -= msgSent;
-                totalMessagesSent += sentMsgInfo.getTotalSentMessageBytes();
-                totalBytesSent += sentMsgInfo.getTotalSentMessages();
+                totalMessagesSent += sentMsgInfo.getTotalSentMessages();
+                totalBytesSent += sentMsgInfo.getTotalSentMessageBytes();
             }
         }
 


### PR DESCRIPTION
### Motivation

For shared-subscription: Rate-limiter acquires byte permits as total-sent messages which derives invalid available permits while dispatching the messages.

### Modifications

Fix dispatched message acquired permits.

### Result

dispatch with correct msg rate for the shared subscription.
