### PR TITLE
Add option to persist unack-msg range to cursor-ledger if range is high

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -282,6 +282,10 @@ managedLedgerCursorRolloverTimeInSeconds=14400
 # crashes.
 managedLedgerMaxUnackedRangesToPersist=1000
 
+# Max number of "acknowledgment holes" that can be stored in Zookeeper. If number of unack message range is higher
+# than this limit then broker will persist unacked ranges into bookkeeper to avoid additional data overhead into
+# zookeeper.  
+managedLedgerMaxUnackedRangesToPersistInZooKeeper=1000
 
 
 ### --- Load balancer --- ###

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -280,7 +280,7 @@ managedLedgerCursorRolloverTimeInSeconds=14400
 # that were acknowledged. After the max number of ranges is reached, the information
 # will only be tracked in memory and messages will be redelivered in case of
 # crashes.
-managedLedgerMaxUnackedRangesToPersist=1000
+managedLedgerMaxUnackedRangesToPersist=10000
 
 # Max number of "acknowledgment holes" that can be stored in Zookeeper. If number of unack message range is higher
 # than this limit then broker will persist unacked ranges into bookkeeper to avoid additional data overhead into

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -246,6 +246,19 @@ managedLedgerCursorMaxEntriesPerLedger=50000
 # Max time before triggering a rollover on a cursor ledger
 managedLedgerCursorRolloverTimeInSeconds=14400
 
+# Max number of "acknowledgment holes" that are going to be persistently stored.
+# When acknowledging out of order, a consumer will leave holes that are supposed
+# to be quickly filled by acking all the messages. The information of which
+# messages are acknowledged is persisted by compressing in "ranges" of messages
+# that were acknowledged. After the max number of ranges is reached, the information
+# will only be tracked in memory and messages will be redelivered in case of
+# crashes.
+managedLedgerMaxUnackedRangesToPersist=1000
+
+# Max number of "acknowledgment holes" that can be stored in Zookeeper. If number of unack message range is higher
+# than this limit then broker will persist unacked ranges into bookkeeper to avoid additional data overhead into
+# zookeeper.  
+managedLedgerMaxUnackedRangesToPersistInZooKeeper=1000
 
 
 ### --- Load balancer --- ###

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -253,7 +253,7 @@ managedLedgerCursorRolloverTimeInSeconds=14400
 # that were acknowledged. After the max number of ranges is reached, the information
 # will only be tracked in memory and messages will be redelivered in case of
 # crashes.
-managedLedgerMaxUnackedRangesToPersist=1000
+managedLedgerMaxUnackedRangesToPersist=10000
 
 # Max number of "acknowledgment holes" that can be stored in Zookeeper. If number of unack message range is higher
 # than this limit then broker will persist unacked ranges into bookkeeper to avoid additional data overhead into

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
@@ -35,6 +35,7 @@ import com.google.common.base.Charsets;
 public class ManagedLedgerConfig {
 
     private int maxUnackedRangesToPersist = 1000;
+    private int maxUnackedRangesToPersistInZk = 1000;
     private int maxEntriesPerLedger = 50000;
     private int maxSizePerLedgerMb = 100;
     private int minimumRolloverTimeMs = 0;
@@ -367,5 +368,17 @@ public class ManagedLedgerConfig {
     public ManagedLedgerConfig setMaxUnackedRangesToPersist(int maxUnackedRangesToPersist) {
         this.maxUnackedRangesToPersist = maxUnackedRangesToPersist;
         return this;
+    }
+    
+    /**
+     * @return max unacked message ranges up to which it can store in Zookeeper
+     * 
+     */
+    public int getMaxUnackedRangesToPersistInZk() {
+        return maxUnackedRangesToPersistInZk;
+    }
+
+    public void setMaxUnackedRangesToPersistInZk(int maxUnackedRangesToPersistInZk) {
+        this.maxUnackedRangesToPersistInZk = maxUnackedRangesToPersistInZk;
     }
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
@@ -34,7 +34,7 @@ import com.google.common.base.Charsets;
 @Beta
 public class ManagedLedgerConfig {
 
-    private int maxUnackedRangesToPersist = 1000;
+    private int maxUnackedRangesToPersist = 10000;
     private int maxUnackedRangesToPersistInZk = 1000;
     private int maxEntriesPerLedger = 50000;
     private int maxSizePerLedgerMb = 100;

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -256,6 +256,10 @@ public class ServiceConfiguration implements PulsarConfiguration {
     // will only be tracked in memory and messages will be redelivered in case of
     // crashes.
     private int managedLedgerMaxUnackedRangesToPersist = 1000;
+    // Max number of "acknowledgment holes" that can be stored in Zookeeper. If number of unack message range is higher
+    // than this limit then broker will persist unacked ranges into bookkeeper to avoid additional data overhead into
+    // zookeeper.  
+    private int managedLedgerMaxUnackedRangesToPersistInZooKeeper = 1000;
 
     /*** --- Load balancer --- ****/
     // Enable load balancer
@@ -917,6 +921,15 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     public void setManagedLedgerMaxUnackedRangesToPersist(int managedLedgerMaxUnackedRangesToPersist) {
         this.managedLedgerMaxUnackedRangesToPersist = managedLedgerMaxUnackedRangesToPersist;
+    }
+
+    public int getManagedLedgerMaxUnackedRangesToPersistInZooKeeper() {
+        return managedLedgerMaxUnackedRangesToPersistInZooKeeper;
+    }
+
+    public void setManagedLedgerMaxUnackedRangesToPersistInZooKeeper(
+            int managedLedgerMaxUnackedRangesToPersistInZookeeper) {
+        this.managedLedgerMaxUnackedRangesToPersistInZooKeeper = managedLedgerMaxUnackedRangesToPersistInZookeeper;
     }
 
     public boolean isLoadBalancerEnabled() {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -255,7 +255,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     // that were acknowledged. After the max number of ranges is reached, the information
     // will only be tracked in memory and messages will be redelivered in case of
     // crashes.
-    private int managedLedgerMaxUnackedRangesToPersist = 1000;
+    private int managedLedgerMaxUnackedRangesToPersist = 10000;
     // Max number of "acknowledgment holes" that can be stored in Zookeeper. If number of unack message range is higher
     // than this limit then broker will persist unacked ranges into bookkeeper to avoid additional data overhead into
     // zookeeper.  

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -664,6 +664,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             managedLedgerConfig.setDigestType(DigestType.CRC32);
 
             managedLedgerConfig.setMaxUnackedRangesToPersist(serviceConfig.getManagedLedgerMaxUnackedRangesToPersist());
+            managedLedgerConfig.setMaxUnackedRangesToPersistInZk(serviceConfig.getManagedLedgerMaxUnackedRangesToPersistInZooKeeper());
             managedLedgerConfig.setMaxEntriesPerLedger(serviceConfig.getManagedLedgerMaxEntriesPerLedger());
             managedLedgerConfig.setMinimumRolloverTime(serviceConfig.getManagedLedgerMinLedgerRolloverTimeMinutes(),
                     TimeUnit.MINUTES);


### PR DESCRIPTION
### Motivation

To address #742, we can solve it by recovering unack-message range while recovering managed-cursor. However, storage of large number of unack-msg range can increase zk footprint size. Therefore, we can store this unack-msg range to bookkeeper instead of ZK if unack-msg range is higher than certain threshold.

### Modifications

introduce threshold to decide if cursor-state should store in zookeeper or bookkeeper-ledger.

### Result

Broker can have capability to store cursor-state into bookkeeper-ledger if unack-range is higher than the threshold.
