### PR TITLE
Use `advertisedAddress` from host IP in Kubernetes deployment

### DIFF
--- a/conf/bookkeeper.conf
+++ b/conf/bookkeeper.conf
@@ -39,6 +39,11 @@ bookiePort=3181
 # set the listening interface.
 allowLoopback=false
 
+# Configure a specific hostname or IP address that the bookie should use to advertise itself to
+# clients. If not set, bookie will advertised its own IP address or hostname, depending on the
+# listeningInterface and `seHostNameAsBookieID settings.
+advertisedAddress=
+
 # Directory Bookkeeper outputs its write ahead log
 journalDirectory=data/bookkeeper/journal
 

--- a/kubernetes/generic/bookie.yaml
+++ b/kubernetes/generic/bookie.yaml
@@ -62,6 +62,7 @@ spec:
                 args:
                   - >
                     bin/apply-config-from-env.py conf/bookkeeper.conf &&
+                    bin/apply-config-from-env.py conf/pulsar_env.sh &&
                     bin/pulsar bookie
                 ports:
                   - containerPort: 3181
@@ -69,6 +70,11 @@ spec:
                 envFrom:
                   - configMapRef:
                         name: bookie-config
+                env:
+                  - name: advertisedAddress
+                    valueFrom:
+                        fieldRef:
+                            fieldPath: status.hostIP
 
                 volumeMounts:
                   - name: journal-disk

--- a/kubernetes/generic/broker.yaml
+++ b/kubernetes/generic/broker.yaml
@@ -55,6 +55,7 @@ spec:
                 args:
                   - >
                     bin/apply-config-from-env.py conf/broker.conf &&
+                    bin/apply-config-from-env.py conf/pulsar_env.sh &&
                     bin/pulsar broker
                 ports:
                   - containerPort: 8080

--- a/kubernetes/generic/zookeeper.yaml
+++ b/kubernetes/generic/zookeeper.yaml
@@ -84,6 +84,7 @@ spec:
                 args:
                   - >
                     bin/apply-config-from-env.py conf/zookeeper.conf &&
+                    bin/apply-config-from-env.py conf/pulsar_env.sh &&
                     bin/generate-zookeeper-config.sh conf/zookeeper.conf &&
                     bin/pulsar zookeeper
                 ports:

--- a/kubernetes/google-container-engine/bookie.yaml
+++ b/kubernetes/google-container-engine/bookie.yaml
@@ -63,6 +63,7 @@ spec:
                 args:
                   - >
                     bin/apply-config-from-env.py conf/bookkeeper.conf &&
+                    bin/apply-config-from-env.py conf/pulsar_env.sh &&
                     bin/pulsar bookie
                 ports:
                   - containerPort: 3181
@@ -70,6 +71,11 @@ spec:
                 envFrom:
                   - configMapRef:
                         name: bookie-config
+                env:
+                  - name: advertisedAddress
+                    valueFrom:
+                        fieldRef:
+                            fieldPath: status.hostIP
 
                 volumeMounts:
                   - name: journal-disk

--- a/kubernetes/google-container-engine/broker.yaml
+++ b/kubernetes/google-container-engine/broker.yaml
@@ -54,6 +54,7 @@ spec:
                 args:
                   - >
                     bin/apply-config-from-env.py conf/broker.conf &&
+                    bin/apply-config-from-env.py conf/pulsar_env.sh &&
                     bin/pulsar broker
                 ports:
                   - containerPort: 8080

--- a/kubernetes/google-container-engine/zookeeper.yaml
+++ b/kubernetes/google-container-engine/zookeeper.yaml
@@ -95,6 +95,7 @@ spec:
                 args:
                   - >
                     bin/apply-config-from-env.py conf/zookeeper.conf &&
+                    bin/apply-config-from-env.py conf/pulsar_env.sh &&
                     bin/generate-zookeeper-config.sh conf/zookeeper.conf &&
                     bin/pulsar zookeeper
                 ports:


### PR DESCRIPTION
### Motivation

Take advantage of the support for bookie `advertisedAddress` introduced in yahoo/bookkeeper#10
. This allows to tie the bookie identity to the node instead of the Kubernetes Pod.

Also, I've added the script calls to apply confing from environment to `conf/pulsar_env.sh` files.
