### PR TITLE
Ensure producer/consumer are creating before upgrading from HTTP to WebSocket

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeTls.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeTls.java
@@ -35,7 +35,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 
 import org.apache.bookkeeper.test.PortManager;
-import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.client.api.TlsProducerConsumerTest;
 import org.apache.pulsar.websocket.WebSocketService;
 import org.apache.pulsar.websocket.service.ProxyServer;
 import org.apache.pulsar.websocket.service.WebSocketProxyConfiguration;
@@ -53,7 +53,7 @@ import org.testng.annotations.Test;
 
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 
-public class ProxyPublishConsumeTls extends ProducerConsumerBase {
+public class ProxyPublishConsumeTls extends TlsProducerConsumerTest {
     protected String methodName;
     private int port;
     private int tlsPort;
@@ -65,8 +65,9 @@ public class ProxyPublishConsumeTls extends ProducerConsumerBase {
 
     @BeforeMethod
     public void setup() throws Exception {
-        super.internalSetup();
-        super.producerBaseSetup();
+        super.setup();
+
+        this.internalSetupForTls();
 
         port = PortManager.nextFreePort();
         tlsPort = PortManager.nextFreePort();
@@ -87,7 +88,7 @@ public class ProxyPublishConsumeTls extends ProducerConsumerBase {
 
     @AfterMethod
     protected void cleanup() throws Exception {
-        super.internalCleanup();
+        super.cleanup();
         service.close();
         proxyServer.stop();
         log.info("Finished Cleaning Up Test setup");
@@ -112,7 +113,6 @@ public class ProxyPublishConsumeTls extends ProducerConsumerBase {
         WebSocketClient consumeClient = new WebSocketClient(sslContextFactory);
         SimpleConsumerSocket consumeSocket = new SimpleConsumerSocket();
         WebSocketClient produceClient = new WebSocketClient(sslContextFactory);
-        SimpleProducerSocket produceSocket = new SimpleProducerSocket();
 
         try {
             consumeClient.start();
@@ -121,8 +121,7 @@ public class ProxyPublishConsumeTls extends ProducerConsumerBase {
             log.info("Connecting to : {}", consumeUri);
             Assert.assertTrue(consumerFuture.get().isOpen());
 
-            Thread.sleep(500);
-
+            SimpleProducerSocket produceSocket = new SimpleProducerSocket();
             ClientUpgradeRequest produceRequest = new ClientUpgradeRequest();
             produceClient.start();
             Future<Session> producerFuture = produceClient.connect(produceSocket, produceUri, produceRequest);

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/AbstractWebSocketHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/AbstractWebSocketHandler.java
@@ -65,16 +65,17 @@ public abstract class AbstractWebSocketHandler extends WebSocketAdapter implemen
         if (service.isAuthenticationEnabled()) {
             try {
                 authRole = service.getAuthenticationService().authenticateHttpRequest(request);
-                log.info("[{}] Authenticated WebSocket client {} on topic {}", request.getRemoteAddr(), authRole,
-                        topic);
+                log.info("[{}:{}] Authenticated WebSocket client {} on topic {}", request.getRemoteAddr(),
+                        request.getRemotePort(), authRole, topic);
 
             } catch (AuthenticationException e) {
-                log.warn("[{}] Failed to authenticated WebSocket client {} on topic {}: {}", request.getRemoteAddr(),
-                        authRole, topic, e.getMessage());
+                log.warn("[{}:{}] Failed to authenticated WebSocket client {} on topic {}: {}", request.getRemoteAddr(),
+                        request.getRemotePort(), authRole, topic, e.getMessage());
                 try {
                     response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Failed to authenticate");
                 } catch (IOException e1) {
-                    log.warn("Failed to send error: {}", e1.getMessage());
+                    log.warn("[{}:{}] Failed to send error: {}", request.getRemoteAddr(), request.getRemotePort(),
+                            e1.getMessage(), e1);
                 }
                 return;
             }
@@ -83,18 +84,19 @@ public abstract class AbstractWebSocketHandler extends WebSocketAdapter implemen
         if (service.isAuthorizationEnabled()) {
             try {
                 if (!isAuthorized(authRole)) {
-                    log.warn("[{}] WebSocket Client [{}] is not authorized on topic {}", request.getRemoteAddr(),
-                            authRole, topic);
-                    response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Not authorized");
+                    log.warn("[{}:{}] WebSocket Client [{}] is not authorized on topic {}", request.getRemoteAddr(),
+                            request.getRemotePort(), authRole, topic);
+                    response.sendError(HttpServletResponse.SC_FORBIDDEN, "Not authorized");
                     return;
                 }
             } catch (Exception e) {
-                log.warn("[{}] Got an exception when authorizing WebSocket client {} on topic {} on: {}",
-                        request.getRemoteAddr(), authRole, topic, e.getMessage());
+                log.warn("[{}:{}] Got an exception when authorizing WebSocket client {} on topic {} on: {}",
+                        request.getRemoteAddr(), request.getRemotePort(), authRole, topic, e.getMessage());
                 try {
                     response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Server error");
                 } catch (IOException e1) {
-                    log.warn("Failed to send error: {}", e1.getMessage());
+                    log.warn("[{}:{}] Failed to send error: {}", request.getRemoteAddr(), request.getRemotePort(),
+                            e1.getMessage(), e1);
                 }
                 return;
             }

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
@@ -91,12 +91,13 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
             this.service.addConsumer(this);
             receiveMessage();
         } catch (Exception e) {
-            log.warn("[{}] Failed in creating subscription {} on topic {}", request.getRemoteAddr(), subscription,
-                    topic, e);
+            log.warn("[{}:{}] Failed in creating subscription {} on topic {}", request.getRemoteAddr(),
+                    request.getRemotePort(), subscription, topic, e);
             try {
                 response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Failed to subscribe");
             } catch (IOException e1) {
-                log.warn("Failed to send error: {}", e1);
+                log.warn("[{}:{}] Failed to send error: {}", request.getRemoteAddr(), request.getRemotePort(),
+                        e1.getMessage(), e1);
             }
         }
     }

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ProducerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ProducerHandler.java
@@ -89,11 +89,13 @@ public class ProducerHandler extends AbstractWebSocketHandler {
             this.producer = service.getPulsarClient().createProducer(topic, conf);
             this.service.addProducer(this);
         } catch (Exception e) {
-            log.warn("[{}] Failed in creating producer on topic {}", request.getRemoteAddr(), topic, e);
+            log.warn("[{}:{}] Failed in creating producer on topic {}", request.getRemoteAddr(),
+                    request.getRemotePort(), topic, e);
             try {
                 response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Failed to create producer");
             } catch (IOException e1) {
-                log.warn("Failed to send error: {}", e1);
+                log.warn("[{}:{}] Failed to send error: {}", request.getRemoteAddr(), request.getRemotePort(),
+                        e1.getMessage(), e1);
             }
         }
     }

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ReaderHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ReaderHandler.java
@@ -18,39 +18,36 @@
  */
 package org.apache.pulsar.websocket;
 
-import static com.google.common.base.Preconditions.checkArgument;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.io.IOException;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.LongAdder;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
-
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Reader;
 import org.apache.pulsar.client.api.ReaderConfiguration;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.client.impl.ReaderImpl;
-import org.apache.pulsar.client.api.Consumer;
-import org.apache.pulsar.client.api.MessageId;
-import org.apache.pulsar.client.api.Reader;
 import org.apache.pulsar.common.naming.DestinationName;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.websocket.data.ConsumerMessage;
-import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.WriteCallback;
+import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.common.base.Splitter;
 
 /**
  *
@@ -67,34 +64,34 @@ public class ReaderHandler extends AbstractWebSocketHandler {
 
     private final int maxPendingMessages;
     private final AtomicInteger pendingMessages = new AtomicInteger();
-    
+
     private final LongAdder numMsgsDelivered;
     private final LongAdder numBytesDelivered;
     private volatile long msgDeliveredCounter = 0;
     private static final AtomicLongFieldUpdater<ReaderHandler> MSG_DELIVERED_COUNTER_UPDATER =
             AtomicLongFieldUpdater.newUpdater(ReaderHandler.class, "msgDeliveredCounter");
 
-    public ReaderHandler(WebSocketService service, HttpServletRequest request) {
-        super(service, request);
+    public ReaderHandler(WebSocketService service, HttpServletRequest request, ServletUpgradeResponse response) {
+        super(service, request, response);
         this.subscription = "";
         this.conf = getReaderConfiguration();
         this.maxPendingMessages = (conf.getReceiverQueueSize() == 0) ? 1 : conf.getReceiverQueueSize();
         this.numMsgsDelivered = new LongAdder();
-        this.numBytesDelivered = new LongAdder();        
-    }
-
-    @Override
-    protected void createClient(Session session) {
+        this.numBytesDelivered = new LongAdder();
 
         try {
             this.reader = service.getPulsarClient().createReader(topic, getMessageId(), conf);
-            this.subscription = ((ReaderImpl)this.reader).getConsumer().getSubscription(); 
+            this.subscription = ((ReaderImpl)this.reader).getConsumer().getSubscription();
             this.service.addReader(this);
             receiveMessage();
         } catch (Exception e) {
-            log.warn("[{}] Failed in creating subscription {} on topic {}", session.getRemoteAddress(), subscription,
+            log.warn("[{}] Failed in creating reader {} on topic {}", request.getRemoteAddr(), subscription,
                     topic, e);
-            close(WebSocketError.FailedToSubscribe, e.getMessage());
+            try {
+                response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Failed to create reader");
+            } catch (IOException e1) {
+                log.warn("Failed to send error: {}", e1);
+            }
         }
     }
 
@@ -184,7 +181,7 @@ public class ReaderHandler extends AbstractWebSocketHandler {
             });
         }
     }
-    
+
     public Consumer getConsumer() {
         return ((ReaderImpl)reader).getConsumer();
     }
@@ -192,7 +189,7 @@ public class ReaderHandler extends AbstractWebSocketHandler {
     public String getSubscription() {
         return subscription;
     }
-    
+
     public SubscriptionType getSubscriptionType() {
         return SubscriptionType.Exclusive;
     }
@@ -208,7 +205,7 @@ public class ReaderHandler extends AbstractWebSocketHandler {
     public long getMsgDeliveredCounter() {
         return MSG_DELIVERED_COUNTER_UPDATER.get(this);
     }
-    
+
     protected void updateDeliverMsgStat(long msgSize) {
         numMsgsDelivered.increment();
         MSG_DELIVERED_COUNTER_UPDATER.incrementAndGet(this);

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ReaderHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ReaderHandler.java
@@ -85,12 +85,13 @@ public class ReaderHandler extends AbstractWebSocketHandler {
             this.service.addReader(this);
             receiveMessage();
         } catch (Exception e) {
-            log.warn("[{}] Failed in creating reader {} on topic {}", request.getRemoteAddr(), subscription,
-                    topic, e);
+            log.warn("[{}:{}] Failed in creating reader {} on topic {}", request.getRemoteAddr(),
+                    request.getRemotePort(), subscription, topic, e);
             try {
                 response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Failed to create reader");
             } catch (IOException e1) {
-                log.warn("Failed to send error: {}", e1);
+                log.warn("[{}:{}] Failed to send error: {}", request.getRemoteAddr(), request.getRemotePort(),
+                        e1.getMessage(), e1);
             }
         }
     }

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketConsumerServlet.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketConsumerServlet.java
@@ -37,6 +37,7 @@ public class WebSocketConsumerServlet extends WebSocketServlet {
     public void configure(WebSocketServletFactory factory) {
         factory.getPolicy().setMaxTextMessageSize(WebSocketService.MaxTextFrameSize);
 
-        factory.setCreator((request, response) -> new ConsumerHandler(service, request.getHttpServletRequest()));
+        factory.setCreator(
+                (request, response) -> new ConsumerHandler(service, request.getHttpServletRequest(), response));
     }
 }

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketProducerServlet.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketProducerServlet.java
@@ -35,6 +35,6 @@ public class WebSocketProducerServlet extends WebSocketServlet {
     @Override
     public void configure(WebSocketServletFactory factory) {
         factory.getPolicy().setMaxTextMessageSize(WebSocketService.MaxTextFrameSize);
-        factory.setCreator((req, resp) -> new ProducerHandler(service, req.getHttpServletRequest()));
+        factory.setCreator((req, resp) -> new ProducerHandler(service, req.getHttpServletRequest(), resp));
     }
 }

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketProducerServlet.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketProducerServlet.java
@@ -35,6 +35,6 @@ public class WebSocketProducerServlet extends WebSocketServlet {
     @Override
     public void configure(WebSocketServletFactory factory) {
         factory.getPolicy().setMaxTextMessageSize(WebSocketService.MaxTextFrameSize);
-        factory.setCreator((req, resp) -> new ProducerHandler(service, req.getHttpServletRequest(), resp));
+        factory.setCreator((request, response) -> new ProducerHandler(service, request.getHttpServletRequest(), response));
     }
 }

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketReaderServlet.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketReaderServlet.java
@@ -37,6 +37,7 @@ public class WebSocketReaderServlet extends WebSocketServlet {
     public void configure(WebSocketServletFactory factory) {
         factory.getPolicy().setMaxTextMessageSize(WebSocketService.MaxTextFrameSize);
 
-        factory.setCreator((request, response) -> new ReaderHandler(service, request.getHttpServletRequest()));
+        factory.setCreator(
+                (request, response) -> new ReaderHandler(service, request.getHttpServletRequest(), response));
     }
 }


### PR DESCRIPTION
### Motivation

We need to ensure the producer or the subscription are created before completing the "upgrade" to websocket in the proxy side. Otherwise the client gets the `onConnect()` event and eventually will get an error if the producer/subscription fails, but it has no way to ensure it was created.
