### PR TITLE
Cleanup load-manager configuration and make ModularLoadManager default load-manager

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -311,10 +311,10 @@ loadBalancerHostUsageCheckIntervalMinutes=1
 
 # Load shedding interval. Broker periodically checks whether some traffic should be offload from
 # some over-loaded broker to other under-loaded brokers
-loadBalancerSheddingIntervalMinutes=10
+loadBalancerSheddingIntervalMinutes=5
 
 # Prevent the same topics to be shed and moved to other broker more that once within this timeframe
-loadBalancerSheddingGracePeriodMinutes=20
+loadBalancerSheddingGracePeriodMinutes=30
 
 # Interval to flush dynamic resource quota to ZooKeeper
 loadBalancerResourceQuotaUpdateIntervalMinutes=15
@@ -332,7 +332,7 @@ loadBalancerNamespaceBundleMaxTopics=1000
 loadBalancerNamespaceBundleMaxSessions=1000
 
 # maximum msgRate (in + out) in a bundle, otherwise bundle split will be triggered
-loadBalancerNamespaceBundleMaxMsgRate=5000
+loadBalancerNamespaceBundleMaxMsgRate=30000
 
 # maximum bandwidth (in + out) in a bundle, otherwise bundle split will be triggered
 loadBalancerNamespaceBundleMaxBandwidthMbytes=100
@@ -342,6 +342,18 @@ loadBalancerNamespaceMaximumBundles=128
 
 # Name of load manager to use
 loadManagerClassName=org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl
+
+# load placement strategy[weightedRandomSelection/leastLoadedServer] (only used by SimpleLoadManagerImpl)
+loadBalancerPlacementStrategy=leastLoadedServer
+
+# Usage threshold to determine a broker as under-loaded (only used by SimpleLoadManagerImpl)
+loadBalancerBrokerUnderloadedThresholdPercentage=50
+
+# Usage threshold to determine a broker as over-loaded (only used by SimpleLoadManagerImpl)
+loadBalancerBrokerOverloadedThresholdPercentage=85
+
+# Usage threshold to determine a broker is having just right level of load (only used by SimpleLoadManagerImpl)
+loadBalancerBrokerComfortLoadLevelPercentage=65
 
 ### --- Replication --- ###
 

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -300,9 +300,6 @@ managedLedgerMaxUnackedRangesToPersistInZooKeeper=1000
 # Enable load balancer
 loadBalancerEnabled=true
 
-# Strategy to assign a new bundle
-loadBalancerPlacementStrategy=weightedRandomSelection
-
 # Percentage of change to trigger load report update
 loadBalancerReportUpdateThresholdPercentage=10
 
@@ -314,28 +311,19 @@ loadBalancerHostUsageCheckIntervalMinutes=1
 
 # Load shedding interval. Broker periodically checks whether some traffic should be offload from
 # some over-loaded broker to other under-loaded brokers
-loadBalancerSheddingIntervalMinutes=30
+loadBalancerSheddingIntervalMinutes=10
 
 # Prevent the same topics to be shed and moved to other broker more that once within this timeframe
-loadBalancerSheddingGracePeriodMinutes=30
+loadBalancerSheddingGracePeriodMinutes=20
 
-# Usage threshold to determine a broker as under-loaded
-loadBalancerBrokerUnderloadedThresholdPercentage=1
-
-# Usage threshold to determine a broker as over-loaded
-loadBalancerBrokerOverloadedThresholdPercentage=85
-
-# Interval to update namespace bundle resource quotat
+# Interval to flush dynamic resource quota to ZooKeeper
 loadBalancerResourceQuotaUpdateIntervalMinutes=15
 
-# Usage threshold to determine a broker is having just right level of load
-loadBalancerBrokerComfortLoadLevelPercentage=65
-
 # enable/disable namespace bundle auto split
-loadBalancerAutoBundleSplitEnabled=false
+loadBalancerAutoBundleSplitEnabled=true
 
 # enable/disable automatic unloading of split bundles
