### PR TITLE
Expose control of sequence id in Java producer API

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -262,7 +262,6 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
                 pulsarStats.recordZkLatencyTimeValue(eventType, latencyMs);
             }
         };
-        PersistentReplicator.setReplicatorQueueSize(pulsar.getConfiguration().getReplicationProducerQueueSize());
     }
 
     public void start() throws Exception {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -32,6 +32,7 @@ import org.apache.bookkeeper.mledger.util.Rate;
 import org.apache.pulsar.broker.service.BrokerServiceException.TopicTerminatedException;
 import org.apache.pulsar.broker.service.Topic.PublishContext;
 import org.apache.pulsar.broker.service.nonpersistent.NonPersistentTopic;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.common.api.Commands;
 import org.apache.pulsar.common.api.proto.PulsarApi.ServerError;
 import org.apache.pulsar.common.naming.DestinationName;
@@ -182,6 +183,18 @@ public class Producer {
     public void recordMessageDrop(int batchSize) {
         if (this.isNonPersistentTopic) {
             msgDrop.recordEvent(batchSize);
+        }
+    }
+
+    /**
+     * Return the sequence id of
+     * @return
+     */
+    public long getLastSequenceId() {
+        if (isNonPersistentTopic) {
+            return -1;
+        } else {
+            return ((PersistentTopic) topic).getLastPublishedSequenceId(producerName);
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -509,7 +509,8 @@ public class ServerCnx extends PulsarHandler {
                         if (isActive()) {
                             if (producerFuture.complete(producer)) {
                                 log.info("[{}] Created new producer: {}", remoteAddress, producer);
-                                ctx.writeAndFlush(Commands.newProducerSuccess(requestId, producerName));
+                                ctx.writeAndFlush(Commands.newProducerSuccess(requestId, producerName,
+                                        producer.getLastSequenceId()));
                                 return;
                             } else {
                                 // The producer's future was completed before by

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentReplicator.java
@@ -34,7 +34,6 @@ import org.apache.pulsar.client.impl.MessageImpl;
 import org.apache.pulsar.client.impl.ProducerImpl;
 import org.apache.pulsar.client.impl.SendCallback;
 import org.apache.pulsar.common.policies.data.NonPersistentReplicatorStats;
-import org.apache.pulsar.common.policies.data.ReplicatorStats;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,8 +52,6 @@ public class NonPersistentReplicator extends AbstractReplicator implements Repli
             BrokerService brokerService) {
         super(topic.getName(), topic.replicatorPrefix, localCluster, remoteCluster, brokerService);
 
-        producerConfiguration
-                .setMaxPendingMessages(brokerService.pulsar().getConfiguration().getReplicationProducerQueueSize());
         producerConfiguration.setBlockIfQueueFull(false);
 
         startProducer();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/MessageDeduplication.java
@@ -417,5 +417,10 @@ public class MessageDeduplication {
         }
     }
 
+    public long getLastPublishedSequenceId(String producerName) {
+        Long sequenceId = highestSequencedPushed.get(producerName);
+        return sequenceId != null ? sequenceId : -1;
+    }
+
     private static final Logger log = LoggerFactory.getLogger(MessageDeduplication.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -58,7 +58,7 @@ public class PersistentReplicator extends AbstractReplicator implements Replicat
     private final PersistentTopic topic;
     private final ManagedCursor cursor;
 
-    private final int producerQueueSize;
+
     private static final int MaxReadBatchSize = 100;
     private int readBatchSize;
 
@@ -97,7 +97,6 @@ public class PersistentReplicator extends AbstractReplicator implements Replicat
         HAVE_PENDING_READ_UPDATER.set(this, FALSE);
         PENDING_MESSAGES_UPDATER.set(this, 0);
 
-        producerQueueSize = brokerService.pulsar().getConfiguration().getReplicationProducerQueueSize();
         readBatchSize = Math.min(producerQueueSize, MaxReadBatchSize);
         producerQueueThreshold = (int) (producerQueueSize * 0.9);
 
@@ -139,14 +138,14 @@ public class PersistentReplicator extends AbstractReplicator implements Replicat
     protected long getNumberOfEntriesInBacklog() {
         return cursor.getNumberOfEntriesInBacklog();
     }
-    
+
     @Override
     protected void disableReplicatorRead() {
         // deactivate cursor after successfully close the producer
         this.cursor.setInactive();
     }
 
-    
+
     protected void readMoreEntries() {
         int availablePermits = producerQueueSize - PENDING_MESSAGES_UPDATER.get(this);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1468,5 +1468,9 @@ public class PersistentTopic implements Topic, AddEntryCallback {
         return this.dispatchRateLimiter;
     }
 
+    public long getLastPublishedSequenceId(String producerName) {
+        return messageDeduplication.getLastPublishedSequenceId(producerName);
+    }
+
     private static final Logger log = LoggerFactory.getLogger(PersistentTopic.class);
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -212,8 +212,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
         }
         Thread.sleep(3000);
 
-        Mockito.verify(pulsarClient, Mockito.times(1)).createProducerAsync(Mockito.anyString(), Mockito.anyObject(),
-                Mockito.anyString());
+        Mockito.verify(pulsarClient, Mockito.times(1)).createProducerAsync(Mockito.anyString(), Mockito.anyObject());
 
     }
 
@@ -623,7 +622,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
     /**
      * It verifies that: if it fails while removing replicator-cluster-cursor: it should not restart the replicator and
      * it should have cleaned up from the list
-     * 
+     *
      * @throws Exception
      */
     @Test
@@ -750,7 +749,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
     /**
      * It verifies that PersistentReplicator considers CursorAlreadyClosedException as non-retriable-read exception and
      * it should closed the producer as cursor is already closed because replicator is already deleted.
-     * 
+     *
      * @throws Exception
      */
     @Test(timeOut = 5000)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientDeduplicationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientDeduplicationTest.java
@@ -1,0 +1,160 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+import java.util.concurrent.TimeUnit;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class ClientDeduplicationTest extends ProducerConsumerBase {
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @AfterClass
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testProducerSequenceAfterReconnect() throws Exception {
+        String topic = "persistent://my-property/use/my-ns/testProducerSequenceAfterReconnect";
+        admin.namespaces().setDeduplicationStatus("my-property/use/my-ns", true);
+
+        ProducerConfiguration conf = new ProducerConfiguration();
+        conf.setProducerName("my-producer-name");
+        Producer producer = pulsarClient.createProducer(topic, conf);
+
+        assertEquals(producer.getLastSequenceId(), -1L);
+
+        for (int i = 0; i < 10; i++) {
+            String message = "my-message-" + i;
+            producer.send(message.getBytes());
+            assertEquals(producer.getLastSequenceId(), i);
+        }
+
+        producer.close();
+
+        producer = pulsarClient.createProducer(topic, conf);
+        assertEquals(producer.getLastSequenceId(), 9L);
+
+        for (int i = 10; i < 20; i++) {
+            String message = "my-message-" + i;
+            producer.send(message.getBytes());
+            assertEquals(producer.getLastSequenceId(), i);
+        }
+
+        producer.close();
+    }
+
+    @Test
+    public void testProducerSequenceAfterRestart() throws Exception {
+        String topic = "persistent://my-property/use/my-ns/testProducerSequenceAfterRestart";
+        admin.namespaces().setDeduplicationStatus("my-property/use/my-ns", true);
+
+        ProducerConfiguration conf = new ProducerConfiguration();
+        conf.setProducerName("my-producer-name");
+        Producer producer = pulsarClient.createProducer(topic, conf);
+
+        assertEquals(producer.getLastSequenceId(), -1L);
+
+        for (int i = 0; i < 10; i++) {
+            String message = "my-message-" + i;
+            producer.send(message.getBytes());
+            assertEquals(producer.getLastSequenceId(), i);
+        }
+
+        producer.close();
+
+        // Kill and restart broker
+        restartBroker();
+
+        producer = pulsarClient.createProducer(topic, conf);
+        assertEquals(producer.getLastSequenceId(), 9L);
+
+        for (int i = 10; i < 20; i++) {
+            String message = "my-message-" + i;
+            producer.send(message.getBytes());
+            assertEquals(producer.getLastSequenceId(), i);
+        }
+
+        producer.close();
+    }
+
+    @Test(timeOut = 30000)
+    public void testProducerDeduplication() throws Exception {
+        String topic = "persistent://my-property/use/my-ns/testProducerDeduplication";
+        admin.namespaces().setDeduplicationStatus("my-property/use/my-ns", true);
+
+        ProducerConfiguration conf = new ProducerConfiguration();
+        conf.setProducerName("my-producer-name");
+
+        // Set infinite timeout
+        conf.setSendTimeout(0, TimeUnit.SECONDS);
+        Producer producer = pulsarClient.createProducer(topic, conf);
+
+        assertEquals(producer.getLastSequenceId(), -1L);
+
+        Consumer consumer = pulsarClient.subscribe(topic, "my-subscription");
+
+        producer.send(MessageBuilder.create().setContent("my-message-0".getBytes()).setSequenceId(0).build());
+        producer.send(MessageBuilder.create().setContent("my-message-1".getBytes()).setSequenceId(1).build());
+        producer.send(MessageBuilder.create().setContent("my-message-2".getBytes()).setSequenceId(2).build());
+
+        // Repeat the messages and verify they're not received by consumer
+        producer.send(MessageBuilder.create().setContent("my-message-1".getBytes()).setSequenceId(1).build());
+        producer.send(MessageBuilder.create().setContent("my-message-2".getBytes()).setSequenceId(2).build());
+
+        producer.close();
+
+        for (int i = 0; i < 3; i++) {
+            Message msg = consumer.receive();
+            assertEquals(new String(msg.getData()), "my-message-" + i);
+            consumer.acknowledge(msg);
+        }
+
+        // No other messages should be received
+        Message msg = consumer.receive(1, TimeUnit.SECONDS);
+        assertNull(msg);
+
+        // Kill and restart broker
+        restartBroker();
+
+        producer = pulsarClient.createProducer(topic, conf);
+        assertEquals(producer.getLastSequenceId(), 2L);
+
+        // Repeat the messages and verify they're not received by consumer
+        producer.send(MessageBuilder.create().setContent("my-message-1".getBytes()).setSequenceId(1).build());
+        producer.send(MessageBuilder.create().setContent("my-message-2".getBytes()).setSequenceId(2).build());
+
+        msg = consumer.receive(1, TimeUnit.SECONDS);
+        assertNull(msg);
+
+        producer.close();
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
@@ -118,7 +118,7 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
      * 5. unload "my-ns2" which closes the connection as broker doesn't have any more client connected on that connection
      * 6. all namespace-bundles are in "connecting" state and waiting for available broker
      * </pre>
-     * 
+     *
      * @throws Exception
      */
     @Test
@@ -237,7 +237,7 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
     /**
      * Verifies: 1. Closing of Broker service unloads all bundle gracefully and there must not be any connected bundles
      * after closing broker service
-     * 
+     *
      * @throws Exception
      */
     @Test
@@ -294,7 +294,7 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
      * 1. broker disconnects that consumer
      * <p>
      * 2. redeliver all those messages to other supported consumer under the same subscription
-     * 
+     *
      * @param subType
      * @throws Exception
      */
@@ -491,7 +491,7 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
      * 3. create multiple producer and make lookup-requests simultaneously
      * 4. Client1 receives TooManyLookupException and should close connection
      * </pre>
-     * 
+     *
      * @throws Exception
      */
     @Test(timeOut = 5000)
@@ -543,7 +543,7 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
                         return null;
                     });
                 });
-                
+
             }
 
             latch.await(10, TimeUnit.SECONDS);
@@ -562,14 +562,14 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
 
     /**
      * It verifies that broker throttles down configured concurrent topic loading requests
-     * 
+     *
      * <pre>
-     * 1. Start broker with N maxConcurrentTopicLoadRequest 
+     * 1. Start broker with N maxConcurrentTopicLoadRequest
      * 2. create concurrent producers on different topics which makes broker to load topics concurrently
      * 3. Producer operationtimeout = 1 ms so, if producers creation will fail for throttled topics
      * 4. verify all producers should have connected
      * </pre>
-     * 
+     *
      * @throws Exception
      */
     @Test(timeOut = 5000)
@@ -613,8 +613,8 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
                     final String randomTopicName1 = topicName + randomUUID().toString();
                     final String randomTopicName2 = topicName + randomUUID().toString();
                     // pass producer-name to avoid exception: producer is already connected to topic
-                    futures.add(pulsarClient2.createProducerAsync(randomTopicName1, config1, randomTopicName1));
-                    futures.add(pulsarClient.createProducerAsync(randomTopicName2, config1, randomTopicName2));
+                    futures.add(pulsarClient2.createProducerAsync(randomTopicName1, config1));
+                    futures.add(pulsarClient.createProducerAsync(randomTopicName2, config1));
                     latch.countDown();
                 });
             }
