### PR TITLE
Add admin-api to unload a specific topic

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/NonPersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/NonPersistentTopics.java
@@ -129,6 +129,18 @@ public class NonPersistentTopics extends PersistentTopics {
             throw new RestException(e);
         }
     }
+
+    @PUT
+    @Path("/{property}/{cluster}/{namespace}/{destination}/unload")
+    @ApiOperation(value = "Unload a topic")
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission") })
+    public void unloadTopic(@PathParam("property") String property, @PathParam("cluster") String cluster,
+            @PathParam("namespace") String namespace, @PathParam("destination") @Encoded String destination,
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
+        log.info("[{}] Unloading topic {}/{}/{}/{}", clientAppId(), property, cluster, namespace,
+                destination);
+        super.unloadTopic(property, cluster, namespace, destination, authoritative);
+    }
     
     protected void validateAdminOperationOnDestination(DestinationName fqdn, boolean authoritative) {
         validateAdminAccessOnProperty(fqdn.getProperty());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/NonPersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/NonPersistentTopics.java
@@ -137,9 +137,10 @@ public class NonPersistentTopics extends PersistentTopics {
     public void unloadTopic(@PathParam("property") String property, @PathParam("cluster") String cluster,
             @PathParam("namespace") String namespace, @PathParam("destination") @Encoded String destination,
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
-        log.info("[{}] Unloading topic {}/{}/{}/{}", clientAppId(), property, cluster, namespace,
-                destination);
-        super.unloadTopic(property, cluster, namespace, destination, authoritative);
+        log.info("[{}] Unloading topic {}/{}/{}/{}", clientAppId(), property, cluster, namespace, destination);
+        destination = decode(destination);
+        DestinationName dn = DestinationName.get(domain(), property, cluster, namespace, destination);
+        unloadTopic(dn, authoritative);
     }
     
     protected void validateAdminOperationOnDestination(DestinationName fqdn, boolean authoritative) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/NonPersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/NonPersistentTopics.java
@@ -133,7 +133,8 @@ public class NonPersistentTopics extends PersistentTopics {
     @PUT
     @Path("/{property}/{cluster}/{namespace}/{destination}/unload")
     @ApiOperation(value = "Unload a topic")
-    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission") })
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Topic does not exist") })
     public void unloadTopic(@PathParam("property") String property, @PathParam("cluster") String cluster,
             @PathParam("namespace") String namespace, @PathParam("destination") @Encoded String destination,
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/PersistentTopics.java
@@ -550,12 +550,12 @@ public class PersistentTopics extends AdminResource {
     @PUT
     @Path("/{property}/{cluster}/{namespace}/{destination}/unload")
     @ApiOperation(value = "Unload a topic")
-    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission") })
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Topic does not exist") })
     public void unloadTopic(@PathParam("property") String property, @PathParam("cluster") String cluster,
             @PathParam("namespace") String namespace, @PathParam("destination") @Encoded String destination,
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
-        log.info("[{}] Unloading topic {}/{}/{}/{}", clientAppId(), property, cluster, namespace,
-                destination);
+        log.info("[{}] Unloading topic {}/{}/{}/{}", clientAppId(), property, cluster, namespace, destination);
         destination = decode(destination);
         DestinationName dn = DestinationName.get(domain(), property, cluster, namespace, destination);
         unloadTopic(dn, authoritative);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -447,6 +447,7 @@ public class NonPersistentTopic implements Topic {
 
         FutureUtil.waitForAll(futures).thenRun(() -> {
             log.info("[{}] Topic closed", topic);
+            brokerService.removeTopicFromCache(topic);
             closeFuture.complete(null);
         }).exceptionally(exception -> {
             log.error("[{}] Error closing topic", topic, exception);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -68,6 +68,7 @@ import org.apache.pulsar.client.api.ProducerConfiguration.MessageRoutingMode;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.lookup.data.LookupData;
+import org.apache.pulsar.common.naming.DestinationDomain;
 import org.apache.pulsar.common.naming.DestinationName;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.NamespaceBundleFactory;
@@ -167,7 +168,8 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
     
     @DataProvider(name = "topicType")
     public Object[][] topicTypeProvider() {
-        return new Object[][] { { "persistent" }, { "non-persistent" } };
+        return new Object[][] { { DestinationDomain.persistent.value() },
+                { DestinationDomain.non_persistent.value() } };
     }
 
     @Test

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/NonPersistentTopics.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/NonPersistentTopics.java
@@ -197,5 +197,32 @@ public interface NonPersistentTopics {
      * @return a future that can be used to track when the partitioned topic is created
      */
     CompletableFuture<Void> createPartitionedTopicAsync(String destination, int numPartitions);
+    
+    /**
+     * Unload a topic.
+     * <p>
+     *
+     * @param destination
+     *            Destination name
+     *
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws NotFoundException
+     *             Destination does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void unload(String destination) throws PulsarAdminException;
+
+    /**
+     * Unload a topic asynchronously.
+     * <p>
+     *
+     * @param destination
+     *            Destination name
+     *
+     * @return a future that can be used to track when the topic is unloaded
+     */
+    CompletableFuture<Void> unloadAsync(String destination);
 
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PersistentTopics.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PersistentTopics.java
@@ -311,6 +311,33 @@ public interface PersistentTopics {
      * @return a future that can be used to track when the topic is deleted
      */
     CompletableFuture<Void> deleteAsync(String destination);
+    
+    /**
+     * Unload a topic.
+     * <p>
+     *
+     * @param destination
+     *            Destination name
+     *
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws NotFoundException
+     *             Destination does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void unload(String destination) throws PulsarAdminException;
+
+    /**
+     * Unload a topic asynchronously.
+     * <p>
+     *
+     * @param destination
+     *            Destination name
+     *
+     * @return a future that can be used to track when the topic is unloaded
+     */
+    CompletableFuture<Void> unloadAsync(String destination);
 
     /**
      * Terminate the topic and prevent any more messages being published on it.

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PersistentTopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PersistentTopicsImpl.java
@@ -252,6 +252,25 @@ public class PersistentTopicsImpl extends BaseResource implements PersistentTopi
     }
 
     @Override
+    public void unload(String destination) throws PulsarAdminException {
+        try {
+            unloadAsync(destination).get();
+        } catch (ExecutionException e) {
+            throw (PulsarAdminException) e.getCause();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarAdminException(e.getCause());
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> unloadAsync(String destination) {
+        DestinationName ds = validateTopic(destination);
+        return asyncPutRequest(persistentTopics.path(ds.getNamespace()).path(ds.getEncodedLocalName()).path("unload"),
+                Entity.entity("", MediaType.APPLICATION_JSON));
+    }
+
+    @Override
     public List<String> getSubscriptions(String destination) throws PulsarAdminException {
         try {
             return getSubscriptionsAsync(destination).get();

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPersistentTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPersistentTopics.java
@@ -57,6 +57,7 @@ public class CmdPersistentTopics extends CmdBase {
         jcommander.addCommand("lookup", new Lookup());
         jcommander.addCommand("bundle-range", new GetBundleRange());
         jcommander.addCommand("delete", new DeleteCmd());
+        jcommander.addCommand("unload", new UnloadCmd());
         jcommander.addCommand("subscriptions", new ListSubscriptions());
         jcommander.addCommand("unsubscribe", new DeleteSubscription());
         jcommander.addCommand("stats", new GetStats());
@@ -249,6 +250,18 @@ public class CmdPersistentTopics extends CmdBase {
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
             persistentTopics.delete(persistentTopic);
+        }
+    }
+
+    @Parameters(commandDescription = "Unload a topic. \n")
+    private class UnloadCmd extends CliCommand {
+        @Parameter(description = "persistent://property/cluster/namespace/destination\n", required = true)
+        private java.util.List<String> params;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String persistentTopic = validatePersistentTopic(params);
+            persistentTopics.unload(persistentTopic);
         }
     }
 

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -351,6 +351,9 @@ public class PulsarAdminToolTest {
         topics.run(split("delete persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).delete("persistent://myprop/clust/ns1/ds1");
 
+        topics.run(split("unload persistent://myprop/clust/ns1/ds1"));
+        verify(mockTopics).unload("persistent://myprop/clust/ns1/ds1");
+
         topics.run(split("list myprop/clust/ns1"));
         verify(mockTopics).getList("myprop/clust/ns1");
 

--- a/site/_data/cli/pulsar-admin.yaml
+++ b/site/_data/cli/pulsar-admin.yaml
@@ -297,6 +297,9 @@ commands:
   - name: delete
     description: Delete a topic. The topic cannot be deleted if there are any active subscriptions or producers connected to the topic.
     argument: persistent://property/cluster/namespace/topic
+  - name: unload
+    description: Unload a topic
+    argument: persistent://property/cluster/namespace/topic    
   - name: subscriptions
     description: Get the list of subscriptions on the topic
     argument: persistent://property/cluster/namespace/topic

--- a/site/_data/cli/pulsar-admin.yaml
+++ b/site/_data/cli/pulsar-admin.yaml
@@ -386,6 +386,21 @@ commands:
       description: Subscription to reset position on
     - flags: -t, --time
       description: "The time, in minutes, to reset back to (or minutes, hours, days, weeks, etc.). Examples: `100m`, `3h`, `2d`, `5w`."
+- name: non-persistent
+  description: Operations on persistent topics
+  subcommands:
+  - name: stats
+    description: Get the stats for the topic and its connected producers and consumers. All rates are computed over a 1-minute window and are relative to the last completed 1-minute period.
+    argument: non-persistent://property/cluster/namespace/topic
+  - name: stats-internal
+    description: Get the internal stats for the topic
+    argument: non-persistent://property/cluster/namespace/topic
+  - name: get-partitioned-topic-metadata
+    description: Get the partitioned topic metadata. If the topic is not created or is a non-partitioned topic, this will return an empty topic with zero partitions.
+    argument: non-persistent://property/cluster/namespace/topic
+  - name: unload
+    description: Unload a topic
+    argument: non-persistent://property/cluster/namespace/topic
 - name: properties
   description: Operations about properties
   subcommands:

--- a/site/docs/latest/admin-api/non-persistent-topics.md
+++ b/site/docs/latest/admin-api/non-persistent-topics.md
@@ -206,7 +206,7 @@ Field | Meaning
 #### pulsar-admin
 
 ```shell
-$ pulsar-admin persistent get-partitioned-topic-metadata \
+$ pulsar-admin non-persistent get-partitioned-topic-metadata \
   non-persistent://my-property/my-cluster-my-namespace/my-topic
 {
   "partitions": 4
@@ -223,4 +223,30 @@ $ pulsar-admin persistent get-partitioned-topic-metadata \
 ```java
 String topicName = "non-persistent://my-property/my-cluster-my-namespace/my-topic";
 admin.nonPersistentTopics().getPartitionedTopicMetadata(topicName);
+```
+
+### Unload topic
+
+It unloads a topic.
+
+#### pulsar-admin
+
+Topic can be unloaded using [`unload`](../../reference/CliTools#unload) command.
+
+```shell
+$ pulsar-admin non-persistent unload \
+  non-persistent://test-property/cl1/ns1/tp1 \
+```
+
+#### REST API
+
+{% endpoint PUT /admin/non-persistent/:property/:cluster/:namespace/:destination/unload %}
+
+[More info](../../reference/RestApi#/admin/non-persistent/:property/:cluster/:namespace/:destination/unload)
+
+#### Java
+
+```java
+String destination = "non-persistent://my-property/my-cluster-my-namespace/my-topic";
+admin.nonPersistentTopics().unload(destination);
 ```

--- a/site/docs/latest/admin-api/persistent-topics.md
+++ b/site/docs/latest/admin-api/persistent-topics.md
@@ -135,6 +135,58 @@ String role = "test-role";
 admin.persistentTopics().revokePermissions(destination, role);
 ```
 
+### Delete topic
+
+It deletes a topic. The topic cannot be deleted if there's any active subscription or producers connected to it.
+
+#### pulsar-admin
+
+Topic can be deleted using [`delete`](../../reference/CliTools#delete) command.
+
+```shell
+$ pulsar-admin persistent delete \
+  persistent://test-property/cl1/ns1/tp1 \
+```
+
+#### REST API
+
+{% endpoint DELETE /admin/persistent/:property/:cluster/:namespace/:destination %}
+
+[More info](../../reference/RestApi#/admin/persistent/:property/:cluster/:namespace/:destination)
+
+#### Java
+
+```java
+String destination = "persistent://my-property/my-cluster-my-namespace/my-topic";
+admin.persistentTopics().delete(destination);
+```
+
+### Unload topic
+
+It unloads a topic.
+
+#### pulsar-admin
+
+Topic can be unloaded using [`unload`](../../reference/CliTools#delete) command.
+
+```shell
+$ pulsar-admin persistent unload \
+  persistent://test-property/cl1/ns1/tp1 \
+```
+
+#### REST API
+
+{% endpoint PUT /admin/persistent/:property/:cluster/:namespace/:destination/unload %}
+
+[More info](../../reference/RestApi#/admin/persistent/:property/:cluster/:namespace/:destination/unload)
+
+#### Java
+
+```java
+String destination = "persistent://my-property/my-cluster-my-namespace/my-topic";
+admin.persistentTopics().unload(destination);
+```
+
 ### Get stats
 
 It shows current statistics of a given non-partitioned topic.

--- a/site/docs/latest/admin-api/persistent-topics.md
+++ b/site/docs/latest/admin-api/persistent-topics.md
@@ -167,7 +167,7 @@ It unloads a topic.
 
 #### pulsar-admin
 
-Topic can be unloaded using [`unload`](../../reference/CliTools#delete) command.
+Topic can be unloaded using [`unload`](../../reference/CliTools#unload) command.
 
 ```shell
 $ pulsar-admin persistent unload \


### PR DESCRIPTION
### Motivation

Many times we need to unload specific topic so, it can recover/reload with update config/state.

### Modifications

- Added `unload topic` admin api
- update the doc

### Result

Now, we can unload topic using admin api.
