### PR TITLE
Allow to configure the default number of bundles for new namespaces

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -94,7 +94,7 @@ brokerDeduplicationProducerInactivityTimeoutMinutes=360
 
 # When a namespace is created without specifying the number of bundle, this
 # value will be used as the default
-defaultNumberOfNamespaceBundles=16
+defaultNumberOfNamespaceBundles=4
 
 # Enable check for minimum allowed client library version
 clientLibraryVersionCheckEnabled=false
@@ -291,7 +291,7 @@ managedLedgerMaxUnackedRangesToPersist=10000
 
 # Max number of "acknowledgment holes" that can be stored in Zookeeper. If number of unack message range is higher
 # than this limit then broker will persist unacked ranges into bookkeeper to avoid additional data overhead into
-# zookeeper.  
+# zookeeper.
 managedLedgerMaxUnackedRangesToPersistInZooKeeper=1000
 
 

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -92,6 +92,10 @@ brokerDeduplicationEntriesInterval=1000
 # relative to a disconnected producer. Default is 6 hours.
 brokerDeduplicationProducerInactivityTimeoutMinutes=360
 
+# When a namespace is created without specifying the number of bundle, this
+# value will be used as the default
+defaultNumberOfNamespaceBundles=16
+
 # Enable check for minimum allowed client library version
 clientLibraryVersionCheckEnabled=false
 

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -85,6 +85,9 @@ brokerDeduplicationEntriesInterval=1000
 # relative to a disconnected producer. Default is 6 hours.
 brokerDeduplicationProducerInactivityTimeoutMinutes=360
 
+# When a namespace is created without specifying the number of bundle, this
+# value will be used as the default
+defaultNumberOfNamespaceBundles=16
 
 # Enable check for minimum allowed client library version
 clientLibraryVersionCheckEnabled=false

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -87,7 +87,7 @@ brokerDeduplicationProducerInactivityTimeoutMinutes=360
 
 # When a namespace is created without specifying the number of bundle, this
 # value will be used as the default
-defaultNumberOfNamespaceBundles=16
+defaultNumberOfNamespaceBundles=4
 
 # Enable check for minimum allowed client library version
 clientLibraryVersionCheckEnabled=false
@@ -263,7 +263,7 @@ managedLedgerMaxUnackedRangesToPersist=10000
 
 # Max number of "acknowledgment holes" that can be stored in Zookeeper. If number of unack message range is higher
 # than this limit then broker will persist unacked ranges into bookkeeper to avoid additional data overhead into
-# zookeeper.  
+# zookeeper.
 managedLedgerMaxUnackedRangesToPersistInZooKeeper=1000
 
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -102,7 +102,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     // When a namespace is created without specifying the number of bundle, this
     // value will be used as the default
