### PR TITLE
CPP Client: Small fixes to make the code work with older libraries - …

### DIFF
--- a/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
+++ b/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
@@ -264,7 +264,7 @@ namespace pulsar {
                         break;
                     }
                     roleToken.token = root["token"].asString();
-                    roleToken.expiryTime = root["expiryTime"].asInt64();
+                    roleToken.expiryTime = root["expiryTime"].asUInt();
                     boost::lock_guard<boost::mutex> lock(cacheMtx_);
                     roleTokenCache_[cacheKey] = roleToken;
                     LOG_DEBUG("Got role token " << roleToken.token)

--- a/pulsar-client-cpp/tests/AuthPluginTest.cc
+++ b/pulsar-client-cpp/tests/AuthPluginTest.cc
@@ -21,7 +21,6 @@
 #include <pulsar/Client.h>
 #include <boost/lexical_cast.hpp>
 #include <boost/asio.hpp>
-#include <boost/range/algorithm/for_each.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/thread.hpp>
 #include <lib/LogUtils.h>

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -1088,7 +1088,7 @@ TEST(BasicEndToEndTest, testHandlerReconnectionLogic) {
     ASSERT_EQ(receivedMsgIndex.size(), 10);
 
     for (int i = 0; i<numOfMessages; i++) {
-        ASSERT_NE(receivedMsgContent.find("msg-" + boost::lexical_cast<std::string>(i)), receivedMsgContent.end());
-        ASSERT_NE(receivedMsgIndex.find(boost::lexical_cast<std::string>(i)), receivedMsgIndex.end());
+        ASSERT_TRUE(receivedMsgContent.find("msg-" + boost::lexical_cast<std::string>(i)) != receivedMsgContent.end());
+        ASSERT_TRUE(receivedMsgIndex.find(boost::lexical_cast<std::string>(i)) != receivedMsgIndex.end());
     }
 }


### PR DESCRIPTION
…no change in code logic

### Motivation
CPP Code currently doesn't compile with old gcc version and json libraries.
Have made small changes to make the code comply with older gcc version and json libraries without changing the application logic.