### PR TITLE
Add PulsarClientImpl.getNumberOfPartitions() to avoid exposing PartitionedTopicMetadata

### DIFF
--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
@@ -184,16 +184,15 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
             for (String topic : topics) {
                 // Create individual subscription on each partition, that way we can keep using the
                 // acknowledgeCumulative()
-                PartitionedTopicMetadata partitionMetadata = ((PulsarClientImpl) client)
-                        .getPartitionedTopicMetadata(topic).get();
+                int numberOfPartitions = ((PulsarClientImpl) client).getNumberOfPartitions(topic).get();
 
                 ConsumerConfiguration conf = new ConsumerConfiguration();
                 conf.setSubscriptionType(SubscriptionType.Failover);
                 conf.setMessageListener(this);
-                if (partitionMetadata.partitions > 1) {
+                if (numberOfPartitions > 1) {
                     // Subscribe to each partition
                     conf.setConsumerName(ConsumerName.generateRandomName());
-                    for (int i = 0; i < partitionMetadata.partitions; i++) {
+                    for (int i = 0; i < numberOfPartitions; i++) {
                         String partitionName = DestinationName.get(topic).getPartition(i).toString();
                         CompletableFuture<org.apache.pulsar.client.api.Consumer> future = client
                                 .subscribeAsync(partitionName, groupId, conf);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -443,6 +443,10 @@ public class PulsarClientImpl implements PulsarClient {
         return eventLoopGroup;
     }
 
+    public CompletableFuture<Integer> getNumberOfPartitions(String topic) {
+        return getPartitionedTopicMetadata(topic).thenApply(metadata -> metadata.partitions);
+    }
+
     public CompletableFuture<PartitionedTopicMetadata> getPartitionedTopicMetadata(String topic) {
 
         CompletableFuture<PartitionedTopicMetadata> metadataFuture;


### PR DESCRIPTION
### Motivation

The `PartitionedTopicMetadata` will be shaded if the pulsar-client library itself it's shaded, so we cannot really use it (for example in Kafka wrapper we need to know the number of partitions).

By returning just the partitions number, we avoid the shading problem.
