### PR TITLE
When trigger kafka producer callback, don't wrap the exception if it's null

### DIFF
--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/producer/PulsarKafkaProducer.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/producer/PulsarKafkaProducer.java
@@ -18,7 +18,6 @@
  */
 package org.apache.kafka.clients.producer;
 
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
@@ -48,7 +47,6 @@ import org.apache.pulsar.client.api.ProducerConfiguration;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.MessageIdImpl;
-import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.kafka.compat.MessageIdUtils;
 import org.apache.pulsar.client.kafka.compat.PulsarKafkaConfig;
 
@@ -146,7 +144,9 @@ public class PulsarKafkaProducer<K, V> implements Producer<K, V> {
         try {
             producer = producers.computeIfAbsent(record.topic(), topic -> createNewProducer(topic));
         } catch (Exception e) {
-            callback.onCompletion(null, e);
+            if (callback != null) {
+                callback.onCompletion(null, e);
+            }
             CompletableFuture<RecordMetadata> future = new CompletableFuture<>();
             future.completeExceptionally(e);
             return future;
@@ -165,8 +165,11 @@ public class PulsarKafkaProducer<K, V> implements Producer<K, V> {
             return null;
         });
 
-        future.handle((recordMetadata, exception) -> {
-            callback.onCompletion(recordMetadata, new Exception(exception));
+        future.handle((recordMetadata, throwable) -> {
+            if (callback != null) {
+                Exception exception = throwable != null ? new Exception(throwable) : null;
+                callback.onCompletion(recordMetadata, exception);
+            }
             return null;
         });
 


### PR DESCRIPTION
### Motivation

When the producer callback is triggered, the exception needs to be null if there are no errors and we don't have to wrap it in a new Exception in that case.