### PR TITLE
Refactored replicator test with backlog quota interactions

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarStats.java
@@ -75,8 +75,13 @@ public class PulsarStats implements Closeable {
 
     @Override
     public void close() {
-        ReferenceCountUtil.safeRelease(topicStatsBuf);
-        ReferenceCountUtil.safeRelease(tempTopicStatsBuf);
+        bufferLock.writeLock().lock();
+        try {
+            ReferenceCountUtil.safeRelease(topicStatsBuf);
+            ReferenceCountUtil.safeRelease(tempTopicStatsBuf);
+        } finally {
+            bufferLock.writeLock().unlock();
+        }
     }
 
     public ClusterReplicationMetrics getClusterReplicationMetrics() {
@@ -193,7 +198,7 @@ public class PulsarStats implements Closeable {
             log.warn("Exception while recording topic load time for topic {}, {}", topic, ex.getMessage());
         }
     }
-    
+
     public void recordZkLatencyTimeValue(EventType eventType, long latencyMs) {
         try {
             if (EventType.write.equals(eventType)) {


### PR DESCRIPTION
### Motivation

The logic for the replicator test with the backlog quota check was not correct.

We need to make sure that the quota gets filled, in order to cause remote backlog,  and then drain the backlog when the quota is available.

### Modifications

Refactored the test to do: 
 * Create 2 regions `r1` and `r2`
 * Created local subscription on `r2`
 * Initially quota is open
 * Publish message `m1` in `r1`. It gets replicated
 * Reduce quota to fit just 1 message
 * Publish next message `m2` in `r1`
 * Verify message is in remote backlog
 * Consume `m1` in `r2`
 * Verify `m2` gets replicated and consumed
