### PR TITLE
Use info log level for message "Reconnecting after timeout" in HandlerBase

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HandlerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/HandlerBase.java
@@ -120,7 +120,7 @@ abstract class HandlerBase {
             log.info("[{}] [{}] Closed connection {} -- Will try again in {} s", topic, getHandlerName(), cnx.channel(),
                     delayMs / 1000.0);
             client.timer().newTimeout(timeout -> {
-                log.warn("[{}] [{}] Reconnecting after timeout", topic, getHandlerName());
+                log.info("[{}] [{}] Reconnecting after timeout", topic, getHandlerName());
                 grabCnx();
             }, delayMs, TimeUnit.MILLISECONDS);
         }


### PR DESCRIPTION
### Motivation

The message in question happens in normal conditions when reconnecting to the broker. There's no reason for it to be a warning.
