### PR TITLE
Add method to returns bytes type in Python client

### DIFF
--- a/pulsar-client-cpp/python/pulsar.py
+++ b/pulsar-client-cpp/python/pulsar.py
@@ -139,7 +139,7 @@ class Message:
 
     def data(self):
         """
-        Returns a string with the content of the message.
+        Returns object typed bytes with the content of the message.
         """
         return self._message.data()
 

--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -101,7 +101,7 @@ class PulsarTest(TestCase):
 
         msg = consumer.receive(1000)
         self.assertTrue(msg)
-        self.assertEqual(msg.data(), 'hello')
+        self.assertEqual(msg.data(), b'hello')
 
         try:
             msg = consumer.receive(100)
@@ -132,9 +132,9 @@ class PulsarTest(TestCase):
 
         time.sleep(0.1)
         self.assertEqual(len(received_messages), 3)
-        self.assertEqual(received_messages[0].data(), "hello-1")
-        self.assertEqual(received_messages[1].data(), "hello-2")
-        self.assertEqual(received_messages[2].data(), "hello-3")
+        self.assertEqual(received_messages[0].data(), b"hello-1")
+        self.assertEqual(received_messages[1].data(), b"hello-2")
+        self.assertEqual(received_messages[2].data(), b"hello-3")
         client.close()
 
     def test_reader_simple(self):
@@ -147,7 +147,7 @@ class PulsarTest(TestCase):
 
         msg = reader.read_next()
         self.assertTrue(msg)
-        self.assertEqual(msg.data(), 'hello')
+        self.assertEqual(msg.data(), b'hello')
 
         try:
             msg = reader.read_next(100)
@@ -174,7 +174,7 @@ class PulsarTest(TestCase):
         for i in range(10, 20):
             msg = reader.read_next()
             self.assertTrue(msg)
-            self.assertEqual(msg.data(), 'hello-%d' % i)
+            self.assertEqual(msg.data(), b'hello-%d' % i)
 
         reader.close()
         client.close()
@@ -202,7 +202,7 @@ class PulsarTest(TestCase):
         for i in range(5, 10):
             msg = reader2.read_next()
             self.assertTrue(msg)
-            self.assertEqual(msg.data(), 'hello-%d' % i)
+            self.assertEqual(msg.data(), b'hello-%d' % i)
 
         reader1.close()
         reader2.close()
@@ -236,7 +236,7 @@ class PulsarTest(TestCase):
         for i in range(5, 11):
             msg = reader2.read_next()
             self.assertTrue(msg)
-            self.assertEqual(msg.data(), 'hello-%d' % i)
+            self.assertEqual(msg.data(), b'hello-%d' % i)
 
         reader1.close()
         reader2.close()
@@ -291,7 +291,7 @@ class PulsarTest(TestCase):
 
         for i in range(3):
             msg = consumer.receive()
-            self.assertEqual(msg.data(), 'hello-%d' % i)
+            self.assertEqual(msg.data(), b'hello-%d' % i)
             consumer.acknowledge(msg)
 
         try:

--- a/pulsar-client-cpp/python/src/message.cc
+++ b/pulsar-client-cpp/python/src/message.cc
@@ -38,6 +38,10 @@ std::string Message_str(const Message& msg) {
     return ss.str();
 }
 
+boost::python::object Message_data_bytes(const Message& msg) {
+    return boost::python::object(boost::python::handle<>(PyBytes_FromStringAndSize((const char*)msg.getData(), msg.getLength())));
+}
+
 const BatchMessageId& Message_getMessageId(const Message& msg) {
     return static_cast<const BatchMessageId&>(msg.getMessageId());
 }
@@ -76,6 +80,7 @@ void export_message() {
 
     class_<Message>("Message")
             .def("properties", &Message::getProperties, return_value_policy<copy_const_reference>())
+            .def("data_bytes", &Message_data_bytes)
             .def("data", &Message::getDataAsString)
             .def("length", &Message::getLength)
             .def("partition_key", &Message::getPartitionKey, return_value_policy<copy_const_reference>())

--- a/pulsar-client-cpp/python/src/message.cc
+++ b/pulsar-client-cpp/python/src/message.cc
@@ -38,7 +38,7 @@ std::string Message_str(const Message& msg) {
     return ss.str();
 }
 
-boost::python::object Message_data_bytes(const Message& msg) {
+boost::python::object Message_data(const Message& msg) {
     return boost::python::object(boost::python::handle<>(PyBytes_FromStringAndSize((const char*)msg.getData(), msg.getLength())));
 }
 
@@ -80,8 +80,7 @@ void export_message() {
 
     class_<Message>("Message")
             .def("properties", &Message::getProperties, return_value_policy<copy_const_reference>())
-            .def("data_bytes", &Message_data_bytes)
-            .def("data", &Message::getDataAsString)
+            .def("data", &Message_data)
             .def("length", &Message::getLength)
             .def("partition_key", &Message::getPartitionKey, return_value_policy<copy_const_reference>())
             .def("publish_timestamp", &Message::getPublishTimestamp)


### PR DESCRIPTION
### Motivation

I described why this change is needed in #801.  Python 3 doesn't have a way to convert broken string (not UTF-8 compatible) to bytes.   So I needed instance method returns `bytes` type.

(Java client provides byte array)

### Modifications

Define method `data_bytes` in `Message` class.

### Result

Example message serialized using protobuf3:

```
In [15]: msg.data()
---------------------------------------------------------------------------
UnicodeDecodeError                        Traceback (most recent call last)
<ipython-input-15-5aa11bf6ab57> in <module>()
----> 1 msg.data()

UnicodeDecodeError: 'utf-8' codec can't decode byte 0x80 in position 33: invalid start byte

In [16]: msg.data_bytes()
Out[16]: b"\x10\x01R)Z'\n\x06hogeaa\x12\x06aaaa01\x1a\x06x12345 \x04(\x80\x012\x08hogefuga"

```