### PR TITLE
Allow consumer to seek to message id from within Pulsar client

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1910,6 +1910,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             log.debug("IsValid position: {} -- last: {}", position, last);
         }
 
+//        if (position.equals(PositionImpl.earliest || position.equals(PositionImpl)))
         if (position.getEntryId() < 0) {
             return false;
         } else if (position.getLedgerId() > last.getLedgerId()) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1910,7 +1910,6 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             log.debug("IsValid position: {} -- last: {}", position, last);
         }
 
-//        if (position.equals(PositionImpl.earliest || position.equals(PositionImpl)))
         if (position.getEntryId() < 0) {
             return false;
         } else if (position.getLedgerId() > last.getLedgerId()) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -696,7 +696,6 @@ public class ServerCnx extends PulsarHandler {
             Consumer consumer = consumerFuture.getNow(null);
             Subscription subscription = consumer.getSubscription();
             MessageIdData msgIdData = seek.getMessageId();
-//            MessageIdImpl msgId = MessageIdImpl.earliest
 
             Position position = new PositionImpl(msgIdData.getLedgerId(), msgIdData.getEntryId());
             long requestId = seek.getRequestId();
@@ -708,7 +707,7 @@ public class ServerCnx extends PulsarHandler {
             }).exceptionally(ex -> {
                 log.warn("[{}][{}] Failed to reset subscription: {}", remoteAddress, subscription, ex.getMessage(), ex);
                 ctx.writeAndFlush(Commands.newError(seek.getRequestId(), ServerError.UnknownError,
-                        "Error when resetting subscription: " + ex.getMessage()));
+                        "Error when resetting subscription: " + ex.getCause().getMessage()));
                 return null;
             });
         } else {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
@@ -28,8 +28,11 @@ import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 
 public interface Subscription {
+
+    Topic getTopic();
+
     String getName();
-    
+
     void addConsumer(Consumer consumer) throws BrokerServiceException;
 
     void removeConsumer(Consumer consumer) throws BrokerServiceException;
@@ -59,7 +62,7 @@ public interface Subscription {
     CompletableFuture<Void> skipMessages(int numMessagesToSkip);
 
     CompletableFuture<Void> resetCursor(long timestamp);
-    
+
     CompletableFuture<Void> resetCursor(Position position);
 
     CompletableFuture<Entry> peekNthMessage(int messagePosition);
@@ -71,11 +74,11 @@ public interface Subscription {
     void redeliverUnacknowledgedMessages(Consumer consumer, List<PositionImpl> positions);
 
     void markTopicWithBatchMessagePublished();
-    
+
     double getExpiredMessageRate();
-    
+
     SubType getType();
-    
+
     String getTypeString();
 
     void addUnAckedMessages(int unAckMessages);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
@@ -32,6 +32,7 @@ import org.apache.pulsar.broker.service.BrokerServiceException.SubscriptionFence
 import org.apache.pulsar.broker.service.Consumer;
 import org.apache.pulsar.broker.service.Dispatcher;
 import org.apache.pulsar.broker.service.Subscription;
+import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 import org.apache.pulsar.common.naming.DestinationName;
@@ -55,7 +56,7 @@ public class NonPersistentSubscription implements Subscription {
     private static final AtomicIntegerFieldUpdater<NonPersistentSubscription> IS_FENCED_UPDATER = AtomicIntegerFieldUpdater
             .newUpdater(NonPersistentSubscription.class, "isFenced");
     private volatile int isFenced = FALSE;
-    
+
     public NonPersistentSubscription(NonPersistentTopic topic, String subscriptionName) {
         this.topic = topic;
         this.topicName = topic.getName();
@@ -66,6 +67,11 @@ public class NonPersistentSubscription implements Subscription {
     @Override
     public String getName() {
         return this.subName;
+    }
+
+    @Override
+    public Topic getTopic() {
+        return topic;
     }
 
     @Override
@@ -342,7 +348,7 @@ public class NonPersistentSubscription implements Subscription {
         // No-op
         return 0;
     }
-    
+
     @Override
     public void markTopicWithBatchMessagePublished() {
         topic.markBatchMessagePublished();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -28,7 +28,6 @@ import org.apache.bookkeeper.mledger.AsyncCallbacks.CloseCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.MarkDeleteCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntryCallback;
-import org.apache.bookkeeper.mledger.AsyncCallbacks.ResetCursorCallback;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedCursor.IndividualDeletedEntries;
@@ -38,14 +37,15 @@ import org.apache.bookkeeper.mledger.ManagedLedgerException.InvalidCursorPositio
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.broker.service.BrokerServiceException;
-import org.apache.pulsar.broker.service.Consumer;
-import org.apache.pulsar.broker.service.Dispatcher;
-import org.apache.pulsar.broker.service.Subscription;
 import org.apache.pulsar.broker.service.BrokerServiceException.PersistenceException;
 import org.apache.pulsar.broker.service.BrokerServiceException.ServerMetadataException;
 import org.apache.pulsar.broker.service.BrokerServiceException.SubscriptionBusyException;
 import org.apache.pulsar.broker.service.BrokerServiceException.SubscriptionFencedException;
 import org.apache.pulsar.broker.service.BrokerServiceException.SubscriptionInvalidCursorPosition;
+import org.apache.pulsar.broker.service.Consumer;
+import org.apache.pulsar.broker.service.Dispatcher;
+import org.apache.pulsar.broker.service.Subscription;
+import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 import org.apache.pulsar.common.naming.DestinationName;
@@ -86,6 +86,11 @@ public class PersistentSubscription implements Subscription {
     @Override
     public String getName() {
         return this.subName;
+    }
+
+    @Override
+    public Topic getTopic() {
+        return topic;
     }
 
     @Override
@@ -469,7 +474,7 @@ public class PersistentSubscription implements Subscription {
     public int getTotalNonContiguousDeletedMessagesRange() {
         return cursor.getTotalNonContiguousDeletedMessagesRange();
     }
-    
+
     /**
      * Close the cursor ledger for this subscription. Requires that there are no active consumers on the dispatcher
      *

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.client.api.ConsumerConfiguration;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ */
+@Test
+public class SubscriptionSeekTest extends BrokerTestBase {
+    @BeforeClass
+    @Override
+    protected void setup() throws Exception {
+        super.baseSetup();
+    }
+
+    @AfterClass
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testSeek() throws Exception {
+        final String topicName = "persistent://prop/use/ns-abc/testSeek";
+
+        Producer producer = pulsarClient.createProducer(topicName);
+
+        ConsumerConfiguration consumerConf = new ConsumerConfiguration();
+
+        // Disable pre-fetch in consumer to track the messages received
+        consumerConf.setReceiverQueueSize(0);
+        org.apache.pulsar.client.api.Consumer consumer = pulsarClient.subscribe(topicName, "my-subscription",
+                consumerConf);
+
+        PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
+        assertNotNull(topicRef);
+        assertEquals(topicRef.getProducers().size(), 1);
+        assertEquals(topicRef.getSubscriptions().size(), 1);
+
+        List<MessageId> messageIds = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            String message = "my-message-" + i;
+            MessageId msgId = producer.send(message.getBytes());
+            messageIds.add(msgId);
+        }
+
+        PersistentSubscription sub = topicRef.getSubscription("my-subscription");
+        assertEquals(sub.getNumberOfEntriesInBacklog(), 10);
+
+        consumer.seek(MessageId.latest);
+        assertEquals(sub.getNumberOfEntriesInBacklog(), 0);
+
+        // Wait for consumer to reconnect
+        Thread.sleep(500);
+        consumer.seek(MessageId.earliest);
+        assertEquals(sub.getNumberOfEntriesInBacklog(), 10);
+
+        Thread.sleep(500);
+        consumer.seek(messageIds.get(5));
+        assertEquals(sub.getNumberOfEntriesInBacklog(), 5);
+    }
+
+    @Test
+    public void testSeekOnPartitionedTopic() throws Exception {
+        final String topicName = "persistent://prop/use/ns-abc/testSeekPartitions";
+
+        admin.persistentTopics().createPartitionedTopic(topicName, 2);
+        org.apache.pulsar.client.api.Consumer consumer = pulsarClient.subscribe(topicName, "my-subscription");
+
+        try {
+            consumer.seek(MessageId.latest);
+            fail("Should not have succeeded");
+        } catch (PulsarClientException e) {
+            // Expected
+        }
+    }
+
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/Consumer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/Consumer.java
@@ -239,4 +239,43 @@ public interface Consumer extends Closeable {
      * breaks, the messages are redelivered after reconnect.
      */
     void redeliverUnacknowledgedMessages();
+
+    /**
+     * Reset the subscription associated with this consumer to a specific message id.
+     * <p>
+     *
+     * The message id can either be a specific message or represent the first or last messages in the topic.
+     * <p>
+     * <ul>
+     * <li><code>MessageId.earliest</code> : Reset the subscription on the earliest message available in the topic
+     * <li><code>MessageId.latest</code> : Reset the subscription on the latest message in the topic
+     * </ul>
+     *
+     * Note: this operation can only be done on non-partitioned topics. For these, one can rather perform the seek() on
+     * the individual partitions.
+     *
+     * @param messageId
+     *            the message id where to reposition the subscription
+     */
+    void seek(MessageId messageId) throws PulsarClientException;
+
+    /**
+     * Reset the subscription associated with this consumer to a specific message id.
+     * <p>
+     *
+     * The message id can either be a specific message or represent the first or last messages in the topic.
+     * <p>
+     * <ul>
+     * <li><code>MessageId.earliest</code> : Reset the subscription on the earliest message available in the topic
+     * <li><code>MessageId.latest</code> : Reset the subscription on the latest message in the topic
+     * </ul>
+     *
+     * Note: this operation can only be done on non-partitioned topics. For these, one can rather perform the seek() on
+     * the individual partitions.
+     *
+     * @param messageId
+     *            the message id where to reposition the subscription
+     * @return a future to track the completion of the seek operation
+     */
+    CompletableFuture<Void> seekAsync(MessageId messageId);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedConsumerImpl.java
@@ -442,7 +442,9 @@ public class PartitionedConsumerImpl extends ConsumerBase {
     public void seek(MessageId messageId) throws PulsarClientException {
         try {
             seekAsync(messageId).get();
-        } catch (ExecutionException | InterruptedException e) {
+        } catch (ExecutionException e) {
+            throw new PulsarClientException(e.getCause());
+        } catch (InterruptedException e) {
             throw new PulsarClientException(e);
         }
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedConsumerImpl.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -435,6 +436,20 @@ public class PartitionedConsumerImpl extends ConsumerBase {
             });
             c.redeliverUnacknowledgedMessages(consumerMessageIds);
         }
+    }
+
+    @Override
+    public void seek(MessageId messageId) throws PulsarClientException {
+        try {
+            seekAsync(messageId).get();
+        } catch (ExecutionException | InterruptedException e) {
+            throw new PulsarClientException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> seekAsync(MessageId messageId) {
+        return FutureUtil.failedFuture(new PulsarClientException("Seek operation not supported on partitioned topics"));
     }
 
     /**

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/PulsarDecoder.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/PulsarDecoder.java
@@ -41,6 +41,7 @@ import org.apache.pulsar.common.api.proto.PulsarApi.CommandProducer;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandProducerSuccess;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandRedeliverUnacknowledgedMessages;
+import org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSend;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSendError;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSendReceipt;
@@ -211,6 +212,12 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
                 cmd.getUnsubscribe().recycle();
                 break;
 
+            case SEEK:
+                checkArgument(cmd.hasSeek());
+                handleSeek(cmd.getSeek());
+                cmd.getSeek().recycle();
+                break;
+
             case PING:
                 checkArgument(cmd.hasPing());
                 handlePing(cmd.getPing());
@@ -323,6 +330,10 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
     }
 
     protected void handleUnsubscribe(CommandUnsubscribe unsubscribe) {
+        throw new UnsupportedOperationException();
+    }
+
+    protected void handleSeek(CommandSeek seek) {
         throw new UnsupportedOperationException();
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
@@ -12587,6 +12587,495 @@ public final class PulsarApi {
     // @@protoc_insertion_point(class_scope:pulsar.proto.CommandUnsubscribe)
   }
   
+  public interface CommandSeekOrBuilder
+      extends com.google.protobuf.MessageLiteOrBuilder {
+    
+    // required uint64 consumer_id = 1;
+    boolean hasConsumerId();
+    long getConsumerId();
+    
+    // required uint64 request_id = 2;
+    boolean hasRequestId();
+    long getRequestId();
+    
+    // optional .pulsar.proto.MessageIdData message_id = 3;
+    boolean hasMessageId();
+    org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData getMessageId();
+  }
+  public static final class CommandSeek extends
+      com.google.protobuf.GeneratedMessageLite
+      implements CommandSeekOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
+    // Use CommandSeek.newBuilder() to construct.
+    private io.netty.util.Recycler.Handle handle;
+    private CommandSeek(io.netty.util.Recycler.Handle handle) {
+      this.handle = handle;
+    }
+    
+     private static final io.netty.util.Recycler<CommandSeek> RECYCLER = new io.netty.util.Recycler<CommandSeek>() {
+            protected CommandSeek newObject(Handle handle) {
+              return new CommandSeek(handle);
+            }
+          };
+        
+        public void recycle() {
+            this.initFields();
+            this.memoizedIsInitialized = -1;
+            this.bitField0_ = 0;
+            this.memoizedSerializedSize = -1;
+            if (handle != null) { RECYCLER.recycle(this, handle); }
+        }
+         
+    private CommandSeek(boolean noInit) {}
+    
+    private static final CommandSeek defaultInstance;
+    public static CommandSeek getDefaultInstance() {
+      return defaultInstance;
+    }
+    
+    public CommandSeek getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+    
+    private int bitField0_;
+    // required uint64 consumer_id = 1;
+    public static final int CONSUMER_ID_FIELD_NUMBER = 1;
+    private long consumerId_;
+    public boolean hasConsumerId() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    public long getConsumerId() {
+      return consumerId_;
+    }
+    
+    // required uint64 request_id = 2;
+    public static final int REQUEST_ID_FIELD_NUMBER = 2;
+    private long requestId_;
+    public boolean hasRequestId() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    public long getRequestId() {
+      return requestId_;
+    }
+    
+    // optional .pulsar.proto.MessageIdData message_id = 3;
+    public static final int MESSAGE_ID_FIELD_NUMBER = 3;
+    private org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData messageId_;
+    public boolean hasMessageId() {
+      return ((bitField0_ & 0x00000004) == 0x00000004);
+    }
+    public org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData getMessageId() {
+      return messageId_;
+    }
+    
+    private void initFields() {
+      consumerId_ = 0L;
+      requestId_ = 0L;
+      messageId_ = org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.getDefaultInstance();
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized != -1) return isInitialized == 1;
+      
+      if (!hasConsumerId()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasRequestId()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (hasMessageId()) {
+        if (!getMessageId().isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+    
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+        throw new RuntimeException("Cannot use CodedOutputStream");
+    }
+    
+    public void writeTo(org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeUInt64(1, consumerId_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeUInt64(2, requestId_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        output.writeMessage(3, messageId_);
+      }
+    }
+    
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+    
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt64Size(1, consumerId_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt64Size(2, requestId_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(3, messageId_);
+      }
+      memoizedSerializedSize = size;
+      return size;
+    }
+    
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+    
+    public static org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+         throw new RuntimeException("Disabled");
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+         throw new RuntimeException("Disabled");
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data).buildParsed();
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input).buildParsed();
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      Builder builder = newBuilder();
+      if (builder.mergeDelimitedFrom(input)) {
+        return builder.buildParsed();
+      } else {
+        return null;
+      }
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      Builder builder = newBuilder();
+      if (builder.mergeDelimitedFrom(input, extensionRegistry)) {
+        return builder.buildParsed();
+      } else {
+        return null;
+      }
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input).buildParsed();
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input, extensionRegistry)
+               .buildParsed();
+    }
+    
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+    
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek, Builder>
+        implements org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
+      // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek.newBuilder()
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
+        this.handle = handle;
+        maybeForceBuilderInitialization();
+      }
+      private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+               return new Builder(handle);
+             }
+            };
+      
+       public void recycle() {
+                clear();
+                if (handle != null) {RECYCLER.recycle(this, handle);}
+            }
+      
+      private void maybeForceBuilderInitialization() {
+      }
+      private static Builder create() {
+        return RECYCLER.get();
+      }
+      
+      public Builder clear() {
+        super.clear();
+        consumerId_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        requestId_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000002);
+        messageId_ = org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.getDefaultInstance();
+        bitField0_ = (bitField0_ & ~0x00000004);
+        return this;
+      }
+      
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+      
+      public org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek getDefaultInstanceForType() {
+        return org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek.getDefaultInstance();
+      }
+      
+      public org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek build() {
+        org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+      
+      private org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek buildParsed()
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(
+            result).asInvalidProtocolBufferException();
+        }
+        return result;
+      }
+      
+      public org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek buildPartial() {
+        org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek result = org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek.RECYCLER.get();
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.consumerId_ = consumerId_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.requestId_ = requestId_;
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        result.messageId_ = messageId_;
+        result.bitField0_ = to_bitField0_;
+        return result;
+      }
+      
+      public Builder mergeFrom(org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek other) {
+        if (other == org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek.getDefaultInstance()) return this;
+        if (other.hasConsumerId()) {
+          setConsumerId(other.getConsumerId());
+        }
+        if (other.hasRequestId()) {
+          setRequestId(other.getRequestId());
+        }
+        if (other.hasMessageId()) {
+          mergeMessageId(other.getMessageId());
+        }
+        return this;
+      }
+      
+      public final boolean isInitialized() {
+        if (!hasConsumerId()) {
+          
+          return false;
+        }
+        if (!hasRequestId()) {
+          
+          return false;
+        }
+        if (hasMessageId()) {
+          if (!getMessageId().isInitialized()) {
+            
+            return false;
+          }
+        }
+        return true;
+      }
+      
+      public Builder mergeFrom(com.google.protobuf.CodedInputStream input,
+                              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                              throws java.io.IOException {
+         throw new java.io.IOException("Merge from CodedInputStream is disabled");
+                              }
+      public Builder mergeFrom(
+          org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        while (true) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              
+              return this;
+            default: {
+              if (!input.skipField(tag)) {
+                
+                return this;
+              }
+              break;
+            }
+            case 8: {
+              bitField0_ |= 0x00000001;
+              consumerId_ = input.readUInt64();
+              break;
+            }
+            case 16: {
+              bitField0_ |= 0x00000002;
+              requestId_ = input.readUInt64();
+              break;
+            }
+            case 26: {
+              org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.Builder subBuilder = org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.newBuilder();
+              if (hasMessageId()) {
+                subBuilder.mergeFrom(getMessageId());
+              }
+              input.readMessage(subBuilder, extensionRegistry);
+              setMessageId(subBuilder.buildPartial());
+              subBuilder.recycle();
+              break;
+            }
+          }
+        }
+      }
+      
+      private int bitField0_;
+      
+      // required uint64 consumer_id = 1;
+      private long consumerId_ ;
+      public boolean hasConsumerId() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      public long getConsumerId() {
+        return consumerId_;
+      }
+      public Builder setConsumerId(long value) {
+        bitField0_ |= 0x00000001;
+        consumerId_ = value;
+        
+        return this;
+      }
+      public Builder clearConsumerId() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        consumerId_ = 0L;
+        
+        return this;
+      }
+      
+      // required uint64 request_id = 2;
+      private long requestId_ ;
+      public boolean hasRequestId() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      public long getRequestId() {
+        return requestId_;
+      }
+      public Builder setRequestId(long value) {
+        bitField0_ |= 0x00000002;
+        requestId_ = value;
+        
+        return this;
+      }
+      public Builder clearRequestId() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        requestId_ = 0L;
+        
+        return this;
+      }
+      
+      // optional .pulsar.proto.MessageIdData message_id = 3;
+      private org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData messageId_ = org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.getDefaultInstance();
+      public boolean hasMessageId() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      public org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData getMessageId() {
+        return messageId_;
+      }
+      public Builder setMessageId(org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        messageId_ = value;
+        
+        bitField0_ |= 0x00000004;
+        return this;
+      }
+      public Builder setMessageId(
+          org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.Builder builderForValue) {
+        messageId_ = builderForValue.build();
+        
+        bitField0_ |= 0x00000004;
+        return this;
+      }
+      public Builder mergeMessageId(org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData value) {
+        if (((bitField0_ & 0x00000004) == 0x00000004) &&
+            messageId_ != org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.getDefaultInstance()) {
+          messageId_ =
+            org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.newBuilder(messageId_).mergeFrom(value).buildPartial();
+        } else {
+          messageId_ = value;
+        }
+        
+        bitField0_ |= 0x00000004;
+        return this;
+      }
+      public Builder clearMessageId() {
+        messageId_ = org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.getDefaultInstance();
+        
+        bitField0_ = (bitField0_ & ~0x00000004);
+        return this;
+      }
+      
+      // @@protoc_insertion_point(builder_scope:pulsar.proto.CommandSeek)
+    }
+    
+    static {
+      defaultInstance = new CommandSeek(true);
+      defaultInstance.initFields();
+    }
+    
+    // @@protoc_insertion_point(class_scope:pulsar.proto.CommandSeek)
+  }
+  
   public interface CommandReachedEndOfTopicOrBuilder
       extends com.google.protobuf.MessageLiteOrBuilder {
     
@@ -17840,6 +18329,10 @@ public final class PulsarApi {
     // optional .pulsar.proto.CommandReachedEndOfTopic reachedEndOfTopic = 27;
     boolean hasReachedEndOfTopic();
     org.apache.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic getReachedEndOfTopic();
+    
+    // optional .pulsar.proto.CommandSeek seek = 28;
+    boolean hasSeek();
+    org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek getSeek();
   }
   public static final class BaseCommand extends
       com.google.protobuf.GeneratedMessageLite
@@ -17903,6 +18396,7 @@ public final class PulsarApi {
       CONSUMER_STATS(23, 25),
       CONSUMER_STATS_RESPONSE(24, 26),
       REACHED_END_OF_TOPIC(25, 27),
+      SEEK(26, 28),
       ;
       
       public static final int CONNECT_VALUE = 2;
@@ -17931,6 +18425,7 @@ public final class PulsarApi {
       public static final int CONSUMER_STATS_VALUE = 25;
       public static final int CONSUMER_STATS_RESPONSE_VALUE = 26;
       public static final int REACHED_END_OF_TOPIC_VALUE = 27;
+      public static final int SEEK_VALUE = 28;
       
       
       public final int getNumber() { return value; }
@@ -17963,6 +18458,7 @@ public final class PulsarApi {
           case 25: return CONSUMER_STATS;
           case 26: return CONSUMER_STATS_RESPONSE;
           case 27: return REACHED_END_OF_TOPIC;
+          case 28: return SEEK;
           default: return null;
         }
       }
@@ -18259,6 +18755,16 @@ public final class PulsarApi {
       return reachedEndOfTopic_;
     }
     
+    // optional .pulsar.proto.CommandSeek seek = 28;
+    public static final int SEEK_FIELD_NUMBER = 28;
+    private org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek seek_;
+    public boolean hasSeek() {
+      return ((bitField0_ & 0x08000000) == 0x08000000);
+    }
+    public org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek getSeek() {
+      return seek_;
+    }
+    
     private void initFields() {
       type_ = org.apache.pulsar.common.api.proto.PulsarApi.BaseCommand.Type.CONNECT;
       connect_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandConnect.getDefaultInstance();
@@ -18287,6 +18793,7 @@ public final class PulsarApi {
       consumerStats_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandConsumerStats.getDefaultInstance();
       consumerStatsResponse_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandConsumerStatsResponse.getDefaultInstance();
       reachedEndOfTopic_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic.getDefaultInstance();
+      seek_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek.getDefaultInstance();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -18441,6 +18948,12 @@ public final class PulsarApi {
           return false;
         }
       }
+      if (hasSeek()) {
+        if (!getSeek().isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
+      }
       memoizedIsInitialized = 1;
       return true;
     }
@@ -18533,6 +19046,9 @@ public final class PulsarApi {
       }
       if (((bitField0_ & 0x04000000) == 0x04000000)) {
         output.writeMessage(27, reachedEndOfTopic_);
+      }
+      if (((bitField0_ & 0x08000000) == 0x08000000)) {
+        output.writeMessage(28, seek_);
       }
     }
     
@@ -18649,6 +19165,10 @@ public final class PulsarApi {
       if (((bitField0_ & 0x04000000) == 0x04000000)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(27, reachedEndOfTopic_);
+      }
+      if (((bitField0_ & 0x08000000) == 0x08000000)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(28, seek_);
       }
       memoizedSerializedSize = size;
       return size;
@@ -18817,6 +19337,8 @@ public final class PulsarApi {
         bitField0_ = (bitField0_ & ~0x02000000);
         reachedEndOfTopic_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic.getDefaultInstance();
         bitField0_ = (bitField0_ & ~0x04000000);
+        seek_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek.getDefaultInstance();
+        bitField0_ = (bitField0_ & ~0x08000000);
         return this;
       }
       
@@ -18958,6 +19480,10 @@ public final class PulsarApi {
           to_bitField0_ |= 0x04000000;
         }
         result.reachedEndOfTopic_ = reachedEndOfTopic_;
+        if (((from_bitField0_ & 0x08000000) == 0x08000000)) {
+          to_bitField0_ |= 0x08000000;
+        }
+        result.seek_ = seek_;
         result.bitField0_ = to_bitField0_;
         return result;
       }
@@ -19044,6 +19570,9 @@ public final class PulsarApi {
         }
         if (other.hasReachedEndOfTopic()) {
           mergeReachedEndOfTopic(other.getReachedEndOfTopic());
+        }
+        if (other.hasSeek()) {
+          mergeSeek(other.getSeek());
         }
         return this;
       }
@@ -19193,6 +19722,12 @@ public final class PulsarApi {
         }
         if (hasReachedEndOfTopic()) {
           if (!getReachedEndOfTopic().isInitialized()) {
+            
+            return false;
+          }
+        }
+        if (hasSeek()) {
+          if (!getSeek().isInitialized()) {
             
             return false;
           }
@@ -19488,6 +20023,16 @@ public final class PulsarApi {
               }
               input.readMessage(subBuilder, extensionRegistry);
               setReachedEndOfTopic(subBuilder.buildPartial());
+              subBuilder.recycle();
+              break;
+            }
+            case 226: {
+              org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek.Builder subBuilder = org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek.newBuilder();
+              if (hasSeek()) {
+                subBuilder.mergeFrom(getSeek());
+              }
+              input.readMessage(subBuilder, extensionRegistry);
+              setSeek(subBuilder.buildPartial());
               subBuilder.recycle();
               break;
             }
@@ -20636,6 +21181,49 @@ public final class PulsarApi {
         reachedEndOfTopic_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic.getDefaultInstance();
         
         bitField0_ = (bitField0_ & ~0x04000000);
+        return this;
+      }
+      
+      // optional .pulsar.proto.CommandSeek seek = 28;
+      private org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek seek_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek.getDefaultInstance();
+      public boolean hasSeek() {
+        return ((bitField0_ & 0x08000000) == 0x08000000);
+      }
+      public org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek getSeek() {
+        return seek_;
+      }
+      public Builder setSeek(org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        seek_ = value;
+        
+        bitField0_ |= 0x08000000;
+        return this;
+      }
+      public Builder setSeek(
+          org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek.Builder builderForValue) {
+        seek_ = builderForValue.build();
+        
+        bitField0_ |= 0x08000000;
+        return this;
+      }
+      public Builder mergeSeek(org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek value) {
+        if (((bitField0_ & 0x08000000) == 0x08000000) &&
+            seek_ != org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek.getDefaultInstance()) {
+          seek_ =
+            org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek.newBuilder(seek_).mergeFrom(value).buildPartial();
+        } else {
+          seek_ = value;
+        }
+        
+        bitField0_ |= 0x08000000;
+        return this;
+      }
+      public Builder clearSeek() {
+        seek_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek.getDefaultInstance();
+        
+        bitField0_ = (bitField0_ & ~0x08000000);
         return this;
       }
       

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -293,6 +293,14 @@ message CommandUnsubscribe {
 	required uint64 request_id  = 2;
 }
 
+// Reset an existing consumer to a particular message id
+message CommandSeek {
+	required uint64 consumer_id = 1;
+	required uint64 request_id  = 2;
+	
+	optional MessageIdData message_id = 3;
+}
+
 // Message sent by broker to client when a topic
 // has been forcefully terminated and there are no more
 // messages left to consume
@@ -434,6 +442,7 @@ message BaseCommand {
 
 		REACHED_END_OF_TOPIC = 27;
 
+		SEEK = 28;
 	}
 
 	required Type type = 1;
@@ -472,4 +481,6 @@ message BaseCommand {
 	optional CommandConsumerStatsResponse consumerStatsResponse         = 26;
 
 	optional CommandReachedEndOfTopic reachedEndOfTopic  = 27;
+	
+	optional CommandSeek seek = 28;
 }


### PR DESCRIPTION
### Motivation

Currently we have the option to "reset" a subscription to a specific timestamp or message id through the Pulsar admin API. 

In some cases, it might be useful to allow the same operation to be done from the `Consumer` API. One such example is related to the Pulsar-Kafka wrapper, in which we need to emulate operations like `seekToBeginning()`, `seekToEnd()` or `seekTo()`.

### Modifications

Added new request command in wire protocol to issue a "seek" command to the broker, relative to the subscription associated with the current consumer.
