### PR TITLE
Validate dynamic-configuration value while updating or init

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/Brokers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/Brokers.java
@@ -137,7 +137,7 @@ public class Brokers extends AdminResource {
     @Path("/configuration")
     @ApiOperation(value = "Get all updatable dynamic configurations's name")
     public List<String> getDynamicConfigurationName() {
-        return BrokerService.getDynamicConfigurationMap().keys();
+        return BrokerService.getDynamicConfiguration();
     }
     
     /**
@@ -151,7 +151,10 @@ public class Brokers extends AdminResource {
      */
     private synchronized void updateDynamicConfigurationOnZk(String configName, String configValue) {
         try {
-            if (BrokerService.getDynamicConfigurationMap().containsKey(configName)) {
+            if (!BrokerService.validateDynamicConfiguration(configName, configValue)) {
+                throw new RestException(Status.PRECONDITION_FAILED, " Invalid dynamic-config value");
+            }
+            if (BrokerService.isDynamicConfiguration(configName)) {
                 ZooKeeperDataCache<Map<String, String>> dynamicConfigurationCache = pulsar().getBrokerService()
                         .getDynamicConfigurationCache();
                 Map<String, String> configurationMap = dynamicConfigurationCache.get(BROKER_SERVICE_CONFIGURATION_PATH)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.impl;
 
+import static org.apache.pulsar.broker.service.BrokerService.BROKER_SERVICE_CONFIGURATION_PATH;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
@@ -33,6 +34,7 @@ import java.lang.reflect.Field;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Set;
 import static java.util.UUID.randomUUID;
@@ -46,6 +48,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.pulsar.broker.namespace.OwnershipCache;
 import org.apache.pulsar.broker.service.Topic;
+import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.ClientConfiguration;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerConfiguration;
@@ -68,7 +71,9 @@ import org.apache.pulsar.common.api.PulsarHandler;
 import org.apache.pulsar.common.naming.DestinationName;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.common.util.collections.ConcurrentLongHashMap;
+import org.apache.pulsar.zookeeper.ZooKeeperDataCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -76,6 +81,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.testng.collections.Maps;
 
 import com.google.common.collect.Sets;
 
@@ -656,6 +662,52 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
             pulsarClient.close();
         } finally {
             pulsar.getConfiguration().setAuthorizationEnabled(false);
+        }
+    }
+
+    @Test
+    public void testInvalidDynamicConfiguration() throws Exception {
+
+        try {
+            // (1) try to update invalid loadManagerClass name
+            try {
+                admin.brokers().updateDynamicConfiguration("loadManagerClassName",
+                        "org.apache.pulsar.invalid.loadmanager");
+                fail("it should have failed due to invalid argument");
+            } catch (PulsarAdminException e) {
+                // Ok: should have failed due to invalid config value
+            }
+
+            // (2) try to update with valid loadManagerClass name
+            try {
+                admin.brokers().updateDynamicConfiguration("loadManagerClassName",
+                        "org.apache.pulsar.broker.loadbalance.ModularLoadManager");
+            } catch (PulsarAdminException e) {
+                fail("it should have failed due to invalid argument", e);
+            }
+
+            // (3) restart broker with invalid config value
+
+            ZooKeeperDataCache<Map<String, String>> dynamicConfigurationCache = pulsar.getBrokerService()
+                    .getDynamicConfigurationCache();
+            Map<String, String> configurationMap = dynamicConfigurationCache.get(BROKER_SERVICE_CONFIGURATION_PATH)
+                    .get();
+            configurationMap.put("loadManagerClassName", "org.apache.pulsar.invalid.loadmanager");
+            byte[] content = ObjectMapperFactory.getThreadLocal().writeValueAsBytes(configurationMap);
+            dynamicConfigurationCache.invalidate(BROKER_SERVICE_CONFIGURATION_PATH);
+            mockZookKeeper.setData(BROKER_SERVICE_CONFIGURATION_PATH, content, -1);
+
+            try {
+                stopBroker();
+                startBroker();
+                fail("it should have failed due to invalid argument");
+            } catch (Exception e) {
+                // Ok: should have failed due to invalid config value
+            }
+        } finally {
+            byte[] content = ObjectMapperFactory.getThreadLocal().writeValueAsBytes(Maps.newHashMap());
+            mockZookKeeper.setData(BROKER_SERVICE_CONFIGURATION_PATH, content, -1);
+            startBroker();
         }
     }
 


### PR DESCRIPTION
### Motivation

- Right now, broker doesn't validate dynamic-configuration value before updating it to zookeeper. So, user may update configuration with typo. 
- also, broker should validate dynamic-config value while starting in order to avoid picking up invalid value.
eg: if someone has dynamic-config present for `loadManagerClassName` in old release and release-1.19 has changed the className then broker startup should notify invalid config value.

### Modifications

- Do dynamic-config validation before updating it 
- Validate dynamic-config value on broker startup
Right now, we just have validation on `loadManagerClassName` configuration.

### Result

- broker will not allow update of invalid dynamic-config
- broker startup will fail if it finds out invalid dynamic config.
