### PR TITLE
Issue 733: Event Time support in java client

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/Message.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/Message.java
@@ -73,7 +73,24 @@ public interface Message {
      */
     MessageId getMessageId();
 
+    /**
+     * Get the publish time of this message. The publish time is the timestamp that a client publish the message.
+     *
+     * @return publish time of this message.
+     * @see #getEventTime()
+     */
     long getPublishTime();
+
+    /**
+     * Get the event time associated with this message. It is typically set by the applications via
+     * {@link MessageBuilder#setEventTime(long)}.
+     *
+     * <p>If there isn't any event time associated with this event, it will return 0.
+     *
+     * @see MessageBuilder#setEventTime(long)
+     * @since 1.20.0
+     */
+    long getEventTime();
 
     /**
      * Check whether the message has a key

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/MessageBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/MessageBuilder.java
@@ -98,6 +98,18 @@ public interface MessageBuilder {
     MessageBuilder setKey(String key);
 
     /**
+     * Set the event time for a given message.
+     *
+     * <p>Applications can retrieve the event time by calling {@link Message#getEventTime()}.
+     *
+     * <p>Note: currently pulsar doesn't support event-time based index. so the subscribers can't
+     * seek the messages by event time.
+     *
+     * @since 1.20.0
+     */
+    MessageBuilder setEventTime(long timestamp);
+
+    /**
      * Override the replication clusters for this message.
      *
      * @param clusters

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageBuilderImpl.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.client.impl;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
@@ -76,6 +78,13 @@ public class MessageBuilderImpl implements MessageBuilder {
     @Override
     public MessageBuilder setKey(String key) {
         msgMetadataBuilder.setPartitionKey(key);
+        return this;
+    }
+
+    @Override
+    public MessageBuilder setEventTime(long timestamp) {
+        checkArgument(timestamp > 0, "Invalid timestamp : '%s'", timestamp);
+        msgMetadataBuilder.setEventTime(timestamp);
         return this;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -152,6 +152,15 @@ public class MessageImpl implements Message {
         return msgMetadataBuilder.getPublishTime();
     }
 
+    @Override
+    public long getEventTime() {
+        checkNotNull(msgMetadataBuilder);
+        if (msgMetadataBuilder.hasEventTime()) {
+            return msgMetadataBuilder.getEventTime();
+        }
+        return 0;
+    }
+
     public boolean isExpired(int messageTTLInSeconds) {
         return messageTTLInSeconds != 0
                 && System.currentTimeMillis() > (getPublishTime() + TimeUnit.SECONDS.toMillis(messageTTLInSeconds));

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageBuilderTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageBuilderTest.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageBuilder;
+import org.junit.Test;
+
+/**
+ * Unit test of {@link MessageBuilderImpl}.
+ */
+public class MessageBuilderTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetEventTimeNegative() {
+        MessageBuilder builder = MessageBuilder.create();
+        builder.setEventTime(-1L);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetEventTimeZero() {
+        MessageBuilder builder = MessageBuilder.create();
+        builder.setEventTime(0L);
+    }
+
+    @Test
+    public void testSetEventTimePositive() {
+        long eventTime = System.currentTimeMillis();
+        MessageBuilder builder = MessageBuilder.create();
+        builder.setContent(new byte[0]);
+        builder.setEventTime(eventTime);
+        Message msg = builder.build();
+        assertEquals(eventTime, msg.getEventTime());
+    }
+
+    @Test
+    public void testBuildMessageWithoutEventTime() {
+        MessageBuilder builder = MessageBuilder.create();
+        builder.setContent(new byte[0]);
+        Message msg = builder.build();
+        assertEquals(0L, msg.getEventTime());
+    }
+
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
@@ -1266,6 +1266,10 @@ public final class PulsarApi {
     // optional int32 num_messages_in_batch = 11 [default = 1];
     boolean hasNumMessagesInBatch();
     int getNumMessagesInBatch();
+    
+    // optional uint64 event_time = 12 [default = 0];
+    boolean hasEventTime();
+    long getEventTime();
   }
   public static final class MessageMetadata extends
       com.google.protobuf.GeneratedMessageLite
@@ -1483,6 +1487,16 @@ public final class PulsarApi {
       return numMessagesInBatch_;
     }
     
+    // optional uint64 event_time = 12 [default = 0];
+    public static final int EVENT_TIME_FIELD_NUMBER = 12;
+    private long eventTime_;
+    public boolean hasEventTime() {
+      return ((bitField0_ & 0x00000100) == 0x00000100);
+    }
+    public long getEventTime() {
+      return eventTime_;
+    }
+    
     private void initFields() {
       producerName_ = "";
       sequenceId_ = 0L;
@@ -1494,6 +1508,7 @@ public final class PulsarApi {
       compression_ = org.apache.pulsar.common.api.proto.PulsarApi.CompressionType.NONE;
       uncompressedSize_ = 0;
       numMessagesInBatch_ = 1;
+      eventTime_ = 0L;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -1560,6 +1575,9 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00000080) == 0x00000080)) {
         output.writeInt32(11, numMessagesInBatch_);
       }
+      if (((bitField0_ & 0x00000100) == 0x00000100)) {
+        output.writeUInt64(12, eventTime_);
+      }
     }
     
     private int memoizedSerializedSize = -1;
