### PR TITLE
Restrict admin access for persistent-policty

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/Namespaces.java
@@ -1081,6 +1081,7 @@ public class Namespaces extends AdminResource {
             @ApiResponse(code = 409, message = "Concurrent modification") })
     public void setPersistence(@PathParam("property") String property, @PathParam("cluster") String cluster,
             @PathParam("namespace") String namespace, PersistencePolicies persistence) {
+        validateSuperUserAccess();
         validatePoliciesReadOnlyAccess();
 
         try {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/PersistencePolicies.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/PersistencePolicies.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.common.policies.data;
 
 import com.google.common.base.Objects;
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class PersistencePolicies {
     private int bookkeeperEnsemble;
@@ -32,6 +33,9 @@ public class PersistencePolicies {
 
     public PersistencePolicies(int bookkeeperEnsemble, int bookkeeperWriteQuorum, int bookkeeperAckQuorum,
             double managedLedgerMaxMarkDeleteRate) {
+        checkArgument(bookkeeperEnsemble > 0, "bookkeeperEnsemble must be > 0");
+        checkArgument(bookkeeperWriteQuorum > 0, "bookkeeperWriteQuorum must be > 0");
+        checkArgument(bookkeeperAckQuorum > 0, "bookkeeperAckQuorum must be > 0");
         this.bookkeeperEnsemble = bookkeeperEnsemble;
         this.bookkeeperWriteQuorum = bookkeeperWriteQuorum;
         this.bookkeeperAckQuorum = bookkeeperAckQuorum;


### PR DESCRIPTION
### Motivation

Right now, client can set `PersistencePolicies` for the namespace and `PersistencePolicies` contains `managedLedgerMaxMarkDeleteRate` which can be misconfigured by a client and it can impact broker as broker needs to make more zk calls. Therefore, `PersistencePolicies` should be only accessed by admin.

### Modifications

- add admin access-right for setting namespace persistencePolicies
- validate `PersistencePolicies` parameter while configuring it

### Result

`Namespace-PersistencePolicies` can't be configured by client.
