### PR TITLE
CPP Client - Athens Client header visibile and remove C++11 features

### DIFF
--- a/pulsar-client-cpp/lib/auth/AuthAthenz.cc
+++ b/pulsar-client-cpp/lib/auth/AuthAthenz.cc
@@ -77,8 +77,9 @@ namespace pulsar {
             Json::Value root;
             Json::Reader reader;
             if (reader.parse(authParamsString, root, false)) {
-                for (auto key: root.getMemberNames()) {
-                    params[key] = root[key].asString();
+                Json::Value::Members members = root.getMemberNames();
+                for (Json::Value::Members::iterator iter = members.begin(); iter != members.end(); iter++) {
+                    params[*iter] = root[*iter].asString();
                 }
             } else {
                 LOG_ERROR("Invalid String Error: " << reader.getFormatedErrorMessages());

--- a/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
+++ b/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
@@ -143,7 +143,7 @@ namespace pulsar {
         size_t length = strlen(input);
         char *result = (char*)malloc(length);
 
-        bio = BIO_new_mem_buf(input, -1);
+        bio = BIO_new_mem_buf((void *)input, -1);
         b64 = BIO_new(BIO_f_base64());
         bio = BIO_push(b64, bio);
 

--- a/pulsar-client-cpp/lib/auth/athenz/ZTSClient.h
+++ b/pulsar-client-cpp/lib/auth/athenz/ZTSClient.h
@@ -20,6 +20,7 @@
 #include <map>
 #include <lib/LogUtils.h>
 #include <boost/thread.hpp>
+#pragma GCC visibility push(default)
 
 namespace pulsar {
 
@@ -61,3 +62,4 @@ namespace pulsar {
         friend class ZTSClientWrapper;
     };
 }
+#pragma GCC visibility pop


### PR DESCRIPTION
Have removed C++11 features, made the header visible to work with -fvisibility=hidden and added a type caste for BIO_new_mem_buf input - some compilers don't do it implicitly.