### PR TITLE
Change timezone of request log from GMT to local one

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/WebService.java
@@ -22,6 +22,7 @@ import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.TimeZone;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.regex.Matcher;
@@ -75,7 +76,6 @@ public class WebService implements AutoCloseable {
 
     public static final String ATTRIBUTE_PULSAR_NAME = "pulsar";
     public static final String HANDLER_CACHE_CONTROL = "max-age=3600";
-    public static final String HANDLER_REQUEST_LOG_TZ = "GMT";
     public static final int NUM_ACCEPTORS = 32; // make it configurable?
     public static final int MAX_CONCURRENT_REQUESTES = 1024; // make it configurable?
 
@@ -195,7 +195,7 @@ public class WebService implements AutoCloseable {
             RequestLogHandler requestLogHandler = new RequestLogHandler();
             Slf4jRequestLog requestLog = new Slf4jRequestLog();
             requestLog.setExtended(true);
-            requestLog.setLogTimeZone(WebService.HANDLER_REQUEST_LOG_TZ);
+            requestLog.setLogTimeZone(TimeZone.getDefault().getID());
             requestLog.setLogLatency(true);
             requestLogHandler.setRequestLog(requestLog);
             handlers.add(0, new ContextHandlerCollection());

--- a/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/server/ServerManager.java
+++ b/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/server/ServerManager.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.security.GeneralSecurityException;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -113,7 +114,7 @@ public class ServerManager {
         RequestLogHandler requestLogHandler = new RequestLogHandler();
         Slf4jRequestLog requestLog = new Slf4jRequestLog();
         requestLog.setExtended(true);
-        requestLog.setLogTimeZone("GMT");
+        requestLog.setLogTimeZone(TimeZone.getDefault().getID());
         requestLog.setLogLatency(true);
         requestLogHandler.setRequestLog(requestLog);
         handlers.add(0, new ContextHandlerCollection());

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/WebServer.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/WebServer.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.proxy.server;
 import java.net.URI;
 import java.security.GeneralSecurityException;
 import java.util.List;
+import java.util.TimeZone;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -106,7 +107,7 @@ public class WebServer {
         RequestLogHandler requestLogHandler = new RequestLogHandler();
         Slf4jRequestLog requestLog = new Slf4jRequestLog();
         requestLog.setExtended(true);
-        requestLog.setLogTimeZone("GMT");
+        requestLog.setLogTimeZone(TimeZone.getDefault().getID());
         requestLog.setLogLatency(true);
         requestLogHandler.setRequestLog(requestLog);
         handlers.add(0, new ContextHandlerCollection());

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/ProxyServer.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/ProxyServer.java
@@ -24,6 +24,7 @@ import java.net.MalformedURLException;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.TimeZone;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -133,7 +134,7 @@ public class ProxyServer {
             RequestLogHandler requestLogHandler = new RequestLogHandler();
             Slf4jRequestLog requestLog = new Slf4jRequestLog();
             requestLog.setExtended(true);
-            requestLog.setLogTimeZone("GMT");
+            requestLog.setLogTimeZone(TimeZone.getDefault().getID());
             requestLog.setLogLatency(true);
             requestLogHandler.setRequestLog(requestLog);
             handlers.add(0, new ContextHandlerCollection());


### PR DESCRIPTION
### Motivation

Currently, the timezone of request logs is fixed to GMT.
However, I think that it is more useful to use the user's local timezone.

### Modifications

Pass `TimeZone.getDefault().getID()` instead of "GMT" to `Slf4jRequestLog#setLogTimeZone()`.

### Result

User's local date/time will be recorded in the request logs.
If we need to specify the timezone explicitly, we can use `-Duser.timezone` option.