### PR TITLE
Fixed race condition in ProxyPublishConsumeTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeTest.java
@@ -129,19 +129,23 @@ public class ProxyPublishConsumeTest extends ProducerConsumerBase {
             Future<Session> readerFuture = readClient.connect(readSocket, readUri, readRequest);
             log.info("Connecting to : {}", readUri);
 
-            ClientUpgradeRequest produceRequest = new ClientUpgradeRequest();
-            produceClient.start();
-            Future<Session> producerFuture = produceClient.connect(produceSocket, produceUri, produceRequest);
             // let it connect
             Assert.assertTrue(consumerFuture1.get().isOpen());
             Assert.assertTrue(consumerFuture2.get().isOpen());
             Assert.assertTrue(readerFuture.get().isOpen());
+
+            // Also make sure subscriptions and reader are already created
+            Thread.sleep(500);
+
+            ClientUpgradeRequest produceRequest = new ClientUpgradeRequest();
+            produceClient.start();
+            Future<Session> producerFuture = produceClient.connect(produceSocket, produceUri, produceRequest);
             Assert.assertTrue(producerFuture.get().isOpen());
 
             int retry = 0;
             int maxRetry = 400;
-            while (consumeSocket1.getReceivedMessagesCount() < 10 && consumeSocket2.getReceivedMessagesCount() < 10
-            		&& readSocket.getReceivedMessagesCount() < 10) {
+            while ((consumeSocket1.getReceivedMessagesCount() < 10 && consumeSocket2.getReceivedMessagesCount() < 10)
+                    || readSocket.getReceivedMessagesCount() < 10) {
                 Thread.sleep(10);
                 if (retry++ > maxRetry) {
                     final String msg = String.format("Consumer still has not received the message after %s ms",
@@ -256,12 +260,16 @@ public class ProxyPublishConsumeTest extends ProducerConsumerBase {
             Future<Session> readerFuture = readClient.connect(readSocket, readUri, readRequest);
             log.info("Connecting to : {}", readUri);
 
+            Assert.assertTrue(consumerFuture1.get().isOpen());
+            Assert.assertTrue(readerFuture.get().isOpen());
+
+            Thread.sleep(500);
+
             ClientUpgradeRequest produceRequest = new ClientUpgradeRequest();
             produceClient.start();
             Future<Session> producerFuture = produceClient.connect(produceSocket, produceUri, produceRequest);
             // let it connect
-            Assert.assertTrue(consumerFuture1.get().isOpen());
-            Assert.assertTrue(readerFuture.get().isOpen());
+
             Assert.assertTrue(producerFuture.get().isOpen());
 
             // sleep so, proxy can deliver few messages to consumers for stats

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeTls.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeTls.java
@@ -47,9 +47,7 @@ import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -60,8 +58,8 @@ public class ProxyPublishConsumeTls extends ProducerConsumerBase {
     private int port;
     private int tlsPort;
     private static final String TLS_SERVER_CERT_FILE_PATH = "./src/test/resources/certificate/server.crt";
-    private static final String TLS_SERVER_KEY_FILE_PATH = "./src/test/resources/certificate/server.key";    
-    
+    private static final String TLS_SERVER_KEY_FILE_PATH = "./src/test/resources/certificate/server.key";
+
     private ProxyServer proxyServer;
     private WebSocketService service;
 
@@ -121,13 +119,14 @@ public class ProxyPublishConsumeTls extends ProducerConsumerBase {
             ClientUpgradeRequest consumeRequest = new ClientUpgradeRequest();
             Future<Session> consumerFuture = consumeClient.connect(consumeSocket, consumeUri, consumeRequest);
             log.info("Connecting to : {}", consumeUri);
+            Assert.assertTrue(consumerFuture.get().isOpen());
+
+            Thread.sleep(500);
 
             ClientUpgradeRequest produceRequest = new ClientUpgradeRequest();
             produceClient.start();
             Future<Session> producerFuture = produceClient.connect(produceSocket, produceUri, produceRequest);
-            // let it connect
-            Thread.sleep(1000);
-            Assert.assertTrue(consumerFuture.get().isOpen());
+
             Assert.assertTrue(producerFuture.get().isOpen());
 
             consumeSocket.awaitClose(1, TimeUnit.SECONDS);


### PR DESCRIPTION
### Motivation

The check condition on the number of message received by the reader was not correct. Also, the `onConnect()` event is actually triggered *before* the consumer has been fully established, so added sleep to account for that. 