### PR TITLE
Fix memory leak in WebSocket proxy

### DIFF
--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/AbstractWebSocketHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/AbstractWebSocketHandler.java
@@ -117,7 +117,7 @@ public abstract class AbstractWebSocketHandler extends WebSocketAdapter implemen
         try {
             close();
         } catch (IOException e) {
-            log.error("Failed in closing producer for topic[{}] with error: [{}]: ", topic, e.getMessage());
+            log.error("Failed in closing WebSocket session for topic {} with error: {}", topic, e.getMessage());
         }
     }
 

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
@@ -88,7 +88,10 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
 
         try {
             this.consumer = service.getPulsarClient().subscribe(topic, subscription, conf);
-            this.service.addConsumer(this);
+            if (!this.service.addConsumer(this)) {
+                log.warn("[{}:{}] Failed to add consumer handler for topic {}", request.getRemoteAddr(),
+                        request.getRemotePort(), topic);
+            }
             receiveMessage();
         } catch (Exception e) {
             log.warn("[{}:{}] Failed in creating subscription {} on topic {}", request.getRemoteAddr(),
@@ -186,7 +189,9 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
     @Override
     public void close() throws IOException {
         if (consumer != null) {
-            this.service.removeConsumer(this);
+            if (!this.service.removeConsumer(this)) {
+                log.warn("[{}] Failed to remove consumer handler", consumer.getTopic());
+            }
             consumer.closeAsync().thenAccept(x -> {
                 if (log.isDebugEnabled()) {
                     log.debug("[{}] Closed consumer asynchronously", consumer.getTopic());


### PR DESCRIPTION
### Motivation

In our Pulsar instance, running WebSocket proxy gradually increase memory usage.
As a result of analyzing the heap dump, I've found that a lot of ConsumerHandler instances are retained by [topicConsumerMap](https://github.com/apache/incubator-pulsar/blob/ccb4d92f25c9046464959cd26a66696e98dc9522/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketService.java#L82).

```java
private final ConcurrentOpenHashMap<String, List<ConsumerHandler>> topicConsumerMap;
```
Since ArrayList is not thread-safe unlike ConcurrentOpenHashMap, it seems that some ConsumerHandler instances are not removed as expected.
This can be confirmed with the following test code:
https://gist.github.com/massakam/5726be965fff0a7bb8b3a6dd7e970e28

### Modifications

Use ConcurrentOpenHashSet instead of ArrayList.
```diff
-private final ConcurrentOpenHashMap<String, List<ConsumerHandler>> topicConsumerMap;
+private final ConcurrentOpenHashMap<String, ConcurrentOpenHashSet<ConsumerHandler>> topicConsumerMap;
```

### Result

ConsumerHandler instances will be removed as expected and memory leak can be avoided.