### PR TITLE
CPP Tests - Prevent failure due to namespace creation on rerun

### DIFF
--- a/pulsar-client-cpp/tests/ClientDeduplicationTest.cc
+++ b/pulsar-client-cpp/tests/ClientDeduplicationTest.cc
@@ -39,11 +39,11 @@ TEST(ClientDeduplicationTest, testProducerSequenceAfterReconnect) {
     // call admin api to create namespace and enable deduplication
     std::string url = adminUrl + "admin/namespaces/sample/standalone/ns-dedup-1";
     int res = makePutRequest(url, "");
-    ASSERT_EQ(res, 204);
+    ASSERT_TRUE(res == 204 || res == 409);
 
     url = adminUrl + "admin/namespaces/sample/standalone/ns-dedup-1/deduplication";
     res = makePostRequest(url, "true");
-    ASSERT_EQ(res, 204);
+    ASSERT_TRUE(res == 204 || res == 409);
 
     ReaderConfiguration readerConf;
     Reader reader;
@@ -87,11 +87,11 @@ TEST(ClientDeduplicationTest, testProducerDeduplication) {
     // call admin api to create namespace and enable deduplication
     std::string url = adminUrl + "admin/namespaces/sample/standalone/ns-dedup-2";
     int res = makePutRequest(url, "");
-    ASSERT_EQ(res, 204);
+    ASSERT_TRUE(res == 204 || res == 409);
 
     url = adminUrl + "admin/namespaces/sample/standalone/ns-dedup-2/deduplication";
     res = makePostRequest(url, "true");
-    ASSERT_EQ(res, 204);
+    ASSERT_TRUE(res == 204 || res == 409);
 
     ReaderConfiguration readerConf;
     Reader reader;


### PR DESCRIPTION
Currently, the CPP Tests can only be run once since the seconds run onwards we get an error - namespace already exists (409)

Fixed the tests to continue if "namespace already exists"