### PR TITLE
CPP Client: Deprecated few APIs that can't be used with batch messages

### DIFF
--- a/pulsar-client-cpp/include/pulsar/Consumer.h
+++ b/pulsar-client-cpp/include/pulsar/Consumer.h
@@ -112,6 +112,10 @@ class Consumer {
      * @return ResultError if there was a failure
      */
     Result acknowledge(const Message& message);
+
+    /*
+     * @deprecated - Not to be used with Batch Messages.
+     */
     Result acknowledge(const MessageId& messageId);
 
     /**
@@ -124,6 +128,10 @@ class Consumer {
      * @param callback callback that will be triggered when the message has been acknowledged
      */
     void acknowledgeAsync(const Message& message, ResultCallback callback);
+
+    /*
+     * @deprecated - Not to be used with Batch Messages.
+     */
     void acknowledgeAsync(const MessageId& messageID, ResultCallback callback);
 
     /**
@@ -143,6 +151,10 @@ class Consumer {
      * @return ResultError if there was a failure
      */
     Result acknowledgeCumulative(const Message& message);
+
+    /*
+     * @deprecated - Not to be used with Batch Messages.
+     */
     Result acknowledgeCumulative(const MessageId& messageId);
 
     /**
@@ -156,6 +168,10 @@ class Consumer {
      * @param callback callback that will be triggered when the message has been acknowledged
      */
     void acknowledgeCumulativeAsync(const Message& message, ResultCallback callback);
+
+    /*
+     * @deprecated - Not to be used with Batch Messages.
+     */
     void acknowledgeCumulativeAsync(const MessageId& messageId, ResultCallback callback);
 
     Result close();


### PR DESCRIPTION
Since we don't have the pimpl trick in MessageId we resorted to using inheritance for BatchMessageId. Due to object slicing we have no guarantee that the MessageId that the user provides can be typecasted to BatchMessageId (i.e we may lose the batch index information). Like for example if a person is using a vector to keep track of messageId and then calling these methods.

@merlimat  and @msb-at-yahoo - your inputs will be valuable