### PR TITLE
Pulsar-testclient should not fetch the shaded pulsar-client dependency

### DIFF
--- a/pulsar-testclient/pom.xml
+++ b/pulsar-testclient/pom.xml
@@ -52,7 +52,7 @@
         </dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
-			<artifactId>pulsar-client</artifactId>
+			<artifactId>pulsar-client-original</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
### Motivation

By depending on the shaded `pulsar-client`, the testclient is getting the shaded jar included into the bin distribution which is causing conflicts in broker/proxy modules.