-loadBalancerAutoUnloadSplitBundlesEnabled=false
+loadBalancerAutoUnloadSplitBundlesEnabled=true
 
 # maximum topics in a bundle, otherwise bundle split will be triggered
 loadBalancerNamespaceBundleMaxTopics=1000
@@ -344,13 +332,16 @@ loadBalancerNamespaceBundleMaxTopics=1000
 loadBalancerNamespaceBundleMaxSessions=1000
 
 # maximum msgRate (in + out) in a bundle, otherwise bundle split will be triggered
-loadBalancerNamespaceBundleMaxMsgRate=1000
+loadBalancerNamespaceBundleMaxMsgRate=5000
 
 # maximum bandwidth (in + out) in a bundle, otherwise bundle split will be triggered
 loadBalancerNamespaceBundleMaxBandwidthMbytes=100
 
 # maximum number of bundles in a namespace
 loadBalancerNamespaceMaximumBundles=128
+
+# Name of load manager to use
+loadManagerClassName=org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl
 
 ### --- Replication --- ###
 
@@ -382,9 +373,6 @@ keepAliveIntervalSeconds=30
 
 # How often broker checks for inactive topics to be deleted (topics with no subscriptions and no one connected)
 brokerServicePurgeInactiveFrequencyInSeconds=60
-
-# Name of load manager to use
-loadManagerClassName=org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl
 
 ### --- WebSocket --- ###
 

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -343,18 +343,6 @@ loadBalancerNamespaceMaximumBundles=128
 # Name of load manager to use
 loadManagerClassName=org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl
 
-# load placement strategy[weightedRandomSelection/leastLoadedServer] (only used by SimpleLoadManagerImpl)
-loadBalancerPlacementStrategy=leastLoadedServer
-
-# Usage threshold to determine a broker as under-loaded (only used by SimpleLoadManagerImpl)
-loadBalancerBrokerUnderloadedThresholdPercentage=50
-
-# Usage threshold to determine a broker as over-loaded (only used by SimpleLoadManagerImpl)
-loadBalancerBrokerOverloadedThresholdPercentage=85
-
-# Usage threshold to determine a broker is having just right level of load (only used by SimpleLoadManagerImpl)
-loadBalancerBrokerComfortLoadLevelPercentage=65
-
 ### --- Replication --- ###
 
 # Enable replication metrics

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -272,9 +272,6 @@ managedLedgerMaxUnackedRangesToPersistInZooKeeper=1000
 # Enable load balancer
 loadBalancerEnabled=false
 
-# Strategy to assign a new bundle
-loadBalancerPlacementStrategy=weightedRandomSelection
-
 # Percentage of change to trigger load report update
 loadBalancerReportUpdateThresholdPercentage=10
 
@@ -286,28 +283,19 @@ loadBalancerHostUsageCheckIntervalMinutes=1
 
 # Load shedding interval. Broker periodically checks whether some traffic should be offload from
 # some over-loaded broker to other under-loaded brokers
-loadBalancerSheddingIntervalMinutes=30
+loadBalancerSheddingIntervalMinutes=10
 
 # Prevent the same topics to be shed and moved to other broker more that once within this timeframe
-loadBalancerSheddingGracePeriodMinutes=30
+loadBalancerSheddingGracePeriodMinutes=20
 
-# Usage threshold to determine a broker as under-loaded
-loadBalancerBrokerUnderloadedThresholdPercentage=1
-
-# Usage threshold to determine a broker as over-loaded
-loadBalancerBrokerOverloadedThresholdPercentage=85
-
-# Interval to update namespace bundle resource quotat
+# Interval to flush dynamic resource quota to ZooKeeper
 loadBalancerResourceQuotaUpdateIntervalMinutes=15
 
-# Usage threshold to determine a broker is having just right level of load
-loadBalancerBrokerComfortLoadLevelPercentage=65
-
 # enable/disable namespace bundle auto split
