### PR TITLE
Publish the shaded pulsar-client as the default dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@ flexible messaging model and an intuitive client API.</description>
     <module>pulsar-client-admin</module>
     <module>pulsar-client-tools</module>
     <module>pulsar-client</module>
+    <module>pulsar-client-shaded</module>
     <module>pulsar-websocket</module>
     <module>pulsar-proxy</module>
     <module>pulsar-discovery-service</module>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -56,7 +56,7 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>pulsar-client</artifactId>
+      <artifactId>pulsar-client-original</artifactId>
       <version>${project.version}</version>
     </dependency>
 
@@ -326,7 +326,7 @@
         <pluginManagement>
           <plugins>
             <plugin>
-              <!--This plugin's configuration is used to store Eclipse m2e settings only. 
+              <!--This plugin's configuration is used to store Eclipse m2e settings only.
                   It has no influence on the Maven build itself.-->
               <groupId>org.eclipse.m2e</groupId>
               <artifactId>lifecycle-mapping</artifactId>

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -66,6 +66,8 @@ public abstract class MockedPulsarServiceBaseTest {
     protected URL brokerUrl;
     protected URL brokerUrlTls;
 
+    protected URI lookupUrl;
+
     protected final int BROKER_WEBSERVICE_PORT = PortManager.nextFreePort();
     protected final int BROKER_WEBSERVICE_PORT_TLS = PortManager.nextFreePort();
     protected final int BROKER_PORT = PortManager.nextFreePort();
@@ -97,11 +99,11 @@ public abstract class MockedPulsarServiceBaseTest {
         init();
         org.apache.pulsar.client.api.ClientConfiguration clientConf = new org.apache.pulsar.client.api.ClientConfiguration();
         clientConf.setStatsInterval(0, TimeUnit.SECONDS);
-        String lookupUrl = brokerUrl.toString();
+        lookupUrl = new URI(brokerUrl.toString());
         if (isTcpLookup) {
-            lookupUrl = new URI("pulsar://localhost:" + BROKER_PORT).toString();
+            lookupUrl = new URI("pulsar://localhost:" + BROKER_PORT);
         }
-        pulsarClient = PulsarClient.create(lookupUrl, clientConf);
+        pulsarClient = PulsarClient.create(lookupUrl.toString(), clientConf);
     }
 
     protected final void internalSetupForStatsTest() throws Exception {

--- a/pulsar-client-admin/pom.xml
+++ b/pulsar-client-admin/pom.xml
@@ -36,7 +36,7 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>pulsar-client</artifactId>
+      <artifactId>pulsar-client-original</artifactId>
       <version>${project.version}</version>
     </dependency>
 
@@ -70,7 +70,7 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
-    
+
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>

--- a/pulsar-client-auth-athenz/pom.xml
+++ b/pulsar-client-auth-athenz/pom.xml
@@ -37,7 +37,7 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>pulsar-client</artifactId>
+      <artifactId>pulsar-client-original</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
 

--- a/pulsar-client-kafka-compat/pulsar-client-kafka-tests/src/test/java/org/apache/pulsar/client/kafka/compat/tests/KafkaApiTest.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka-tests/src/test/java/org/apache/pulsar/client/kafka/compat/tests/KafkaApiTest.java
@@ -44,6 +44,11 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class KafkaApiTest extends BrokerTestBase {
+
+    public KafkaApiTest() {
+        super.isTcpLookup = true;
+    }
+
     @BeforeClass
     @Override
     protected void setup() throws Exception {

--- a/pulsar-client-kafka-compat/pulsar-client-kafka/pom.xml
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/pom.xml
@@ -96,6 +96,7 @@
                 <includes>
                   <include>org.apache.kafka:kafka-clients</include>
                   <include>org.apache.pulsar:pulsar-client</include>
+                  <include>org.apache.pulsar:pulsar-common</include>
                 </includes>
               </artifactSet>
               <relocations>
@@ -114,6 +115,14 @@
                 <relocation>
                   <pattern>org.apache.kafka.clients.consumer.PulsarKafkaConsumer</pattern>
                   <shadedPattern>org.apache.kafka.clients.consumer.KafkaConsumer</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.pulsar.common</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.apache.pulsar.common</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.pulsar.policies</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.apache.pulsar.policies</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/pulsar-client-kafka-compat/pulsar-client-kafka/pom.xml
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/pom.xml
@@ -95,6 +95,7 @@
               <artifactSet>
                 <includes>
                   <include>org.apache.kafka:kafka-clients</include>
+                  <include>org.apache.pulsar:pulsar-client</include>
                 </includes>
               </artifactSet>
               <relocations>

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -1,0 +1,144 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.pulsar</groupId>
+    <artifactId>pulsar</artifactId>
+    <version>1.21.0-incubating-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+
+  <artifactId>pulsar-client</artifactId>
+  <name>Pulsar Client Java</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-client-original</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <!-- Shade all the dependencies to avoid conflicts -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
+              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+              <minimizeJar>false</minimizeJar>
+
+              <artifactSet>
+                <includes>
+                  <include>org.apache.pulsar:pulsar-client-original</include>
+                  <include>org.apache.commons:commons-lang3</include>
+                  <include>commons-codec:commons-codec</include>
+                  <include>commons-collections:commons-collections</include>
+                  <include>org.asynchttpclient:*</include>
+                  <include>io.netty:netty-codec-http</include>
+                  <include>io.netty:netty-transport-native-epoll</include>
+                  <include>org.reactivestreams:reactive-streams</include>
+                  <include>com.typesafe.netty:netty-reactive-streams</include>
+                  <include>org.javassist:javassist</include>
+                  <include>com.google.protobuf:protobuf-java</include>
+                  <include>com.google.guava:guava</include>
+                  <include>com.google.code.gson:gson</include>
+                  <include>com.fasterxml.jackson.core</include>
+                  <include>io.netty:netty</include>
+                  <include>io.netty:netty-all</include>
+                  <include>org.apache.pulsar:pulsar-common</include>
+                  <include>org.apache.pulsar:pulsar-checksum</include>
+                  <include>net.jpountz.lz4:lz4</include>
+                  <include>com.yahoo.datasketches:sketches-core</include>
+                </includes>
+              </artifactSet>
+              <filters>
+                <filter>
+                  <artifact>net.jpountz.lz4:lz4</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+              </filters>
+              <relocations>
+                <relocation>
+                    <pattern>org.asynchttpclient</pattern>
+                    <shadedPattern>org.apache.pulsar.shade.org.asynchttpclient</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.commons</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.apache.commons</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.com.google</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.fasterxml.jackson</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.com.fasterxml.jackson</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>io.netty</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.io.netty</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.pulsar.common</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.apache.pulsar.common</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.pulsar.checksum</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.apache.pulsar.checksum</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.scurrilous.circe</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.com.scurrilous.circe</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>net.jpountz</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.net.jpountz</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.yahoo.datasketches</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.com.yahoo.datasketches</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.yahoo.sketches</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.com.yahoo.sketches</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -111,10 +111,6 @@
                   <shadedPattern>org.apache.pulsar.shade.io.netty</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>org.apache.pulsar.common</pattern>
-                  <shadedPattern>org.apache.pulsar.shade.org.apache.pulsar.common</shadedPattern>
-                </relocation>
-                <relocation>
                   <pattern>org.apache.pulsar.checksum</pattern>
                   <shadedPattern>org.apache.pulsar.shade.org.apache.pulsar.checksum</shadedPattern>
                 </relocation>

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -91,8 +91,8 @@
               </filters>
               <relocations>
                 <relocation>
-                    <pattern>org.asynchttpclient</pattern>
-                    <shadedPattern>org.apache.pulsar.shade.org.asynchttpclient</shadedPattern>
+                  <pattern>org.asynchttpclient</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.asynchttpclient</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.apache.commons</pattern>
@@ -109,6 +109,14 @@
                 <relocation>
                   <pattern>io.netty</pattern>
                   <shadedPattern>org.apache.pulsar.shade.io.netty</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.pulsar.common</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.apache.pulsar.common</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.pulsar.policies</pattern>
+                  <shadedPattern>org.apache.pulsar.shade.org.apache.pulsar.policies</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.apache.pulsar.checksum</pattern>

--- a/pulsar-client-tools/pom.xml
+++ b/pulsar-client-tools/pom.xml
@@ -60,7 +60,7 @@
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
-			<artifactId>pulsar-client</artifactId>
+			<artifactId>pulsar-client-original</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>

--- a/pulsar-client/pom.xml
+++ b/pulsar-client/pom.xml
@@ -29,7 +29,7 @@
     <relativePath>..</relativePath>
   </parent>
 
-  <artifactId>pulsar-client</artifactId>
+  <artifactId>pulsar-client-original</artifactId>
   <name>Pulsar Client Java</name>
 
   <dependencies>
@@ -78,102 +78,5 @@
         <filtering>true</filtering>
       </resource>
     </resources>
-
-    <plugins>
-      <plugin>
-        <!-- Shade all the dependencies to avoid conflicts -->
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <createDependencyReducedPom>true</createDependencyReducedPom>
-              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
-              <shadedArtifactAttached>true</shadedArtifactAttached>
-              <shadedClassifierName>shaded</shadedClassifierName>
-              <minimizeJar>true</minimizeJar>
-
-              <artifactSet>
-                <includes>
-                  <include>org.apache.commons:commons-lang3</include>
-                  <include>commons-codec:commons-codec</include>
-                  <include>commons-collections:commons-collections</include>
-                  <include>org.asynchttpclient:*</include>
-                  <include>io.netty:netty-codec-http</include>
-                  <include>io.netty:netty-transport-native-epoll</include>
-                  <include>org.reactivestreams:reactive-streams</include>
-                  <include>com.typesafe.netty:netty-reactive-streams</include>
-                  <include>org.javassist:javassist</include>
-                  <include>com.google.protobuf:protobuf-java</include>
-                  <include>com.google.guava:guava</include>
-                  <include>com.google.code.gson:gson</include>
-                  <include>com.fasterxml.jackson.core</include>
-                  <include>io.netty:netty</include>
-                  <include>io.netty:netty-all</include>
-                  <include>org.apache.pulsar:pulsar-common</include>
-                  <include>org.apache.pulsar:pulsar-checksum</include>
-                  <include>net.jpountz.lz4:lz4</include>
-                  <include>com.yahoo.datasketches:sketches-core</include>
-                </includes>
-              </artifactSet>
-              <filters>
-                <filter>
-                  <artifact>net.jpountz.lz4:lz4</artifact>
-                  <includes>
-                    <include>**</include>
-                  </includes>
-                </filter>
-              </filters>
-              <relocations>
-                <relocation>
-                    <pattern>org.asynchttpclient</pattern>
-                    <shadedPattern>org.apache.pulsar.shade.org.asynchttpclient</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.commons</pattern>
-                  <shadedPattern>org.apache.pulsar.shade.org.apache.commons</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>com.google</pattern>
-                  <shadedPattern>org.apache.pulsar.shade.com.google</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>com.fasterxml.jackson</pattern>
-                  <shadedPattern>org.apache.pulsar.shade.com.fasterxml.jackson</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>io.netty</pattern>
-                  <shadedPattern>org.apache.pulsar.shade.io.netty</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.pulsar.common</pattern>
-                  <shadedPattern>org.apache.pulsar.shade.org.apache.pulsar.common</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>org.apache.pulsar.checksum</pattern>
-                  <shadedPattern>org.apache.pulsar.shade.org.apache.pulsar.checksum</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>com.scurrilous.circe</pattern>
-                  <shadedPattern>org.apache.pulsar.shade.com.scurrilous.circe</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>net.jpountz</pattern>
-                  <shadedPattern>org.apache.pulsar.shade.net.jpountz</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>com.yahoo.datasketches</pattern>
-                  <shadedPattern>org.apache.pulsar.shade.com.yahoo.datasketches</shadedPattern>
-                </relocation>
-              </relocations>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
   </build>
 </project>

--- a/pulsar-proxy/pom.xml
+++ b/pulsar-proxy/pom.xml
@@ -39,7 +39,7 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>pulsar-client</artifactId>
+      <artifactId>pulsar-client-original</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/pulsar-websocket/pom.xml
+++ b/pulsar-websocket/pom.xml
@@ -47,7 +47,7 @@
 
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>pulsar-client</artifactId>
+      <artifactId>pulsar-client-original</artifactId>
       <version>${project.version}</version>
     </dependency>
 


### PR DESCRIPTION
### Motivation

Currently, we are publishing on maven central the regular `org.apache.pulsar:pulsar-client` dependency which has the full list of dependencies. 

In most cases, though, a user might want to just the shaded pulsar client in order to avoid problems with conflicting dependencies. While we're publishing the shaded jar on maven central, it's a bit tricky to: 
 1. Know that it's available
 2. Specify the `classifier=shaded` in the dependency
 3. The reduced pom is not available on Maven central

For these reason, I think we should just let the shaded library be the default. Internally, the Pulsar broker will still be using the "unshaded" library and for that reason I had to break it down into 2 separate maven modules. 
