### PR TITLE
Enable json format to be used as an authentication params string

### DIFF
--- a/pulsar-client-cpp/lib/auth/AuthAthenz.cc
+++ b/pulsar-client-cpp/lib/auth/AuthAthenz.cc
@@ -70,7 +70,29 @@ namespace pulsar {
 
     AuthAthenz::~AuthAthenz() {
     }
-
+    
+    ParamMap parseAuthParamsString(const std::string& authParamsString) {
+        ParamMap params;
+        if(!authParamsString.empty()) {
+            Json::Value root;
+            Json::Reader reader;
+            if (reader.parse(authParamsString, root, false)) {
+                for (auto key: root.getMemberNames()) {
+                    params[key] = root[key].asString();
+                }
+            } else {
+                LOG_ERROR("Invalid String Error: " << reader.getFormatedErrorMessages());
+            }
+        }
+        return params;
+    }
+    
+    AuthenticationPtr AuthAthenz::create(const std::string& authParamsString) {
+        ParamMap params = parseAuthParamsString(authParamsString);
+        AuthenticationDataPtr authDataAthenz = AuthenticationDataPtr(new AuthDataAthenz(params));
+        return AuthenticationPtr(new AuthAthenz(authDataAthenz));
+    }
+    
     AuthenticationPtr AuthAthenz::create(ParamMap& params) {
         AuthenticationDataPtr authDataAthenz = AuthenticationDataPtr(new AuthDataAthenz(params));
         return AuthenticationPtr(new AuthAthenz(authDataAthenz));
@@ -83,6 +105,12 @@ namespace pulsar {
     Result AuthAthenz::getAuthData(AuthenticationDataPtr& authDataContent) const {
         authDataContent = authDataAthenz_;
         return ResultOk;
+    }
+    
+    extern "C" Authentication* create(const std::string& authParamsString) {
+        ParamMap params = parseAuthParamsString(authParamsString);
+        AuthenticationDataPtr authDataAthenz = AuthenticationDataPtr(new AuthDataAthenz(params));
+        return new AuthAthenz(authDataAthenz);
     }
 
     extern "C" Authentication* createFromMap(ParamMap& params) {

--- a/pulsar-client-cpp/lib/auth/AuthAthenz.h
+++ b/pulsar-client-cpp/lib/auth/AuthAthenz.h
@@ -46,6 +46,7 @@ namespace pulsar {
         AuthAthenz(AuthenticationDataPtr&);
         ~AuthAthenz();
         static AuthenticationPtr create(ParamMap& params);
+        static AuthenticationPtr create(const std::string& authParamsString);
         const std::string getAuthMethodName() const;
         Result getAuthData(AuthenticationDataPtr& authDataAthenz) const;
     private:

--- a/pulsar-client-cpp/tests/AuthPluginTest.cc
+++ b/pulsar-client-cpp/tests/AuthPluginTest.cc
@@ -132,7 +132,7 @@ namespace testAthenz {
             if (kv[0]=="Athenz-Principal-Auth:") {
                 principalToken = kv[1];
             }
-            
+
             if (headerLine == "\r" || headerLine == "\n" || headerLine == "\r\n") {
                 std::string mockToken = "{\"token\":\"mockToken\",\"expiryTime\":4133980800}";
                 stream << "HTTP/1.1 200 OK" << std::endl;
@@ -150,12 +150,13 @@ namespace testAthenz {
 TEST(AuthPluginTest, testAthenz) {
     boost::thread zts(&testAthenz::mockZTS);
     pulsar::AuthenticationDataPtr data;
-    ParamMap params;
-    params["tenantDomain"] = "pulsar.test.tenant";
-    params["tenantService"] = "service";
-    params["providerDomain"] = "pulsar.test.provider";
-    params["privateKey"] = "file:../../pulsar-broker/src/test/resources/authentication/tls/client-key.pem";
-    params["ztsUrl"] = "http://localhost:9999";
+    std::string params = R"({
+        "tenantDomain": "pulsar.test.tenant",
+        "tenantService": "service",
+        "providerDomain": "pulsar.test.provider",
+        "privateKey": "file:../../pulsar-broker/src/test/resources/authentication/tls/client-key.pem",
+        "ztsUrl": "http://localhost:9999"
+    })";
     pulsar::AuthenticationPtr auth = pulsar::AuthFactory::create("../lib/auth/libauthathenz.so", params);
     ASSERT_EQ(auth->getAuthMethodName(), "athenz");
     ASSERT_EQ(auth->getAuthData(data), pulsar::ResultOk);


### PR DESCRIPTION
### Motivation

Now, Athenz plugin for C++ Client cannot parse authentication params string.

### Modifications

Added a method to parse json string.

### Result
Athenz plugin for C++ Client can be created from json format string.