### PR TITLE
Fix ConsumerHandler in WebSocket Proxy

### DIFF
--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
@@ -112,7 +112,7 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
 
     private void receiveMessage() {
         if (log.isDebugEnabled()) {
-            log.debug("[{}] [{}] [{}] Receive next message", getSession().getRemoteAddress(), topic, subscription);
+            log.debug("[{}:{}] [{}] [{}] Receive next message", request.getRemoteAddr(), request.getRemotePort(), topic, subscription);
         }
 
         consumer.receiveAsync().thenAccept(msg -> {


### PR DESCRIPTION
### Motivation

When log level is debug, `receiveMessage` is called although `session` is null and NullPointerException causes.


### Modifications

Replaced `getSession().getRemoteAddress()` with `request.getRemoteAddr() and request.getRemotePort()`.

### Result

NullPointerException doesn't cause.
