### PR TITLE
Reduce the default per-thread retained objects in netty Recycler

### DIFF
--- a/conf/bkenv.sh
+++ b/conf/bkenv.sh
@@ -39,7 +39,7 @@ BOOKIE_MEM=" -Xms2g -Xmx2g -XX:MaxDirectMemorySize=2g"
 BOOKIE_GC=" -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB"
 
 # Extra options to be passed to the jvm
-BOOKIE_EXTRA_OPTS="${BOOKIE_MEM} ${BOOKIE_GC} -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024"
+BOOKIE_EXTRA_OPTS="${BOOKIE_MEM} ${BOOKIE_GC} -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.maxCapacity.default=1000 -Dio.netty.recycler.linkCapacity=1024"
 
 # Add extra paths to the bookkeeper classpath
 # BOOKIE_EXTRA_CLASSPATH=

--- a/conf/pulsar_env.sh
+++ b/conf/pulsar_env.sh
@@ -48,7 +48,7 @@ PULSAR_MEM=" -Xms2g -Xmx2g -XX:MaxDirectMemorySize=4g"
 PULSAR_GC=" -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB"
 
 # Extra options to be passed to the jvm
-PULSAR_EXTRA_OPTS="${PULSAR_MEM} ${PULSAR_GC} -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024"
+PULSAR_EXTRA_OPTS="${PULSAR_MEM} ${PULSAR_GC} -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.maxCapacity.default=1000 -Dio.netty.recycler.linkCapacity=1024"
 
 # Add extra paths to the bookkeeper classpath
 # PULSAR_EXTRA_CLASSPATH=


### PR DESCRIPTION
### Motivation

By default, netty recyclers can accumulate up to 32K messages on each thread's queues. This can result in lots of objects being retained and in same workload scenarios it will lead to high GC pauses. 

### Modifications
Reduce the max amount of object to retain in the pool.