### PR TITLE
Fixed the jar name for the aspectjweaver

### DIFF
--- a/bin/pulsar
+++ b/bin/pulsar
@@ -204,7 +204,7 @@ elif [ $COMMAND == "zookeeper" ]; then
     PULSAR_LOG_FILE=${PULSAR_LOG_FILE:-"zookeeper.log"}
 
     # Add instrumentation
-    WEAVER_JAR=`find $PULSAR_HOME/lib -name 'aspectjweaver-*.jar'`
+    WEAVER_JAR=`find $PULSAR_HOME/lib -name 'org.aspectj-aspectjweaver-*.jar'`
     if [ -n "$WEAVER_JAR" ]; then OPTS="$OPTS -javaagent:$WEAVER_JAR"; fi
     exec $JAVA $OPTS -Dpulsar.log.file=$PULSAR_LOG_FILE org.apache.pulsar.zookeeper.ZooKeeperStarter $PULSAR_ZK_CONF $@
 elif [ $COMMAND == "global-zookeeper" ]; then
@@ -212,7 +212,7 @@ elif [ $COMMAND == "global-zookeeper" ]; then
     # Allow global ZK to turn into read-only mode when it cannot reach the quorum
     OPTS="${OPTS} -Dreadonlymode.enabled=true"
     # Add instrumentation
-    WEAVER_JAR=`find $PULSAR_HOME/lib -name 'aspectjweaver-*.jar'`
+    WEAVER_JAR=`find $PULSAR_HOME/lib -name 'org.aspectj-aspectjweaver-*.jar'`
     if [ -n "$WEAVER_JAR" ]; then OPTS="$OPTS -javaagent:$WEAVER_JAR"; fi
     exec $JAVA $OPTS -Dpulsar.log.file=$PULSAR_LOG_FILE org.apache.pulsar.zookeeper.ZooKeeperStarter $PULSAR_GLOBAL_ZK_CONF $@
 elif [ $COMMAND == "discovery" ]; then

--- a/bin/pulsar
+++ b/bin/pulsar
@@ -202,18 +202,11 @@ elif [ $COMMAND == "bookie" ]; then
     exec $JAVA $OPTS -Dpulsar.log.file=$PULSAR_LOG_FILE org.apache.bookkeeper.proto.BookieServer --conf $PULSAR_BOOKKEEPER_CONF $@
 elif [ $COMMAND == "zookeeper" ]; then
     PULSAR_LOG_FILE=${PULSAR_LOG_FILE:-"zookeeper.log"}
-
-    # Add instrumentation
-    WEAVER_JAR=`find $PULSAR_HOME/lib -name 'org.aspectj-aspectjweaver-*.jar'`
-    if [ -n "$WEAVER_JAR" ]; then OPTS="$OPTS -javaagent:$WEAVER_JAR"; fi
     exec $JAVA $OPTS -Dpulsar.log.file=$PULSAR_LOG_FILE org.apache.pulsar.zookeeper.ZooKeeperStarter $PULSAR_ZK_CONF $@
 elif [ $COMMAND == "global-zookeeper" ]; then
     PULSAR_LOG_FILE=${PULSAR_LOG_FILE:-"global-zookeeper.log"}
     # Allow global ZK to turn into read-only mode when it cannot reach the quorum
     OPTS="${OPTS} -Dreadonlymode.enabled=true"
-    # Add instrumentation
-    WEAVER_JAR=`find $PULSAR_HOME/lib -name 'org.aspectj-aspectjweaver-*.jar'`
-    if [ -n "$WEAVER_JAR" ]; then OPTS="$OPTS -javaagent:$WEAVER_JAR"; fi
     exec $JAVA $OPTS -Dpulsar.log.file=$PULSAR_LOG_FILE org.apache.pulsar.zookeeper.ZooKeeperStarter $PULSAR_GLOBAL_ZK_CONF $@
 elif [ $COMMAND == "discovery" ]; then
     PULSAR_LOG_FILE=${PULSAR_LOG_FILE:-"discovery.log"}

--- a/pulsar-zookeeper/pom.xml
+++ b/pulsar-zookeeper/pom.xml
@@ -69,6 +69,11 @@
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>com.ea.agentloader</groupId>
+      <artifactId>ea-agent-loader</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pulsar-zookeeper/src/main/java/org/apache/pulsar/zookeeper/ZooKeeperStarter.java
+++ b/pulsar-zookeeper/src/main/java/org/apache/pulsar/zookeeper/ZooKeeperStarter.java
@@ -21,11 +21,14 @@ package org.apache.pulsar.zookeeper;
 import java.net.InetSocketAddress;
 
 import org.apache.zookeeper.server.quorum.QuorumPeerMain;
+import org.aspectj.weaver.loadtime.Agent;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.ea.agentloader.AgentLoader;
 
 import io.prometheus.client.exporter.MetricsServlet;
 import io.prometheus.client.hotspot.DefaultExports;
@@ -34,6 +37,9 @@ public class ZooKeeperStarter {
     public static void main(String[] args) throws Exception {
         // Register basic JVM metrics
         DefaultExports.initialize();
+
+        // load aspectj-weaver agent for instrumentation
+        AgentLoader.loadAgentClass(Agent.class.getName(), null);
 
         // Start Jetty to serve stats
         int port = Integer.parseInt(System.getProperties().getProperty("stats_server_port", "8080"));


### PR DESCRIPTION
### Motivation

The jar names in `libs` folder were renamed to include the artifact group id (for better identification). 

When we start the zookeeper process, we need to pass the right jar for AspectjWeaver in order to enabled detailed ZK stats.