### PR TITLE
Cpp producer sequence id changes

### DIFF
--- a/pulsar-client-cpp/include/pulsar/MessageBuilder.h
+++ b/pulsar-client-cpp/include/pulsar/MessageBuilder.h
@@ -76,6 +76,24 @@ class MessageBuilder {
     MessageBuilder& setEventTimestamp(uint64_t eventTimestamp);
 
     /**
+     * Specify a custom sequence id for the message being published.
+     * <p>
+     * The sequence id can be used for deduplication purposes and it needs to follow these rules:
+     * <ol>
+     * <li><code>sequenceId >= 0</code>
+     * <li>Sequence id for a message needs to be greater than sequence id for earlier messages:
+     * <code>sequenceId(N+1) > sequenceId(N)</code>
+     * <li>It's not necessary for sequence ids to be consecutive. There can be holes between messages. Eg. the
+     * <code>sequenceId</code> could represent an offset or a cumulative size.
+     * </ol>
+     *
+     * @param sequenceId
+     *            the sequence id to assign to the current message
+     * @since 1.20.0
+     */
+    MessageBuilder& setSequenceId(int64_t sequenceId);
+
+    /**
      * override namespace replication clusters.  note that it is the
      * caller's responsibility to provide valid cluster names, and that
      * all clusters have been previously configured as destinations.

--- a/pulsar-client-cpp/include/pulsar/Producer.h
+++ b/pulsar-client-cpp/include/pulsar/Producer.h
@@ -42,6 +42,11 @@ class Producer {
     const std::string& getTopic() const;
 
     /**
+     * @return the producer name which could have been assigned by the system or specified by the client
+     */
+    const std::string& getProducerName() const;
+
+    /**
      * Publish a message on the topic associated with this Producer.
      *
      * This method will block until the message will be accepted and persisted
@@ -74,6 +79,19 @@ class Producer {
      * @param callback the callback to get notification of the completion
      */
     void sendAsync(const Message& msg, SendCallback callback);
+
+    /**
+     * Get the last sequence id that was published by this producer.
+     *
+     * This represent either the automatically assigned or custom sequence id (set on the MessageBuilder) that
+     * was published and acknowledged by the broker.
+     *
+     * After recreating a producer with the same producer name, this will return the last message that was published in
+     * the previous producer session, or -1 if there no message was ever published.
+     *
+     * @return the last sequence id published by this producer
+     */
+    int64_t getLastSequenceId() const;
 
     /**
      * Close the producer and release resources allocated.

--- a/pulsar-client-cpp/include/pulsar/ProducerConfiguration.h
+++ b/pulsar-client-cpp/include/pulsar/ProducerConfiguration.h
@@ -48,8 +48,14 @@ class ProducerConfiguration {
     ProducerConfiguration(const ProducerConfiguration&);
     ProducerConfiguration& operator=(const ProducerConfiguration&);
 
+    ProducerConfiguration& setProducerName(const std::string& producerName);
+    const std::string& getProducerName() const;
+
     ProducerConfiguration& setSendTimeout(int sendTimeoutMs);
     int getSendTimeout() const;
+
+    ProducerConfiguration& setInitialSequenceId(int64_t initialSequenceId);
+    int64_t getInitialSequenceId() const;
 
     ProducerConfiguration& setCompressionType(CompressionType compressionType);
     CompressionType getCompressionType() const;

--- a/pulsar-client-cpp/lib/ClientConnection.h
+++ b/pulsar-client-cpp/lib/ClientConnection.h
@@ -68,6 +68,8 @@ class LookupDataResult;
 
 struct OpSendMsg;
 
+typedef std::pair<std::string, int64_t> ResponseData;
+
 class ClientConnection : public boost::enable_shared_from_this<ClientConnection> {
     enum State {
         Pending,
@@ -125,7 +127,7 @@ class ClientConnection : public boost::enable_shared_from_this<ClientConnection>
      * Send a request with a specific Id over the connection. The future will be
      * triggered when the response for this request is received
      */
-    Future<Result, std::string> sendRequestWithId(SharedBuffer cmd, int requestId);
+    Future<Result, ResponseData> sendRequestWithId(SharedBuffer cmd, int requestId);
 
     const std::string& brokerAddress() const;
 
@@ -138,7 +140,7 @@ class ClientConnection : public boost::enable_shared_from_this<ClientConnection>
     Future<Result, BrokerConsumerStatsImpl> newConsumerStats(uint64_t consumerId, uint64_t requestId) ;
  private:
     struct PendingRequestData {
-        Promise<Result, std::string> promise;
+        Promise<Result, ResponseData> promise;
         DeadlineTimerPtr timer;
     };
 

--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -701,7 +701,7 @@ void ConsumerImpl::closeAsync(ResultCallback callback) {
     // Lock is no longer required
     lock.unlock();
     int requestId = client->newRequestId();
-    Future<Result, std::string> future = cnx->sendRequestWithId(
+    Future<Result, ResponseData> future = cnx->sendRequestWithId(
             Commands::newCloseConsumer(consumerId_, requestId), requestId);
     if (!callback.empty()) {
         future.addListener(

--- a/pulsar-client-cpp/lib/MessageBuilder.cc
+++ b/pulsar-client-cpp/lib/MessageBuilder.cc
@@ -107,6 +107,9 @@ MessageBuilder& MessageBuilder::setEventTimestamp(uint64_t eventTimestamp) {
 }
 
 MessageBuilder& MessageBuilder::setSequenceId(int64_t sequenceId) {
+    if (sequenceId < 0) {
+        throw "sequenceId needs to be >= 0";
+    }
     checkMetadata();
     impl_->metadata.set_sequence_id(sequenceId);
     return *this;

--- a/pulsar-client-cpp/lib/MessageBuilder.cc
+++ b/pulsar-client-cpp/lib/MessageBuilder.cc
@@ -106,6 +106,12 @@ MessageBuilder& MessageBuilder::setEventTimestamp(uint64_t eventTimestamp) {
     return *this;
 }
 
+MessageBuilder& MessageBuilder::setSequenceId(int64_t sequenceId) {
+    checkMetadata();
+    impl_->metadata.set_sequence_id(sequenceId);
+    return *this;
+}
+
 MessageBuilder& MessageBuilder::setReplicationClusters(const std::vector<std::string>& clusters) {
     checkMetadata();
     google::protobuf::RepeatedPtrField<std::string> r(clusters.begin(), clusters.end());

--- a/pulsar-client-cpp/lib/PartitionedProducerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedProducerImpl.cc
@@ -136,6 +136,19 @@ namespace pulsar {
         lock.unlock();
     }
 
+    const std::string& PartitionedProducerImpl::getProducerName() const {
+        return producers_[0]->getProducerName();
+    }
+
+    int64_t PartitionedProducerImpl::getLastSequenceId() const {
+        int64_t currentMax = -1L;
+        for (int i = 0; i < producers_.size(); i++) {
+            currentMax = std::max(currentMax, producers_[i]->getLastSequenceId());
+        }
+
+        return currentMax;
+    }
+
     /*
      * if createProducerCallback is set, it means the closeAsync is called from CreateProducer API which failed to create
      * one or many producers for partitions. So, we have to notify with ERROR on createProducerFailure

--- a/pulsar-client-cpp/lib/PartitionedProducerImpl.h
+++ b/pulsar-client-cpp/lib/PartitionedProducerImpl.h
@@ -54,6 +54,10 @@ namespace pulsar {
      */
     virtual void closeAsync(CloseCallback closeCallback);
 
+    virtual const std::string& getProducerName() const;
+
+    virtual int64_t getLastSequenceId() const;
+
     virtual void start();
 
     virtual void shutdown();

--- a/pulsar-client-cpp/lib/Producer.cc
+++ b/pulsar-client-cpp/lib/Producer.cc
@@ -57,6 +57,14 @@ void Producer::sendAsync(const Message& msg, SendCallback callback) {
     impl_->sendAsync(msg, callback);
 }
 
+const std::string& Producer::getProducerName() const {
+    return impl_->getProducerName();
+}
+
+int64_t Producer::getLastSequenceId() const {
+    return impl_->getLastSequenceId();
+}
+
 Result Producer::close() {
     Promise<bool, Result> promise;
     closeAsync(WaitForCallback(promise));

--- a/pulsar-client-cpp/lib/ProducerConfiguration.cc
+++ b/pulsar-client-cpp/lib/ProducerConfiguration.cc
@@ -36,6 +36,25 @@ ProducerConfiguration& ProducerConfiguration::operator=(const ProducerConfigurat
     return *this;
 }
 
+ProducerConfiguration& ProducerConfiguration::setProducerName(const std::string& producerName) {
+    impl_->producerName = Optional<std::string>::of(producerName);
+    return *this;
+}
+
+const std::string& ProducerConfiguration::getProducerName() const {
+    static const std::string emptyString;
+    return impl_->producerName.is_present() ? impl_->producerName.value() : emptyString;
+}
+
+ProducerConfiguration& ProducerConfiguration::setInitialSequenceId(int64_t initialSequenceId) {
+    impl_->initialSequenceId = Optional<int64_t>::of(initialSequenceId);
+    return *this;
+}
+
+int64_t ProducerConfiguration::getInitialSequenceId() const {
+    return impl_->initialSequenceId.is_present() ? impl_->initialSequenceId.value() : -1ll;
+}
+
 ProducerConfiguration& ProducerConfiguration::setSendTimeout(int sendTimeoutMs) {
     impl_->sendTimeoutMs = sendTimeoutMs;
     return *this;

--- a/pulsar-client-cpp/lib/ProducerConfigurationImpl.h
+++ b/pulsar-client-cpp/lib/ProducerConfigurationImpl.h
@@ -22,9 +22,13 @@
 #include <pulsar/ProducerConfiguration.h>
 #include <boost/make_shared.hpp>
 
+#include "Utils.h"
+
 namespace pulsar {
 
 struct ProducerConfigurationImpl {
+    Optional<std::string> producerName;
+    Optional<int64_t> initialSequenceId;
     int sendTimeoutMs;
     CompressionType compressionType;
     int maxPendingMessages;

--- a/pulsar-client-cpp/lib/ProducerImpl.h
+++ b/pulsar-client-cpp/lib/ProducerImpl.h
@@ -75,6 +75,10 @@ class ProducerImpl : public HandlerBase, public boost::enable_shared_from_this<P
 
     virtual void disconnectProducer();
 
+    const std::string& getProducerName() const;
+
+    int64_t getLastSequenceId() const;
+
     uint64_t getProducerId() const;
 
     virtual void start();
@@ -111,7 +115,7 @@ class ProducerImpl : public HandlerBase, public boost::enable_shared_from_this<P
     void printStats();
 
     void handleCreateProducer(const ClientConnectionPtr& cnx, Result result,
-                              const std::string& producerName);
+                              const ResponseData& responseData);
 
     void statsCallBackHandler(Result , const Message& , SendCallback , boost::posix_time::ptime );
 
@@ -130,9 +134,11 @@ class ProducerImpl : public HandlerBase, public boost::enable_shared_from_this<P
     std::string producerName_;
     std::string producerStr_;
     uint64_t producerId_;
-    uint64_t msgSequenceGenerator_;
+    int64_t msgSequenceGenerator_;
     proto::BaseCommand cmd_;
     BatchMessageContainerPtr batchMessageContainer;
+
+    volatile int64_t lastSequenceIdPublished_;
 
     typedef boost::shared_ptr<boost::asio::deadline_timer> TimerPtr;
     TimerPtr sendTimer_;

--- a/pulsar-client-cpp/lib/ProducerImplBase.h
+++ b/pulsar-client-cpp/lib/ProducerImplBase.h
@@ -32,6 +32,10 @@ public:
   virtual ~ProducerImplBase(){
   }
 
+  virtual const std::string& getProducerName() const = 0;
+
+  virtual int64_t getLastSequenceId() const = 0;
+
   virtual void sendAsync(const Message& msg, SendCallback callback) = 0;
   virtual void closeAsync(CloseCallback callback) = 0;
   virtual void start() = 0;

--- a/pulsar-client-cpp/python/pulsar.py
+++ b/pulsar-client-cpp/python/pulsar.py
@@ -584,6 +584,7 @@ class Producer:
         """
         Close the producer.
         """
+        self._producer.close()
 
     def _build_msg(self, content, properties, partition_key, sequence_id,
                    replication_clusters, disable_replication):

--- a/pulsar-client-cpp/python/pulsar.py
+++ b/pulsar-client-cpp/python/pulsar.py
@@ -260,6 +260,8 @@ class Client:
         self._consumers = []
 
     def create_producer(self, topic,
+                        producer_name=None,
+                        initial_sequence_id=None,
                         send_timeout_millis=30000,
                         compression_type=CompressionType.NONE,
                         max_pending_messages=1000,
@@ -278,7 +280,17 @@ class Client:
           The topic name
 
         **Options**
-
+        * `producer_name`:
+           Specify a name for the producer. If not assigned,
+           the system will generate a globally unique name which can be accessed
+           with `Producer.producer_name()`. When specifying a name, it is app to
+           the user to ensure that, for a given topic, the producer name is unique
+           across all Pulsar's clusters.
+        * `initial_sequence_id`:
+           Set the baseline for the sequence ids for messages
+           published by the producer. First message will be using
+           `(initialSequenceId + 1)`` as its sequence id and subsequent messages will
+           be assigned incremental sequence ids, if not otherwise specified.
         * `send_timeout_seconds`:
           If a message is not acknowledged by the server before the
           `send_timeout` expires, an error will be reported.
@@ -303,6 +315,10 @@ class Client:
         conf.batching_max_messages(batching_max_messages)
         conf.batching_max_allowed_size_in_bytes(batching_max_allowed_size_in_bytes)
         conf.batching_max_publish_delay_ms(batching_max_publish_delay_ms)
+        if producer_name:
+            conf.producer_name(producer_name)
+        if initial_sequence_id:
+            conf.initial_sequence_id(initial_sequence_id)
         p = Producer()
         p._producer = self._client.create_producer(topic, conf)
         return p
@@ -452,9 +468,36 @@ class Producer:
     The Pulsar message producer, used to publish messages on a topic.
     """
 
+    def topic(self):
+        """
+        Return the topic which producer is publishing to
+        """
+        return self._producer.topic()
+
+    def producer_name(self):
+        """
+        Return the producer name which could have been assigned by the
+        system or specified by the client
+        """
+        return self._producer.producer_name()
+
+    def last_sequence_id(self):
+        """
+        Get the last sequence id that was published by this producer.
+
+        This represent either the automatically assigned or custom sequence id
+        (set on the `MessageBuilder`) that was published and acknowledged by the broker.
+
+        After recreating a producer with the same producer name, this will return the
+        last message that was published in the previous producer session, or -1 if
+        there no message was ever published.
+        """
+        return self._producer.last_sequence_id()
+
     def send(self, content,
              properties=None,
              partition_key=None,
+             sequence_id=None,
              replication_clusters=None,
              disable_replication=False
              ):
@@ -473,6 +516,8 @@ class Producer:
         * `partition_key`:
           Sets the partition key for message routing. A hash of this key is used
           to determine the message's destination partition.
+        * `sequence_id`:
+          Specify a custom sequence id for the message being published.
         * `replication_clusters`:
           Override namespace replication clusters. Note that it is the caller's
           responsibility to provide valid cluster names and that all clusters
@@ -481,13 +526,14 @@ class Producer:
         * `disable_replication`:
           Do not replicate this message.
         """
-        msg = self._build_msg(content, properties, partition_key,
+        msg = self._build_msg(content, properties, partition_key, sequence_id,
                               replication_clusters, disable_replication)
         return self._producer.send(msg)
 
     def send_async(self, content, callback,
                    properties=None,
                    partition_key=None,
+                   sequence_id=None,
                    replication_clusters=None,
                    disable_replication=False
                    ):
@@ -520,6 +566,8 @@ class Producer:
         * `partition_key`:
           Sets the partition key for the message routing. A hash of this key is
           used to determine the message's destination partition.
+        * `sequence_id`:
+          Specify a custom sequence id for the message being published.
         * `replication_clusters`: Override namespace replication clusters. Note
           that it is the caller's responsibility to provide valid cluster names
           and that all clusters have been previously configured as destinations.
@@ -528,7 +576,7 @@ class Producer:
         * `disable_replication`:
           Do not replicate this message.
         """
-        msg = self._build_msg(content, properties, partition_key,
+        msg = self._build_msg(content, properties, partition_key, sequence_id,
                               replication_clusters, disable_replication)
         self._producer.send_async(msg, callback)
 
@@ -537,7 +585,7 @@ class Producer:
         Close the producer.
         """
 
-    def _build_msg(self, content, properties, partition_key,
+    def _build_msg(self, content, properties, partition_key, sequence_id,
                    replication_clusters, disable_replication):
         mb = _pulsar.MessageBuilder()
         mb.content(content)
@@ -546,6 +594,8 @@ class Producer:
                 mb.property(k, v)
         if partition_key:
             mb.partition_key(partition_key)
+        if sequence_id:
+            mb.sequence_id(sequence_id)
         if replication_clusters:
             mb.replication_clusters(replication_clusters)
         if disable_replication:

--- a/pulsar-client-cpp/python/src/config.cc
+++ b/pulsar-client-cpp/python/src/config.cc
@@ -98,7 +98,7 @@ void export_config() {
             ;
 
     class_<ProducerConfiguration>("ProducerConfiguration")
-            .def("producer_name", &ProducerConfiguration::getProducerName)
+            .def("producer_name", &ProducerConfiguration::getProducerName, return_value_policy<copy_const_reference>())
             .def("producer_name", &ProducerConfiguration::setProducerName, return_self<>())
             .def("send_timeout_millis", &ProducerConfiguration::getSendTimeout)
             .def("send_timeout_millis", &ProducerConfiguration::setSendTimeout, return_self<>())

--- a/pulsar-client-cpp/python/src/config.cc
+++ b/pulsar-client-cpp/python/src/config.cc
@@ -98,8 +98,12 @@ void export_config() {
             ;
 
     class_<ProducerConfiguration>("ProducerConfiguration")
+            .def("producer_name", &ProducerConfiguration::getProducerName)
+            .def("producer_name", &ProducerConfiguration::setProducerName, return_self<>())
             .def("send_timeout_millis", &ProducerConfiguration::getSendTimeout)
             .def("send_timeout_millis", &ProducerConfiguration::setSendTimeout, return_self<>())
+            .def("initial_sequence_id", &ProducerConfiguration::getInitialSequenceId)
+            .def("initial_sequence_id", &ProducerConfiguration::setInitialSequenceId, return_self<>())
             .def("compression_type", &ProducerConfiguration::getCompressionType)
             .def("compression_type", &ProducerConfiguration::setCompressionType, return_self<>())
             .def("max_pending_messages", &ProducerConfiguration::getMaxPendingMessages)

--- a/pulsar-client-cpp/python/src/message.cc
+++ b/pulsar-client-cpp/python/src/message.cc
@@ -51,6 +51,7 @@ void export_message() {
             .def("content", MessageBuilderSetContentString, return_self<>())
             .def("property", &MessageBuilder::setProperty, return_self<>())
             .def("properties", &MessageBuilder::setProperties, return_self<>())
+            .def("sequence_id", &MessageBuilder::setSequenceId, return_self<>())
             .def("partition_key", &MessageBuilder::setPartitionKey, return_self<>())
             .def("event_timestamp", &MessageBuilder::setEventTimestamp, return_self<>())
             .def("replication_clusters", &MessageBuilder::setReplicationClusters, return_self<>())

--- a/pulsar-client-cpp/python/src/producer.cc
+++ b/pulsar-client-cpp/python/src/producer.cc
@@ -68,6 +68,10 @@ void export_producer() {
     class_<Producer>("Producer", no_init)
             .def("topic", &Producer::getTopic, "return the topic to which producer is publishing to",
                  return_value_policy<copy_const_reference>())
+            .def("producer_name", &Producer::getProducerName,
+                 "return the producer name which could have been assigned by the system or specified by the client",
+                 return_value_policy<copy_const_reference>())
+            .def("last_sequence_id", &Producer::getLastSequenceId)
             .def("send", &Producer_send,
                  "Publish a message on the topic associated with this Producer.\n"
                          "\n"

--- a/pulsar-client-cpp/tests/ClientDeduplicationTest.cc
+++ b/pulsar-client-cpp/tests/ClientDeduplicationTest.cc
@@ -1,0 +1,142 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <pulsar/Client.h>
+
+#include <gtest/gtest.h>
+#include <boost/lexical_cast.hpp>
+
+#include "HttpHelper.h"
+
+#include <string>
+
+using namespace pulsar;
+
+static std::string serviceUrl = "pulsar://localhost:8885";
+static std::string adminUrl = "http://localhost:8765/";
+
+TEST(ClientDeduplicationTest, testProducerSequenceAfterReconnect) {
+    Client client(serviceUrl);
+
+    std::string topicName = "persistent://sample/standalone/ns1/testProducerSequenceAfterReconnect-"
+            + boost::lexical_cast<std::string>(time(NULL));
+
+    // call admin api to make enable deduplication
+    std::string url = adminUrl + "admin/namespaces/sample/standalone/ns1/deduplication";
+    int res = makePostRequest(url, "true");
+    ASSERT_EQ(res, 204);
+
+    ReaderConfiguration readerConf;
+    Reader reader;
+    ASSERT_EQ(client.createReader(topicName, MessageId::earliest(), readerConf, reader), ResultOk);
+
+    Producer producer;
+    ProducerConfiguration producerConf;
+    producerConf.setProducerName("my-producer-name");
+    ASSERT_EQ(client.createProducer(topicName, producerConf, producer), ResultOk);
+
+    ASSERT_EQ(producer.getLastSequenceId(), -1L);
+
+    for (int i = 0; i < 10; i++) {
+        std::string content = "my-message-" + boost::lexical_cast<std::string>(i);
+        Message msg = MessageBuilder().setContent(content).build();
+        ASSERT_EQ(producer.send(msg), ResultOk);
+        ASSERT_EQ(producer.getLastSequenceId(), i);
+    }
+
+    producer.close();
+
+    ASSERT_EQ(ResultOk, client.createProducer(topicName, producerConf, producer));
+    ASSERT_EQ(producer.getLastSequenceId(), 9);
+
+    for (int i = 10; i < 20; i++) {
+        std::string content = "my-message-" + boost::lexical_cast<std::string>(i);
+        Message msg = MessageBuilder().setContent(content).build();
+        ASSERT_EQ(producer.send(msg), ResultOk);
+        ASSERT_EQ(producer.getLastSequenceId(), i);
+    }
+
+    client.close();
+}
+
+TEST(ClientDeduplicationTest, testProducerDeduplication) {
+    Client client(serviceUrl);
+
+    std::string topicName = "persistent://sample/standalone/ns1/testProducerDeduplication-"
+            + boost::lexical_cast<std::string>(time(NULL));
+
+    // call admin api to make enable deduplication
+    std::string url = adminUrl + "admin/namespaces/sample/standalone/ns1/deduplication";
+    int res = makePostRequest(url, "true");
+    ASSERT_EQ(res, 204);
+
+    ReaderConfiguration readerConf;
+    Reader reader;
+    ASSERT_EQ(client.createReader(topicName, MessageId::earliest(), readerConf, reader), ResultOk);
+
+    Producer producer;
+    ProducerConfiguration producerConf;
+    producerConf.setProducerName("my-producer-name");
+    ASSERT_EQ(client.createProducer(topicName, producerConf, producer), ResultOk);
+
+    ASSERT_EQ(producer.getLastSequenceId(), -1L);
+
+    Consumer consumer;
+    ASSERT_EQ(client.subscribe(topicName, "my-subscription", consumer), ResultOk);
+
+    ASSERT_EQ(producer.send(MessageBuilder().setContent("my-message-0").setSequenceId(0).build()),
+              ResultOk);
+    ASSERT_EQ(producer.send(MessageBuilder().setContent("my-message-1").setSequenceId(1).build()),
+              ResultOk);
+    ASSERT_EQ(producer.send(MessageBuilder().setContent("my-message-2").setSequenceId(2).build()),
+              ResultOk);
+
+    // Repeat the messages and verify they're not received by consumer
+    ASSERT_EQ(producer.send(MessageBuilder().setContent("my-message-1").setSequenceId(1).build()),
+              ResultOk);
+    ASSERT_EQ(producer.send(MessageBuilder().setContent("my-message-2").setSequenceId(2).build()),
+              ResultOk);
+
+    producer.close();
+
+    Message msg;
+    for (int i = 0; i < 3; i++) {
+        consumer.receive(msg);
+
+        ASSERT_EQ(msg.getDataAsString(), "my-message-" + boost::lexical_cast<std::string>(i));
+        consumer.acknowledge(msg);
+    }
+
+    // No other messages should be received
+    ASSERT_EQ(consumer.receive(msg, 1000), ResultTimeout);
+
+    ASSERT_EQ(ResultOk, client.createProducer(topicName, producerConf, producer));
+    ASSERT_EQ(producer.getLastSequenceId(), 2);
+
+    // Repeat the messages and verify they're not received by consumer
+    ASSERT_EQ(producer.send(MessageBuilder().setContent("my-message-1").setSequenceId(1).build()),
+              ResultOk);
+    ASSERT_EQ(producer.send(MessageBuilder().setContent("my-message-2").setSequenceId(2).build()),
+              ResultOk);
+
+    // No other messages should be received
+    ASSERT_EQ(consumer.receive(msg, 1000), ResultTimeout);
+
+    client.close();
+}
+

--- a/pulsar-client-cpp/tests/HttpHelper.cc
+++ b/pulsar-client-cpp/tests/HttpHelper.cc
@@ -21,7 +21,7 @@
  #include <curl/curl.h>
 
 
-int makePutRequest(const std::string& url, const std::string& body) {
+static int makeRequest(const std::string& method, const std::string& url, const std::string& body) {
     CURL* curl = curl_easy_init();
 
     struct curl_slist *list = NULL;
@@ -30,7 +30,7 @@ int makePutRequest(const std::string& url, const std::string& body) {
 
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, list);
     curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
-    curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PUT");
+    curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, method.c_str());
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
     int res = curl_easy_perform(curl);
     curl_slist_free_all(list); /* free the list again */
@@ -43,4 +43,12 @@ int makePutRequest(const std::string& url, const std::string& body) {
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &httpResult);
     curl_easy_cleanup(curl);
     return (int) httpResult;
+}
+
+int makePutRequest(const std::string& url, const std::string& body) {
+    return makeRequest("PUT", url, body);
+}
+
+int makePostRequest(const std::string& url, const std::string& body) {
+    return makeRequest("POST", url, body);
 }

--- a/pulsar-client-cpp/tests/HttpHelper.h
+++ b/pulsar-client-cpp/tests/HttpHelper.h
@@ -22,6 +22,7 @@
 #include <string>
 
 int makePutRequest(const std::string& url, const std::string& body);
+int makePostRequest(const std::string& url, const std::string& body);
 
 
 #endif /* end of include guard: HTTP_HELPER */


### PR DESCRIPTION
### Motivation

C++ and Python equivalent of the Java client library changes made in #760 

Last set of changes for [PIP-6](https://github.com/apache/incubator-pulsar/wiki/PIP-6:-Guaranteed-Message-Deduplication) implementation. 

Changes in client side to expose sequence id in the `Producer` and `MessageBuilder` interfaces.

This change will enable applications to take advantage of deduplication and ensure messages can be stored only-once even after the producer application crashes or get restarted.

### Modifications

 * Added few `ProducerConfiguration` options: 
   - `setProducerName()` This was already used internally by replicator. Exposed in public API
   -  `setInitialSequenceId()` Let the application specify the initial sequence id
 * In `Producer` interface: 
    - Added `Producer.getLastSequenceId()` to return the last persisted sequence id for a producer
    - `Producer.getProducerName()` to access the auto-generated producer name
 * `MessageBuilder.setSequenceId()`: manually specify the sequence id of a message. This may be related to some application specific property

