### PR TITLE
Fix: profobuf interface generation on doc

### DIFF
--- a/site/_includes/protobuf.html
+++ b/site/_includes/protobuf.html
@@ -18,9 +18,9 @@
     under the License.
 
 -->
-{% assign proto = site.data.protobuf[0] %}
-{% assign messages = proto.file_messages %}
-{% assign enums = proto.file_enums %}
+{% assign proto = site.data.protobuf.files[0] %}
+{% assign messages = proto.messages %}
+{% assign enums = proto.enums %}
 {% assign atomic_types = "bool,bytes,double,int32,string,uint32,uint64" | split: "," %}
 
 <div class="protobuf">
@@ -31,8 +31,8 @@
         <ul>
           {% for message in messages %}
           <li>
-            <a href="#{{ message.message_full_name }}">
-              {{ message.message_name }}
+            <a href="#{{ message.fullName }}">
+              {{ message.name }}
             </a>
           </li>
           {% endfor %} <!-- for message in messages -->
@@ -43,8 +43,8 @@
         <ul>
           {% for enum in enums %}
           <li>
-            <a href="#{{ enum.enum_full_name }}">
-              {{ enum.enum_name }}
+            <a href="#{{ enum.fullName }}">
+              {{ enum.name }}
             </a>
           </li>
           {% endfor %} <!-- for enum in enums -->
@@ -56,16 +56,16 @@
   <h3>Protobuf messages</h3>
 
   <div class="card messages">
-    {% for message in messages %}{% assign fields = message.message_fields %}
+    {% for message in messages %}{% assign fields = message.fields %}
     <div class="card-block">
       <div class="card-title">
-        <h5 class="message-name" id="{{ message.message_full_name }}">
-          {{ message.message_name }}
+        <h5 class="message-name" id="{{ message.fullName }}">
+          {{ message.name }}
         </h5>
-        <p class="message-name">{{ message.message_full_name }}</p>
-        {% if message.message_description %}<p class="lead">{{ message.message_description }}</p>{% endif %}
+        <p class="message-name">{{ message.fullName }}</p>
+        {% if message.description %}<p class="lead">{{ message.description }}</p>{% endif %}
       </div>
-      {% if message.message_has_fields %}
+      {% if message.hasFields %}
       <div class="card">
         <h5>Fields</h5>
         <table class="protobuf-table">
@@ -81,15 +81,15 @@
           <tbody>
             {% for field in fields %}
             <tr>
-              <td class="wrap">{{ field.field_name }}</td>
-              {% if atomic_types contains field.field_type %}
-              <td class="wrap">{{ field.field_type }}</td>
+              <td class="wrap">{{ field.name }}</td>
+              {% if atomic_types contains field.type %}
+              <td class="wrap">{{ field.type }}</td>
               {% else %}
-              <td class="wrap"><a href="#{{ field.field_full_type }}">{{ field.field_type }}</a></td>
+              <td class="wrap"><a href="#{{ field.fullType }}">{{ field.type }}</a></td>
               {% endif %}
-              <td>{{ field.field_label }}</td>
-              <td>{{ field.field_default_value }}</td>
-              <td>{{ field.field_description }}</td>
+              <td>{{ field.label }}</td>
+              <td>{{ field.defaultValue }}</td>
+              <td>{{ field.description }}</td>
             </tr>
             {% endfor %} <!-- for field in fields -->
           </tbody>
@@ -105,11 +105,11 @@
   <h3>Protobuf enums</h3>
 
   <div class="card enums">
-    {% for enum in enums %}{% assign values = enum.enum_values %}
+    {% for enum in enums %}{% assign values = enum.values %}
     <div class="card-block">
       <div class="card-title">
-        <h5 class="enum-name" id="{{ enum.enum_full_name }}">{{ enum.enum_name }}</h5>
-        {% if enum.enum_description %}<p class="lead">{{ enum.enum_description | markdownify }}</p>{% endif %}
+        <h5 class="enum-name" id="{{ enum.fullName }}">{{ enum.name }}</h5>
+        {% if enum.description %}<p class="lead">{{ enum.description | markdownify }}</p>{% endif %}
       </div>
       <div class="card">
         <h5>Enum values</h5>
@@ -124,9 +124,9 @@
           <tbody>
             {% for value in values %}
             <tr>
-              <td>{{ value.value_name }}</td>
-              <td>{{ value.value_number }}</td>
-              <td>{{ value.value_description | markdownify }}</td>
+              <td>{{ value.name }}</td>
+              <td>{{ value.number }}</td>
+              <td>{{ value.description | markdownify }}</td>
             </tr>
             {% endfor %} <!-- for value in values -->
           </tbody>


### PR DESCRIPTION
### Motivation

Right now, [BinaryProtocol-Interface](https://pulsar.incubator.apache.org/docs/v1.19.0-incubating/project/BinaryProtocol/) doc is broken and not showing data.
eg:
[Sample generated json](https://gist.github.com/rdhabalia/9528dadcfa3e4a9d3c06a3a1322153dc) which site parses.

### Modifications

Fix json parsing for protobuf-doc.

### Result

site-doc should show protobuf-interface.