-loadBalancerAutoBundleSplitEnabled=false
+loadBalancerAutoBundleSplitEnabled=true
 
 # enable/disable automatic unloading of split bundles
-loadBalancerAutoUnloadSplitBundlesEnabled=false
+loadBalancerAutoUnloadSplitBundlesEnabled=true
 
 # maximum topics in a bundle, otherwise bundle split will be triggered
 loadBalancerNamespaceBundleMaxTopics=1000
@@ -316,7 +304,7 @@ loadBalancerNamespaceBundleMaxTopics=1000
 loadBalancerNamespaceBundleMaxSessions=1000
 
 # maximum msgRate (in + out) in a bundle, otherwise bundle split will be triggered
-loadBalancerNamespaceBundleMaxMsgRate=1000
+loadBalancerNamespaceBundleMaxMsgRate=5000
 
 # maximum bandwidth (in + out) in a bundle, otherwise bundle split will be triggered
 loadBalancerNamespaceBundleMaxBandwidthMbytes=100

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -283,10 +283,10 @@ loadBalancerHostUsageCheckIntervalMinutes=1
 
 # Load shedding interval. Broker periodically checks whether some traffic should be offload from
 # some over-loaded broker to other under-loaded brokers
-loadBalancerSheddingIntervalMinutes=10
+loadBalancerSheddingIntervalMinutes=5
 
 # Prevent the same topics to be shed and moved to other broker more that once within this timeframe
-loadBalancerSheddingGracePeriodMinutes=20
+loadBalancerSheddingGracePeriodMinutes=30
 
 # Interval to flush dynamic resource quota to ZooKeeper
 loadBalancerResourceQuotaUpdateIntervalMinutes=15
@@ -304,7 +304,7 @@ loadBalancerNamespaceBundleMaxTopics=1000
 loadBalancerNamespaceBundleMaxSessions=1000
 
 # maximum msgRate (in + out) in a bundle, otherwise bundle split will be triggered
