### PR TITLE
Namespace-isolation policy should consider secondary brokers

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
@@ -52,7 +52,7 @@ public class LoadManagerShared {
     private static final Set<String> primariesCache = new HashSet<>();
 
     // Cache for shard brokers according to policies.
-    private static final Set<String> secondary = new HashSet<>();
+    private static final Set<String> secondaryCache = new HashSet<>();
     
     // update LoadReport at most every 5 seconds
     public static final long LOAD_REPORT_UPDATE_MIMIMUM_INTERVAL = TimeUnit.SECONDS.toMillis(5);
@@ -68,7 +68,7 @@ public class LoadManagerShared {
             final Set<String> availableBrokers,
             final BrokerTopicLoadingPredicate brokerTopicLoadingPredicate) {
         primariesCache.clear();
-        secondary.clear();
+        secondaryCache.clear();
         NamespaceName namespace = serviceUnit.getNamespaceObject();
         boolean isIsolationPoliciesPresent = policies.IsIsolationPoliciesPresent(namespace);
         boolean isNonPersistentTopic = (serviceUnit instanceof NamespaceBundle)
@@ -97,7 +97,7 @@ public class LoadManagerShared {
                                 + " namespace - [{}] with policies", brokerUrl.getHost(), namespace.toString());
                     }
                 } else if (policies.isSecondaryBroker(namespace, brokerUrl.getHost())) {
-                    secondary.add(broker);
+                    secondaryCache.add(broker);
                     if (log.isDebugEnabled()) {
                         log.debug(
                                 "Added Shared Broker - [{}] as possible "
@@ -127,7 +127,7 @@ public class LoadManagerShared {
                                 brokerUrl.getHost(), namespace.toString());
                     }
                 } else if (policies.isSharedBroker(brokerUrl.getHost())) {
-                    secondary.add(broker);
+                    secondaryCache.add(broker);
                     if (log.isDebugEnabled()) {
                         log.debug("Added Shared Broker - [{}] as possible Candidates for namespace - [{}]",
                                 brokerUrl.getHost(), namespace.toString());
@@ -141,15 +141,15 @@ public class LoadManagerShared {
                 log.debug(
                         "Not enough of primaries [{}] available for namespace - [{}], "
                                 + "adding shared [{}] as possible candidate owners",
-                        primariesCache.size(), namespace.toString(), secondary.size());
-                brokerCandidateCache.addAll(secondary);
+                        primariesCache.size(), namespace.toString(), secondaryCache.size());
+                brokerCandidateCache.addAll(secondaryCache);
             }
         } else {
             log.debug(
                     "Policies not present for namespace - [{}] so only "
                             + "considering shared [{}] brokers for possible owner",
-                    namespace.toString(), secondary.size());
-            brokerCandidateCache.addAll(secondary);
+                    namespace.toString(), secondaryCache.size());
+            brokerCandidateCache.addAll(secondaryCache);
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
@@ -52,7 +52,7 @@ public class LoadManagerShared {
     private static final Set<String> primariesCache = new HashSet<>();
 
     // Cache for shard brokers according to policies.
-    private static final Set<String> sharedCache = new HashSet<>();
+    private static final Set<String> secondary = new HashSet<>();
     
     // update LoadReport at most every 5 seconds
     public static final long LOAD_REPORT_UPDATE_MIMIMUM_INTERVAL = TimeUnit.SECONDS.toMillis(5);
@@ -68,7 +68,7 @@ public class LoadManagerShared {
             final Set<String> availableBrokers,
             final BrokerTopicLoadingPredicate brokerTopicLoadingPredicate) {
         primariesCache.clear();
-        sharedCache.clear();
+        secondary.clear();
         NamespaceName namespace = serviceUnit.getNamespaceObject();
         boolean isIsolationPoliciesPresent = policies.IsIsolationPoliciesPresent(namespace);
         boolean isNonPersistentTopic = (serviceUnit instanceof NamespaceBundle)
@@ -96,8 +96,8 @@ public class LoadManagerShared {
                         log.debug("Added Primary Broker - [{}] as possible Candidates for"
                                 + " namespace - [{}] with policies", brokerUrl.getHost(), namespace.toString());
                     }
-                } else if (policies.isSharedBroker(brokerUrl.getHost())) {
-                    sharedCache.add(broker);
+                } else if (policies.isSecondaryBroker(namespace, brokerUrl.getHost())) {
+                    secondary.add(broker);
                     if (log.isDebugEnabled()) {
                         log.debug(
                                 "Added Shared Broker - [{}] as possible "
@@ -127,7 +127,7 @@ public class LoadManagerShared {
                                 brokerUrl.getHost(), namespace.toString());
                     }
                 } else if (policies.isSharedBroker(brokerUrl.getHost())) {
-                    sharedCache.add(broker);
+                    secondary.add(broker);
                     if (log.isDebugEnabled()) {
                         log.debug("Added Shared Broker - [{}] as possible Candidates for namespace - [{}]",
                                 brokerUrl.getHost(), namespace.toString());
@@ -141,15 +141,15 @@ public class LoadManagerShared {
                 log.debug(
                         "Not enough of primaries [{}] available for namespace - [{}], "
                                 + "adding shared [{}] as possible candidate owners",
-                        primariesCache.size(), namespace.toString(), sharedCache.size());
-                brokerCandidateCache.addAll(sharedCache);
+                        primariesCache.size(), namespace.toString(), secondary.size());
+                brokerCandidateCache.addAll(secondary);
             }
         } else {
             log.debug(
                     "Policies not present for namespace - [{}] so only "
                             + "considering shared [{}] brokers for possible owner",
-                    namespace.toString(), sharedCache.size());
-            brokerCandidateCache.addAll(sharedCache);
+                    namespace.toString(), secondary.size());
+            brokerCandidateCache.addAll(secondary);
         }
     }
 
@@ -273,7 +273,7 @@ public class LoadManagerShared {
         }
     }
     
-    interface BrokerTopicLoadingPredicate {
+    public interface BrokerTopicLoadingPredicate {
         boolean isEnablePersistentTopics(String brokerUrl);
 
         boolean isEnableNonPersistentTopics(String brokerUrl);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleResourceAllocationPolicies.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleResourceAllocationPolicies.java
@@ -37,7 +37,7 @@ public class SimpleResourceAllocationPolicies {
     private final ZooKeeperDataCache<NamespaceIsolationPolicies> namespaceIsolationPolicies;
     private final PulsarService pulsar;
 
-    SimpleResourceAllocationPolicies(PulsarService pulsar) {
+    public SimpleResourceAllocationPolicies(PulsarService pulsar) {
         this.namespaceIsolationPolicies = pulsar.getConfigurationCache().namespaceIsolationPoliciesCache();
         this.pulsar = pulsar;
     }


### PR DESCRIPTION
### Motivation

Right now, LoadManager is not considering secondary-brokers from NamespaceIsolation-Policy while selecting broker-candidates.

For example: if NamespaceIsolation-policies has primary and secondary brokers configured and if primary is not available then load-manager should only consider secondary brokers and should never look into shared-pool brokers.

Right now, load-manager is completely ignoring secondary brokers and always look into shared brokers if it doesn't find enough primary broker.

**NOTE**: Pulsar has this behavior from the beginning and both load-manager has the same behavior.

### Modifications

Broker should consider secondary brokers while selecting broker candidate.

### Result

Load-manager follows namespace-isolation policy correctly by considering primary and secondary brokers appropriately. 
