### PR TITLE
Fix: Non-persistent topic race condition while acking dropped message

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
@@ -50,16 +50,16 @@ import org.apache.pulsar.broker.service.nonpersistent.NonPersistentReplicator;
 import org.apache.pulsar.broker.service.nonpersistent.NonPersistentTopic;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.impl.ConsumerImpl;
+import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.apache.pulsar.client.impl.ProducerImpl;
 import org.apache.pulsar.common.naming.DestinationName;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.NonPersistentPublisherStats;
 import org.apache.pulsar.common.policies.data.NonPersistentSubscriptionStats;
 import org.apache.pulsar.common.policies.data.NonPersistentTopicStats;
-import org.apache.pulsar.common.policies.data.SubscriptionStats;
-import org.apache.pulsar.common.policies.data.PersistentTopicStats;
 import org.apache.pulsar.common.policies.data.PropertyAdmin;
-import org.apache.pulsar.common.policies.data.PublisherStats;
+import org.apache.pulsar.common.policies.data.SubscriptionStats;
 import org.apache.pulsar.zookeeper.LocalBookkeeperEnsemble;
 import org.apache.pulsar.zookeeper.ZookeeperServerTest;
 import org.slf4j.Logger;
@@ -743,7 +743,8 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             consumerConfig2.setReceiverQueueSize(1);
             consumerConfig2.setSubscriptionType(SubscriptionType.Shared);
             Consumer consumer2 = pulsarClient.subscribe(topicName, "subscriber-2", consumerConfig2);
-            Producer producer = pulsarClient.createProducer(topicName, producerConf);
+            ProducerImpl producer = (ProducerImpl) pulsarClient.createProducer(topicName, producerConf);
+            String firstTimeConnected = producer.getConnectedSince();
             ExecutorService executor = Executors.newFixedThreadPool(5);
             byte[] msgData = "testData".getBytes();
             final int totalProduceMessages = 200;
@@ -767,6 +768,8 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             assertTrue(npStats.msgDropRate > 0);
             assertTrue(sub1Stats.msgDropRate > 0);
             assertTrue(sub2Stats.msgDropRate > 0);
+            // make sure producer connection not disconnected due to unordered ack
+            assertEquals(firstTimeConnected, producer.getConnectedSince());
 
             producer.close();
             consumer.close();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -179,8 +179,8 @@ public class ClientCnx extends PulsarHandler {
         }
 
         if (ledgerId == -1 && entryId == -1) {
-            log.warn("[{}] Message has been dropped for non-persistent topic producer-id {}", ctx.channel(),
-                    producerId);
+            log.warn("[{}] Message has been dropped for non-persistent topic producer-id {}-{}", ctx.channel(),
+                    producerId, sequenceId);
         }
 
         if (log.isDebugEnabled()) {


### PR DESCRIPTION
### Motivation

For non-persistent topic if message gets dropped due to throttling then due to race condition broker is not able to send ack in order which cause ack-failure at client side because client expects msg-ack in sequence.
Right now, non-persistent message gets [processed](https://github.com/apache/incubator-pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java#L182) using ordered-executor and [dropped-message](https://github.com/apache/incubator-pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java#L595) also acked using same ordered-executor.  But, message-processing has another async step to process message (send-msg to subscriber/replicator) which sometimes doesn't give ack-ordering guarantee if one of the message is dropped.
Therefore, those dropped messages must be acked after all previous messages have been processed and acked successfully.

### Modifications

- add dropped message into the pending queue and ack those messages once, all previous messages have been processed and acked successfully.

### Result

- Client will receive ack in sequence even if message has been dropped at broker.
- It will also fix #867 as `NonPersistentTopicTest.testMsgDropStat` fails because dropped-msg's ack doesn't come in expected sequence which disconnects producers and test doesn't find expected producer in the list.
