### PR TITLE
Add debug logs for LoadManager and cleanup unncessary logs

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/cache/ConfigurationCacheService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/cache/ConfigurationCacheService.java
@@ -56,7 +56,7 @@ public class ConfigurationCacheService {
     private ZooKeeperDataCache<NamespaceIsolationPolicies> namespaceIsolationPoliciesCache;
 
     public static final String POLICIES = "policies";
-    protected static final String POLICIES_ROOT = "/admin/policies";
+    public static final String POLICIES_ROOT = "/admin/policies";
     private static final String CLUSTERS_ROOT = "/admin/clusters";
 
     public ConfigurationCacheService(ZooKeeperCache cache) throws PulsarServerException {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
@@ -24,6 +24,7 @@ import org.apache.bookkeeper.client.BookKeeperAdmin;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory;
 import org.apache.bookkeeper.util.ZkUtils;
+import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES_ROOT;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.zookeeper.ZooKeeperClientFactory;
@@ -110,7 +111,7 @@ public class PulsarClusterMetadataSetup {
         localZk.create("/namespace", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
 
         try {
-            ZkUtils.createFullPathOptimistic(globalZk, "/admin/policies", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE,
+            ZkUtils.createFullPathOptimistic(globalZk, POLICIES_ROOT, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE,
                     CreateMode.PERSISTENT);
         } catch (NodeExistsException e) {
             // Ignore

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -35,6 +35,7 @@ import java.util.function.Supplier;
 
 import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.bookkeeper.util.OrderedSafeExecutor;
+import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.pulsar.broker.admin.AdminResource;
 import org.apache.pulsar.broker.cache.ConfigurationCacheService;
 import org.apache.pulsar.broker.cache.LocalZooKeeperCacheService;
@@ -338,7 +339,8 @@ public class PulsarService implements AutoCloseable {
             acquireSLANamespace();
 
             LOG.info("messaging service is ready, bootstrap service on port={}, broker url={}, cluster={}, configs={}",
-                    config.getWebServicePort(), brokerServiceUrl, config.getClusterName(), config);
+                    config.getWebServicePort(), brokerServiceUrl, config.getClusterName(),
+                    ReflectionToStringBuilder.toString(config));
         } catch (Exception e) {
             LOG.error(e.getMessage(), e);
             throw new PulsarServerException(e);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/TimeAverageBrokerData.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/TimeAverageBrokerData.java
@@ -24,6 +24,8 @@ import java.util.Set;
 import org.apache.pulsar.policies.data.loadbalancer.JSONWritable;
 import org.apache.pulsar.policies.data.loadbalancer.NamespaceBundleStats;
 
+import com.google.common.base.Objects;
+
 /**
  * Data class aggregating the short term and long term data across all bundles belonging to a broker.
  */
@@ -168,5 +170,15 @@ public class TimeAverageBrokerData extends JSONWritable {
 
     public void setLongTermMsgRateOut(double longTermMsgRateOut) {
         this.longTermMsgRateOut = longTermMsgRateOut;
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this).add("shortTermMsgThroughputIn", shortTermMsgThroughputIn)
+                .add("shortTermMsgThroughputOut", shortTermMsgThroughputOut)
+                .add("shortTermMsgRateIn", shortTermMsgRateIn).add("shortTermMsgRateOut", shortTermMsgRateOut)
+                .add("longTermMsgThroughputIn", longTermMsgThroughputIn)
+                .add("longTermMsgThroughputOut", longTermMsgThroughputOut).add("longTermMsgRateIn", longTermMsgRateIn)
+                .add("longTermMsgRateOut", longTermMsgRateOut).toString();
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -187,9 +187,6 @@ public abstract class AdminResource extends PulsarWebResource {
      */
     protected List<String> getListOfNamespaces(String property) throws Exception {
         List<String> namespaces = Lists.newArrayList();
-        // First get the list of cluster nodes
-        log.info("Children of {} : {}", path(POLICIES, property),
-                globalZk().getChildren(path(POLICIES, property), null));
 
         for (String cluster : globalZk().getChildren(path(POLICIES, property), false)) {
             // Then get the list of namespaces

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -421,6 +421,9 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
 
     // Update both the broker data and the bundle data.
     private void updateAll() {
+        if (log.isDebugEnabled()) {
+            log.debug("Updating broker and bundle data for loadreport");
+        }
         updateAllBrokerData();
         updateBundleData();
         // broker has latest load-report: check if any bundle requires split
@@ -678,6 +681,9 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
 
             // Choose a broker among the potentially smaller filtered list, when possible
             String broker = placementStrategy.selectBroker(brokerCandidateCache, data, loadData, conf);
+            if (log.isDebugEnabled()) {
+                log.debug("Selected broker {} from candidate brokers {}", broker, brokerCandidateCache);
+            }
 
             final double overloadThreshold = conf.getLoadBalancerBrokerOverloadedThresholdPercentage() / 100.0;
             final double maxUsage = loadData.getBrokerData().get(broker).getLocalData().getMaxResourceUsage();
@@ -825,6 +831,9 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
                 final String zooKeeperPath = TIME_AVERAGE_BROKER_ZPATH + "/" + broker;
                 createZPathIfNotExists(zkClient, zooKeeperPath);
                 zkClient.setData(zooKeeperPath, data.getJsonBytes(), -1);
+                if (log.isDebugEnabled()) {
+                    log.debug("Writing zookeeper report {}", data);
+                }
             } catch (Exception e) {
                 log.warn("Error when writing time average broker data for {} to ZooKeeper: {}", broker, e);
             }


### PR DESCRIPTION
### Motivation

- Added some more debug logs into `ModularLoadManager` to understand it's behavior in certain conditions.
- Clean up unnecessary log under `AdminResource.java`
- Fix: `PulsarService.java` is not printing `ServiceConfiguration.proprties`  at startup.

### Result

No functional changes.
