### PR TITLE
Fix test: shutdown executor and intermittent test failure

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
@@ -732,7 +732,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
         try {
             final String topicName = "non-persistent://my-property/use/my-ns/stats-topic";
             // restart broker with lower publish rate limit
-            conf.setMaxConcurrentNonPersistentMessagePerConnection(2);
+            conf.setMaxConcurrentNonPersistentMessagePerConnection(1);
             stopBroker();
             startBroker();
             ProducerConfiguration producerConf = new ProducerConfiguration();
@@ -771,6 +771,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             producer.close();
             consumer.close();
             consumer2.close();
+            executor.shutdown();
         } finally {
             conf.setMaxConcurrentNonPersistentMessagePerConnection(defaultNonPersistentMessageRate);
         }


### PR DESCRIPTION
### Motivation

Recently saw a intermittent test failure in one of the internal build also same test didn't shutdown the executor.
```
22:42:47 [ERROR] testMsgDropStat(org.apache.pulsar.client.api.NonPersistentTopicTest)  Time elapsed: 30.436 s  <<< FAILURE!
22:42:47 java.lang.AssertionError: expected [true] but found [false]
22:42:47 	at org.apache.pulsar.client.api.NonPersistentTopicTest.testMsgDropStat(NonPersistentTopicTest.java:767)
22:42:47 
```

### Modifications

- shutdown executor in test
- allow only 1 pending msg so, broker can definitely drops to verify in test.
