### PR TITLE
Introduce auto bundle split and unloading of split bundle in ModularLoadManager

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -330,6 +330,9 @@ loadBalancerBrokerComfortLoadLevelPercentage=65
 # enable/disable namespace bundle auto split
 loadBalancerAutoBundleSplitEnabled=false
 
+# enable/disable automatic unloading of split bundles
+loadBalancerAutoUnloadSplitBundlesEnabled=false
+
 # maximum topics in a bundle, otherwise bundle split will be triggered
 loadBalancerNamespaceBundleMaxTopics=1000
 

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -303,6 +303,9 @@ loadBalancerBrokerComfortLoadLevelPercentage=65
 # enable/disable namespace bundle auto split
 loadBalancerAutoBundleSplitEnabled=false
 
+# enable/disable automatic unloading of split bundles
+loadBalancerAutoUnloadSplitBundlesEnabled=false
+
 # maximum topics in a bundle, otherwise bundle split will be triggered
 loadBalancerNamespaceBundleMaxTopics=1000
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -302,6 +302,8 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private int loadBalancerBrokerComfortLoadLevelPercentage = 65;
     // enable/disable automatic namespace bundle split
     private boolean loadBalancerAutoBundleSplitEnabled = false;
+    // enable/disable automatic unloading of split bundles
+    private boolean loadBalancerAutoUnloadSplitBundlesEnabled = false;
     // maximum topics in a bundle, otherwise bundle split will be triggered
     private int loadBalancerNamespaceBundleMaxTopics = 1000;
     // maximum sessions (producers + consumers) in a bundle, otherwise bundle split will be triggered
