### PR TITLE
Avoid bundle-split with old load-report

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
@@ -1098,11 +1098,14 @@ public class SimpleLoadManagerImpl implements LoadManager, ZooKeeperCacheListene
 
     @Override
     public LoadReport generateLoadReport() throws Exception {
+        if (!isLoadReportGenerationIntervalPassed()) {
+            return lastLoadReport;
+        }
+        return generateLoadReportForcefully();
+    }
+    
+    private LoadReport generateLoadReportForcefully() throws Exception {    
         synchronized (bundleGainsCache) {
-            long timeSinceLastGenMillis = System.currentTimeMillis() - lastLoadReport.getTimestamp();
-            if (timeSinceLastGenMillis <= LOAD_REPORT_UPDATE_MIMIMUM_INTERVAL) {
-                return lastLoadReport;
-            }
             try {
                 LoadReport loadReport = new LoadReport(pulsar.getWebServiceAddress(), pulsar.getWebServiceAddressTls(),
                         pulsar.getBrokerServiceUrl(), pulsar.getBrokerServiceUrlTls());
@@ -1262,7 +1265,7 @@ public class SimpleLoadManagerImpl implements LoadManager, ZooKeeperCacheListene
         }
 
         if (needUpdate) {
-            LoadReport lr = generateLoadReport();
+            LoadReport lr = generateLoadReportForcefully();
             pulsar.getZkClient().setData(brokerZnodePath, ObjectMapperFactory.getThreadLocal().writeValueAsBytes(lr),
                     -1);
             this.lastLoadReport = lr;
@@ -1270,6 +1273,17 @@ public class SimpleLoadManagerImpl implements LoadManager, ZooKeeperCacheListene
             // split-bundle if requires
             doNamespaceBundleSplit();
         }
+    }
+
+    /**
+     * Check if last generated load-report time passed the minimum time for load-report update.
+     * 
+     * @return true: if last load-report generation passed the minimum interval and load-report can be generated false:
+     *         if load-report generation has not passed minimum interval to update load-report again
+     */
+    private boolean isLoadReportGenerationIntervalPassed() {
+        long timeSinceLastGenMillis = System.currentTimeMillis() - lastLoadReport.getTimestamp();
+        return timeSinceLastGenMillis > LOAD_REPORT_UPDATE_MIMIMUM_INTERVAL;
     }
 
     // todo: changeme: this can be optimized, we don't have to iterate through everytime

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
@@ -175,7 +175,7 @@ public class SimpleLoadManagerImpl implements LoadManager, ZooKeeperCacheListene
     // update LoadReport at most every 5 seconds
     public static final long LOAD_REPORT_UPDATE_MIMIMUM_INTERVAL = TimeUnit.SECONDS.toMillis(5);
     // last LoadReport stored in ZK
-    private LoadReport lastLoadReport;
+    private volatile LoadReport lastLoadReport;
     // last timestamp resource usage was checked
     private long lastResourceUsageTimestamp = -1;
     // flag to force update load report

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -720,6 +720,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
                 // remove old bundle from the map
                 synchronized (multiLayerTopicsMap) {
                     multiLayerTopicsMap.get(oldBundle.getNamespaceObject().toString()).remove(oldBundle.toString());
+                    pulsarStats.invalidBundleStats(oldBundle.toString());
                 }
             }
         } catch (Exception e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarStats.java
@@ -174,6 +174,10 @@ public class PulsarStats implements Closeable {
         }
     }
 
+    public NamespaceBundleStats invalidBundleStats(String bundleName) {
+        return bundleStats.remove(bundleName);
+    }
+    
     public void getDimensionMetrics(Consumer<ByteBuf> consumer) {
         bufferLock.readLock().lock();
         try {


### PR DESCRIPTION
### Motivation

As mentioned at #821 

This issue happens due to stale data into LoadBalancer and it tries to split already split bundle. So, it  doesn't have any functional issue and it would be resolved after a minute as soon as load-manager will get latest data. So, to fix it: load-balancer should get latest data after bundle-split. After reproducing, I am seeing below logs
```
// (1) Load-balancer selected bundle to split
20:26:57.438 [pulsar-load-manager-11-1] INFO  o.a.p.b.l.impl.SimpleLoadManagerImpl - Will split hot namespace bundle cms-java-systest/perf/part-bundle2/0x78000000_0x80000000, topics 2, producers+consumers 2, msgRate in+out 3753.588550254447, bandwidth in+out 3967543.0976189505
// (2) Split is successful
20:26:57.525 [pulsar-web-72-11] INFO  o.a.pulsar.broker.admin.Namespaces   -  Split namespace bundle cms-java-systest/perf/part-bundle2/0x78000000_0x80000000
20:26:57.545 [pulsar-load-manager-11-1] INFO  o.a.p.b.l.impl.SimpleLoadManagerImpl - Successfully split namespace bundle cms-java-systest/perf/part-bundle2/0x78000000_0x80000000

// (3) Again Load-balancer selected same bundle to split with same old data. and it fails while splitiing 
20:27:02.396 [pulsar-load-manager-11-1] INFO  o.a.p.b.l.impl.SimpleLoadManagerImpl - Will split hot namespace bundle cms-java-systest/perf/part-bundle2/0x78000000_0x80000000, topics 2, producers+consumers 2, msgRate in+out 3753.588550254447, bandwidth in+out 3967543.0976189505
20:27:02.396 [pulsar-simple-load-manager-70-1] INFO  o.a.p.b.l.impl.SimpleLoadManagerImpl - doLoadRanking - load balancing strategy: weightedRandomSelection
20:27:02.468 [pulsar-web-72-15] INFO  o.a.pulsar.broker.admin.Namespaces   - Split namespace bundle cms-java-systest/perf/part-bundle2/0x78000000_0x80000000
20:27:02.469 [pulsar-web-72-15] INFO  o.a.p.broker.web.PulsarWebResource   - Successfully validated clusters on property [cms-java-systest]
20:27:02.470 [pulsar-web-72-15] ERROR o.a.p.broker.web.PulsarWebResource   - Failed to validate namespace bundle cms-java-systest/perf-gq1/part-bundle2/0x78000000_0x80000000
java.lang.IllegalArgumentException: Invalid upper boundary for bundle
        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:93) ~[guava-15.0.jar:na]
        at org.apache.pulsar.common.naming.NamespaceBundles.validateBundle(NamespaceBundles.java:110) ~[pulsar-broker-1.20.0-incubating-yahoo.jar:1.20.0-incubating-yahoo]
        at org.apache.pulsar.broker.web.PulsarWebResource.validateNamespaceBundleRange(PulsarWebResource.java:369) [pulsar-broker-1.20.0-incubating-yahoo.jar:1.20.0-incubating-yahoo]
        at org.apache.pulsar.broker.web.PulsarWebResource.validateNamespaceBundleOwnership(PulsarWebResource.java:395) [pulsar-broker-1.20.0-incubating-yahoo.jar:1.20.0-incubating-yahoo]
        at org.apache.pulsar.broker.admin.Namespaces.splitNamespaceBundle(Namespaces.java:854) [pulsar-broker-1.20.0-incubating-yahoo.jar:1.20.0-incubating-yahoo]
        at sun.reflect.GeneratedMethodAccessor115.invoke(Unknown Source) ~[na:na]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_131]
        at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_131]
```

### Modifications

Generate load-report forcefully if load-manager already derived generation is needed.

### Result

Load-manager will not try to split bundle based on old load-report which will prevent split-bundle failure.
