### PR TITLE
Added setting for anonymous user role

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -210,6 +210,9 @@ brokerClientAuthenticationParameters=
 # Supported Athenz provider domain names(comma separated) for authentication
 athenzDomainNames=
 
+# When this parameter is not empty, unauthenticated users perform as anonymousUserRole
+anonymousUserRole=
+
 ### --- BookKeeper Client --- ###
 
 # Authentication plugin to use when connecting to bookies

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -176,6 +176,9 @@ brokerClientAuthenticationParameters=
 # Supported Athenz provider domain names(comma separated) for authentication
 athenzDomainNames=
 
+# When this parameter is not empty, unauthenticated users perform as anonymousUserRole
+anonymousUserRole=
+
 ### --- BookKeeper Client --- ###
 
 # Authentication plugin to use when connecting to bookies

--- a/conf/websocket.conf
+++ b/conf/websocket.conf
@@ -72,6 +72,9 @@ superUserRoles=
 brokerClientAuthenticationPlugin=
 brokerClientAuthenticationParameters=
 
+# When this parameter is not empty, unauthenticated users perform as anonymousUserRole
+anonymousUserRole=
+
 ### --- TLS --- ###
 
 # Enable TLS

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -201,6 +201,9 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private String brokerClientAuthenticationPlugin = "org.apache.pulsar.client.impl.auth.AuthenticationDisabled";
     private String brokerClientAuthenticationParameters = "";
 
+    // When this parameter is not empty, unauthenticated users perform as anonymousUserRole
+    private String anonymousUserRole = "";
+
     /**** --- BookKeeper Client --- ****/
     // Authentication plugin to use when connecting to bookies
     private String bookkeeperClientAuthenticationPlugin;
