### PR TITLE
Use ZK watches to cach non-existing z-nodes

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -32,8 +32,6 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.nio.file.Files;
-import java.nio.file.LinkOption;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
@@ -763,7 +761,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         // 3.b Close subscriber2: which will trigger cache to clear the cache
         subscriber2.close();
-        
+
         // retry strategically until broker clean up closed subscribers and invalidate all cache entries
         int retry = 5;
         for (int i = 0; i < retry; i++) {
@@ -2368,7 +2366,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         final int totalMsg = 10;
 
         ProducerConfiguration producerConf = new ProducerConfiguration();
-        
+
         Message msg = null;
         Set<String> messageSet = Sets.newHashSet();
         ConsumerConfiguration conf = new ConsumerConfiguration();
@@ -2392,7 +2390,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         producerConf.setCryptoKeyReader(new EncKeyReader());
         producerConf.addEncryptionKey("client-rsa.pem");
         Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/myenc-topic1", producerConf);
-        
+
         for (int i = 0; i < totalMsg; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
@@ -2408,7 +2406,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         consumer.close();
         consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/myenc-topic1", "my-subscriber-name",
                 conf);
-        
+
         int msgNum = 0;
         try {
             // Receive should proceed and deliver encrypted message

--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZooKeeperCache.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZooKeeperCache.java
@@ -91,7 +91,8 @@ public abstract class ZooKeeperCache implements Watcher {
 
     protected AtomicReference<ZooKeeper> zkSession = new AtomicReference<ZooKeeper>(null);
 
-    public ZooKeeperCache(ZooKeeper zkSession, OrderedSafeExecutor executor, ScheduledExecutorService scheduledExecutor) {
+    public ZooKeeperCache(ZooKeeper zkSession, OrderedSafeExecutor executor,
+            ScheduledExecutorService scheduledExecutor) {
         checkNotNull(executor);
         checkNotNull(scheduledExecutor);
         this.executor = executor;
@@ -296,32 +297,57 @@ public abstract class ZooKeeperCache implements Watcher {
         CompletableFuture<Optional<Entry<T, Stat>>> future = new CompletableFuture<>();
         dataCache.get(path, (p, executor) -> {
             // Return a future for the z-node to be fetched from ZK
+            final CompletableFuture<Boolean> existsFuture = new CompletableFuture<>();
             CompletableFuture<Entry<Object, Stat>> zkFuture = new CompletableFuture<>();
 
             // Broker doesn't restart on global-zk session lost: so handling unexpected exception
             try {
-                this.zkSession.get().getData(path, watcher, (rc, path1, ctx, content, stat) -> {
-                    Executor exec = scheduledExecutor != null ? scheduledExecutor : executor;
+                // Check for existence first, then get data: this allows us to put the watch on unconditionally.
+                zkSession.get().exists(path, watcher, (rc, path1, ctx, stat) -> {
+                    final Executor exec = scheduledExecutor != null ? scheduledExecutor : executor;
                     if (rc == Code.OK.intValue()) {
-                        try {
-                            T obj = deserializer.deserialize(path, content);
-                            // avoid using the zk-client thread to process the result
-                            exec.execute(() -> zkFuture.complete(new SimpleImmutableEntry<Object, Stat>(obj, stat)));
-                        } catch (Exception e) {
-                            exec.execute(() -> zkFuture.completeExceptionally(e));
-                        }
+                        exec.execute(() -> existsFuture.complete(true));
                     } else if (rc == Code.NONODE.intValue()) {
-                        // Return null values for missing z-nodes, as this is not "exceptional" condition
-                        exec.execute(() -> zkFuture.complete(null));
+                        exec.execute(() -> existsFuture.complete(false));
                     } else {
-                        exec.execute(() -> zkFuture.completeExceptionally(KeeperException.create(rc)));
+                        exec.execute(() -> existsFuture.completeExceptionally(KeeperException.create(rc)));
                     }
-                }, null);                
+                }, null);
             } catch (Exception e) {
                 LOG.warn("Failed to access zkSession for {} {}", path, e.getMessage(), e);
-                zkFuture.completeExceptionally(e);
+                existsFuture.completeExceptionally(e);
             }
-            
+            existsFuture.thenAccept(existed -> {
+                if (existed) {
+                    try {
+                        this.zkSession.get().getData(path, null, (rc, path1, ctx, content, stat) -> {
+                            Executor exec = scheduledExecutor != null ? scheduledExecutor : executor;
+                            if (rc == Code.OK.intValue()) {
+                                try {
+                                    T obj = deserializer.deserialize(path, content);
+                                    // avoid using the zk-client thread to process the result
+                                    exec.execute(() -> zkFuture.complete(new SimpleImmutableEntry<Object, Stat>(obj, stat)));
+                                } catch (Exception e) {
+                                    exec.execute(() -> zkFuture.completeExceptionally(e));
+                                }
+                            } else if (rc == Code.NONODE.intValue()) {
+                                // Return null values for missing z-nodes, as this is not "exceptional" condition
+                                exec.execute(() -> zkFuture.complete(null));
+                            } else {
+                                exec.execute(() -> zkFuture.completeExceptionally(KeeperException.create(rc)));
+                            }
+                        }, null);
+                    } catch (Exception e) {
+                        LOG.warn("Failed to access zkSession for {} {}", path, e.getMessage(), e);
+                        zkFuture.completeExceptionally(e);
+                    }
+                } else {
+                    zkFuture.complete(null);
+                }
+            }).exceptionally(e -> {
+                zkFuture.completeExceptionally(e);
+                return null;
+            });
             return zkFuture;
         }).thenAccept(result -> {
             if (result != null) {
@@ -405,7 +431,7 @@ public abstract class ZooKeeperCache implements Watcher {
             }
         }
     }
-    
+
     public void stop() {
         if (shouldShutdownExecutor) {
             this.executor.shutdown();


### PR DESCRIPTION
Carrying over #437 from @bobbeyreese 

### Motivation

Previously, nodes which had not yet been created for `ZooKeeperCache` did not have a watch put on them, and thus had to be manually invalidated. This PR is a stepping stone for #385, which required this feature in order for the split-and-unload feature to work correctly and without as much pain.

### Modifications

When `ZooKeeperCache` is queried for a non-existent node, an exists watch is added to that node so that the most recent updates are obtained. When the node did exist, the behavior is the same.

### Result

`ZooKeeperCache` will now always add a watch to a node and #385 will be closer to being merged.
