### PR TITLE
Separate ports used by global and local zookeeper

### DIFF
--- a/bin/pulsar
+++ b/bin/pulsar
@@ -207,7 +207,7 @@ elif [ $COMMAND == "global-zookeeper" ]; then
     PULSAR_LOG_FILE=${PULSAR_LOG_FILE:-"global-zookeeper.log"}
     # Allow global ZK to turn into read-only mode when it cannot reach the quorum
     OPTS="${OPTS} -Dreadonlymode.enabled=true"
-    exec $JAVA $OPTS -Dpulsar.log.file=$PULSAR_LOG_FILE org.apache.pulsar.zookeeper.ZooKeeperStarter $PULSAR_GLOBAL_ZK_CONF $@
+    exec $JAVA $OPTS -Dpulsar.log.file=$PULSAR_LOG_FILE org.apache.pulsar.zookeeper.GlobalZooKeeperStarter $PULSAR_GLOBAL_ZK_CONF $@
 elif [ $COMMAND == "discovery" ]; then
     PULSAR_LOG_FILE=${PULSAR_LOG_FILE:-"discovery.log"}
     exec $JAVA $OPTS -Dpulsar.log.file=$PULSAR_LOG_FILE org.apache.pulsar.discovery.service.server.DiscoveryServiceStarter $PULSAR_DISCOVERY_CONF $@

--- a/conf/bkenv.sh
+++ b/conf/bkenv.sh
@@ -39,7 +39,7 @@ BOOKIE_MEM=" -Xms2g -Xmx2g -XX:MaxDirectMemorySize=2g"
 BOOKIE_GC=" -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB"
 
 # Extra options to be passed to the jvm
-BOOKIE_EXTRA_OPTS="${BOOKIE_MEM} ${BOOKIE_GC} -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.maxCapacity.default=1000 -Dio.netty.recycler.linkCapacity=1024"
+BOOKIE_EXTRA_OPTS="${BOOKIE_EXTRA_OPTS} ${BOOKIE_MEM} ${BOOKIE_GC} -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.maxCapacity.default=1000 -Dio.netty.recycler.linkCapacity=1024"
 
 # Add extra paths to the bookkeeper classpath
 # BOOKIE_EXTRA_CLASSPATH=

--- a/conf/pulsar_env.sh
+++ b/conf/pulsar_env.sh
@@ -48,7 +48,7 @@ PULSAR_MEM=" -Xms2g -Xmx2g -XX:MaxDirectMemorySize=4g"
 PULSAR_GC=" -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB"
 
 # Extra options to be passed to the jvm
-PULSAR_EXTRA_OPTS="${PULSAR_MEM} ${PULSAR_GC} -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.maxCapacity.default=1000 -Dio.netty.recycler.linkCapacity=1024"
+PULSAR_EXTRA_OPTS="${PULSAR_EXTRA_OPTS} ${PULSAR_MEM} ${PULSAR_GC} -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.maxCapacity.default=1000 -Dio.netty.recycler.linkCapacity=1024"
 
 # Add extra paths to the bookkeeper classpath
 # PULSAR_EXTRA_CLASSPATH=

--- a/conf/pulsar_tools_env.sh
+++ b/conf/pulsar_tools_env.sh
@@ -48,7 +48,7 @@ PULSAR_MEM=" -Xmx256m -XX:MaxDirectMemorySize=256m"
 PULSAR_GC=" -client "
 
 # Extra options to be passed to the jvm
-PULSAR_EXTRA_OPTS="${PULSAR_MEM} ${PULSAR_GC} -Dio.netty.leakDetectionLevel=disabled"
+PULSAR_EXTRA_OPTS="${PULSAR_EXTRA_OPTS} ${PULSAR_MEM} ${PULSAR_GC} -Dio.netty.leakDetectionLevel=disabled"
 
 # Add extra paths to the bookkeeper classpath
 # PULSAR_EXTRA_CLASSPATH=

--- a/pulsar-zookeeper/pom.xml
+++ b/pulsar-zookeeper/pom.xml
@@ -41,6 +41,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.aspectj</groupId>
       <artifactId>aspectjrt</artifactId>
     </dependency>

--- a/pulsar-zookeeper/pom.xml
+++ b/pulsar-zookeeper/pom.xml
@@ -41,11 +41,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.aspectj</groupId>
       <artifactId>aspectjrt</artifactId>
     </dependency>

--- a/pulsar-zookeeper/src/main/java/org/apache/pulsar/zookeeper/GlobalZooKeeperStarter.java
+++ b/pulsar-zookeeper/src/main/java/org/apache/pulsar/zookeeper/GlobalZooKeeperStarter.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.zookeeper;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class GlobalZooKeeperStarter extends ZooKeeperStarter {
+    public static void main(String[] args) throws Exception {
+        start(args, "pulsar.zookeeper.global.stats.server.port", "8001");
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalZooKeeperStarter.class);
+}