@@ -794,6 +797,14 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     public void setBrokerClientAuthenticationParameters(String brokerClientAuthenticationParameters) {
         this.brokerClientAuthenticationParameters = brokerClientAuthenticationParameters;
+    }
+
+    public String getAnonymousUserRole() {
+        return anonymousUserRole;
+    }
+
+    public void setAnonymousUserRole(String anonymousUserRole) {
+        this.anonymousUserRole = anonymousUserRole;
     }
 
     public String getBookkeeperClientAuthenticationPlugin() {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -202,7 +202,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private String brokerClientAuthenticationParameters = "";
 
     // When this parameter is not empty, unauthenticated users perform as anonymousUserRole
-    private String anonymousUserRole = "";
+    private String anonymousUserRole = null;
 
     /**** --- BookKeeper Client --- ****/
     // Authentication plugin to use when connecting to bookies

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationService.java
@@ -39,12 +39,12 @@ import com.google.common.collect.Maps;
  */
 public class AuthenticationService implements Closeable {
     private static final Logger LOG = LoggerFactory.getLogger(AuthenticationService.class);
-    private final String anoymousUserRole;
+    private final String anonymousUserRole;
 
     private final Map<String, AuthenticationProvider> providers = Maps.newHashMap();
 
     public AuthenticationService(ServiceConfiguration conf) throws PulsarServerException {
-        anoymousUserRole = conf.getAnonymousUserRole();
+        anonymousUserRole = conf.getAnonymousUserRole();
         if (conf.isAuthenticationEnabled()) {
             try {
                 AuthenticationProvider provider;
@@ -74,8 +74,8 @@ public class AuthenticationService implements Closeable {
         if (provider != null) {
             return provider.authenticate(authData);
         } else {
-            if (StringUtils.isNotBlank(anoymousUserRole)) {
-                return anoymousUserRole;
+            if (StringUtils.isNotBlank(anonymousUserRole)) {
+                return anonymousUserRole;
             }
             throw new AuthenticationException("Unsupported authentication mode: " + authMethodName);
         }
@@ -94,8 +94,8 @@ public class AuthenticationService implements Closeable {
 
         // No authentication provided
         if (!providers.isEmpty()) {
-            if (StringUtils.isNotBlank(anoymousUserRole)) {
-                return anoymousUserRole;
+            if (StringUtils.isNotBlank(anonymousUserRole)) {
+                return anonymousUserRole;
             }
             // If at least a provider was configured, then the authentication needs to be provider
             throw new AuthenticationException("Authentication required");

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationService.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import javax.naming.AuthenticationException;
 import javax.servlet.http.HttpServletRequest;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.slf4j.Logger;
@@ -38,10 +39,12 @@ import com.google.common.collect.Maps;
  */
 public class AuthenticationService implements Closeable {
     private static final Logger LOG = LoggerFactory.getLogger(AuthenticationService.class);
+    private final String anoymousUserRole;
 
     private final Map<String, AuthenticationProvider> providers = Maps.newHashMap();
 
     public AuthenticationService(ServiceConfiguration conf) throws PulsarServerException {
+        anoymousUserRole = conf.getAnonymousUserRole();
         if (conf.isAuthenticationEnabled()) {
             try {
                 AuthenticationProvider provider;
@@ -71,6 +74,9 @@ public class AuthenticationService implements Closeable {
         if (provider != null) {
             return provider.authenticate(authData);
         } else {
+            if (StringUtils.isNotBlank(anoymousUserRole)) {
+                return anoymousUserRole;
+            }
             throw new AuthenticationException("Unsupported authentication mode: " + authMethodName);
         }
     }
@@ -88,6 +94,9 @@ public class AuthenticationService implements Closeable {
 
         // No authentication provided
         if (!providers.isEmpty()) {
+            if (StringUtils.isNotBlank(anoymousUserRole)) {
+                return anoymousUserRole;
+            }
             // If at least a provider was configured, then the authentication needs to be provider
             throw new AuthenticationException("Authentication required");
         } else {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthenticatedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthenticatedProducerConsumerTest.java
@@ -20,12 +20,10 @@ package org.apache.pulsar.client.api;
 
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
+import static org.testng.AssertJUnit.assertTrue;
 
 import java.net.URI;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import javax.ws.rs.InternalServerErrorException;
@@ -42,6 +40,7 @@ import org.apache.pulsar.client.api.ProducerConfiguration;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.auth.AuthenticationTls;
+import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.PropertyAdmin;
 import org.mockito.Mockito;
@@ -68,6 +67,10 @@ public class AuthenticatedProducerConsumerTest extends ProducerConsumerBase {
     @BeforeMethod
     @Override
     protected void setup() throws Exception {
+        if (methodName.equals("testAnonymousSyncProducerAndConsumer")) {
+            conf.setAnonymousUserRole("anonymousUser");
+        }
+
         conf.setAuthenticationEnabled(true);
         conf.setAuthorizationEnabled(true);
 
@@ -119,26 +122,10 @@ public class AuthenticatedProducerConsumerTest extends ProducerConsumerBase {
         return new Object[][] { { 0 }, { 1000 } };
     }
 
-    @Test(dataProvider = "batch")
-    public void testTlsSyncProducerAndConsumer(int batchMessageDelayMs) throws Exception {
-        log.info("-- Starting {} test --", methodName);
-
-        Map<String, String> authParams = new HashMap<>();
-        authParams.put("tlsCertFile", TLS_CLIENT_CERT_FILE_PATH);
-        authParams.put("tlsKeyFile", TLS_CLIENT_KEY_FILE_PATH);
-        Authentication authTls = new AuthenticationTls();
-        authTls.configure(authParams);
-        internalSetup(authTls);
-
-        admin.clusters().createCluster("use", new ClusterData(brokerUrl.toString(), brokerUrlTls.toString(),
-                "pulsar://localhost:" + BROKER_PORT, "pulsar+ssl://localhost:" + BROKER_PORT_TLS));
-        admin.properties().createProperty("my-property",
-                new PropertyAdmin(Lists.newArrayList("appid1", "appid2"), Sets.newHashSet("use")));
-        admin.namespaces().createNamespace("my-property/use/my-ns");
-
+    public void testSyncProducerAndConsumer(int batchMessageDelayMs) throws Exception {
         ConsumerConfiguration conf = new ConsumerConfiguration();
         conf.setSubscriptionType(SubscriptionType.Exclusive);
-        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic1", "my-subscriber-name",
+        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic", "my-subscriber-name",
                 conf);
 
         ProducerConfiguration producerConf = new ProducerConfiguration();
@@ -149,7 +136,7 @@ public class AuthenticatedProducerConsumerTest extends ProducerConsumerBase {
             producerConf.setBatchingMaxMessages(5);
         }
 
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic1", producerConf);
+        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic", producerConf);
         for (int i = 0; i < 10; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
@@ -167,6 +154,70 @@ public class AuthenticatedProducerConsumerTest extends ProducerConsumerBase {
         // Acknowledge the consumption of all messages at once
         consumer.acknowledgeCumulative(msg);
         consumer.close();
+    }
+
+    @Test(dataProvider = "batch")
+    public void testTlsSyncProducerAndConsumer(int batchMessageDelayMs) throws Exception {
+        log.info("-- Starting {} test --", methodName);
+
+        Map<String, String> authParams = new HashMap<>();
+        authParams.put("tlsCertFile", TLS_CLIENT_CERT_FILE_PATH);
+        authParams.put("tlsKeyFile", TLS_CLIENT_KEY_FILE_PATH);
+        Authentication authTls = new AuthenticationTls();
+        authTls.configure(authParams);
+        internalSetup(authTls);
+
+        admin.clusters().createCluster("use", new ClusterData(brokerUrl.toString(), brokerUrlTls.toString(),
+                "pulsar://localhost:" + BROKER_PORT, "pulsar+ssl://localhost:" + BROKER_PORT_TLS));
+        admin.properties().createProperty("my-property",
+                new PropertyAdmin(Lists.newArrayList("appid1", "appid2"), Sets.newHashSet("use")));
+        admin.namespaces().createNamespace("my-property/use/my-ns");
+
+        testSyncProducerAndConsumer(batchMessageDelayMs);
+
+        log.info("-- Exiting {} test --", methodName);
+    }
+
+    @Test(dataProvider = "batch")
+    public void testAnonymousSyncProducerAndConsumer(int batchMessageDelayMs) throws Exception {
+        log.info("-- Starting {} test --", methodName);
+
+        Map<String, String> authParams = new HashMap<>();
+        authParams.put("tlsCertFile", TLS_CLIENT_CERT_FILE_PATH);
+        authParams.put("tlsKeyFile", TLS_CLIENT_KEY_FILE_PATH);
+        Authentication authTls = new AuthenticationTls();
+        authTls.configure(authParams);
+        internalSetup(authTls);
+
+        admin.clusters().createCluster("use", new ClusterData(brokerUrl.toString(), brokerUrlTls.toString(),
+                "pulsar://localhost:" + BROKER_PORT, "pulsar+ssl://localhost:" + BROKER_PORT_TLS));
+        admin.properties().createProperty("my-property",
+                new PropertyAdmin(Lists.newArrayList("anonymousUser"), Sets.newHashSet("use")));
+
+        // make a PulsarAdmin instance as "anonymousUser" for http request
+        admin.close();
+        ClientConfiguration clientConf = new ClientConfiguration();
+        clientConf.setOperationTimeout(1, TimeUnit.SECONDS);
+        admin = spy(new PulsarAdmin(brokerUrl, clientConf));
+        admin.namespaces().createNamespace("my-property/use/my-ns");
+        admin.persistentTopics().grantPermission("persistent://my-property/use/my-ns/my-topic", "anonymousUser", EnumSet
+                .allOf(AuthAction.class));
+
+        // setup the client
+        pulsarClient.close();
+        pulsarClient = PulsarClient.create("pulsar://localhost:" + BROKER_PORT, clientConf);
+
+        // unauthorized topic test
+        Exception pulsarClientException = null;
+        try {
+            pulsarClient.subscribe("persistent://my-property/use/my-ns/other-topic", "my-subscriber-name");
+        } catch (Exception e) {
+            pulsarClientException = e;
+        }
+        assertTrue(pulsarClientException instanceof PulsarClientException);
+
+        testSyncProducerAndConsumer(batchMessageDelayMs);
+
         log.info("-- Exiting {} test --", methodName);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthenticatedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthenticatedProducerConsumerTest.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.client.api;
 
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
-import static org.testng.AssertJUnit.assertTrue;
 
 import java.net.URI;
 import java.util.*;
@@ -214,7 +213,7 @@ public class AuthenticatedProducerConsumerTest extends ProducerConsumerBase {
         } catch (Exception e) {
             pulsarClientException = e;
         }
-        assertTrue(pulsarClientException instanceof PulsarClientException);
+        Assert.assertTrue(pulsarClientException instanceof PulsarClientException);
 
         testSyncProducerAndConsumer(batchMessageDelayMs);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/MockUnauthenticationProvider.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/MockUnauthenticationProvider.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.websocket.proxy;
+
+import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
+
+import javax.naming.AuthenticationException;
+
+public class MockUnauthenticationProvider extends MockAuthenticationProvider {
+
+    @Override
+    public String getAuthMethodName() {
+        // method name
+        return "mockunauth";
+    }
+
+    @Override
+    public String authenticate(AuthenticationDataSource authData) throws AuthenticationException {
+        throw new AuthenticationException();
+    }
+
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyAuthenticationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyAuthenticationTest.java
@@ -21,7 +21,10 @@ package org.apache.pulsar.websocket.proxy;
 import static java.util.concurrent.Executors.newFixedThreadPool;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 
+import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -55,11 +58,15 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.Sets;
 
+import javax.validation.constraints.AssertTrue;
+
 public class ProxyAuthenticationTest extends ProducerConsumerBase {
-    
+
     private int port;
     private ProxyServer proxyServer;
     private WebSocketService service;
+    private WebSocketClient consumeClient;
+    private WebSocketClient produceClient;
 
     @BeforeMethod
     public void setup() throws Exception {
@@ -71,10 +78,21 @@ public class ProxyAuthenticationTest extends ProducerConsumerBase {
         config.setWebServicePort(port);
         config.setClusterName("use");
         config.setAuthenticationEnabled(true);
-        config.setAuthenticationProviders(
-                Sets.newHashSet("org.apache.pulsar.websocket.proxy.MockAuthenticationProvider"));
         config.setGlobalZookeeperServers("dummy-zk-servers");
         config.setSuperUserRoles(Sets.newHashSet("pulsar.super_user"));
+
+        // If this is not set, 500 error occurs.
+        config.setGlobalZookeeperServers("dummy");
+
+        if (methodName.equals("authenticatedSocketTest")) {
+            config.setAuthenticationProviders(Sets.newHashSet("org.apache.pulsar.websocket.proxy.MockAuthenticationProvider"));
+        } else {
+            config.setAuthenticationProviders(Sets.newHashSet("org.apache.pulsar.websocket.proxy.MockUnauthenticationProvider"));
+        }
+        if (methodName.equals("anonymousSocketTest")) {
+            config.setAnonymousUserRole("anonymousUser");
+        }
+
         service = spy(new WebSocketService(config));
         doReturn(mockZooKeeperClientFactory).when(service).getZooKeeperClientFactory();
         proxyServer = new ProxyServer(config);
@@ -84,6 +102,22 @@ public class ProxyAuthenticationTest extends ProducerConsumerBase {
 
     @AfterMethod
     protected void cleanup() throws Exception {
+        ExecutorService executor = newFixedThreadPool(1);
+        try {
+            executor.submit(() -> {
+                try {
+                    consumeClient.stop();
+                    produceClient.stop();
+                    log.info("proxy clients are stopped successfully");
+                } catch (Exception e) {
+                    log.error(e.getMessage());
+                }
+            }).get(2, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            log.error("failed to close clients ", e);
+        }
+        executor.shutdownNow();
+
         super.internalCleanup();
         service.close();
         proxyServer.stop();
@@ -91,7 +125,6 @@ public class ProxyAuthenticationTest extends ProducerConsumerBase {
 
     }
 
-    @Test(timeOut=10000)
     public void socketTest() throws Exception {
         final String topic = "my-property/use/my-ns/my-topic1";
         final String consumerUri = "ws://localhost:" + port + "/ws/consumer/persistent/" + topic + "/my-sub";
@@ -99,46 +132,47 @@ public class ProxyAuthenticationTest extends ProducerConsumerBase {
         URI consumeUri = URI.create(consumerUri);
         URI produceUri = URI.create(producerUri);
 
-        WebSocketClient consumeClient = new WebSocketClient();
+        consumeClient = new WebSocketClient();
         SimpleConsumerSocket consumeSocket = new SimpleConsumerSocket();
-        WebSocketClient produceClient = new WebSocketClient();
+        produceClient = new WebSocketClient();
         SimpleProducerSocket produceSocket = new SimpleProducerSocket();
 
+        consumeClient.start();
+        ClientUpgradeRequest consumeRequest = new ClientUpgradeRequest();
+        Future<Session> consumerFuture = consumeClient.connect(consumeSocket, consumeUri, consumeRequest);
+        log.info("Connecting to : {}", consumeUri);
+
+        ClientUpgradeRequest produceRequest = new ClientUpgradeRequest();
+        produceClient.start();
+        Future<Session> producerFuture = produceClient.connect(produceSocket, produceUri, produceRequest);
+        Assert.assertTrue(consumerFuture.get().isOpen());
+        Assert.assertTrue(producerFuture.get().isOpen());
+
+        consumeSocket.awaitClose(1, TimeUnit.SECONDS);
+        produceSocket.awaitClose(1, TimeUnit.SECONDS);
+        Assert.assertTrue(produceSocket.getBuffer().size() > 0);
+        Assert.assertEquals(produceSocket.getBuffer(), consumeSocket.getBuffer());
+    }
+
+    @Test(timeOut=10000)
+    public void authenticatedSocketTest() throws Exception {
+        socketTest();
+    }
+
+    @Test(timeOut=10000)
+    public void anonymousSocketTest() throws Exception {
+        socketTest();
+    }
+
+    @Test(timeOut=10000)
+    public void unauthenticatedSocketTest() throws Exception{
+        Exception exception = null;
         try {
-            consumeClient.start();
-            ClientUpgradeRequest consumeRequest = new ClientUpgradeRequest();
-            Future<Session> consumerFuture = consumeClient.connect(consumeSocket, consumeUri, consumeRequest);
-            log.info("Connecting to : {}", consumeUri);
-
-            ClientUpgradeRequest produceRequest = new ClientUpgradeRequest();
-            produceClient.start();
-            Future<Session> producerFuture = produceClient.connect(produceSocket, produceUri, produceRequest);
-            // let it connect
-            Thread.sleep(1000);
-            Assert.assertTrue(consumerFuture.get().isOpen());
-            Assert.assertTrue(producerFuture.get().isOpen());
-
-            consumeSocket.awaitClose(1, TimeUnit.SECONDS);
-            produceSocket.awaitClose(1, TimeUnit.SECONDS);
-            Assert.assertTrue(produceSocket.getBuffer().size() > 0);
-            Assert.assertEquals(produceSocket.getBuffer(), consumeSocket.getBuffer());
-        } finally {
-            ExecutorService executor = newFixedThreadPool(1);
-            try {
-                executor.submit(() -> {
-                    try {
-                        consumeClient.stop();
-                        produceClient.stop();
-                        log.info("proxy clients are stopped successfully");
-                    } catch (Exception e) {
-                        log.error(e.getMessage());
-                    }
-                }).get(2, TimeUnit.SECONDS);
-            } catch (Exception e) {
-                log.error("failed to close clients ", e);
-            }
-            executor.shutdownNow();
+            socketTest();
+        } catch (Exception e) {
+            exception = e;
         }
+        assertTrue(exception instanceof java.util.concurrent.ExecutionException);
     }
 
     @Test(timeOut=10000)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyAuthenticationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyAuthenticationTest.java
@@ -21,8 +21,6 @@ package org.apache.pulsar.websocket.proxy;
 import static java.util.concurrent.Executors.newFixedThreadPool;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
-import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertTrue;
 
 import java.lang.reflect.Method;
 import java.net.URI;
@@ -58,8 +56,6 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.Sets;
 
-import javax.validation.constraints.AssertTrue;
-
 public class ProxyAuthenticationTest extends ProducerConsumerBase {
 
     private int port;
@@ -84,7 +80,7 @@ public class ProxyAuthenticationTest extends ProducerConsumerBase {
         // If this is not set, 500 error occurs.
         config.setGlobalZookeeperServers("dummy");
 
-        if (methodName.equals("authenticatedSocketTest")) {
+        if (methodName.equals("authenticatedSocketTest") || methodName.equals("statsTest")) {
             config.setAuthenticationProviders(Sets.newHashSet("org.apache.pulsar.websocket.proxy.MockAuthenticationProvider"));
         } else {
             config.setAuthenticationProviders(Sets.newHashSet("org.apache.pulsar.websocket.proxy.MockUnauthenticationProvider"));
@@ -172,7 +168,7 @@ public class ProxyAuthenticationTest extends ProducerConsumerBase {
         } catch (Exception e) {
             exception = e;
         }
-        assertTrue(exception instanceof java.util.concurrent.ExecutionException);
+        Assert.assertTrue(exception instanceof java.util.concurrent.ExecutionException);
     }
 
     @Test(timeOut=10000)

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
@@ -82,7 +82,7 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     private int connectionsPerBroker = Runtime.getRuntime().availableProcessors();
 
     // When this parameter is not empty, unauthenticated users perform as anonymousUserRole
-    private String anonymousUserRole = "";
+    private String anonymousUserRole = null;
 
     /***** --- TLS --- ****/
     // Enable TLS

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
@@ -81,6 +81,9 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     // Number of connections per Broker in Pulsar Client used in WebSocket proxy
     private int connectionsPerBroker = Runtime.getRuntime().availableProcessors();
 
+    // When this parameter is not empty, unauthenticated users perform as anonymousUserRole
+    private String anonymousUserRole = "";
+
     /***** --- TLS --- ****/
     // Enable TLS
     private boolean tlsEnabled = false;
@@ -238,6 +241,14 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     public int getConnectionsPerBroker() { return connectionsPerBroker; }
 
     public void setConnectionsPerBroker(int connectionsPerBroker) { this.connectionsPerBroker = connectionsPerBroker; }
+
+    public String getAnonymousUserRole() {
+        return anonymousUserRole;
+    }
+
+    public void setAnonymousUserRole(String anonymousUserRole) {
+        this.anonymousUserRole = anonymousUserRole;
+    }
 
     public boolean isTlsEnabled() {
         return tlsEnabled;


### PR DESCRIPTION
### Motivation
In #469, #530, we supported wildcard matching for authorization.
However, even if we set "*" for an authorized role, authentication is required.
It is inconvenient, when we want to make a completely public topic.

### Modifications
- Add setting `anonymousUserRole`
- Fix AuthenticationService

### Result 
When anonymousUserRole is set, unauthenticated clients perform as the configured role.
Now, we can make a completely public topic.