### PR TITLE
[#766] - Disabling IOUtilsTest.test5() for failures

### DIFF
--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/utils/IOUtilsTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/utils/IOUtilsTest.java
@@ -123,7 +123,9 @@ public class IOUtilsTest {
         }
     }
 
-    @Test(description = "Should go into infinte loop since \r means next line.")
+    // TODO: Disabled because it fails with maven surefire 2.20
+    // https://github.com/apache/incubator-pulsar/issues/766
+    @Test(enabled = false, description = "Should go into infinte loop since \r means next line.")
     public void test6() {
         try {
             String data = "\n";

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/utils/IOUtilsTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/utils/IOUtilsTest.java
@@ -97,7 +97,9 @@ public class IOUtilsTest {
         }
     }
 
-    @Test(description = "Should go into infinte loop since j is an invalid response.")
+    // TODO: Disabled because it fails with maven surefire 2.20
+    // https://github.com/apache/incubator-pulsar/issues/766
+    @Test(enabled = false, description = "Should go into infinte loop since j is an invalid response.")
     public void test5() {
         try {
             String data = "j";


### PR DESCRIPTION
### Motivation

As explained in #766, the tests is triggering a bug in Maven Surefire plugin which makes the tests to be failing in certain environments. Disabling the test until Surefire has a fix available.