-    private int defaultNumberOfNamespaceBundles = 16;
+    private int defaultNumberOfNamespaceBundles = 4;
 
     // Enable check for minimum allowed client library version
     private boolean clientLibraryVersionCheckEnabled = false;

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -100,6 +100,10 @@ public class ServiceConfiguration implements PulsarConfiguration {
     // relative to a disconnected producer. Default is 6 hours.
     private int brokerDeduplicationProducerInactivityTimeoutMinutes = 360;
 
+    // When a namespace is created without specifying the number of bundle, this
+    // value will be used as the default
+    private int defaultNumberOfNamespaceBundles = 16;
+
     // Enable check for minimum allowed client library version
     private boolean clientLibraryVersionCheckEnabled = false;
     // Allow client libraries with no version information
@@ -269,7 +273,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private int managedLedgerMaxUnackedRangesToPersist = 10000;
     // Max number of "acknowledgment holes" that can be stored in Zookeeper. If number of unack message range is higher
     // than this limit then broker will persist unacked ranges into bookkeeper to avoid additional data overhead into
-    // zookeeper.  
+    // zookeeper.
     private int managedLedgerMaxUnackedRangesToPersistInZooKeeper = 1000;
 
     /*** --- Load balancer --- ****/
@@ -500,6 +504,14 @@ public class ServiceConfiguration implements PulsarConfiguration {
     public void setBrokerDeduplicationProducerInactivityTimeoutMinutes(
             int brokerDeduplicationProducerInactivityTimeoutMinutes) {
         this.brokerDeduplicationProducerInactivityTimeoutMinutes = brokerDeduplicationProducerInactivityTimeoutMinutes;
+    }
+
+    public int getDefaultNumberOfNamespaceBundles() {
+        return defaultNumberOfNamespaceBundles;
+    }
+
+    public void setDefaultNumberOfNamespaceBundles(int defaultNumberOfNamespaceBundles) {
+        this.defaultNumberOfNamespaceBundles = defaultNumberOfNamespaceBundles;
     }
 
     public long getBrokerDeleteInactiveTopicsFrequencySeconds() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/Namespaces.java
@@ -217,6 +217,9 @@ public class Namespaces extends AdminResource {
                 } else {
                     policies.bundles = validateBundlesData(initialBundles);
                 }
+            } else {
+                int defaultNumberOfBundles = config().getDefaultNumberOfNamespaceBundles();
+                policies.bundles = getBundles(defaultNumberOfBundles);
             }
 
             zkCreateOptimistic(path(POLICIES, property, cluster, namespace),
@@ -1170,7 +1173,7 @@ public class Namespaces extends AdminResource {
                     (persistence.getBookkeeperEnsemble() >= persistence.getBookkeeperWriteQuorum())
                             && (persistence.getBookkeeperWriteQuorum() >= persistence.getBookkeeperAckQuorum()),
                     "Bookkeeper Ensemble (%s) >= WriteQuorum (%s) >= AckQuoru (%s)", persistence.getBookkeeperEnsemble(),
-                    persistence.getBookkeeperWriteQuorum(), persistence.getBookkeeperAckQuorum());            
+                    persistence.getBookkeeperWriteQuorum(), persistence.getBookkeeperAckQuorum());
         }catch(NullPointerException | IllegalArgumentException e) {
             throw new RestException(Status.PRECONDITION_FAILED, e.getMessage());
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/SLAMonitoringTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/SLAMonitoringTest.java
@@ -91,6 +91,7 @@ public class SLAMonitoringTest {
             config.setWebServicePort(brokerWebServicePorts[i]);
             config.setZookeeperServers("127.0.0.1" + ":" + ZOOKEEPER_PORT);
             config.setBrokerServicePort(brokerNativeBrokerPorts[i]);
+            config.setDefaultNumberOfNamespaceBundles(1);
             configurations[i] = config;
 
             pulsarServices[i] = new PulsarService(config);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -93,6 +93,7 @@ public abstract class MockedPulsarServiceBaseTest {
         this.conf.setAdvertisedAddress("localhost"); // there are TLS tests in here, they need to use localhost because of the certificate
         this.conf.setManagedLedgerCacheSizeMB(8);
         this.conf.setActiveConsumerFailoverDelayTimeMillis(0);
+        this.conf.setDefaultNumberOfNamespaceBundles(1);
     }
 
     protected final void internalSetup() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceCreateBundlesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceCreateBundlesTest.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.namespace;
+
+import static org.testng.Assert.assertEquals;
+
+import org.apache.pulsar.broker.service.BrokerTestBase;
+import org.apache.pulsar.common.policies.data.Policies;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class NamespaceCreateBundlesTest extends BrokerTestBase {
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        conf.setDefaultNumberOfNamespaceBundles(16);
+        super.baseSetup();
+    }
+
+    @AfterMethod
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testCreateNamespaceWithDefaultBundles() throws Exception {
+        String namespaceName = "prop/use/default-bundles";
+
+        admin.namespaces().createNamespace(namespaceName);
+
+        Policies policies = admin.namespaces().getPolicies(namespaceName);
+        assertEquals(policies.bundles.numBundles, 16);
+        assertEquals(policies.bundles.boundaries.size(), 17);
+    }
+
+}

--- a/site/docs/latest/deployment/Kubernetes.md
+++ b/site/docs/latest/deployment/Kubernetes.md
@@ -237,8 +237,8 @@ $ bin/pulsar-admin properties create $MY_PROPERTY \
   --admin-roles admin \
   --allowed-clusters us-central
 
-# Create a namespace that can be spread across up to 16 brokers
-$ bin/pulsar-admin namespaces create $MY_NAMESPACE --bundles 16
+# Create a namespace
+$ bin/pulsar-admin namespaces create $MY_NAMESPACE
 ```
 
 #### Experimenting with your cluster

--- a/site/ja/deployment/Kubernetes.md
+++ b/site/ja/deployment/Kubernetes.md
@@ -238,7 +238,7 @@ $ bin/pulsar-admin properties create $MY_PROPERTY \
   --allowed-clusters us-central
 
 # 16のBrokerを横断しうるネームスペースの作成
-$ bin/pulsar-admin namespaces create $MY_NAMESPACE --bundles 16
+$ bin/pulsar-admin namespaces create $MY_NAMESPACE
 ```
 
 #### 作成したクラスタでの実験

--- a/site/ja/deployment/Kubernetes.md
+++ b/site/ja/deployment/Kubernetes.md
@@ -237,7 +237,7 @@ $ bin/pulsar-admin properties create $MY_PROPERTY \
   --admin-roles admin \
   --allowed-clusters us-central
 
-# 16のBrokerを横断しうるネームスペースの作成
+# 4のBrokerを横断しうるネームスペースの作成
 $ bin/pulsar-admin namespaces create $MY_NAMESPACE
 ```
 


### PR DESCRIPTION
### Motivation

By default namespaces are currently created with a single bundle.

In many examples, we need then to explain how to specify a number of bundles (and explaining what bundles are and what they mean). 

Bundles are meant to be a very internal concept that in the overweeningly number of cases user shouldn't need to be aware of. 
Apart from auto-splitting, which is currently disabled, we need to ensure to start with a reasonable default of bundles that will allow to spread traffic across multiple broker immediately.

### Modifications

 * Added a configuration setting in broker to set the default number of bundles
 * When a namespace is created, it will use that value unless something different is specified by the user 

### Result

A small step towards hiding the bundles from user sight.

