### PR TITLE
Don't reuse JVM forks when running tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -591,7 +591,7 @@ flexible messaging model and an intuitive client API.</description>
             -Dorg.slf4j.simpleLogger.log.org.apache.bookkeeper=off
             -Dorg.slf4j.simpleLogger.log.org.apache.bookkeeper.mledger=info
           </argLine>
-          <reuseForks>true</reuseForks>
+          <reuseForks>false</reuseForks>
           <forkCount>1</forkCount>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
         </configuration>


### PR DESCRIPTION
### Motivation

Use different JVM forks for each test (all tests within a class). 

That should help avoiding interference between unit tests and reducing flaky tests, at the expense of a slightly longer build time (due to restarting the JVM many times).