-loadBalancerNamespaceBundleMaxMsgRate=5000
+loadBalancerNamespaceBundleMaxMsgRate=30000
 
 # maximum bandwidth (in + out) in a bundle, otherwise bundle split will be triggered
 loadBalancerNamespaceBundleMaxBandwidthMbytes=100

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -279,7 +279,8 @@ public class ServiceConfiguration implements PulsarConfiguration {
     /*** --- Load balancer --- ****/
     // Enable load balancer
     private boolean loadBalancerEnabled = false;
-    // load placement strategy
+    // load placement strategy[weightedRandomSelection/leastLoadedServer] (only used by SimpleLoadManagerImpl)
+    @Deprecated
     private String loadBalancerPlacementStrategy = "weightedRandomSelection"; // weighted random selection
     // Percentage of change to trigger load report update
     @FieldContext(dynamic = true)
@@ -289,37 +290,42 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private int loadBalancerReportUpdateMaxIntervalMinutes = 15;
     // Frequency of report to collect
     private int loadBalancerHostUsageCheckIntervalMinutes = 1;
-    // Load shedding interval. Broker periodically checks whether some traffic
-    // should be offload from
-    // some over-loaded broker to other under-loaded brokers
-    private int loadBalancerSheddingIntervalMinutes = 30;
+    // Load shedding interval. Broker periodically checks whether some traffic should be offload from some over-loaded
+    // broker to other under-loaded brokers
+    private int loadBalancerSheddingIntervalMinutes = 10;
     // Prevent the same topics to be shed and moved to other broker more that
     // once within this timeframe
-    private long loadBalancerSheddingGracePeriodMinutes = 30;
-    // Usage threshold to determine a broker as under-loaded
+    private long loadBalancerSheddingGracePeriodMinutes = 20;
+    // Usage threshold to determine a broker as under-loaded (only used by SimpleLoadManagerImpl)
+    @Deprecated
     private int loadBalancerBrokerUnderloadedThresholdPercentage = 50;
-    // Usage threshold to determine a broker as over-loaded
+    // Usage threshold to determine a broker as over-loaded (only used by SimpleLoadManagerImpl)
+    @Deprecated
     private int loadBalancerBrokerOverloadedThresholdPercentage = 85;
-    // interval to flush dynamic resource quota to ZooKeeper
+    // Interval to flush dynamic resource quota to ZooKeeper
     private int loadBalancerResourceQuotaUpdateIntervalMinutes = 15;
-    // Usage threshold to defermine a broker is having just right level of load
+    // Usage threshold to determine a broker is having just right level of load (only used by SimpleLoadManagerImpl)
+    @Deprecated
     private int loadBalancerBrokerComfortLoadLevelPercentage = 65;
     // enable/disable automatic namespace bundle split
     @FieldContext(dynamic = true)
-    private boolean loadBalancerAutoBundleSplitEnabled = false;
+    private boolean loadBalancerAutoBundleSplitEnabled = true;
     // enable/disable automatic unloading of split bundles
     @FieldContext(dynamic = true)
-    private boolean loadBalancerAutoUnloadSplitBundlesEnabled = false;
+    private boolean loadBalancerAutoUnloadSplitBundlesEnabled = true;
     // maximum topics in a bundle, otherwise bundle split will be triggered
     private int loadBalancerNamespaceBundleMaxTopics = 1000;
     // maximum sessions (producers + consumers) in a bundle, otherwise bundle split will be triggered
     private int loadBalancerNamespaceBundleMaxSessions = 1000;
     // maximum msgRate (in + out) in a bundle, otherwise bundle split will be triggered
-    private int loadBalancerNamespaceBundleMaxMsgRate = 1000;
+    private int loadBalancerNamespaceBundleMaxMsgRate = 5000;
     // maximum bandwidth (in + out) in a bundle, otherwise bundle split will be triggered
     private int loadBalancerNamespaceBundleMaxBandwidthMbytes = 100;
     // maximum number of bundles in a namespace
     private int loadBalancerNamespaceMaximumBundles = 128;
+    // Name of load manager to use
+    @FieldContext(dynamic = true)
+    private String loadManagerClassName = "org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl";
 
     /**** --- Replication --- ****/
     // Enable replication metrics
@@ -346,9 +352,6 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private int brokerServicePurgeInactiveFrequencyInSeconds = 60;
     private List<String> bootstrapNamespaces = new ArrayList<String>();
     private Properties properties = new Properties();
-    // Name of load manager to use
-    @FieldContext(dynamic = true)
-    private String loadManagerClassName = "org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl";
     // If true, (and ModularLoadManagerImpl is being used), the load manager will attempt to
     // use only brokers running the latest software version (to minimize impact to bundles)
     @FieldContext(dynamic = true)

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -281,7 +281,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private boolean loadBalancerEnabled = false;
     // load placement strategy[weightedRandomSelection/leastLoadedServer] (only used by SimpleLoadManagerImpl)
     @Deprecated
-    private String loadBalancerPlacementStrategy = "weightedRandomSelection"; // weighted random selection
+    private String loadBalancerPlacementStrategy = "leastLoadedServer"; // weighted random selection
     // Percentage of change to trigger load report update
     @FieldContext(dynamic = true)
     private int loadBalancerReportUpdateThresholdPercentage = 10;
@@ -292,10 +292,10 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private int loadBalancerHostUsageCheckIntervalMinutes = 1;
     // Load shedding interval. Broker periodically checks whether some traffic should be offload from some over-loaded
     // broker to other under-loaded brokers
-    private int loadBalancerSheddingIntervalMinutes = 10;
+    private int loadBalancerSheddingIntervalMinutes = 5;
     // Prevent the same topics to be shed and moved to other broker more that
     // once within this timeframe
-    private long loadBalancerSheddingGracePeriodMinutes = 20;
+    private long loadBalancerSheddingGracePeriodMinutes = 30;
     // Usage threshold to determine a broker as under-loaded (only used by SimpleLoadManagerImpl)
     @Deprecated
     private int loadBalancerBrokerUnderloadedThresholdPercentage = 50;
@@ -318,7 +318,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     // maximum sessions (producers + consumers) in a bundle, otherwise bundle split will be triggered
     private int loadBalancerNamespaceBundleMaxSessions = 1000;
     // maximum msgRate (in + out) in a bundle, otherwise bundle split will be triggered
-    private int loadBalancerNamespaceBundleMaxMsgRate = 5000;
+    private int loadBalancerNamespaceBundleMaxMsgRate = 30000;
     // maximum bandwidth (in + out) in a bundle, otherwise bundle split will be triggered
     private int loadBalancerNamespaceBundleMaxBandwidthMbytes = 100;
     // maximum number of bundles in a namespace

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/BrokerStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/BrokerStats.java
@@ -168,7 +168,8 @@ public class BrokerStats extends AdminResource {
     @ApiOperation(value = "Broker availability report", notes = "This API gives the current broker availability in percent, each resource percentage usage is calculated and then"
             + "sum of all of the resource usage percent is called broker-resource-availability"
             + "<br/><br/>THIS API IS ONLY FOR USE BY TESTING FOR CONFIRMING NAMESPACE ALLOCATION ALGORITHM", response = ResourceUnit.class, responseContainer = "Map")
-    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission") })
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 409, message = "Load-manager doesn't support operation") })
     public Map<Long, Collection<ResourceUnit>> getBrokerResourceAvailability(@PathParam("property") String property,
             @PathParam("cluster") String cluster, @PathParam("namespace") String namespace) throws Exception {
         try {
@@ -177,7 +178,7 @@ public class BrokerStats extends AdminResource {
             if (lm instanceof SimpleLoadManagerImpl) {
                 return ((SimpleLoadManagerImpl) lm).getResourceAvailabilityFor(ns).asMap();
             } else {
-                return null;
+                throw new RestException(Status.CONFLICT, lm.getClass().getName() + " does not support this operation");
             }
         } catch (Exception e) {
             log.error("Unable to get Resource Availability - [{}]", e);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
@@ -408,16 +408,6 @@ public class SimpleLoadManagerImpl implements LoadManager, ZooKeeperCacheListene
         return strategy;
     }
 
-    private double getCpuLoadFactorFromZK(double defaultValue) {
-        return getDynamicConfigurationDouble(LOADBALANCER_DYNAMIC_SETTING_LOAD_FACTOR_CPU_ZPATH,
-                SETTING_NAME_LOAD_FACTOR_CPU, defaultValue);
-    }
-
-    private double getMemoryLoadFactorFromZK(double defaultValue) {
-        return getDynamicConfigurationDouble(LOADBALANCER_DYNAMIC_SETTING_LOAD_FACTOR_MEM_ZPATH,
-                SETTING_NAME_LOAD_FACTOR_MEM, defaultValue);
-    }
-
     @Override
     public boolean isCentralized() {
         String strategy = this.getLoadBalancerPlacementStrategy();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadBalancerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadBalancerTest.java
@@ -138,6 +138,7 @@ public class LoadBalancerTest {
             config.setWebServicePort(brokerWebServicePorts[i]);
             config.setZookeeperServers("127.0.0.1" + ":" + ZOOKEEPER_PORT);
             config.setBrokerServicePort(brokerNativeBrokerPorts[i]);
+            config.setLoadManagerClassName(SimpleLoadManagerImpl.class.getName());
 
             pulsarServices[i] = new PulsarService(config);
             pulsarServices[i].start();
@@ -665,27 +666,28 @@ public class LoadBalancerTest {
         Thread.sleep(5000);
         pulsarServices[0].getLoadManager().get().doNamespaceBundleSplit();
 
+        boolean isAutoUnooadSplitBundleEnabled = pulsarServices[0].getConfiguration().isLoadBalancerAutoUnloadSplitBundlesEnabled();
         // verify bundles are split
         verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-01", "0x00000000_0x80000000",
-                false);
+                isAutoUnooadSplitBundleEnabled);
         verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-02", "0x00000000_0x80000000",
-                false);
+                isAutoUnooadSplitBundleEnabled);
         verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-03", "0x00000000_0x80000000",
-                false);
+                isAutoUnooadSplitBundleEnabled);
         verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-04", "0x00000000_0x80000000",