--- a/pulsar-zookeeper/src/main/java/org/apache/pulsar/zookeeper/GlobalZooKeeperStarter.java
+++ b/pulsar-zookeeper/src/main/java/org/apache/pulsar/zookeeper/GlobalZooKeeperStarter.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 
 public class GlobalZooKeeperStarter extends ZooKeeperStarter {
     public static void main(String[] args) throws Exception {
-        start(args, "pulsar.zookeeper.global.stats.server.port", "8001");
+        start(args, "8001");
     }
 
     private static final Logger log = LoggerFactory.getLogger(GlobalZooKeeperStarter.class);

--- a/pulsar-zookeeper/src/main/java/org/apache/pulsar/zookeeper/ZooKeeperStarter.java
+++ b/pulsar-zookeeper/src/main/java/org/apache/pulsar/zookeeper/ZooKeeperStarter.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pulsar.zookeeper;
 
-import static org.apache.commons.lang3.StringUtils.isBlank;
-
 import java.net.InetSocketAddress;
 
 import org.apache.zookeeper.server.quorum.QuorumPeerMain;
@@ -37,10 +35,10 @@ import io.prometheus.client.hotspot.DefaultExports;
 
 public class ZooKeeperStarter {
     public static void main(String[] args) throws Exception {
-        start(args, "pulsar.zookeeper.local.stats.server.port", "8000");
+        start(args, "8000");
     }
 
-    protected static void start(String[] args, String statsPortProperty, String defaultStatsPort) throws Exception {
+    protected static void start(String[] args, String defaultStatsPort) throws Exception {
         // Register basic JVM metrics
         DefaultExports.initialize();
 
@@ -48,11 +46,7 @@ public class ZooKeeperStarter {
         AgentLoader.loadAgentClass(Agent.class.getName(), null);
 
         // Start Jetty to serve stats
-        String portStr = System.getProperty(statsPortProperty);
-        if (isBlank(portStr)) {
-            portStr = System.getProperty("stats_server_port", defaultStatsPort);
-        }
-        int port = Integer.parseInt(portStr);
+        int port = Integer.parseInt(System.getProperties().getProperty("stats_server_port", defaultStatsPort));
 
         log.info("Starting ZK stats HTTP server at port {}", port);
         InetSocketAddress httpEndpoint = InetSocketAddress.createUnresolved("0.0.0.0", port);

--- a/pulsar-zookeeper/src/main/java/org/apache/pulsar/zookeeper/ZooKeeperStarter.java
+++ b/pulsar-zookeeper/src/main/java/org/apache/pulsar/zookeeper/ZooKeeperStarter.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.zookeeper;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
 import java.net.InetSocketAddress;
 
 import org.apache.zookeeper.server.quorum.QuorumPeerMain;
@@ -35,6 +37,10 @@ import io.prometheus.client.hotspot.DefaultExports;
 
 public class ZooKeeperStarter {
     public static void main(String[] args) throws Exception {
+        start(args, "pulsar.zookeeper.local.stats.server.port", "8000");
+    }
+
+    protected static void start(String[] args, String statsPortProperty, String defaultStatsPort) throws Exception {
         // Register basic JVM metrics
         DefaultExports.initialize();
 
@@ -42,7 +48,11 @@ public class ZooKeeperStarter {
         AgentLoader.loadAgentClass(Agent.class.getName(), null);
 
         // Start Jetty to serve stats
-        int port = Integer.parseInt(System.getProperties().getProperty("stats_server_port", "8080"));
+        String portStr = System.getProperty(statsPortProperty);
+        if (isBlank(portStr)) {
+            portStr = System.getProperty("stats_server_port", defaultStatsPort);
+        }
+        int port = Integer.parseInt(portStr);
 
         log.info("Starting ZK stats HTTP server at port {}", port);
         InetSocketAddress httpEndpoint = InetSocketAddress.createUnresolved("0.0.0.0", port);

--- a/site/docs/latest/deployment/Monitoring.md
+++ b/site/docs/latest/deployment/Monitoring.md
@@ -66,7 +66,7 @@ http://$GLOBAL_ZK_SERVER:8001/metrics
 ```
 
 The default port of local ZooKeeper is `8000` and that of global ZooKeeper is `8001`.
-These can be changed by specifying system properties, `pulsar.zookeeper.local.stats.server.port` and `pulsar.zookeeper.global.stats.server.port`.
+These can be changed by specifying system property `stats_server_port`.
 
 ### BookKeeper stats
 

--- a/site/docs/latest/deployment/Monitoring.md
+++ b/site/docs/latest/deployment/Monitoring.md
@@ -57,12 +57,16 @@ http://$BROKER_ADDRESS:8080/metrics
 
 ### ZooKeeper stats
 
-The ZooKeeper server and clients that are shipped with Pulsar have been instrumented to expose
+The local/global ZooKeeper server and clients that are shipped with Pulsar have been instrumented to expose
 detailed stats through Prometheus as well.
 
 ```shell
-http://$ZK_SERVER:8080/metrics
+http://$LOCAL_ZK_SERVER:8000/metrics
+http://$GLOBAL_ZK_SERVER:8001/metrics
 ```
+
+The default port of local ZooKeeper is `8000` and that of global ZooKeeper is `8001`.
+These can be changed by specifying system properties, `pulsar.zookeeper.local.stats.server.port` and `pulsar.zookeeper.global.stats.server.port`.
 
 ### BookKeeper stats
 


### PR DESCRIPTION
### Motivation

This closes [#813](https://github.com/apache/incubator-pulsar/issues/813)

### Modifications

* Add `GlobalZooKeeperStarter` class that extends `ZooKeeperStarter`
* ~~Introduce new system properties `pulsar.zookeeper.local.stats.server.port` and `pulsar.zookeeper.global.stats.server.port` that are substitute for `stats_server_port`~~
* Change the default stats server port in order to avoid conflict with the port used by admin server of zookeeper
* Fix `conf/*env.sh` to be able to change the stats server ports

### Result

Users will be able to run global and local zookeeper on the same machine.