@@ -1612,6 +1630,10 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00000080) == 0x00000080)) {
         size += com.google.protobuf.CodedOutputStream
           .computeInt32Size(11, numMessagesInBatch_);
+      }
+      if (((bitField0_ & 0x00000100) == 0x00000100)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt64Size(12, eventTime_);
       }
       memoizedSerializedSize = size;
       return size;
@@ -1746,6 +1768,8 @@ public final class PulsarApi {
         bitField0_ = (bitField0_ & ~0x00000100);
         numMessagesInBatch_ = 1;
         bitField0_ = (bitField0_ & ~0x00000200);
+        eventTime_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000400);
         return this;
       }
       
@@ -1822,6 +1846,10 @@ public final class PulsarApi {
           to_bitField0_ |= 0x00000080;
         }
         result.numMessagesInBatch_ = numMessagesInBatch_;
+        if (((from_bitField0_ & 0x00000400) == 0x00000400)) {
+          to_bitField0_ |= 0x00000100;
+        }
+        result.eventTime_ = eventTime_;
         result.bitField0_ = to_bitField0_;
         return result;
       }
@@ -1871,6 +1899,9 @@ public final class PulsarApi {
         }
         if (other.hasNumMessagesInBatch()) {
           setNumMessagesInBatch(other.getNumMessagesInBatch());
+        }
+        if (other.hasEventTime()) {
+          setEventTime(other.getEventTime());
         }
         return this;
       }
@@ -1972,6 +2003,11 @@ public final class PulsarApi {
             case 88: {
               bitField0_ |= 0x00000200;
               numMessagesInBatch_ = input.readInt32();
+              break;
+            }
+            case 96: {
+              bitField0_ |= 0x00000400;
+              eventTime_ = input.readUInt64();
               break;
             }
           }
@@ -2337,6 +2373,27 @@ public final class PulsarApi {
       public Builder clearNumMessagesInBatch() {
         bitField0_ = (bitField0_ & ~0x00000200);
         numMessagesInBatch_ = 1;
+        
+        return this;
+      }
+      
+      // optional uint64 event_time = 12 [default = 0];
+      private long eventTime_ ;
+      public boolean hasEventTime() {
+        return ((bitField0_ & 0x00000400) == 0x00000400);
+      }
+      public long getEventTime() {
+        return eventTime_;
+      }
+      public Builder setEventTime(long value) {
+        bitField0_ |= 0x00000400;
+        eventTime_ = value;
+        
+        return this;
+      }
+      public Builder clearEventTime() {
+        bitField0_ = (bitField0_ & ~0x00000400);
+        eventTime_ = 0L;
         
         return this;
       }

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -60,6 +60,10 @@ message MessageMetadata {
 	//optional sfixed64 checksum = 10;
 	// differentiate single and batch message metadata
 	optional int32 num_messages_in_batch = 11 [default = 1];
+
+        // the timestamp that this event occurs. it is typically set by applications.
+        // if this field is omitted, `publish_time` can be used for the purpose of `event_time`.
+        optional uint64 event_time = 12 [default = 0];
 }
 
 


### PR DESCRIPTION

### Motivation

Introduce `event_time` in message for use cases (e.g. stream computing) that needs event time.

This change is part of #732 

### Modifications

- add `event_time` field in message metadata proto
- expose `setEventTime` in MessageBuilder
- expose `getEventTime` in Message
- add event_time test cases for message & message builder

### Result

After this change, clients are able to set and get event time from messages.