-                false);
+                isAutoUnooadSplitBundleEnabled);
         verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-05", "0x00000000_0x80000000",
-                false);
+                isAutoUnooadSplitBundleEnabled);
         verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-06", "0x00000000_0x80000000",
-                false);
+                isAutoUnooadSplitBundleEnabled);
         verify(namespaceAdmin, times(1)).splitNamespaceBundle("pulsar/use/primary-ns-07", "0x00000000_0x80000000",
-                false);
+                isAutoUnooadSplitBundleEnabled);
         verify(namespaceAdmin, never()).splitNamespaceBundle("pulsar/use/primary-ns-08", "0x00000000_0x80000000",
-                false);
+                isAutoUnooadSplitBundleEnabled);
         verify(namespaceAdmin, never()).splitNamespaceBundle("pulsar/use/primary-ns-09", "0x00000000_0x80000000",
-                false);
+                isAutoUnooadSplitBundleEnabled);
         verify(namespaceAdmin, never()).splitNamespaceBundle("pulsar/use/primary-ns-10", "0x00000000_0x02000000",
-                false);
+                isAutoUnooadSplitBundleEnabled);
     }
 
     /*

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/SimpleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/SimpleLoadManagerImplTest.java
@@ -144,6 +144,7 @@ public class SimpleLoadManagerImplTest {
         config1.setWebServicePort(PRIMARY_BROKER_WEBSERVICE_PORT);
         config1.setZookeeperServers("127.0.0.1" + ":" + ZOOKEEPER_PORT);
         config1.setBrokerServicePort(PRIMARY_BROKER_PORT);
+        config1.setLoadManagerClassName(SimpleLoadManagerImpl.class.getName());
         pulsar1 = new PulsarService(config1);
 
         pulsar1.start();
@@ -160,6 +161,7 @@ public class SimpleLoadManagerImplTest {
         config2.setWebServicePort(SECONDARY_BROKER_WEBSERVICE_PORT);
         config2.setZookeeperServers("127.0.0.1" + ":" + ZOOKEEPER_PORT);
         config2.setBrokerServicePort(SECONDARY_BROKER_PORT);
+        config2.setLoadManagerClassName(SimpleLoadManagerImpl.class.getName());
         pulsar2 = new PulsarService(config2);
 
         pulsar2.start();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -321,7 +321,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         consumer.close();
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
         JsonArray metrics = brokerStatsClient.getMetrics();
-        assertEquals(metrics.size(), 6, metrics.toString());
+        assertEquals(metrics.size(), 5, metrics.toString());
 
         // these metrics seem to be arriving in different order at different times...
         // is the order really relevant here?


### PR DESCRIPTION
### Motivation

We have introduced [ModularLoadManager](https://pulsar.incubator.apache.org/docs/v1.19.0-incubating/admin/ModularLoadManager/) in `1.17` release and it considers more variables to distribute load across the brokers. Therefore, we can change default load-manager as `ModularLoadManager` and clean up configuration which are not required by `ModularLoadManager`.

### Modifications

- Make default `ModularLoadManager` as default load-manager
- Deprecate configuration which is not used by `ModularLoadManager`
- Tune load-balancer configuration value
- Remove not used config from `broker.conf` and `standalone.conf`
- By default: Enable bundle-split and unloading bundle by load-balancer

### Result

It will enable `ModularLoadManager` with enabled configuration for splitting bundle and unloading split bundles.
