### PR TITLE
Use thread local to allocate temp byte[] instead of allocator

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/Commands.java
@@ -71,10 +71,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.RecyclableDuplicateByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.buffer.UnpooledByteBufAllocator;
-import io.netty.buffer.UnpooledHeapByteBuf;
-import io.netty.util.Recycler;
-import io.netty.util.Recycler.Handle;
 
 public class Commands {
 
@@ -822,32 +818,6 @@ public class Commands {
     private static int getCurrentProtocolVersion() {
         // Return the last ProtocolVersion enum value
         return ProtocolVersion.values()[ProtocolVersion.values().length - 1].getNumber();
-    }
-
-    public static final class RecyclableHeapByteBuf extends UnpooledHeapByteBuf {
-        private static final Recycler<RecyclableHeapByteBuf> RECYCLER = new Recycler<RecyclableHeapByteBuf>() {
-            @Override
-            protected RecyclableHeapByteBuf newObject(Handle handle) {
-                return new RecyclableHeapByteBuf(handle);
-            }
-        };
-
-        private final Handle handle;
-
-        private RecyclableHeapByteBuf(Handle handle) {
-            super(UnpooledByteBufAllocator.DEFAULT, 4096, PulsarDecoder.MaxMessageSize);
-            this.handle = handle;
-        }
-
-        public static RecyclableHeapByteBuf get() {
-            return RECYCLER.get();
-
-        }
-
-        public void recycle() {
-            clear();
-            RECYCLER.recycle(this, handle);
-        }
     }
 
     public static enum ChecksumType {


### PR DESCRIPTION
### Motivation

When serializing/deserializing protobuf, we use a temporary `byte[]` to extract data from a direct byte buffer and wrap it in a protobuf `ByteString` object.

The current implementation is using a `RecyclableHeapByteBuf` to get a heap buffer from a pool and releasing it immediately in the same thread. 

The problem is that the Netty ByteBuf allocator is allocating a new local heap arena for each thread, using 16Mb `byte[]`. If there are many threads doing serialization/deserialization, this can end up using a lot of heap mem: 16Mb per thread.

Since we really need just 1 tiny temp buffer, we can achieve that more easily with a thread local `byte[]` which will not need to have the arena for allocation.
