### PR TITLE
Avoid interrupted exception in PulsarKafkaConsumer when shutting down

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -309,8 +309,14 @@ public class ConsumerImpl extends ConsumerBase {
             return message;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            stats.incrementNumReceiveFailed();
-            throw new PulsarClientException(e);
+
+            State state = getState();
+            if (state != State.Closing && state != State.Closed) {
+                stats.incrementNumReceiveFailed();
+                throw new PulsarClientException(e);
+            } else {
+                return null;
+            }
         }
     }
 


### PR DESCRIPTION
### Motivation

Avoid having interrupted exception stack traces when the Kafka consumer wrapper is getting closed.

The exceptions can be triggered when the executors are shut down and they're waiting on the blocking queue operations. The exception itself represent the normal operating way and it should not be printed, unless some other unexpected condition.
