### PR TITLE
Fix: Non-persistent topic acking sequence for dropped message

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -588,15 +588,19 @@ public class ServerCnx extends PulsarHandler {
             printSendCommandDebug(send, headersAndPayload);
         }
 
-        // avoid processing non-persist message if reached max concurrent-message limit
-        if (producer.isNonPersistentTopic() && nonPersistentPendingMessages++ > MaxNonPersistentPendingMessages) {
-            final long producerId = send.getProducerId();
-            final long sequenceId = send.getSequenceId();
-            service.getTopicOrderedExecutor().submitOrdered(producer.getTopic(), SafeRun.safeRun(() -> {
-                ctx.writeAndFlush(Commands.newSendReceipt(producerId, sequenceId, -1, -1), ctx.voidPromise());
-            }));
-            producer.recordMessageDrop(send.getNumMessages());
-            return;
+        if (producer.isNonPersistentTopic()) {
+            // avoid processing non-persist message if reached max concurrent-message limit
+            if (nonPersistentPendingMessages > MaxNonPersistentPendingMessages) {
+                final long producerId = send.getProducerId();
+                final long sequenceId = send.getSequenceId();
+                service.getTopicOrderedExecutor().submitOrdered(producer.getTopic().getName(), SafeRun.safeRun(() -> {
+                    ctx.writeAndFlush(Commands.newSendReceipt(producerId, sequenceId, -1, -1), ctx.voidPromise());
+                }));
+                producer.recordMessageDrop(send.getNumMessages());
+                return;
+            } else {
+                nonPersistentPendingMessages++;
+            }
         }
 
         startSendOperation();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -183,8 +183,8 @@ public class ClientCnx extends PulsarHandler {
         }
 
         if (ledgerId == -1 && entryId == -1) {
-            log.warn("[{}] Message has been dropped for non-persistent topic producer-id {}", ctx.channel(),
-                    producerId);
+            log.warn("[{}] Message has been dropped for non-persistent topic producer-id {}-{}", ctx.channel(),
+                    producerId, sequenceId);
         }
 
         if (log.isDebugEnabled()) {


### PR DESCRIPTION
### Motivation

For non-persistent topic: Broker sends ack in incorrect order for dropped message which cause client-producer to disconnect and reconnect again.
Earlier ordering key for 
failure message execution: [NonPersistentTopic.toString()](https://github.com/apache/incubator-pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java#L595) and successful execution: [topicName](https://github.com/apache/incubator-pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java#L182) so, ordering was messed up. Now, both use `topicName` for ordering.

### Modifications

- fix acking order for dropped message
- fix: don't increment concurrent-request count for dropped message
- add unit-test assertion to check producer is not disconnected
- added dropped-message sequence-id in client log

### Result

It will fix ack-ordering for dropped message of non-persistent topic and it will also fix  #867 
