### PR TITLE
Add proxy configuration for kubernetes

### DIFF
--- a/kubernetes/generic/proxy.yaml
+++ b/kubernetes/generic/proxy.yaml
@@ -23,7 +23,7 @@ kind: ConfigMap
 metadata:
     name: proxy-config
 data:
-    PULSAR_MEM: "\" -Xms28g -Xmx28g -XX:MaxDirectMemorySize=28g\""
+    PULSAR_MEM: "\" -Xms4g -Xmx4g -XX:MaxDirectMemorySize=4g\""
     zookeeperServers: zk-0.zookeeper,zk-1.zookeeper,zk-2.zookeeper
     globalZookeeperServers: zk-0.zookeeper,zk-1.zookeeper,zk-2.zookeeper
     clusterName: us-central

--- a/kubernetes/generic/proxy.yaml
+++ b/kubernetes/generic/proxy.yaml
@@ -1,0 +1,89 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: proxy-config
+data:
+    PULSAR_MEM: "\" -Xms28g -Xmx28g -XX:MaxDirectMemorySize=28g\""
+    zookeeperServers: zk-0.zookeeper,zk-1.zookeeper,zk-2.zookeeper
+    globalZookeeperServers: zk-0.zookeeper,zk-1.zookeeper,zk-2.zookeeper
+    clusterName: us-central
+---
+##
+## Proxy deployment definition
+##
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+    name: proxy
+spec:
+    replicas: 5
+    template:
+        metadata:
+            labels:
+                app: pulsar
+                component: proxy
+            annotations:
+                prometheus.io/scrape: "true"
+                prometheus.io/port: "8080"
+        spec:
+            containers:
+              - name: proxy
+                image: apachepulsar/pulsar:latest
+                command: ["sh", "-c"]
+                args:
+                  - >
+                    bin/apply-config-from-env.py conf/proxy.conf &&
+                    bin/apply-config-from-env.py conf/pulsar_env.sh &&
+                    bin/pulsar proxy
+                ports:
+                  - containerPort: 8080
+                envFrom:
+                  - configMapRef:
+                        name: proxy-config
+---
+
+##
+## Expose all nodes on port so that you can reach cluster from outside k8
+##
+apiVersion: v1
+kind: Service
+metadata:
+    name: proxy
+    labels:
+        app: pulsar
+        component: proxy
+spec:
+    type: NodePort
+    ports:
+      - name: http
+        nodePort: 30001
+        port: 8080
+        protocol: TCP
+      - name: tcp
+        nodePort: 30002
+        port: 6650
+        protocol: TCP
+    selector:
+        app: pulsar
+        component: proxy
+---


### PR DESCRIPTION
### Motivation

We need to access pulsar from outside of a Kubernetes cluster.  

### Modifications

This contribution configures the pulsar proxy to listen on every kubernetes node. Every node in the k8 cluster allows ports 30001 and 30002 to act as http and broker ports respectively. 

### Result

You can optionally run a proxy server on every node and access it from outside of your kubernetes cluster. 
