### PR TITLE
 Implement seekToBeginning()/end operations in Kafka consumer wrapper 

### DIFF
--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
@@ -418,10 +418,11 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
         for (TopicPartition tp : partitions) {
             org.apache.pulsar.client.api.Consumer c = consumers.get(tp);
             if (c == null) {
-                throw new IllegalArgumentException("Cannot seek on a partition where we are not subscribed");
+                futures.add(FutureUtil.failedFuture(
+                        new IllegalArgumentException("Cannot seek on a partition where we are not subscribed")));
+            } else {
+                futures.add(c.seekAsync(MessageId.earliest));
             }
-
-            c.seekAsync(MessageId.earliest);
         }
 
         FutureUtil.waitForAll(futures).join();
@@ -438,10 +439,11 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
         for (TopicPartition tp : partitions) {
             org.apache.pulsar.client.api.Consumer c = consumers.get(tp);
             if (c == null) {
-                throw new IllegalArgumentException("Cannot seek on a partition where we are not subscribed");
+                futures.add(FutureUtil.failedFuture(
+                        new IllegalArgumentException("Cannot seek on a partition where we are not subscribed")));
+            } else {
+                futures.add(c.seekAsync(MessageId.latest));
             }
-
-            c.seekAsync(MessageId.latest);
         }
 
         FutureUtil.waitForAll(futures).join();

--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
@@ -48,6 +48,7 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.pulsar.client.api.ClientConfiguration;
 import org.apache.pulsar.client.api.ConsumerConfiguration;
 import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MessageListener;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -59,7 +60,8 @@ import org.apache.pulsar.client.kafka.compat.PulsarKafkaConfig;
 import org.apache.pulsar.client.util.ConsumerName;
 import org.apache.pulsar.client.util.FutureUtil;
 import org.apache.pulsar.common.naming.DestinationName;
-import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Lists;
 
@@ -179,7 +181,14 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
 
     @Override
     public void subscribe(Collection<String> topics) {
+        subscribe(topics, null);
+    }
+
+    @Override
+    public void subscribe(Collection<String> topics, ConsumerRebalanceListener callback) {
         List<CompletableFuture<org.apache.pulsar.client.api.Consumer>> futures = new ArrayList<>();
+
+        List<TopicPartition> topicPartitions = new ArrayList<>();
         try {
             for (String topic : topics) {
                 // Create individual subscription on each partition, that way we can keep using the
@@ -197,25 +206,32 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
                         CompletableFuture<org.apache.pulsar.client.api.Consumer> future = client
                                 .subscribeAsync(partitionName, groupId, conf);
                         int partitionIndex = i;
-                        future.thenAccept(
-                                consumer -> consumers.putIfAbsent(new TopicPartition(topic, partitionIndex), consumer));
+                        TopicPartition tp = new TopicPartition(topic, partitionIndex);
+                        future.thenAccept(consumer -> consumers.putIfAbsent(tp, consumer));
                         futures.add(future);
+                        topicPartitions.add(tp);
                     }
-
                 } else {
                     // Topic has a single partition
                     CompletableFuture<org.apache.pulsar.client.api.Consumer> future = client.subscribeAsync(topic,
                             groupId, conf);
-                    future.thenAccept(consumer -> consumers.putIfAbsent(new TopicPartition(topic, 0), consumer));
+                    TopicPartition tp = new TopicPartition(topic, 0);
+                    future.thenAccept(consumer -> consumers.putIfAbsent(tp, consumer));
                     futures.add(future);
+                    topicPartitions.add(tp);
                 }
             }
 
             // Wait for all consumers to be ready
             futures.forEach(CompletableFuture::join);
 
+            // Notify the listener is now owning all topics/partitions
+            if (callback != null) {
+                callback.onPartitionsAssigned(topicPartitions);
+            }
+
         } catch (Exception e) {
-            // Close all consumer that might have been sucessfully created
+            // Close all consumer that might have been successfully created
             futures.forEach(f -> {
                 try {
                     f.get().close();
@@ -226,11 +242,6 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
 
             throw new RuntimeException(e);
         }
-    }
-
-    @Override
-    public void subscribe(Collection<String> topics, ConsumerRebalanceListener callback) {
-        throw new UnsupportedOperationException("ConsumerRebalanceListener is not supported");
     }
 
     @Override
@@ -383,17 +394,57 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
 
     @Override
     public void seek(TopicPartition partition, long offset) {
-        throw new UnsupportedOperationException();
+        MessageId msgId = MessageIdUtils.getMessageId(offset);
+        org.apache.pulsar.client.api.Consumer c = consumers.get(partition);
+        if (c == null) {
+            throw new IllegalArgumentException("Cannot seek on a partition where we are not subscribed");
+        }
+
+        try {
+            c.seek(msgId);
+        } catch (PulsarClientException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override
     public void seekToBeginning(Collection<TopicPartition> partitions) {
-        throw new UnsupportedOperationException();
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+        if (partitions.isEmpty()) {
+            partitions = consumers.keySet();
+        }
+
+        for (TopicPartition tp : partitions) {
+            org.apache.pulsar.client.api.Consumer c = consumers.get(tp);
+            if (c == null) {
+                throw new IllegalArgumentException("Cannot seek on a partition where we are not subscribed");
+            }
+
+            c.seekAsync(MessageId.earliest);
+        }
+
+        FutureUtil.waitForAll(futures).join();
     }
 
     @Override
     public void seekToEnd(Collection<TopicPartition> partitions) {
-        throw new UnsupportedOperationException();
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+        if (partitions.isEmpty()) {
+            partitions = consumers.keySet();
+        }
+
+        for (TopicPartition tp : partitions) {
+            org.apache.pulsar.client.api.Consumer c = consumers.get(tp);
+            if (c == null) {
+                throw new IllegalArgumentException("Cannot seek on a partition where we are not subscribed");
+            }
+
+            c.seekAsync(MessageId.latest);
+        }
+
+        FutureUtil.waitForAll(futures).join();
     }
 
     @Override
@@ -472,4 +523,6 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
     public void wakeup() {
         throw new UnsupportedOperationException();
     }
+
+    private static final Logger log = LoggerFactory.getLogger(PulsarKafkaConsumer.class);
 }


### PR DESCRIPTION
### Motivation

The Kafka `ConsumerPerformance` benchmark tool makes use of the `seekToBeginning()`, `seekToEnd()` operations, so it makes sense for Pulsar wrapper to implement those, in order to have an out-of-the-box support for the commonly used tools.

### Modifications

This PR is based on top of #848 and makes use of the newly introduced API. I'll rebase once that is merge.
