### PR TITLE
Restrict partitioned-metadata rest-api access for cpp-client older than 1.21

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -105,6 +105,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private int defaultNumberOfNamespaceBundles = 4;
 
     // Enable check for minimum allowed client library version
+    @FieldContext(dynamic = true)
     private boolean clientLibraryVersionCheckEnabled = false;
     // Allow client libraries with no version information
     private boolean clientLibraryVersionCheckAllowUnversioned = true;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/PersistentTopics.java
@@ -107,7 +107,6 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.google.common.primitives.Doubles;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
@@ -1501,7 +1500,7 @@ public class PersistentTopics extends AdminResource {
                 if (splits != null && splits.length > 1) {
                     if (LEAST_SUPPORTED_CLIENT_VERSION_PREFIX.getMajorVersion() > Integer.parseInt(splits[0])
                             || LEAST_SUPPORTED_CLIENT_VERSION_PREFIX.getMinorVersion() > Integer.parseInt(splits[1])) {
-                        throw new UnsupportedOperationException("version " + tokens[1] + " is not supported");
+                        throw new UnsupportedOperationException("version " + userAgent + " is not supported");
                     }
                 }
             } catch (UnsupportedOperationException ue) {


### PR DESCRIPTION
### Motivation

As per #836 CPP-client older than 1.21 should not allow to create producers/consumers for partitioned-topic. As we discussed in #827, we should have a way to prevent it at broker. The easiest way to reject partitioned-metadata-request for partitioned-topics coming from old-legacy cpp-client.
Right now, client-lib gets partitioned topic metadata using http or binary-protocol.

**1. http**
- Pulsar-client-java library: always used to pass client-version using `userAgent` header-value.
- Pulsar-client-cpp library: was not passing `userAgent` header-value until 1.20 in #765 where it passes version as `Pulsar-CPP-vX`
Therefore, we can reject all http-requests for partitioned metadata if it has empty version or version which is < 1.21

**2. Binary-lookup**
 client-version placeholder was introduced in 1.18 version in #387. So, we can't validate request based on version in binaryProtocol. However, none of the client uses binary-proto-lookup yet. So, we can silently ignore validation on binary-lookup as we don't have a way to validate.


### Modifications

- Introduce client-cpp version validation for partitioned-metadata-lookup.
- Make validation dynamic configurable so, we can disable/enable if we see potential client impact.

### Result

Broker can be dynamically enabled to validate incompatible cpp-client library to access partitioned-topic.
