### PR TITLE
Fix testActiveAndInActiveConsumerEntryCacheBehavior

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -733,7 +733,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         msg = subscriber1.receive(5, TimeUnit.SECONDS);
 
         // Verify: cache has to be cleared as there is no message needs to be consumed by active subscriber
-        assertTrue(entryCache.getSize() == 0);
+        assertEquals(entryCache.getSize(), 0, 1);
 
         /************ usecase-2: *************/
         // 1.b Subscriber slower-subscriber
@@ -763,7 +763,18 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         // 3.b Close subscriber2: which will trigger cache to clear the cache
         subscriber2.close();
-
+        
+        // retry strategically until broker clean up closed subscribers and invalidate all cache entries
+        int retry = 5;
+        for (int i = 0; i < retry; i++) {
+            if (entryCache.getSize() != 0) {
+                if (i != retry - 1) {
+                    Thread.sleep(100);
+                }
+            } else {
+                break;
+            }
+        }
         // Verify: EntryCache should be cleared
         assertTrue(entryCache.getSize() == 0);
         subscriber1.close();


### PR DESCRIPTION
### Motivation

As mentioned at #806 , `testActiveAndInActiveConsumerEntryCacheBehavior` tries to produce messages and consumes it. with the last published and consumed message, broker [discards](https://github.com/apache/incubator-pulsar/blob/master/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java#L1399) all the messages up to cursor's lastReadPosition from `EntryCache`. However, it's not necessary that cursor's readPosition is updated with last-position when `discardEntriesFromCache` gets triggered. 

So, entry-cache may have 1 entry left in case `discardEntriesFromCache` gets triggered before `entryCache.asyncReadEntry(..)` reads entry and updates the position.

### Modifications

- add delta of 1 entry in entry-cache size assertion
- add retry while checking entryCache-cleanup on subscriber-close.