@@ -630,7 +630,7 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
     }
     /**
      * It verifies that client closes the connection on internalSerevrError which is "ServiceNotReady" from Broker-side
-     * 
+     *
      * @throws Exception
      */
     @Test(timeOut = 5000)

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/MessageBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/MessageBuilder.java
@@ -110,6 +110,24 @@ public interface MessageBuilder {
     MessageBuilder setEventTime(long timestamp);
 
     /**
+     * Specify a custom sequence id for the message being published.
+     * <p>
+     * The sequence id can be used for deduplication purposes and it needs to follow these rules:
+     * <ol>
+     * <li><code>sequenceId >= 0</code>
+     * <li>Sequence id for a message needs to be greater than sequence id for earlier messages:
+     * <code>sequenceId(N+1) > sequenceId(N)</code>
+     * <li>It's not necessary for sequence ids to be consecutive. There can be holes between messages. Eg. the
+     * <code>sequenceId</code> could represent an offset or a cumulative size.
+     * </ol>
+     *
+     * @param sequenceId
+     *            the sequence id to assign to the current message
+     * @since 1.20.0
+     */
+    MessageBuilder setSequenceId(long sequenceId);
+
+    /**
      * Override the replication clusters for this message.
      *
      * @param clusters

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/Producer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/Producer.java
@@ -25,7 +25,7 @@ import org.apache.pulsar.client.impl.ProducerStats;
 
 /**
  * Producer object.
- * 
+ *
  * The producer is used to publish messages on a topic
  *
  *
@@ -36,6 +36,11 @@ public interface Producer extends Closeable {
      * @return the topic which producer is publishing to
      */
     String getTopic();
+
+    /**
+     * @return the producer name which could have been assigned by the system or specified by the client
+     */
+    String getProducerName();
 
     /**
      * Send a message
@@ -82,7 +87,7 @@ public interface Producer extends Closeable {
      * contain the {@link MessageId} assigned by the broker to the published message.
      * <p>
      * Example:
-     * 
+     *
      * <pre>
      * <code>Message msg = MessageBuilder.create().setContent(myContent).build();
      * producer.sendAsync(msg).thenRun(v -> {
@@ -104,24 +109,37 @@ public interface Producer extends Closeable {
     CompletableFuture<MessageId> sendAsync(Message message);
 
     /**
+     * Get the last sequence id that was published by this producer.
+     * <p>
+     * This represent either the automatically assigned or custom sequence id (set on the {@link MessageBuilder}) that
+     * was published and acknowledged by the broker.
+     * <p>
+     * After recreating a producer with the same producer name, this will return the last message that was published in
+     * the previous producer session, or -1 if there no message was ever published.
+     *
+     * @return the last sequence id published by this producer
+     */
+    long getLastSequenceId();
+
+    /**
      * Get statistics for the producer
-     * 
+     *
      * numMsgsSent : Number of messages sent in the current interval numBytesSent : Number of bytes sent in the current
      * interval numSendFailed : Number of messages failed to send in the current interval numAcksReceived : Number of
      * acks received in the current interval totalMsgsSent : Total number of messages sent totalBytesSent : Total number
      * of bytes sent totalSendFailed : Total number of messages failed to send totalAcksReceived: Total number of acks
      * received
-     * 
+     *
      * @return statistic for the producer or null if ProducerStats is disabled.
      */
     ProducerStats getStats();
 
     /**
      * Close the producer and releases resources allocated.
-     * 
+     *
      * No more writes will be accepted from this producer. Waits until all pending write request are persisted. In case
      * of errors, pending writes will not be retried.
-     * 
+     *
      * @throws PulsarClientException.AlreadyClosedException
      *             if the producer was already closed
      */
@@ -130,10 +148,10 @@ public interface Producer extends Closeable {
 
     /**
      * Close the producer and releases resources allocated.
-     * 
+     *
      * No more writes will be accepted from this producer. Waits until all pending write request are persisted. In case
      * of errors, pending writes will not be retried.
-     * 
+     *
      * @return a future that can used to track when the producer has been closed
      */
     CompletableFuture<Void> closeAsync();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ProducerConfiguration.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ProducerConfiguration.java
@@ -49,7 +49,8 @@ public class ProducerConfiguration implements Serializable {
 
     private CompressionType compressionType = CompressionType.NONE;
 
-    private Optional<Long> initialSequenceId = Optional.empty();
+    // Cannot use Optional<Long> since it's not serializable
+    private Long initialSequenceId = null;
 
     public enum MessageRoutingMode {
         SinglePartition, RoundRobinPartition, CustomPartition
@@ -323,7 +324,7 @@ public class ProducerConfiguration implements Serializable {
     }
 
     public Optional<Long> getInitialSequenceId() {
-        return initialSequenceId;
+        return initialSequenceId != null ? Optional.of(initialSequenceId) : Optional.empty();
     }
 
     /**
@@ -336,7 +337,7 @@ public class ProducerConfiguration implements Serializable {
      * @return
      */
     public ProducerConfiguration setInitialSequenceId(long initialSequenceId) {
-        this.initialSequenceId = Optional.of(initialSequenceId);
+        this.initialSequenceId = initialSequenceId;
         return this;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageBuilderImpl.java
@@ -89,6 +89,13 @@ public class MessageBuilderImpl implements MessageBuilder {
     }
 
     @Override
+    public MessageBuilder setSequenceId(long sequenceId) {
+        checkArgument(sequenceId >= 0);
+        msgMetadataBuilder.setSequenceId(sequenceId);
+        return this;
+    }
+
+    @Override
     public MessageBuilder setReplicationClusters(List<String> clusters) {
         Preconditions.checkNotNull(clusters);
         msgMetadataBuilder.clearReplicateTo();
@@ -102,4 +109,6 @@ public class MessageBuilderImpl implements MessageBuilder {
         msgMetadataBuilder.addReplicateTo("__local__");
         return this;
     }
+
+
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -149,13 +149,7 @@ public class PulsarClientImpl implements PulsarClient {
         return createProducerAsync(topic, new ProducerConfiguration());
     }
 
-    @Override
     public CompletableFuture<Producer> createProducerAsync(final String topic, final ProducerConfiguration conf) {
-        return createProducerAsync(topic, conf, null);
-    }
-
-    public CompletableFuture<Producer> createProducerAsync(final String topic, final ProducerConfiguration conf,
-            String producerName) {
         if (state.get() != State.Open) {
             return FutureUtil.failedFuture(new PulsarClientException.AlreadyClosedException("Client already closed"));
         }
@@ -180,8 +174,7 @@ public class PulsarClientImpl implements PulsarClient {
                 producer = new PartitionedProducerImpl(PulsarClientImpl.this, topic, conf, metadata.partitions,
                         producerCreatedFuture);
             } else {
-                producer = new ProducerImpl(PulsarClientImpl.this, topic, producerName, conf, producerCreatedFuture,
-                        -1);
+                producer = new ProducerImpl(PulsarClientImpl.this, topic, conf, producerCreatedFuture, -1);
             }
 
             synchronized (producers) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/Commands.java
@@ -173,9 +173,14 @@ public class Commands {
     }
 
     public static ByteBuf newProducerSuccess(long requestId, String producerName) {
+        return newProducerSuccess(requestId, producerName, -1);
+    }
+
+    public static ByteBuf newProducerSuccess(long requestId, String producerName, long lastSequenceId) {
         CommandProducerSuccess.Builder producerSuccessBuilder = CommandProducerSuccess.newBuilder();
         producerSuccessBuilder.setRequestId(requestId);
         producerSuccessBuilder.setProducerName(producerName);
+        producerSuccessBuilder.setLastSequenceId(lastSequenceId);
         CommandProducerSuccess producerSuccess = producerSuccessBuilder.build();
         ByteBuf res = serializeWithSize(
                 BaseCommand.newBuilder().setType(Type.PRODUCER_SUCCESS).setProducerSuccess(producerSuccess));

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
@@ -250,11 +250,11 @@ public final class PulsarApi {
   public interface MessageIdDataOrBuilder
       extends com.google.protobuf.MessageLiteOrBuilder {
     
-    // required uint64 ledgerId = 1;
+    // required int64 ledgerId = 1;
     boolean hasLedgerId();
     long getLedgerId();
     
-    // required uint64 entryId = 2;
+    // required int64 entryId = 2;
     boolean hasEntryId();
     long getEntryId();
     
@@ -301,7 +301,7 @@ public final class PulsarApi {
     }
     
     private int bitField0_;
-    // required uint64 ledgerId = 1;
+    // required int64 ledgerId = 1;
     public static final int LEDGERID_FIELD_NUMBER = 1;
     private long ledgerId_;
     public boolean hasLedgerId() {
@@ -311,7 +311,7 @@ public final class PulsarApi {
       return ledgerId_;
     }
     
-    // required uint64 entryId = 2;
+    // required int64 entryId = 2;
     public static final int ENTRYID_FIELD_NUMBER = 2;
     private long entryId_;
     public boolean hasEntryId() {
@@ -373,10 +373,10 @@ public final class PulsarApi {
                         throws java.io.IOException {
       getSerializedSize();
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        output.writeUInt64(1, ledgerId_);
+        output.writeInt64(1, ledgerId_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        output.writeUInt64(2, entryId_);
+        output.writeInt64(2, entryId_);
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         output.writeInt32(3, partition_);
@@ -394,11 +394,11 @@ public final class PulsarApi {
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeUInt64Size(1, ledgerId_);
+          .computeInt64Size(1, ledgerId_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeUInt64Size(2, entryId_);
+          .computeInt64Size(2, entryId_);
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         size += com.google.protobuf.CodedOutputStream
@@ -635,12 +635,12 @@ public final class PulsarApi {
             }
             case 8: {
               bitField0_ |= 0x00000001;
-              ledgerId_ = input.readUInt64();
+              ledgerId_ = input.readInt64();
               break;
             }
             case 16: {
               bitField0_ |= 0x00000002;
-              entryId_ = input.readUInt64();
+              entryId_ = input.readInt64();
               break;
             }
             case 24: {
@@ -659,7 +659,7 @@ public final class PulsarApi {
       
       private int bitField0_;
       
-      // required uint64 ledgerId = 1;
+      // required int64 ledgerId = 1;
       private long ledgerId_ ;
       public boolean hasLedgerId() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
@@ -680,7 +680,7 @@ public final class PulsarApi {
         return this;
       }
       
-      // required uint64 entryId = 2;
+      // required int64 entryId = 2;
       private long entryId_ ;
       public boolean hasEntryId() {
         return ((bitField0_ & 0x00000002) == 0x00000002);
@@ -13618,6 +13618,10 @@ public final class PulsarApi {
     // required string producer_name = 2;
     boolean hasProducerName();
     String getProducerName();
+    
+    // optional int64 last_sequence_id = 3 [default = -1];
+    boolean hasLastSequenceId();
+    long getLastSequenceId();
   }
   public static final class CommandProducerSuccess extends
       com.google.protobuf.GeneratedMessageLite
@@ -13696,9 +13700,20 @@ public final class PulsarApi {
       }
     }
     
+    // optional int64 last_sequence_id = 3 [default = -1];
+    public static final int LAST_SEQUENCE_ID_FIELD_NUMBER = 3;
+    private long lastSequenceId_;
+    public boolean hasLastSequenceId() {
+      return ((bitField0_ & 0x00000004) == 0x00000004);
+    }
+    public long getLastSequenceId() {
+      return lastSequenceId_;
+    }
+    
     private void initFields() {
       requestId_ = 0L;
       producerName_ = "";
+      lastSequenceId_ = -1L;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -13731,6 +13746,9 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         output.writeBytes(2, getProducerNameBytes());
       }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        output.writeInt64(3, lastSequenceId_);
+      }
     }
     
     private int memoizedSerializedSize = -1;
@@ -13746,6 +13764,10 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(2, getProducerNameBytes());
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(3, lastSequenceId_);
       }
       memoizedSerializedSize = size;
       return size;
@@ -13864,6 +13886,8 @@ public final class PulsarApi {
         bitField0_ = (bitField0_ & ~0x00000001);
         producerName_ = "";
         bitField0_ = (bitField0_ & ~0x00000002);
+        lastSequenceId_ = -1L;
+        bitField0_ = (bitField0_ & ~0x00000004);
         return this;
       }
       
@@ -13905,6 +13929,10 @@ public final class PulsarApi {
           to_bitField0_ |= 0x00000002;
         }
         result.producerName_ = producerName_;
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        result.lastSequenceId_ = lastSequenceId_;
         result.bitField0_ = to_bitField0_;
         return result;
       }
@@ -13916,6 +13944,9 @@ public final class PulsarApi {
         }
         if (other.hasProducerName()) {
           setProducerName(other.getProducerName());
+        }
+        if (other.hasLastSequenceId()) {
+          setLastSequenceId(other.getLastSequenceId());
         }
         return this;
       }
@@ -13962,6 +13993,11 @@ public final class PulsarApi {
             case 18: {
               bitField0_ |= 0x00000002;
               producerName_ = input.readBytes();
+              break;
+            }
+            case 24: {
+              bitField0_ |= 0x00000004;
+              lastSequenceId_ = input.readInt64();
               break;
             }
           }
@@ -14025,6 +14061,27 @@ public final class PulsarApi {
         bitField0_ |= 0x00000002;
         producerName_ = value;
         
+      }
+      
+      // optional int64 last_sequence_id = 3 [default = -1];
+      private long lastSequenceId_ = -1L;
+      public boolean hasLastSequenceId() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      public long getLastSequenceId() {
+        return lastSequenceId_;
+      }
+      public Builder setLastSequenceId(long value) {
+        bitField0_ |= 0x00000004;
+        lastSequenceId_ = value;
+        
+        return this;
+      }
+      public Builder clearLastSequenceId() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        lastSequenceId_ = -1L;
+        
+        return this;
       }
       
       // @@protoc_insertion_point(builder_scope:pulsar.proto.CommandProducerSuccess)

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/protobuf/ByteBufCodedOutputStream.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/protobuf/ByteBufCodedOutputStream.java
@@ -127,11 +127,16 @@ public class ByteBufCodedOutputStream {
         writeInt32NoTag(value);
     }
 
+    public void writeInt64(final int fieldNumber, final long value) throws IOException {
+        writeTag(fieldNumber, WireFormat.WIRETYPE_VARINT);
+        writeInt64NoTag(value);
+    }
+
     public void writeUInt64(final int fieldNumber, final long value) throws IOException {
         writeTag(fieldNumber, WireFormat.WIRETYPE_VARINT);
         writeUInt64NoTag(value);
     }
-    
+
     /** Write a {@code bool} field, including tag, to the stream. */
     public void writeBool(final int fieldNumber, final boolean value) throws IOException {
         writeTag(fieldNumber, WireFormat.WIRETYPE_VARINT);
@@ -142,7 +147,12 @@ public class ByteBufCodedOutputStream {
     public void writeBoolNoTag(final boolean value) throws IOException {
       writeRawByte(value ? 1 : 0);
     }
-    
+
+    /** Write a {@code uint64} field to the stream. */
+    public void writeInt64NoTag(final long value) throws IOException {
+        writeRawVarint64(value);
+    }
+
     /** Write a {@code uint64} field to the stream. */
     public void writeUInt64NoTag(final long value) throws IOException {
         writeRawVarint64(value);

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -310,6 +310,10 @@ message CommandSuccess {
 message CommandProducerSuccess {
 	required uint64 request_id    = 1;
 	required string producer_name = 2;
+	
+	// The last sequence id that was stored by this producer in the previous session
+	// This will only be meaningful if deduplication has been enabled.
+	optional int64  last_sequence_id = 3 [default = -1];
 }
 
 message CommandError {


### PR DESCRIPTION
### Motivation

Last set of changes for [PIP-6](https://github.com/apache/incubator-pulsar/wiki/PIP-6:-Guaranteed-Message-Deduplication) implementation. 

Changes in client side to expose sequence id in the `Producer` and `MessageBuilder` interfaces.

This change will enable applications to take advantage of deduplication and ensure messages can be stored only-once even after the producer application crashes or get restarted.

### Modifications

 * Added few `ProducerConfiguration` options: 
   - `setProducerName()` This was already used internally by replicator. Exposed in public API
   -  `setInitialSequenceId()` Let the application specify the initial sequence id
 * In `Producer` interface: 
    - Added `Producer.getLastSequenceId()` to return the last persisted sequence id for a producer
    - `Producer.getProducerName()` to access the auto-generated producer name
 * `MessageBuilder.setSequenceId()`: manually specify the sequence id of a message. This may be related to some application specific property

