### PR TITLE
Add persistent-policies validation and dynamic policy update on managed-ledger/cursor

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
@@ -475,4 +475,18 @@ public interface ManagedCursor {
      * @return
      */
     int getTotalNonContiguousDeletedMessagesRange();
+
+    /**
+     * Returns cursor throttle mark-delete rate
+     * 
+     * @return
+     */
+    double getThrottleMarkDelete();
+
+    /**
+     * Update throttle mark delete rate
+     * 
+     */
+    void setThrottleMarkDelete(double throttleMarkDelete);
+
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
@@ -321,4 +321,16 @@ public interface ManagedLedger {
      * Returns whether the managed ledger was terminated
      */
     public boolean isTerminated();
+
+    /**
+     * Returns managed-ledger config 
+     */
+    ManagedLedgerConfig getConfig();
+
+    /**
+     * Updates managed-ledger config
+     * 
+     * @param config
+     */
+    void setConfig(ManagedLedgerConfig config);
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -121,7 +121,7 @@ public class ManagedCursorImpl implements ManagedCursor {
     private final RangeSet<PositionImpl> individualDeletedMessages = TreeRangeSet.create();
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
-    private final RateLimiter markDeleteLimiter;
+    private RateLimiter markDeleteLimiter;
 
     class MarkDeleteEntry {
         final PositionImpl newPosition;
@@ -2294,7 +2294,16 @@ public class ManagedCursorImpl implements ManagedCursor {
 
     @Override
     public void setThrottleMarkDelete(double throttleMarkDelete) {
-        this.markDeleteLimiter.setRate(throttleMarkDelete);
+        if (throttleMarkDelete > 0.0) {
+            if (markDeleteLimiter == null) {
+                markDeleteLimiter = RateLimiter.create(throttleMarkDelete);
+            } else {
+                this.markDeleteLimiter.setRate(throttleMarkDelete);
+            }
+        } else {
+            // Disable mark-delete rate limiter
+            markDeleteLimiter = null;
+        }
     }
     
     private static final Logger log = LoggerFactory.getLogger(ManagedCursorImpl.class);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -2287,5 +2287,15 @@ public class ManagedCursorImpl implements ManagedCursor {
         return STATE_UPDATER.get(this).toString();
     }
 
+    @Override
+    public double getThrottleMarkDelete() {
+        return this.markDeleteLimiter.getRate();
+    }
+
+    @Override
+    public void setThrottleMarkDelete(double throttleMarkDelete) {
+        this.markDeleteLimiter.setRate(throttleMarkDelete);
+    }
+    
     private static final Logger log = LoggerFactory.getLogger(ManagedCursorImpl.class);
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -99,7 +99,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     private final BookKeeper bookKeeper;
     private final String name;
 
-    private final ManagedLedgerConfig config;
+    private ManagedLedgerConfig config;
     private final MetaStore store;
 
     private final ConcurrentLongHashMap<CompletableFuture<LedgerHandle>> ledgerCache = new ConcurrentLongHashMap<>();
@@ -2092,8 +2092,14 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         return store;
     }
 
-    ManagedLedgerConfig getConfig() {
+    @Override
+    public ManagedLedgerConfig getConfig() {
         return config;
+    }
+
+    @Override
+    public void setConfig(ManagedLedgerConfig config) {
+        this.config = config;
     }
 
     static interface ManagedLedgerInitializeLedgerCallback {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2100,6 +2100,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     @Override
     public void setConfig(ManagedLedgerConfig config) {
         this.config = config;
+        this.cursors.forEach(c -> c.setThrottleMarkDelete(config.getThrottleMarkDelete()));
     }
 
     static interface ManagedLedgerInitializeLedgerCallback {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
@@ -263,6 +263,15 @@ public class ManagedCursorContainerTest {
         public int getTotalNonContiguousDeletedMessagesRange() {
             return 0;
         }
+
+        @Override
+        public void setThrottleMarkDelete(double throttleMarkDelete) {
+        }
+
+        @Override
+        public double getThrottleMarkDelete() {
+            return -1;
+        }
     }
 
     @Test

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -226,6 +226,15 @@ public class ServiceConfiguration implements PulsarConfiguration {
     // Number of guaranteed copies (acks to wait before write is complete)
     @FieldContext(minValue = 1)
     private int managedLedgerDefaultAckQuorum = 1;
+    // Max number of bookies to use when creating a ledger
+    @FieldContext(minValue = 1)
+    private int managedLedgerMaxEnsembleSize = 5;
+    // Max number of copies to store for each message
+    @FieldContext(minValue = 1)
+    private int managedLedgerMaxWriteQuorum = 5;
+    // Max number of guaranteed copies (acks to wait before write is complete)
+    @FieldContext(minValue = 1)
+    private int managedLedgerMaxAckQuorum = 5;
     // Amount of memory to use for caching data payload in managed ledger. This
     // memory
     // is allocated from JVM direct memory and it's shared across all the topics
@@ -849,6 +858,30 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     public void setManagedLedgerDefaultAckQuorum(int managedLedgerDefaultAckQuorum) {
         this.managedLedgerDefaultAckQuorum = managedLedgerDefaultAckQuorum;
+    }
+
+    public int getManagedLedgerMaxEnsembleSize() {
+        return managedLedgerMaxEnsembleSize;
+    }
+
+    public void setManagedLedgerMaxEnsembleSize(int managedLedgerMaxEnsembleSize) {
+        this.managedLedgerMaxEnsembleSize = managedLedgerMaxEnsembleSize;
+    }
+
+    public int getManagedLedgerMaxWriteQuorum() {
+        return managedLedgerMaxWriteQuorum;
+    }
+
+    public void setManagedLedgerMaxWriteQuorum(int managedLedgerMaxWriteQuorum) {
+        this.managedLedgerMaxWriteQuorum = managedLedgerMaxWriteQuorum;
+    }
+
+    public int getManagedLedgerMaxAckQuorum() {
+        return managedLedgerMaxAckQuorum;
+    }
+
+    public void setManagedLedgerMaxAckQuorum(int managedLedgerMaxAckQuorum) {
+        this.managedLedgerMaxAckQuorum = managedLedgerMaxAckQuorum;
     }
 
     public int getManagedLedgerCacheSizeMB() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -947,7 +947,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
     public void onUpdate(String path, Policies data, Stat stat) {
         final NamespaceName namespace = new NamespaceName(NamespaceBundleFactory.getNamespaceFromPoliciesPath(path));
 
-        log.info("Updated {}", path);
+        log.info("{} updating with {}", path, data);
 
         topics.forEach((name, topicFuture) -> {
             if (namespace.includes(DestinationName.get(name))) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -736,7 +736,6 @@ public class PersistentTopic implements Topic, AddEntryCallback {
         brokerService.getManagedLedgerConfig(topicName).thenAccept(config -> {
             // update managed-ledger config and managed-cursor.markDeleteRate
             this.ledger.setConfig(config);
-            this.ledger.getCursors().forEach(c -> c.setThrottleMarkDelete(config.getThrottleMarkDelete()));
             future.complete(null);
         }).exceptionally(ex -> {
             log.warn("[{}] Failed to update persistence-policies {}", topic, ex.getMessage());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -730,6 +730,22 @@ public class PersistentTopic implements Topic, AddEntryCallback {
         return messageDeduplication.checkStatus();
     }
 
+    private CompletableFuture<Void> checkPersistencePolicies() {
+        DestinationName topicName = DestinationName.get(topic);
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        brokerService.getManagedLedgerConfig(topicName).thenAccept(config -> {
+            // update managed-ledger config and managed-cursor.markDeleteRate
+            this.ledger.setConfig(config);
+            this.ledger.getCursors().forEach(c -> c.setThrottleMarkDelete(config.getThrottleMarkDelete()));
+            future.complete(null);
+        }).exceptionally(ex -> {
+            log.warn("[{}] Failed to update persistence-policies {}", topic, ex.getMessage());
+            future.completeExceptionally(ex);
+            return null;
+        });
+        return future;
+    }
+    
     @Override
     public CompletableFuture<Void> checkReplication() {
         DestinationName name = DestinationName.get(topic);
@@ -1331,7 +1347,8 @@ public class PersistentTopic implements Topic, AddEntryCallback {
         checkMessageExpiry();
         CompletableFuture<Void> replicationFuture = checkReplicationAndRetryOnFailure();
         CompletableFuture<Void> dedupFuture = checkDeduplicationStatus();
-        return CompletableFuture.allOf(replicationFuture, dedupFuture);
+        CompletableFuture<Void> persistentPoliciesFuture = checkPersistencePolicies();
+        return CompletableFuture.allOf(replicationFuture, dedupFuture, persistentPoliciesFuture);
     }
 
     /**

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -41,6 +41,7 @@ import javax.ws.rs.client.WebTarget;
 
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.namespace.NamespaceEphemeralData;
 import org.apache.pulsar.broker.namespace.NamespaceService;
@@ -127,7 +128,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
 
         // create otherbroker to test redirect on calls that need
         // namespace ownership
-        mockPulsarSetup = new MockedPulsarService();
+        mockPulsarSetup = new MockedPulsarService(this.conf, this.pulsar, this.admin);
         mockPulsarSetup.setup();
         otherPulsar = mockPulsarSetup.getPulsar();
         otheradmin = mockPulsarSetup.getAdmin();
@@ -1691,111 +1692,19 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         assertEquals(uriStats.get().subscriptions.size(), 1);
     }
 
-    /**
-     * <pre>
-     * It verifies increasing partitions for partitioned-topic.
-     * 1. create a partitioned-topic
-     * 2. update partitions with larger number of partitions
-     * 3. verify: getPartitionedMetadata and check number of partitions
-     * 4. verify: this api creates existing subscription to new partitioned-topics 
-     *            so, message will not be lost in new partitions 
-     *  a. start producer and produce messages
-     *  b. check existing subscription for new topics and it should have backlog msgs
-     * 
-     * </pre>
-     * 
-     * @param topicName
-     * @throws Exception
-     */
-    @Test
-    public void testIncrementPartitionsOfTopic() throws Exception {
-        final String topicName = "increment-partitionedTopic";
-        final String subName1 = topicName + "-my-sub 1";
-        final String subName2 = topicName + "-my-sub 2";
-        final int startPartitions = 4;
-        final int newPartitions = 8;
-        final String partitionedTopicName = "persistent://prop-xyz/use/ns1/" + topicName;
-
-        URL pulsarUrl = new URL("http://127.0.0.1" + ":" + BROKER_WEBSERVICE_PORT);
-
-        admin.persistentTopics().createPartitionedTopic(partitionedTopicName, startPartitions);
-        // validate partition topic is created
-        assertEquals(admin.persistentTopics().getPartitionedTopicMetadata(partitionedTopicName).partitions,
-                startPartitions);
-
-        // create consumer and subscriptions : check subscriptions
-        PulsarClient client = PulsarClient.create(pulsarUrl.toString());
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Shared);
-        Consumer consumer1 = client.subscribe(partitionedTopicName, subName1, conf);
-        assertEquals(admin.persistentTopics().getSubscriptions(partitionedTopicName), Lists.newArrayList(subName1));
-        Consumer consumer2 = client.subscribe(partitionedTopicName, subName2, conf);
-        assertEquals(Sets.newHashSet(admin.persistentTopics().getSubscriptions(partitionedTopicName)),
-                Sets.newHashSet(subName1, subName2));
-
-        // (1) update partitions
-        admin.persistentTopics().updatePartitionedTopic(partitionedTopicName, newPartitions);
-        // invalidate global-cache to make sure that mock-zk-cache reds fresh data
-        pulsar.getGlobalZkCache().invalidateAll();
-        // verify new partitions have been created
-        assertEquals(admin.persistentTopics().getPartitionedTopicMetadata(partitionedTopicName).partitions,
-                newPartitions);
-        // (2) No Msg loss: verify new partitions have the same existing subscription names
-        final String newPartitionTopicName = DestinationName.get(partitionedTopicName).getPartition(startPartitions + 1)
-                .toString();
-
-        // (3) produce messages to all partitions including newly created partitions (RoundRobin)
-        ProducerConfiguration prodConf = new ProducerConfiguration();
-        prodConf.setMessageRoutingMode(MessageRoutingMode.RoundRobinPartition);
-        Producer producer = client.createProducer(partitionedTopicName, prodConf);
-        final int totalMessages = newPartitions * 2;
-        for (int i = 0; i < totalMessages; i++) {
-            String message = "message-" + i;
-            producer.send(message.getBytes());
+    static class MockedPulsarService extends MockedPulsarServiceBaseTest {
+        
+        private ServiceConfiguration conf;
+        private PulsarService pulsar;
+        private PulsarAdmin admin;
+        
+        public MockedPulsarService(ServiceConfiguration conf, PulsarService pulsar, PulsarAdmin admin) {
+            super();
+            this.conf = conf;
+            this.pulsar = pulsar;
+            this.admin = admin;
         }
-
-        // (4) verify existing subscription has not lost any message: create new consumer with sub-2: it will load all
-        // newly created partition topics
-        consumer2.close();
-        consumer2 = client.subscribe(partitionedTopicName, subName2, conf);
-        // sometime: mockZk fails to refresh ml-cache: so, invalidate the cache to get fresh data
-        pulsar.getLocalZkCacheService().managedLedgerListCache().clearTree();
-        assertEquals(Sets.newHashSet(admin.persistentTopics().getSubscriptions(newPartitionTopicName)),
-                Sets.newHashSet(subName1, subName2));
-
-        assertEquals(Sets.newHashSet(admin.persistentTopics().getList("prop-xyz/use/ns1")).size(), newPartitions);
-
-        // test cumulative stats for partitioned topic
-        PartitionedTopicStats topicStats = admin.persistentTopics().getPartitionedStats(partitionedTopicName, false);
-        assertEquals(topicStats.subscriptions.keySet(), Sets.newTreeSet(Lists.newArrayList(subName1, subName2)));
-        assertEquals(topicStats.subscriptions.get(subName2).consumers.size(), 1);
-        assertEquals(topicStats.subscriptions.get(subName2).msgBacklog, totalMessages);
-        assertEquals(topicStats.publishers.size(), 1);
-        assertEquals(topicStats.partitions, Maps.newHashMap());
-
-        // (5) verify: each partition should have backlog
-        topicStats = admin.persistentTopics().getPartitionedStats(partitionedTopicName, true);
-        assertEquals(topicStats.metadata.partitions, newPartitions);
-        Set<String> partitionSet = Sets.newHashSet();
-        for (int i = 0; i < newPartitions; i++) {
-            partitionSet.add(partitionedTopicName + "-partition-" + i);
-        }
-        assertEquals(topicStats.partitions.keySet(), partitionSet);
-        for (int i = 0; i < newPartitions; i++) {
-            PersistentTopicStats partitionStats = topicStats.partitions
-                    .get(DestinationName.get(partitionedTopicName).getPartition(i).toString());
-            assertEquals(partitionStats.publishers.size(), 1);
-            assertEquals(partitionStats.subscriptions.get(subName2).consumers.size(), 1);
-            assertEquals(partitionStats.subscriptions.get(subName2).msgBacklog, 2, 1);
-        }
-
-        producer.close();
-        consumer1.close();
-        consumer2.close();
-        consumer2.close();
-    }
-
-    class MockedPulsarService extends MockedPulsarServiceBaseTest {
+        
         @Override
         protected void setup() throws Exception {
             conf.setLoadBalancerEnabled(false);
@@ -1816,52 +1725,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
             return admin;
         }
     }
-    /**
-     * verifies admin api command for non-persistent topic.
-     * It verifies: partitioned-topic, stats
-     * @throws Exception
-     */
-    @Test
-    public void nonPersistentTopics() throws Exception {
-        final String topicName = "nonPersistentTopic";
-
-        final String persistentTopicName = "non-persistent://prop-xyz/use/ns1/" + topicName;
-        // Force to create a destination
-        publishMessagesOnPersistentTopic("non-persistent://prop-xyz/use/ns1/" + topicName, 0);
-
-        // create consumer and subscription
-        URL pulsarUrl = new URL("http://127.0.0.1" + ":" + BROKER_WEBSERVICE_PORT);
-        ClientConfiguration clientConf = new ClientConfiguration();
-        clientConf.setStatsInterval(0, TimeUnit.SECONDS);
-        PulsarClient client = PulsarClient.create(pulsarUrl.toString(), clientConf);
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-        Consumer consumer = client.subscribe(persistentTopicName, "my-sub", conf);
-
-        publishMessagesOnPersistentTopic("non-persistent://prop-xyz/use/ns1/" + topicName, 10);
-
-        NonPersistentTopicStats topicStats = admin.nonPersistentTopics().getStats(persistentTopicName);
-        assertEquals(topicStats.getSubscriptions().keySet(), Sets.newTreeSet(Lists.newArrayList("my-sub")));
-        assertEquals(topicStats.getSubscriptions().get("my-sub").consumers.size(), 1);
-        assertEquals(topicStats.getPublishers().size(), 0);
-
-        PersistentTopicInternalStats internalStats = admin.nonPersistentTopics().getInternalStats(persistentTopicName);
-        assertEquals(internalStats.cursors.keySet(), Sets.newTreeSet(Lists.newArrayList("my-sub")));
-
-        consumer.close();
-        client.close();
-
-        topicStats = admin.nonPersistentTopics().getStats(persistentTopicName);
-        assertTrue(topicStats.getSubscriptions().keySet().contains("my-sub"));
-        assertEquals(topicStats.getPublishers().size(), 0);
-
-        // test partitioned-topic
-        final String partitionedTopicName = "non-persistent://prop-xyz/use/ns1/paritioned";
-        assertEquals(admin.nonPersistentTopics().getPartitionedTopicMetadata(partitionedTopicName).partitions, 0);
-        admin.nonPersistentTopics().createPartitionedTopic(partitionedTopicName, 5);
-        assertEquals(admin.nonPersistentTopics().getPartitionedTopicMetadata(partitionedTopicName).partitions, 5);
-    }
-
+    
     @Test
     public void testDestinationBundleRangeLookup() throws PulsarAdminException, PulsarServerException, Exception {
         admin.clusters().createCluster("usw", new ClusterData());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
@@ -1,0 +1,348 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.admin;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import java.net.URL;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.admin.AdminApiTest.MockedPulsarService;
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.ClientConfiguration;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.ConsumerConfiguration;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerConfiguration;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.api.ProducerConfiguration.MessageRoutingMode;
+import org.apache.pulsar.common.naming.DestinationName;
+import org.apache.pulsar.common.naming.NamespaceBundleFactory;
+import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.NonPersistentTopicStats;
+import org.apache.pulsar.common.policies.data.PartitionedTopicStats;
+import org.apache.pulsar.common.policies.data.PersistencePolicies;
+import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
+import org.apache.pulsar.common.policies.data.PersistentTopicStats;
+import org.apache.pulsar.common.policies.data.PropertyAdmin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.common.hash.Hashing;
+
+public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AdminApiTest2.class);
+
+    private MockedPulsarService mockPulsarSetup;
+
+    private PulsarService otherPulsar;
+
+    private PulsarAdmin otheradmin;
+
+    private NamespaceBundleFactory bundleFactory;
+
+    @BeforeMethod
+    @Override
+    public void setup() throws Exception {
+        conf.setLoadBalancerEnabled(true);
+        super.internalSetup();
+
+        bundleFactory = new NamespaceBundleFactory(pulsar, Hashing.crc32());
+
+        // create otherbroker to test redirect on calls that need
+        // namespace ownership
+        mockPulsarSetup = new MockedPulsarService(this.conf, this.pulsar, this.admin);
+        mockPulsarSetup.setup();
+        otherPulsar = mockPulsarSetup.getPulsar();
+        otheradmin = mockPulsarSetup.getAdmin();
+
+        // Setup namespaces
+        admin.clusters().createCluster("use", new ClusterData("http://127.0.0.1" + ":" + BROKER_WEBSERVICE_PORT));
+        PropertyAdmin propertyAdmin = new PropertyAdmin(Lists.newArrayList("role1", "role2"), Sets.newHashSet("use"));
+        admin.properties().createProperty("prop-xyz", propertyAdmin);
+        admin.namespaces().createNamespace("prop-xyz/use/ns1");
+    }
+
+    @AfterMethod
+    @Override
+    public void cleanup() throws Exception {
+        super.internalCleanup();
+        mockPulsarSetup.cleanup();
+    }
+
+    /**
+     * <pre>
+     * It verifies increasing partitions for partitioned-topic.
+     * 1. create a partitioned-topic
+     * 2. update partitions with larger number of partitions
+     * 3. verify: getPartitionedMetadata and check number of partitions
+     * 4. verify: this api creates existing subscription to new partitioned-topics 
+     *            so, message will not be lost in new partitions 
+     *  a. start producer and produce messages
+     *  b. check existing subscription for new topics and it should have backlog msgs
+     * 
+     * </pre>
+     * 
+     * @param topicName
+     * @throws Exception
+     */
+    @Test
+    public void testIncrementPartitionsOfTopic() throws Exception {
+        final String topicName = "increment-partitionedTopic";
+        final String subName1 = topicName + "-my-sub 1";
+        final String subName2 = topicName + "-my-sub 2";
+        final int startPartitions = 4;
+        final int newPartitions = 8;
+        final String partitionedTopicName = "persistent://prop-xyz/use/ns1/" + topicName;
+
+        URL pulsarUrl = new URL("http://127.0.0.1" + ":" + BROKER_WEBSERVICE_PORT);
+
+        admin.persistentTopics().createPartitionedTopic(partitionedTopicName, startPartitions);
+        // validate partition topic is created
+        assertEquals(admin.persistentTopics().getPartitionedTopicMetadata(partitionedTopicName).partitions,
+                startPartitions);
+
+        // create consumer and subscriptions : check subscriptions
+        PulsarClient client = PulsarClient.create(pulsarUrl.toString());
+        ConsumerConfiguration conf = new ConsumerConfiguration();
+        conf.setSubscriptionType(SubscriptionType.Shared);
+        Consumer consumer1 = client.subscribe(partitionedTopicName, subName1, conf);
+        assertEquals(admin.persistentTopics().getSubscriptions(partitionedTopicName), Lists.newArrayList(subName1));
+        Consumer consumer2 = client.subscribe(partitionedTopicName, subName2, conf);
+        assertEquals(Sets.newHashSet(admin.persistentTopics().getSubscriptions(partitionedTopicName)),
+                Sets.newHashSet(subName1, subName2));
+
+        // (1) update partitions
+        admin.persistentTopics().updatePartitionedTopic(partitionedTopicName, newPartitions);
+        // invalidate global-cache to make sure that mock-zk-cache reds fresh data
+        pulsar.getGlobalZkCache().invalidateAll();
+        // verify new partitions have been created
+        assertEquals(admin.persistentTopics().getPartitionedTopicMetadata(partitionedTopicName).partitions,
+                newPartitions);
+        // (2) No Msg loss: verify new partitions have the same existing subscription names
+        final String newPartitionTopicName = DestinationName.get(partitionedTopicName).getPartition(startPartitions + 1)
+                .toString();
+
+        // (3) produce messages to all partitions including newly created partitions (RoundRobin)
+        ProducerConfiguration prodConf = new ProducerConfiguration();
+        prodConf.setMessageRoutingMode(MessageRoutingMode.RoundRobinPartition);
+        Producer producer = client.createProducer(partitionedTopicName, prodConf);
+        final int totalMessages = newPartitions * 2;
+        for (int i = 0; i < totalMessages; i++) {
+            String message = "message-" + i;
+            producer.send(message.getBytes());
+        }
+
+        // (4) verify existing subscription has not lost any message: create new consumer with sub-2: it will load all
+        // newly created partition topics
+        consumer2.close();
+        consumer2 = client.subscribe(partitionedTopicName, subName2, conf);
+        // sometime: mockZk fails to refresh ml-cache: so, invalidate the cache to get fresh data
+        pulsar.getLocalZkCacheService().managedLedgerListCache().clearTree();
+        assertEquals(Sets.newHashSet(admin.persistentTopics().getSubscriptions(newPartitionTopicName)),
+                Sets.newHashSet(subName1, subName2));
+
+        assertEquals(Sets.newHashSet(admin.persistentTopics().getList("prop-xyz/use/ns1")).size(), newPartitions);
+
+        // test cumulative stats for partitioned topic
+        PartitionedTopicStats topicStats = admin.persistentTopics().getPartitionedStats(partitionedTopicName, false);
+        assertEquals(topicStats.subscriptions.keySet(), Sets.newTreeSet(Lists.newArrayList(subName1, subName2)));
+        assertEquals(topicStats.subscriptions.get(subName2).consumers.size(), 1);
+        assertEquals(topicStats.subscriptions.get(subName2).msgBacklog, totalMessages);
+        assertEquals(topicStats.publishers.size(), 1);
+        assertEquals(topicStats.partitions, Maps.newHashMap());
+
+        // (5) verify: each partition should have backlog
+        topicStats = admin.persistentTopics().getPartitionedStats(partitionedTopicName, true);
+        assertEquals(topicStats.metadata.partitions, newPartitions);
+        Set<String> partitionSet = Sets.newHashSet();
+        for (int i = 0; i < newPartitions; i++) {
+            partitionSet.add(partitionedTopicName + "-partition-" + i);
+        }
+        assertEquals(topicStats.partitions.keySet(), partitionSet);
+        for (int i = 0; i < newPartitions; i++) {
+            PersistentTopicStats partitionStats = topicStats.partitions
+                    .get(DestinationName.get(partitionedTopicName).getPartition(i).toString());
+            assertEquals(partitionStats.publishers.size(), 1);
+            assertEquals(partitionStats.subscriptions.get(subName2).consumers.size(), 1);
+            assertEquals(partitionStats.subscriptions.get(subName2).msgBacklog, 2, 1);
+        }
+
+        producer.close();
+        consumer1.close();
+        consumer2.close();
+        consumer2.close();
+    }
+
+    /**
+     * verifies admin api command for non-persistent topic.
+     * It verifies: partitioned-topic, stats
+     * @throws Exception
+     */
+    @Test
+    public void nonPersistentTopics() throws Exception {
+        final String topicName = "nonPersistentTopic";
+
+        final String persistentTopicName = "non-persistent://prop-xyz/use/ns1/" + topicName;
+        // Force to create a destination
+        publishMessagesOnTopic("non-persistent://prop-xyz/use/ns1/" + topicName, 0, 0);
+
+        // create consumer and subscription
+        URL pulsarUrl = new URL("http://127.0.0.1" + ":" + BROKER_WEBSERVICE_PORT);
+        ClientConfiguration clientConf = new ClientConfiguration();
+        clientConf.setStatsInterval(0, TimeUnit.SECONDS);
+        PulsarClient client = PulsarClient.create(pulsarUrl.toString(), clientConf);
+        ConsumerConfiguration conf = new ConsumerConfiguration();
+        conf.setSubscriptionType(SubscriptionType.Exclusive);
+        Consumer consumer = client.subscribe(persistentTopicName, "my-sub", conf);
+
+        publishMessagesOnTopic("non-persistent://prop-xyz/use/ns1/" + topicName, 10, 0);
+
+        NonPersistentTopicStats topicStats = admin.nonPersistentTopics().getStats(persistentTopicName);
+        assertEquals(topicStats.getSubscriptions().keySet(), Sets.newTreeSet(Lists.newArrayList("my-sub")));
+        assertEquals(topicStats.getSubscriptions().get("my-sub").consumers.size(), 1);
+        assertEquals(topicStats.getPublishers().size(), 0);
+
+        PersistentTopicInternalStats internalStats = admin.nonPersistentTopics().getInternalStats(persistentTopicName);
+        assertEquals(internalStats.cursors.keySet(), Sets.newTreeSet(Lists.newArrayList("my-sub")));
+
+        consumer.close();
+        client.close();
+
+        topicStats = admin.nonPersistentTopics().getStats(persistentTopicName);
+        assertTrue(topicStats.getSubscriptions().keySet().contains("my-sub"));
+        assertEquals(topicStats.getPublishers().size(), 0);
+
+        // test partitioned-topic
+        final String partitionedTopicName = "non-persistent://prop-xyz/use/ns1/paritioned";
+        assertEquals(admin.nonPersistentTopics().getPartitionedTopicMetadata(partitionedTopicName).partitions, 0);
+        admin.nonPersistentTopics().createPartitionedTopic(partitionedTopicName, 5);
+        assertEquals(admin.nonPersistentTopics().getPartitionedTopicMetadata(partitionedTopicName).partitions, 5);
+    }
+
+    private void publishMessagesOnTopic(String topicName, int messages, int startIdx) throws Exception {
+        Producer producer = pulsarClient.createProducer(topicName);
+
+        for (int i = startIdx; i < (messages + startIdx); i++) {
+            String message = "message-" + i;
+            producer.send(message.getBytes());
+        }
+
+        producer.close();
+    }
+    
+    /**
+     * verifies validation on persistent-policies
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testSetPersistencepolicies() throws Exception {
+
+        final String namespace = "prop-xyz/use/ns2";
+        admin.namespaces().createNamespace(namespace);
+
+        assertEquals(admin.namespaces().getPersistence(namespace), new PersistencePolicies(1, 1, 1, 0.0));
+        admin.namespaces().setPersistence(namespace, new PersistencePolicies(3, 3, 3, 10.0));
+        assertEquals(admin.namespaces().getPersistence(namespace), new PersistencePolicies(3, 3, 3, 10.0));
+
+        try {
+            admin.namespaces().setPersistence(namespace, new PersistencePolicies(3, 4, 3, 10.0));
+            fail("should have failed");
+        } catch (PulsarAdminException e) {
+            assertEquals(e.getStatusCode(), 412);
+        }
+        try {
+            admin.namespaces().setPersistence(namespace, new PersistencePolicies(3, 3, 4, 10.0));
+            fail("should have failed");
+        } catch (PulsarAdminException e) {
+            assertEquals(e.getStatusCode(), 412);
+        }
+        try {
+            admin.namespaces().setPersistence(namespace, new PersistencePolicies(6, 3, 1, 10.0));
+            fail("should have failed");
+        } catch (PulsarAdminException e) {
+            assertEquals(e.getStatusCode(), 412);
+        }
+
+        // make sure policies has not been changed
+        assertEquals(admin.namespaces().getPersistence(namespace), new PersistencePolicies(3, 3, 3, 10.0));
+    }
+
+    /**
+     * validates update of persistent-policies reflects on managed-ledger and managed-cursor
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testUpdatePersistencePolicyUpdateManagedCursor() throws Exception {
+
+        final String namespace = "prop-xyz/use/ns2";
+        final String topicName = "persistent://" + namespace + "/topic1";
+        admin.namespaces().createNamespace(namespace);
+
+        admin.namespaces().setPersistence(namespace, new PersistencePolicies(3, 3, 3, 50.0));
+        assertEquals(admin.namespaces().getPersistence(namespace), new PersistencePolicies(3, 3, 3, 50.0));
+
+        Producer producer = pulsarClient.createProducer(topicName);
+        Consumer consumer = pulsarClient.subscribe(topicName, "my-sub");
+
+        PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getTopic(topicName).get();
+        ManagedLedgerImpl managedLedger = (ManagedLedgerImpl) topic.getManagedLedger();
+        ManagedCursorImpl cursor = (ManagedCursorImpl) managedLedger.getCursors().iterator().next();
+
+        final double newThrottleRate = 100;
+        final int newEnsembleSize = 5;
+        admin.namespaces().setPersistence(namespace, new PersistencePolicies(newEnsembleSize, 3, 3, newThrottleRate));
+
+        for (int i = 0; i < 5; i++) {
+            if ((managedLedger.getConfig().getEnsembleSize() != newEnsembleSize
+                    && cursor.getThrottleMarkDelete() != newThrottleRate) || i == 4) {
+                Thread.sleep(200);
+            }
+        }
+
+        // (1) verify cursor.markDelete has been updated
+        assertEquals(cursor.getThrottleMarkDelete(), newThrottleRate);
+
+        // (2) verify new ledger creation takes new config
+
+        producer.close();
+        consumer.close();
+
+    }
+
+}


### PR DESCRIPTION
### Motivation

As discussed in #739 we need a way to prevent client setting invalid persistent-policy. therefore, we need a way to validate persistent-policies when client tries to update it. and broker should also update new policies to managed-ledger dynamically to avoid unloading bundle.

### Modifications

- added validation for admin-api while updating persistent-policies
- update `managed-ledger.config` and `managed-cursor.markDeleteThrottlingLimit` dynamically when policies get updated.

### Result

- it will prevent client to configure invalid persistent-policies
- it will update managed-ledger config dynamically to avoid bundle unloading