@@ -1106,6 +1108,14 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     public void setLoadBalancerAutoBundleSplitEnabled(boolean enabled) {
         this.loadBalancerAutoBundleSplitEnabled = enabled;
+    }
+
+    public boolean isLoadBalancerAutoUnloadSplitBundlesEnabled() {
+        return loadBalancerAutoUnloadSplitBundlesEnabled;
+    }
+
+    public void setLoadBalancerAutoUnloadSplitBundlesEnabled(boolean loadBalancerAutoUnloadSplitBundlesEnabled) {
+        this.loadBalancerAutoUnloadSplitBundlesEnabled = loadBalancerAutoUnloadSplitBundlesEnabled;
     }
 
     public void setLoadBalancerNamespaceMaximumBundles(int bundles) {

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -301,8 +301,10 @@ public class ServiceConfiguration implements PulsarConfiguration {
     // Usage threshold to defermine a broker is having just right level of load
     private int loadBalancerBrokerComfortLoadLevelPercentage = 65;
     // enable/disable automatic namespace bundle split
+    @FieldContext(dynamic = true)
     private boolean loadBalancerAutoBundleSplitEnabled = false;
     // enable/disable automatic unloading of split bundles
+    @FieldContext(dynamic = true)
     private boolean loadBalancerAutoUnloadSplitBundlesEnabled = false;
     // maximum topics in a bundle, otherwise bundle split will be triggered
     private int loadBalancerNamespaceBundleMaxTopics = 1000;
@@ -1102,7 +1104,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
         this.loadBalancerBrokerComfortLoadLevelPercentage = percentage;
     }
 
-    public boolean getLoadBalancerAutoBundleSplitEnabled() {
+    public boolean isLoadBalancerAutoBundleSplitEnabled() {
         return this.loadBalancerAutoBundleSplitEnabled;
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.broker;
 
+import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
+
 import java.io.IOException;
 import java.net.URL;
 import java.util.List;
@@ -42,7 +44,7 @@ import org.apache.pulsar.broker.loadbalance.LoadManager;
 import org.apache.pulsar.broker.loadbalance.LoadReportUpdaterTask;
 import org.apache.pulsar.broker.loadbalance.LoadResourceQuotaUpdaterTask;
 import org.apache.pulsar.broker.loadbalance.LoadSheddingTask;
-import org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl;
+import org.apache.pulsar.broker.loadbalance.impl.LoadManagerShared;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.Topic;
@@ -74,7 +76,6 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.Lists;
 
 import io.netty.util.concurrent.DefaultThreadFactory;
-import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
 
 /**
  * Main class for Pulsar broker service
@@ -428,7 +429,7 @@ public class PulsarService implements AutoCloseable {
         if (config.isLoadBalancerEnabled()) {
             LOG.info("Starting load balancer");
             if (this.loadReportTask == null) {
-                long loadReportMinInterval = SimpleLoadManagerImpl.LOAD_REPORT_UPDATE_MIMIMUM_INTERVAL;
+                long loadReportMinInterval = LoadManagerShared.LOAD_REPORT_UPDATE_MIMIMUM_INTERVAL;
                 this.loadReportTask = this.loadManagerExecutor.scheduleAtFixedRate(
                         new LoadReportUpdaterTask(loadManager), loadReportMinInterval, loadReportMinInterval,
                         TimeUnit.MILLISECONDS);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/TimeAverageMessageData.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/TimeAverageMessageData.java
@@ -161,4 +161,22 @@ public class TimeAverageMessageData {
     public void setMsgRateOut(double msgRateOut) {
         this.msgRateOut = msgRateOut;
     }
+    
+    /**
+     * Get the total message rate.
+     * 
+     * @return Message rate in + message rate out.
+     */
+    public double totalMsgRate() {
+        return msgRateIn + msgRateOut;
+    }
+
+    /**
+     * Get the total message throughput.
+     * 
+     * @return Message throughput in + message throughput out.
+     */
+    public double totalMsgThroughput() {
+        return msgThroughputIn + msgThroughputOut;
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/Namespaces.java
@@ -838,7 +838,8 @@ public class Namespaces extends AdminResource {
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission") })
     public void splitNamespaceBundle(@PathParam("property") String property, @PathParam("cluster") String cluster,
             @PathParam("namespace") String namespace, @PathParam("bundle") String bundleRange,
-            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
+            @QueryParam("authoritative") @DefaultValue("false") boolean authoritative,
+            @QueryParam("unload") @DefaultValue("false") boolean unload) {
         log.info("[{}] Split namespace bundle {}/{}/{}/{}", clientAppId(), property, cluster, namespace, bundleRange);
 
         validateSuperUserAccess();
@@ -855,7 +856,7 @@ public class Namespaces extends AdminResource {
                 true);
 
         try {
-            pulsar().getNamespaceService().splitAndOwnBundle(nsBundle).get();
+            pulsar().getNamespaceService().splitAndOwnBundle(nsBundle, unload).get();
             log.info("[{}] Successfully split namespace bundle {}", clientAppId(), nsBundle.toString());
         } catch (IllegalArgumentException e) {
             log.error("[{}] Failed to split namespace bundle {}/{} due to {}", clientAppId(), fqnn.toString(),

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/BundleSplitStrategy.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/BundleSplitStrategy.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.loadbalance;
+
+import java.util.Set;
+
+import org.apache.pulsar.broker.PulsarService;
+
+/**
+ * Load Manager component which determines what bundles should be split into two bundles.
+ */
+public interface BundleSplitStrategy {
+    /**
+     * Determines which bundles, if any, should be split.
+     * 
+     * @param loadData
+     *            Load data to base decisions on (does not have benefit of preallocated data since this may not be the
+     *            leader broker).
+     * @param pulsar
+     *            Service to use.
+     * @return A set of the bundles that should be split.
+     */
+    Set<String> findBundlesToSplit(LoadData loadData, PulsarService pulsar);
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/ModularLoadManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/ModularLoadManager.java
@@ -47,7 +47,7 @@ public interface ModularLoadManager {
     /**
      * As the leader broker, attempt to automatically detect and split hot namespace bundles.
      */
-    void doNamespaceBundleSplit();
+    void checkNamespaceBundleSplit();
 
     /**
      * Initialize this load manager using the given pulsar service.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BundleSplitterTask.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/BundleSplitterTask.java
@@ -1,0 +1,111 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.loadbalance.impl;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.pulsar.broker.LocalBrokerData;
+//import org.apache.pulsar.broker.MessageData;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.TimeAverageMessageData;
+import org.apache.pulsar.broker.loadbalance.BundleSplitStrategy;
+import org.apache.pulsar.broker.loadbalance.LoadData;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.policies.data.loadbalancer.NamespaceBundleStats;
+
+/**
+ * Determines which bundles should be split based on various thresholds.
+ */
+public class BundleSplitterTask implements BundleSplitStrategy {
+    private static final Logger log = LoggerFactory.getLogger(BundleSplitStrategy.class);
+    private final Set<String> bundleCache;
+
+    /**
+     * Construct a BundleSplitterTask.
+     * 
+     * @param pulsar
+     *            Service to construct from.
+     */
+    public BundleSplitterTask(final PulsarService pulsar) {
+        bundleCache = new HashSet<>();
+    }
+
+    /**
+     * Determines which bundles should be split based on various thresholds.
+     * 
+     * @param loadData
+     *            Load data to base decisions on (does not have benefit of preallocated data since this may not be the
+     *            leader broker).
+     * @param localData
+     *            Local data for the broker we are splitting on.
+     * @param pulsar
+     *            Service to use.
+     * @return All bundles who have exceeded configured thresholds in number of topics, number of sessions, total
+     *         message rates, or total throughput.
+     */
+    @Override
+    public Set<String> findBundlesToSplit(final LoadData loadData, final PulsarService pulsar) {
+        bundleCache.clear();
+        final ServiceConfiguration conf = pulsar.getConfiguration();
+        int maxBundleCount = conf.getLoadBalancerNamespaceMaximumBundles();
+        long maxBundleTopics = conf.getLoadBalancerNamespaceBundleMaxTopics();
+        long maxBundleSessions = conf.getLoadBalancerNamespaceBundleMaxSessions();
+        long maxBundleMsgRate = conf.getLoadBalancerNamespaceBundleMaxMsgRate();
+        long maxBundleBandwidth = conf.getLoadBalancerNamespaceBundleMaxBandwidthMbytes() * LoadManagerShared.MIBI;
+        loadData.getBrokerData().forEach((broker, brokerData) -> {
+            LocalBrokerData localData = brokerData.getLocalData();
+            for (final Map.Entry<String, NamespaceBundleStats> entry : localData.getLastStats().entrySet()) {
+                final String bundle = entry.getKey();
+                final NamespaceBundleStats stats = entry.getValue();
+                double totalMessageRate = 0;
+                double totalMessageThroughput = 0;
+                // Attempt to consider long-term message data, otherwise effectively ignore.
+                if (loadData.getBundleData().containsKey(bundle)) {
+                    final TimeAverageMessageData longTermData = loadData.getBundleData().get(bundle).getLongTermData();
+                    totalMessageRate = longTermData.totalMsgRate();
+                    totalMessageThroughput = longTermData.totalMsgThroughput();
+                }
+                if (stats.topics > maxBundleTopics || stats.consumerCount + stats.producerCount > maxBundleSessions
+                        || totalMessageRate > maxBundleMsgRate || totalMessageThroughput > maxBundleBandwidth) {
+                    final String namespace = LoadManagerShared.getNamespaceNameFromBundleName(bundle);
+                    try {
+                        final int bundleCount = pulsar.getNamespaceService()
+                                .getBundleCount(new NamespaceName(namespace));
+                        if (bundleCount < maxBundleCount) {
+                            bundleCache.add(bundle);
+                        } else {
+                            log.warn(
+                                    "Could not split namespace bundle {} because namespace {} has too many bundles: {}",
+                                    bundle, namespace, bundleCount);
+                        }
+                    } catch (Exception e) {
+                        log.warn("Error while getting bundle count for namespace {}", namespace, e);
+                    }
+                }
+            }
+        });
+        return bundleCache;
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
@@ -26,6 +26,7 @@ import java.net.URL;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.admin.AdminResource;
@@ -52,6 +53,9 @@ public class LoadManagerShared {
 
     // Cache for shard brokers according to policies.
     private static final Set<String> sharedCache = new HashSet<>();
+    
+    // update LoadReport at most every 5 seconds
+    public static final long LOAD_REPORT_UPDATE_MIMIMUM_INTERVAL = TimeUnit.SECONDS.toMillis(5);
 
     // Don't allow construction: static method namespace only.
     private LoadManagerShared() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -592,7 +592,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
     @Override
     public void checkNamespaceBundleSplit() {
         
-        if (!conf.getLoadBalancerAutoBundleSplitEnabled() || pulsar.getLeaderElectionService() == null
+        if (!conf.isLoadBalancerAutoBundleSplitEnabled() || pulsar.getLeaderElectionService() == null
                 || !pulsar.getLeaderElectionService().isLeader()) {
             return;
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -827,7 +827,9 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
     private void deleteBundleDataFromZookeeper(String bundle) {
         final String zooKeeperPath = getBundleDataZooKeeperPath(bundle);
         try {
-            zkClient.delete(zooKeeperPath, -1);
+            if (zkClient.exists(zooKeeperPath, null) != null) {
+                zkClient.delete(zooKeeperPath, -1);
+            }
         } catch (Exception e) {
             log.warn("Failed to delete bundle-data {} from zookeeper", bundle, e);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerWrapper.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerWrapper.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.broker.loadbalance.impl;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -55,7 +54,7 @@ public class ModularLoadManagerWrapper implements LoadManager {
 
     @Override
     public void doNamespaceBundleSplit() {
-        loadManager.doNamespaceBundleSplit();
+        loadManager.checkNamespaceBundleSplit();
     }
 
     @Override
@@ -113,5 +112,9 @@ public class ModularLoadManagerWrapper implements LoadManager {
     @Override
     public Deserializer<? extends ServiceLookupData> getLoadReportDeserializer() {
         return loadManager.getLoadReportDeserializer();
+    }
+    
+    public ModularLoadManager getLoadManager() {
+        return loadManager;
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
@@ -448,7 +448,7 @@ public class SimpleLoadManagerImpl implements LoadManager, ZooKeeperCacheListene
     private boolean getLoadBalancerAutoBundleSplitEnabled() {
         return this.getDynamicConfigurationBoolean(LOADBALANCER_DYNAMIC_SETTING_AUTO_BUNDLE_SPLIT_ENABLED,
                 SETTING_NAME_AUTO_BUNDLE_SPLIT_ENABLED,
-                pulsar.getConfiguration().getLoadBalancerAutoBundleSplitEnabled());
+                pulsar.getConfiguration().isLoadBalancerAutoBundleSplitEnabled());
     }
 
     /*

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
@@ -47,6 +47,7 @@ import org.apache.pulsar.broker.loadbalance.LoadManager;
 import org.apache.pulsar.broker.loadbalance.PlacementStrategy;
 import org.apache.pulsar.broker.loadbalance.ResourceUnit;
 import org.apache.pulsar.broker.loadbalance.impl.LoadManagerShared.BrokerTopicLoadingPredicate;
+import static org.apache.pulsar.broker.loadbalance.impl.LoadManagerShared.LOAD_REPORT_UPDATE_MIMIMUM_INTERVAL;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.ServiceUnitId;
 import org.apache.pulsar.common.policies.data.ResourceQuota;
@@ -172,8 +173,6 @@ public class SimpleLoadManagerImpl implements LoadManager, ZooKeeperCacheListene
     private ZooKeeperChildrenCache availableActiveBrokers;
 
     private static final long MBytes = 1024 * 1024;
-    // update LoadReport at most every 5 seconds
-    public static final long LOAD_REPORT_UPDATE_MIMIMUM_INTERVAL = TimeUnit.SECONDS.toMillis(5);
     // last LoadReport stored in ZK
     private volatile LoadReport lastLoadReport;
     // last timestamp resource usage was checked
@@ -1463,7 +1462,8 @@ public class SimpleLoadManagerImpl implements LoadManager, ZooKeeperCacheListene
                 try {
                     pulsar.getAdminClient().namespaces().splitNamespaceBundle(
                             LoadManagerShared.getNamespaceNameFromBundleName(bundleName),
-                            LoadManagerShared.getBundleRangeFromBundleName(bundleName));
+                            LoadManagerShared.getBundleRangeFromBundleName(bundleName),
+                            pulsar.getConfiguration().isLoadBalancerAutoUnloadSplitBundlesEnabled());
                     log.info("Successfully split namespace bundle {}", bundleName);
                 } catch (Exception e) {
                     log.error("Failed to split namespace bundle {}", bundleName, e);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -41,7 +41,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import javax.validation.constraints.Future;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -54,7 +53,6 @@ import org.apache.pulsar.broker.loadbalance.ResourceUnit;
 import org.apache.pulsar.broker.lookup.LookupResult;
 import org.apache.pulsar.broker.service.BrokerServiceException.ServiceUnitNotReadyException;
 import org.apache.pulsar.client.admin.PulsarAdmin;
-import org.apache.pulsar.client.util.FutureUtil;
 import org.apache.pulsar.common.lookup.data.LookupData;
 import org.apache.pulsar.common.naming.DestinationName;
 import org.apache.pulsar.common.naming.NamespaceBundle;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -41,6 +41,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import javax.validation.constraints.Future;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.PulsarServerException;
@@ -52,6 +54,7 @@ import org.apache.pulsar.broker.loadbalance.ResourceUnit;
 import org.apache.pulsar.broker.lookup.LookupResult;
 import org.apache.pulsar.broker.service.BrokerServiceException.ServiceUnitNotReadyException;
 import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.util.FutureUtil;
 import org.apache.pulsar.common.lookup.data.LookupData;
 import org.apache.pulsar.common.naming.DestinationName;
 import org.apache.pulsar.common.naming.NamespaceBundle;
@@ -552,11 +555,11 @@ public class NamespaceService {
      * @return
      * @throws Exception
      */
-    public CompletableFuture<Void> splitAndOwnBundle(NamespaceBundle bundle) throws Exception {
+    public CompletableFuture<Void> splitAndOwnBundle(NamespaceBundle bundle, final boolean unload) throws Exception {
 
-        final CompletableFuture<Void> future = new CompletableFuture<>();
+        final CompletableFuture<Void> unloadFuture = new CompletableFuture<>();
 
-        Pair<NamespaceBundles, List<NamespaceBundle>> splittedBundles = bundleFactory.splitBundles(bundle,
+        final Pair<NamespaceBundles, List<NamespaceBundle>> splittedBundles = bundleFactory.splitBundles(bundle,
                 2 /* by default split into 2 */);
         if (splittedBundles != null) {
             checkNotNull(splittedBundles.getLeft());
@@ -580,34 +583,49 @@ public class NamespaceService {
                                     // update bundled_topic cache for load-report-generation
                                     pulsar.getBrokerService().refreshTopicToStatsMaps(bundle);
                                     loadManager.get().setLoadReportForceUpdateFlag();
-                                    future.complete(null);
+                                    unloadFuture.complete(null);
                                 } catch (Exception e) {
                                     String msg1 = format(
                                             "failed to disable bundle %s under namespace [%s] with error %s",
                                             nsname.toString(), bundle.toString(), e.getMessage());
                                     LOG.warn(msg1, e);
-                                    future.completeExceptionally(new ServiceUnitNotReadyException(msg1));
+                                    unloadFuture.completeExceptionally(new ServiceUnitNotReadyException(msg1));
                                 }
                             } else {
                                 String msg2 = format("failed to update namespace [%s] policies due to %s",
                                         nsname.toString(),
                                         KeeperException.create(KeeperException.Code.get(rc)).getMessage());
                                 LOG.warn(msg2);
-                                future.completeExceptionally(new ServiceUnitNotReadyException(msg2));
+                                unloadFuture.completeExceptionally(new ServiceUnitNotReadyException(msg2));
                             }
                         })));
             } catch (Exception e) {
                 String msg = format("failed to aquire ownership of split bundle for namespace [%s], %s",
                         nsname.toString(), e.getMessage());
                 LOG.warn(msg, e);
-                future.completeExceptionally(new ServiceUnitNotReadyException(msg));
+                unloadFuture.completeExceptionally(new ServiceUnitNotReadyException(msg));
             }
 
         } else {
             String msg = format("bundle %s not found under namespace", bundle.toString());
-            future.completeExceptionally(new ServiceUnitNotReadyException(msg));
+            unloadFuture.completeExceptionally(new ServiceUnitNotReadyException(msg));
         }
-        return future;
+        
+        return unloadFuture.thenApply(res -> {
+            if (!unload) {
+                return null;
+            }
+            // unload new split bundles
+            splittedBundles.getRight().forEach(splitBundle -> {
+                try {
+                    unloadNamespaceBundle(splitBundle);
+                } catch (Exception e) {
+                    LOG.warn("Failed to unload split bundle {}", splitBundle, e);
+                    throw new RuntimeException("Failed to unload split bundle " + splitBundle, e);
+                }
+            });
+            return null;
+        });
     }
 
     /**
@@ -634,6 +652,8 @@ public class NamespaceService {
         policies.get().bundles = getBundlesData(nsBundles);
         this.pulsar.getLocalZkCache().getZooKeeper().setData(path,
                 ObjectMapperFactory.getThreadLocal().writeValueAsBytes(policies.get()), -1, callback, null);
+        // invalidate namespace's local-policies
+        this.pulsar.getLocalZkCacheService().policiesCache().invalidate(path);
     }
 
     public OwnershipCache getOwnershipCache() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -885,7 +885,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         assertEquals(admin.persistentTopics().getList(namespace), Lists.newArrayList(topicName));
 
         try {
-            admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0xffffffff");
+            admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0xffffffff", true);
         } catch (Exception e) {
             fail("split bundle shouldn't have thrown exception");
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -879,7 +879,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         // split bundles
         try {
             namespaces.splitNamespaceBundle(testProperty, testLocalCluster, bundledNsLocal, "0x08375b1a_0x08375b1b",
-                    false);
+                    false, false);
         } catch (RestException re) {
             assertEquals(re.getResponse().getStatus(), Status.PRECONDITION_FAILED.getStatusCode());
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/NamespacesTest.java
@@ -847,7 +847,7 @@ public class NamespacesTest extends MockedPulsarServiceBaseTest {
         // split bundles
         try {
             namespaces.splitNamespaceBundle(testProperty, testLocalCluster, bundledNsLocal, "0x00000000_0xffffffff",
-                    false);
+                    false, true);
             // verify split bundles
             BundlesData bundlesData = namespaces.getBundlesData(testProperty, testLocalCluster, bundledNsLocal);
             assertNotNull(bundlesData);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadBalancerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadBalancerTest.java
@@ -668,16 +668,26 @@ public class LoadBalancerTest {
         pulsarServices[0].getLoadManager().get().doNamespaceBundleSplit();
 
         // verify bundles are split
-        verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-01", "0x00000000_0x80000000");
-        verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-02", "0x00000000_0x80000000");
-        verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-03", "0x00000000_0x80000000");
-        verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-04", "0x00000000_0x80000000");
-        verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-05", "0x00000000_0x80000000");
-        verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-06", "0x00000000_0x80000000");
-        verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-07", "0x00000000_0x80000000");
-        verify(namespaceAdmin, never()).splitNamespaceBundle("pulsar/use/primary-ns-08", "0x00000000_0x80000000");
-        verify(namespaceAdmin, never()).splitNamespaceBundle("pulsar/use/primary-ns-09", "0x00000000_0x80000000");
-        verify(namespaceAdmin, never()).splitNamespaceBundle("pulsar/use/primary-ns-10", "0x00000000_0x02000000");
+        verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-01", "0x00000000_0x80000000",
+                false);
+        verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-02", "0x00000000_0x80000000",
+                false);
+        verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-03", "0x00000000_0x80000000",
+                false);
+        verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-04", "0x00000000_0x80000000",
+                false);
+        verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-05", "0x00000000_0x80000000",
+                false);
+        verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-06", "0x00000000_0x80000000",
+                false);
+        verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-07", "0x00000000_0x80000000",
+                false);
+        verify(namespaceAdmin, never()).splitNamespaceBundle("pulsar/use/primary-ns-08", "0x00000000_0x80000000",
+                false);
+        verify(namespaceAdmin, never()).splitNamespaceBundle("pulsar/use/primary-ns-09", "0x00000000_0x80000000",
+                false);
+        verify(namespaceAdmin, never()).splitNamespaceBundle("pulsar/use/primary-ns-10", "0x00000000_0x02000000",
+                false);
     }
 
     /*

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
@@ -112,7 +112,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
         NamespaceBundle originalBundle = bundles.findBundle(dn);
 
         // Split bundle and take ownership of split bundles
-        CompletableFuture<Void> result = namespaceService.splitAndOwnBundle(originalBundle);
+        CompletableFuture<Void> result = namespaceService.splitAndOwnBundle(originalBundle, false);
 
         try {
             result.get();
@@ -192,7 +192,7 @@ public class NamespaceServiceTest extends BrokerTestBase {
         assertNotNull(list);
 
         // Split bundle and take ownership of split bundles
-        CompletableFuture<Void> result = namespaceService.splitAndOwnBundle(originalBundle);
+        CompletableFuture<Void> result = namespaceService.splitAndOwnBundle(originalBundle, false);
         try {
             result.get();
         } catch (Exception e) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.spy;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
@@ -37,6 +38,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
@@ -52,7 +54,10 @@ import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.broker.authentication.AuthenticationProvider;
+import org.apache.pulsar.broker.loadbalance.LeaderElectionService;
 import org.apache.pulsar.broker.loadbalance.LoadManager;
+import org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl;
+import org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerWrapper;
 import org.apache.pulsar.broker.loadbalance.impl.SimpleResourceUnit;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.client.api.Authentication;
@@ -813,7 +818,7 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
         Assert.assertEquals(bundleInBroker2.toString(), unsplitBundle);
 
         // (5) Split the bundle for topic-1
-        admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0xffffffff");
+        admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0xffffffff", true);
 
         // (6) Broker-2 should get the watch and update bundle cache
         final int retry = 5;
@@ -839,6 +844,136 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
         pulsar2.close();
 
     }
+    
+    /**
+     * 
+     * <pre>
+     * When broker-1's Modula-rload-manager splits the bundle and update local-policies, broker-2 should get watch of
+     * local-policies and update bundleCache so, new lookup can be redirected properly.
+     * 
+     * (1) Start broker-1 and broker-2
+     * (2) Make sure broker-2 always assign bundle to broker1
+     * (3) Broker-2 receives topic-1 request, creates local-policies and sets the watch
+     * (4) Broker-1 will own topic-1
+     * (5) Broker-2 will be a leader and trigger Split the bundle for topic-1
+     * (6) Broker-2 should get the watch and update bundle cache
+     * (7) Make lookup request again to Broker-2 which should succeed.
+     * 
+     * </pre>
+     * 
+     * @throws Exception
+     */
+    @Test(timeOut = 5000)
+    public void testModularLoadManagerSplitBundle() throws Exception {
+
+        log.info("-- Starting {} test --", methodName);
+        final String loadBalancerName = conf.getLoadManagerClassName();
+
+        try {
+            final String namespace = "my-property/use/my-ns";
+            // (1) Start broker-1
+            ServiceConfiguration conf2 = new ServiceConfiguration();
+            conf2.setBrokerServicePort(PortManager.nextFreePort());
+            conf2.setBrokerServicePortTls(PortManager.nextFreePort());
+            conf2.setWebServicePort(PortManager.nextFreePort());
+            conf2.setWebServicePortTls(PortManager.nextFreePort());
+            conf2.setAdvertisedAddress("localhost");
+            conf2.setClusterName(conf.getClusterName());
+            conf2.setLoadManagerClassName(ModularLoadManagerImpl.class.getName());
+            PulsarService pulsar2 = startBroker(conf2);
+
+            // configure broker-1 with ModularLoadlManager
+            stopBroker();
+            conf.setLoadManagerClassName(ModularLoadManagerImpl.class.getName());
+            startBroker();
+
+            pulsar.getLoadManager().get().writeLoadReportOnZookeeper();
+            pulsar2.getLoadManager().get().writeLoadReportOnZookeeper();
+
+            LoadManager loadManager1 = spy(pulsar.getLoadManager().get());
+            LoadManager loadManager2 = spy(pulsar2.getLoadManager().get());
+            Field loadManagerField = NamespaceService.class.getDeclaredField("loadManager");
+            loadManagerField.setAccessible(true);
+
+            // (2) Make sure broker-2 always assign bundle to broker1
+            // mock: redirect request to leader [2]
+            doReturn(true).when(loadManager2).isCentralized();
+            loadManagerField.set(pulsar2.getNamespaceService(), new AtomicReference<>(loadManager2));
+            // mock: return Broker1 as a Least-loaded broker when leader receies request [3]
+            doReturn(true).when(loadManager1).isCentralized();
+            SimpleResourceUnit resourceUnit = new SimpleResourceUnit(pulsar.getWebServiceAddress(), null);
+            doReturn(resourceUnit).when(loadManager1).getLeastLoaded(any(ServiceUnitId.class));
+            loadManagerField.set(pulsar.getNamespaceService(), new AtomicReference<>(loadManager1));
+
+            URI broker2ServiceUrl = new URI("pulsar://localhost:" + conf2.getBrokerServicePort());
+            PulsarClient pulsarClient2 = PulsarClient.create(broker2ServiceUrl.toString(), new ClientConfiguration());
+
+            // (3) Broker-2 receives topic-1 request, creates local-policies and sets the watch
+            final String topic1 = "persistent://" + namespace + "/topic1";
+            Consumer consumer1 = pulsarClient2.subscribe(topic1, "my-subscriber-name", new ConsumerConfiguration());
+
+            Set<String> serviceUnits1 = pulsar.getNamespaceService().getOwnedServiceUnits().stream()
+                    .map(nb -> nb.toString()).collect(Collectors.toSet());
+
+            // (4) Broker-1 will own topic-1
+            final String unsplitBundle = namespace + "/0x00000000_0xffffffff";
+            Assert.assertTrue(serviceUnits1.contains(unsplitBundle));
+            // broker-2 should have this bundle into the cache
+            DestinationName destination = DestinationName.get(topic1);
+            NamespaceBundle bundleInBroker2 = pulsar2.getNamespaceService().getBundle(destination);
+            Assert.assertEquals(bundleInBroker2.toString(), unsplitBundle);
+
+            // update broker-1 bundle report to zk
+            pulsar.getBrokerService().updateRates();
+            pulsar.getLoadManager().get().writeLoadReportOnZookeeper();
+            // this will create znode for bundle-data
+            pulsar.getLoadManager().get().writeResourceQuotasToZooKeeper();
+            pulsar2.getLoadManager().get().writeLoadReportOnZookeeper();
+
+            // (5) Modular-load-manager will split the bundle due to max-topic threshold reached
+            Field leaderField = LeaderElectionService.class.getDeclaredField("isLeader");
+            Method updateAllMethod = ModularLoadManagerImpl.class.getDeclaredMethod("updateAll");
+            updateAllMethod.setAccessible(true);
+            leaderField.setAccessible(true);
+            AtomicBoolean isLeader = (AtomicBoolean) leaderField.get(pulsar2.getLeaderElectionService());
+            isLeader.set(true);
+            ModularLoadManagerImpl loadManager = (ModularLoadManagerImpl) ((ModularLoadManagerWrapper) pulsar2
+                    .getLoadManager().get()).getLoadManager();
+            // broker-2 loadManager is a leader and let it refresh load-report from all the brokers
+            updateAllMethod.invoke(loadManager);
+            conf2.setLoadBalancerAutoBundleSplitEnabled(true);
+            conf2.setLoadBalancerAutoUnloadSplitBundlesEnabled(true);
+            conf2.setLoadBalancerNamespaceBundleMaxTopics(0);
+            loadManager.checkNamespaceBundleSplit();
+
+            // (6) Broker-2 should get the watch and update bundle cache
+            final int retry = 5;
+            for (int i = 0; i < retry; i++) {
+                if (pulsar2.getNamespaceService().getBundle(destination).equals(bundleInBroker2) && i != retry - 1) {
+                    Thread.sleep(200);
+                } else {
+                    break;
+                }
+            }
+
+            // (7) Make lookup request again to Broker-2 which should succeed.
+            final String topic2 = "persistent://" + namespace + "/topic2";
+            Consumer consumer2 = pulsarClient2.subscribe(topic2, "my-subscriber-name", new ConsumerConfiguration());
+
+            NamespaceBundle bundleInBroker1AfterSplit = pulsar2.getNamespaceService()
+                    .getBundle(DestinationName.get(topic2));
+            Assert.assertFalse(bundleInBroker1AfterSplit.equals(unsplitBundle));
+
+            consumer1.close();
+            consumer2.close();
+            pulsarClient2.close();
+            pulsar2.close();
+        } finally {
+            conf.setLoadManagerClassName(loadBalancerName);
+        }
+
+    }
+    
     /**** helper classes ****/
 
     public static class MockAuthenticationProvider implements AuthenticationProvider {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
@@ -832,7 +832,7 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
 
         // (7) Make lookup request again to Broker-2 which should succeed.
         final String topic2 = "persistent://" + namespace + "/topic2";
-        Consumer consumer2 = pulsarClient2.subscribe(topic2, "my-subscriber-name", new ConsumerConfiguration());
+        Consumer consumer2 = pulsarClient.subscribe(topic2, "my-subscriber-name", new ConsumerConfiguration());
 
         NamespaceBundle bundleInBroker1AfterSplit = pulsar2.getNamespaceService()
                 .getBundle(DestinationName.get(topic2));
@@ -848,7 +848,7 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
     /**
      * 
      * <pre>
-     * When broker-1's Modula-rload-manager splits the bundle and update local-policies, broker-2 should get watch of
+     * When broker-1's Modular-load-manager splits the bundle and update local-policies, broker-2 should get watch of
      * local-policies and update bundleCache so, new lookup can be redirected properly.
      * 
      * (1) Start broker-1 and broker-2
@@ -958,7 +958,7 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
 
             // (7) Make lookup request again to Broker-2 which should succeed.
             final String topic2 = "persistent://" + namespace + "/topic2";
-            Consumer consumer2 = pulsarClient2.subscribe(topic2, "my-subscriber-name", new ConsumerConfiguration());
+            Consumer consumer2 = pulsarClient.subscribe(topic2, "my-subscriber-name", new ConsumerConfiguration());
 
             NamespaceBundle bundleInBroker1AfterSplit = pulsar2.getNamespaceService()
                     .getBundle(DestinationName.get(topic2));

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
@@ -724,10 +724,11 @@ public interface Namespaces {
      *
      * @param namespace
      * @param range of bundle to split
+     * @param unload newly split bundles from the broker
      * @throws PulsarAdminException
      *             Unexpected error
      */
-    void splitNamespaceBundle(String namespace, String bundle) throws PulsarAdminException;
+    void splitNamespaceBundle(String namespace, String bundle, boolean unloadSplitBundles) throws PulsarAdminException;
 
     /**
      * Set message-dispatch-rate (topics under this namespace can dispatch this many messages per second)

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
@@ -355,11 +355,13 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     }
 
     @Override
-    public void splitNamespaceBundle(String namespace, String bundle) throws PulsarAdminException {
+    public void splitNamespaceBundle(String namespace, String bundle, boolean unloadSplitBundles)
+            throws PulsarAdminException {
         try {
             NamespaceName ns = new NamespaceName(namespace);
             request(namespaces.path(ns.getProperty()).path(ns.getCluster()).path(ns.getLocalName()).path(bundle)
-                    .path("split")).put(Entity.entity("", MediaType.APPLICATION_JSON), ErrorData.class);
+                    .path("split").queryParam("unload", Boolean.toString(unloadSplitBundles)))
+                            .put(Entity.entity("", MediaType.APPLICATION_JSON), ErrorData.class);
         } catch (Exception e) {
             throw getApiException(e);
         }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaces.java
@@ -308,11 +308,15 @@ public class CmdNamespaces extends CmdBase {
 
         @Parameter(names = { "--bundle", "-b" }, description = "{start-boundary}_{end-boundary}\n", required = true)
         private String bundle;
+        
+        @Parameter(names = { "--unload",
+                "-u" }, description = "Unload newly split bundles after splitting old bundle", required = false)
+        private boolean unload;
 
         @Override
         void run() throws PulsarAdminException {
             String namespace = validateNamespace(params);
-            admin.namespaces().splitNamespaceBundle(namespace, bundle);
+            admin.namespaces().splitNamespaceBundle(namespace, bundle, unload);
         }
     }
 

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -212,7 +212,7 @@ public class PulsarAdminToolTest {
         verify(mockNamespaces).unloadNamespaceBundle("myprop/clust/ns1", "0x80000000_0xffffffff");
 
         namespaces.run(split("split-bundle myprop/clust/ns1 -b 0x00000000_0xffffffff"));
-        verify(mockNamespaces).splitNamespaceBundle("myprop/clust/ns1", "0x00000000_0xffffffff");
+        verify(mockNamespaces).splitNamespaceBundle("myprop/clust/ns1", "0x00000000_0xffffffff", false);
 
         namespaces.run(split("get-backlog-quotas myprop/clust/ns1"));
         verify(mockNamespaces).getBacklogQuotaMap("myprop/clust/ns1");


### PR DESCRIPTION
### Motivation

As described in #385 
ModularLoadManagerImpl lacked bundle split capabilities. Additionally, automatic bundle splits reassigned the bundles to the same broker when the bundle could more usefully be reassigned after being split.

### Modifications

This PR has same logic as #385  to find out bundles which are eligible for splitting. But this PR have additional changes which we haven't addressed in #385 
- no need depend on zk.exist watch
- bundle split happens only at leader
- split-bundle api has additional query-param to unload split bundle which gives more flexibility to control unload split bundles
- delete bundle data for original split bundle from zk

### Result

ModularLoadManager can  auto split and unload bundles.
