### PR TITLE
Add msg ack-hole metrics to internal-stats and broker-stats

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
@@ -425,4 +425,18 @@ public interface ManagedCursor {
      * Tells whether the cursor is durable or just kept in memory
      */
     public boolean isDurable();
+
+    /**
+     * Returns total number of entries from the first not-acked message to current dispatching position 
+     * 
+     * @return
+     */
+    long getNumberOfEntriesSinceFirstNotAckedMessage();
+
+    /**
+     * Returns number of mark-Delete range
+     * 
+     * @return
+     */
+    int getTotalNonContiguousDeletedMessagesRange();
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -593,8 +593,14 @@ public class ManagedCursorImpl implements ManagedCursor {
         return getNumberOfEntries(Range.closedOpen(readPosition, ledger.getLastPosition().getNext()));
     }
 
+    @Override
     public long getNumberOfEntriesSinceFirstNotAckedMessage() {
         return ledger.getNumberOfEntries(Range.openClosed(markDeletePosition, readPosition));
+    }
+    
+    @Override
+    public int getTotalNonContiguousDeletedMessagesRange() {
+        return individualDeletedMessages.asRanges().size();
     }
 
     @Override

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
@@ -235,6 +235,16 @@ public class ManagedCursorContainerTest {
         public boolean isActive() {
             return true;
         }
+
+        @Override
+        public long getNumberOfEntriesSinceFirstNotAckedMessage() {
+            return 0;
+        }
+
+        @Override
+        public int getTotalNonContiguousDeletedMessagesRange() {
+            return 0;
+        }
     }
 
     @Test

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -449,6 +449,14 @@ public class PersistentSubscription implements Subscription {
         return this.dispatcher;
     }
 
+    public long getNumberOfEntriesSinceFirstNotAckedMessage() {
+        return cursor.getNumberOfEntriesSinceFirstNotAckedMessage();
+    }
+
+    public int getTotalNonContiguousDeletedMessagesRange() {
+        return cursor.getTotalNonContiguousDeletedMessagesRange();
+    }
+    
     /**
      * Close the cursor ledger for this subscription. Requires that there are no active consumers on the dispatcher
      *

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1027,6 +1027,8 @@ public class PersistentTopic implements Topic, AddEntryCallback {
                 destStatsStream.writePair("msgRateOut", subMsgRateOut);
                 destStatsStream.writePair("msgThroughputOut", subMsgThroughputOut);
                 destStatsStream.writePair("msgRateRedeliver", subMsgRateRedeliver);
+                destStatsStream.writePair("numberOfEntriesSinceFirstNotAckedMessage", subscription.getNumberOfEntriesSinceFirstNotAckedMessage());
+                destStatsStream.writePair("totalNonContiguousDeletedMessagesRange", subscription.getTotalNonContiguousDeletedMessagesRange());
                 destStatsStream.writePair("type", subscription.getTypeString());
                 if (SubType.Shared.equals(subscription.getType())) {
                     if(subscription.getDispatcher() instanceof PersistentDispatcherMultipleConsumers) {
@@ -1176,6 +1178,8 @@ public class PersistentTopic implements Topic, AddEntryCallback {
             cs.individuallyDeletedMessages = cursor.getIndividuallyDeletedMessages();
             cs.lastLedgerSwitchTimestamp = DATE_FORMAT.format(Instant.ofEpochMilli(cursor.getLastLedgerSwitchTimestamp()));
             cs.state = cursor.getState();
+            cs.numberOfEntriesSinceFirstNotAckedMessage = cursor.getNumberOfEntriesSinceFirstNotAckedMessage();
+            cs.totalNonContiguousDeletedMessagesRange = cursor.getTotalNonContiguousDeletedMessagesRange();
             stats.cursors.put(cursor.getName(), cs);
         });
         return stats;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/stats/client/PulsarBrokerStatsClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/stats/client/PulsarBrokerStatsClientTest.java
@@ -19,13 +19,16 @@
 package org.apache.pulsar.stats.client;
 
 import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.assertEquals;
 import static org.mockito.Mockito.spy;
 
 import java.net.URL;
+import java.util.concurrent.TimeUnit;
 
 import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.ServerErrorException;
 
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.admin.PulsarAdminException.ConflictException;
@@ -35,17 +38,43 @@ import org.apache.pulsar.client.admin.PulsarAdminException.PreconditionFailedExc
 import org.apache.pulsar.client.admin.PulsarAdminException.ServerSideErrorException;
 import org.apache.pulsar.client.admin.internal.BrokerStatsImpl;
 import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.ConsumerConfiguration;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerConfiguration;
+import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
+import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats.CursorStats;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-public class PulsarBrokerStatsClientTest {
+import com.google.common.collect.Sets;
+
+public class PulsarBrokerStatsClientTest extends ProducerConsumerBase {
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @AfterMethod
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
 
     @Test
     public void testServiceException() throws Exception {
         URL url = new URL("http://localhost:15000");
-		PulsarAdmin admin = new PulsarAdmin(url, (Authentication) null);
-		BrokerStatsImpl client = (BrokerStatsImpl) spy(admin.brokerStats());
+        PulsarAdmin admin = new PulsarAdmin(url, (Authentication) null);
+        BrokerStatsImpl client = (BrokerStatsImpl) spy(admin.brokerStats());
         try {
             client.getLoadReport();
         } catch (PulsarAdminException e) {
@@ -72,6 +101,45 @@ public class PulsarBrokerStatsClientTest {
         log.info("Client: ", client);
 
         admin.close();
+    }
+
+    @Test
+    public void testTopicInternalStats() throws Exception {
+        log.info("-- Starting {} test --", methodName);
+
+        final String topicName = "persistent://my-property/use/my-ns/my-topic1";
+        final String subscriptionName = "my-subscriber-name";
+        ConsumerConfiguration conf = new ConsumerConfiguration();
+        conf.setSubscriptionType(SubscriptionType.Exclusive);
+        Consumer consumer = pulsarClient.subscribe(topicName, subscriptionName, conf);
+
+        ProducerConfiguration producerConf = new ProducerConfiguration();
+
+        Producer producer = pulsarClient.createProducer(topicName, producerConf);
+        final int numberOfMsgs = 1000;
+        for (int i = 0; i < numberOfMsgs; i++) {
+            String message = "my-message-" + i;
+            producer.send(message.getBytes());
+        }
+
+        Message msg = null;
+        int count = 0;
+        for (int i = 0; i < numberOfMsgs; i++) {
+            msg = consumer.receive(5, TimeUnit.SECONDS);
+            if (msg != null && count++ % 2 == 0) {
+                consumer.acknowledge(msg);
+            }
+        }
+
+        PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getTopic(topicName).get();
+        PersistentTopicInternalStats internalStats = topic.getInternalStats();
+        CursorStats cursor = internalStats.cursors.get(subscriptionName);
+        assertEquals(cursor.numberOfEntriesSinceFirstNotAckedMessage, numberOfMsgs);
+        assertEquals(cursor.totalNonContiguousDeletedMessagesRange, numberOfMsgs / 2 - 1);
+        
+        producer.close();
+        consumer.close();
+        log.info("-- Exiting {} test --", methodName);
     }
 
     private static final Logger log = LoggerFactory.getLogger(PulsarBrokerStatsClientTest.class);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/PersistentTopicInternalStats.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/PersistentTopicInternalStats.java
@@ -59,6 +59,9 @@ public class PersistentTopicInternalStats {
         public String individuallyDeletedMessages;
         public String lastLedgerSwitchTimestamp;
         public String state;
+        public long numberOfEntriesSinceFirstNotAckedMessage;
+        public int totalNonContiguousDeletedMessagesRange;
+        
     }
 
 }


### PR DESCRIPTION
### Motivation

Right now, if consumer doesn't ack message properly then it can create large number of ack-holes at broker and cursor's `markDeletePosition` doesn't move forward. Therefore, topic unloading may create a huge backlog for that consumer and it causes redelivery of duplicate messages.
Therefore, broker should have a metrics for msg ack-holes and it should be accessible by client and admin for monitoring and alert.

### Modifications

Expose msg ack-hole metrics in
- topic's internal-stats
- broker-stats metrics

### Result

No functional change but it will provide additional msg ack-hole metrics.
