### PR TITLE
Use "trimStackTrace" option in Maven surefire

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -594,6 +594,7 @@ flexible messaging model and an intuitive client API.</description>
           <reuseForks>false</reuseForks>
           <forkCount>1</forkCount>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
+          <trimStackTrace>false</trimStackTrace>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
### Motivation

This option will print the full stack trace of exception thrown within the test execution. In many cases, this should help in identifying the test failures reasons.
