### PR TITLE
Handle NPE at load-manager when leader couldn't find available broker

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleResourceUnit.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleResourceUnit.java
@@ -21,6 +21,8 @@ package org.apache.pulsar.broker.loadbalance.impl;
 import org.apache.pulsar.broker.loadbalance.ResourceDescription;
 import org.apache.pulsar.broker.loadbalance.ResourceUnit;
 
+import com.google.common.base.Objects;
+
 public class SimpleResourceUnit implements ResourceUnit {
 
     private String resourceId;
@@ -66,4 +68,10 @@ public class SimpleResourceUnit implements ResourceUnit {
     public int hashCode() {
         return this.resourceId.hashCode();
     }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this).add("resourceId", resourceId).toString();
+    }
+    
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/DestinationLookup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/DestinationLookup.java
@@ -256,7 +256,8 @@ public class DestinationLookup extends PulsarWebResource {
                             }
 
                             if (!lookupResult.isPresent()) {
-                                lookupfuture.complete(newLookupErrorResponse(ServerError.ServiceNotReady, "Namespace bundle is not owned by any broker", requestId));
+                                lookupfuture.complete(newLookupErrorResponse(ServerError.ServiceNotReady,
+                                        "No broker was available to own " + fqdn, requestId));
                                 return;
                             }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -336,8 +336,7 @@ public class NamespaceService {
                 if (!this.loadManager.get().isCentralized() || pulsar.getLeaderElectionService().isLeader()) {
                     Optional<String> availableBroker = getLeastLoadedFromLoadManager(bundle);
                     if (!availableBroker.isPresent()) {
-                        lookupFuture.completeExceptionally(
-                                new ServiceUnitNotReadyException("Couldn't find available broker for " + bundle));
+                        lookupFuture.complete(Optional.empty());
                         return;
                     }
                     candidateBroker = availableBroker.get();


### PR DESCRIPTION
### Motivation

- Broker lookup gives NPE when it couldn't find any available broker and it should be handle with correct error-msg.
```
pulsar-256-8] WARN org.apache.pulsar.broker.namespace.NamespaceService - Error when searching for candidate broker to acquire my-property/use/con-ns1/0x00000000_0xffffffff: null
java.lang.NullPointerException
    at org.apache.pulsar.broker.namespace.NamespaceService.getLeastLoadedFromLoadManager(NamespaceService.java:456)
    at org.apache.pulsar.broker.namespace.NamespaceService.searchForCandidateBroker(NamespaceService.java:336)
    at org.apache.pulsar.broker.namespace.NamespaceService.lambda$14(NamespaceService.java:299)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at io.netty.util.concurrent.DefaultThreadFactory$DefaultRunnableDecorator.run(DefaultThreadFactory.java:144)
    at java.lang.Thread.run(Thread.java:745)
```

- also [SimpleLoadManager](https://github.com/apache/incubator-pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java#L974) is not logging list of available broker because of missing `toString()` into `SimpleResourceUnit`


### Modifications

handle NPE when lookup doesn't find available broker.
