### PR TITLE
In C++ partitioned consumer, do not append partition index in subscription name

### DIFF
--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
@@ -178,10 +178,8 @@ namespace pulsar {
         // create consumer on each partition
         for (unsigned int i = 0; i < numPartitions_; i++ ) {
             std::string topicPartitionName = destinationName_->getTopicPartitionName(i);
-            std::stringstream partitionSubName;
-            partitionSubName << subscriptionName_ << i;
             consumer = boost::make_shared<ConsumerImpl>(client_, topicPartitionName,
-                                                        partitionSubName.str(), config,
+                                                        subscriptionName_, config,
                                                         internalListenerExecutor, Partitioned);
             consumer->getConsumerCreatedFuture().addListener(boost::bind(&PartitionedConsumerImpl::handleSinglePartitionConsumerCreated,
                                                                          shared_from_this(), _1, _2, i));

--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
@@ -186,7 +186,7 @@ namespace pulsar {
             consumer->setPartitionIndex(i);
             consumers_.push_back(consumer);
 
-            LOG_DEBUG("Creating Consumer for single Partition - " << topicPartitionName << "SubName - " << partitionSubName.str());
+            LOG_DEBUG("Creating Consumer for single Partition - " << topicPartitionName << "SubName - " << subscriptionName_);
         }
         for (ConsumerList::const_iterator consumer = consumers_.begin(); consumer != consumers_.end(); consumer++) {
             (*consumer)->start();

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -442,12 +442,12 @@ TEST(BasicEndToEndTest, testPartitionedProducerConsumerSubscriptionName)
     ASSERT_FALSE(res != 204 && res != 409);
 
     Consumer partitionedConsumer;
-    Result result = client.subscribe(topicName, "subscription-A", consumer);
+    Result result = client.subscribe(topicName, "subscription-A", partitionedConsumer);
     ASSERT_EQ(ResultOk, result);
 
     // The consumer should be already be registered "subscription-A" for all the partitions
     Consumer individualPartitionConsumer;
-    result = client.subscribe(topicName + "-partition-0", "subscription-A", consumer);
+    result = client.subscribe(topicName + "-partition-0", "subscription-A", individualPartitionConsumer);
     ASSERT_EQ(ResultConsumerBusy, result);
 
     client.shutdown();

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -75,7 +75,7 @@ TEST(BasicEndToEndTest, testBatchMessages)
     // Enable batching on producer side
     int batchSize = 2;
     int numOfMessages = 1000;
-    
+
     ProducerConfiguration conf;
     conf.setCompressionType(CompressionLZ4);
     conf.setBatchingMaxMessages(batchSize);
@@ -395,12 +395,12 @@ TEST(BasicEndToEndTest, testPartitionedProducerConsumer)
     std::string topicName = "persistent://prop/unit/ns/testPartitionedProducerConsumer";
 
     // call admin api to make it partitioned
-    std::string url = adminUrl + "admin/persistent/prop/unit/ns/partition-test/partitions";
+    std::string url = adminUrl + "admin/persistent/prop/unit/ns/testPartitionedProducerConsumer/partitions";
     int res = makePutRequest(url, "3");
 
     LOG_INFO("res = "<<res);
     ASSERT_FALSE(res != 204 && res != 409);
-    
+
     Producer producer;
     Result result = client.createProducer(topicName, producer);
     ASSERT_EQ(ResultOk, result);
@@ -426,6 +426,30 @@ TEST(BasicEndToEndTest, testPartitionedProducerConsumer)
         consumer.receive(m, 10000);
         consumer.acknowledge(m);
     }
+    client.shutdown();
+}
+
+TEST(BasicEndToEndTest, testPartitionedProducerConsumerSubscriptionName)
+{
+    Client client(lookupUrl);
+    std::string topicName = "persistent://prop/unit/ns/testPartitionedProducerConsumerSubscriptionName";
+
+    // call admin api to make it partitioned
+    std::string url = adminUrl + "admin/persistent/prop/unit/ns/testPartitionedProducerConsumerSubscriptionName/partitions";
+    int res = makePutRequest(url, "3");
+
+    LOG_INFO("res = "<<res);
+    ASSERT_FALSE(res != 204 && res != 409);
+
+    Consumer partitionedConsumer;
+    result = client.subscribe(topicName, "subscription-A", consumer);
+    ASSERT_EQ(ResultOk, result);
+
+    // The consumer should be already be registered "subscription-A" for all the partitions
+    Consumer individualPartitionConsumer;
+    result = client.subscribe(topicName + "-partition-0", "subscription-A", consumer);
+    ASSERT_EQ(ResultConsumerBusy, result);
+
     client.shutdown();
 }
 
@@ -819,7 +843,7 @@ TEST(BasicEndToEndTest, testMessageListenerPause)
     consumer.resumeMessageListener();
     // Sleeping for 2 seconds
     usleep(2 * 1000 * 1000);
-    
+
     ASSERT_EQ(globalCount, 10000);
     consumer.close();
     producer.close();

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -442,7 +442,7 @@ TEST(BasicEndToEndTest, testPartitionedProducerConsumerSubscriptionName)
     ASSERT_FALSE(res != 204 && res != 409);
 
     Consumer partitionedConsumer;
-    result = client.subscribe(topicName, "subscription-A", consumer);
+    Result result = client.subscribe(topicName, "subscription-A", consumer);
     ASSERT_EQ(ResultOk, result);
 
     // The consumer should be already be registered "subscription-A" for all the partitions


### PR DESCRIPTION

### Motivation

As described in #827, the C++ partitioned consumer is appending the partition id to the subscription name, unlike the Java partitioned consumer. That breaks the assumptions made by many tools and APIs to associate the same subscription id across all the partitions (eg: unsubscribe a subscription from all partitions at once).

### Modifications

Make C++ client to use the same convention as Java client in this case.
