### PR TITLE
E2e in perf-consumer

### DIFF
--- a/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/DiscoveryService.java
+++ b/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/DiscoveryService.java
@@ -104,13 +104,13 @@ public class DiscoveryService implements Closeable {
         bootstrap.childHandler(new ServiceChannelInitializer(this, config, false));
         // Bind and start to accept incoming connections.
         bootstrap.bind(config.getServicePort()).sync();
-        LOG.info("Started Pulsar Discovery service on port {}", config.getWebServicePort());
+        LOG.info("Started Pulsar Discovery service on port {}", config.getServicePort());
 
         if (config.isTlsEnabled()) {
             ServerBootstrap tlsBootstrap = bootstrap.clone();
             tlsBootstrap.childHandler(new ServiceChannelInitializer(this, config, true));
             tlsBootstrap.bind(config.getServicePortTls()).sync();
-            LOG.info("Started Pulsar Discovery TLS service on port {}", config.getWebServicePortTls());
+            LOG.info("Started Pulsar Discovery TLS service on port {}", config.getServicePortTls());
         }
     }
 

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -282,6 +282,13 @@ public class PerformanceConsumer {
         log.info("Start receiving from {} consumers on {} destinations", arguments.numConsumers,
                 arguments.numDestinations);
 
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            public void run() {
+                printAggregatedStats();
+            }
+        });
+
+
         long oldTime = System.nanoTime();
 
         Histogram reportHistogram = null;
@@ -319,7 +326,6 @@ public class PerformanceConsumer {
         }
 
         pulsarClient.close();
-        printAggregatedStats();
     }
     private static void printAggregatedStats() {
         Histogram reportHistogram = cumulativeRecorder.getIntervalHistogram();

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -23,8 +23,6 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.text.DecimalFormat;
@@ -36,12 +34,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
 
 import org.HdrHistogram.Histogram;
-import org.HdrHistogram.HistogramLogWriter;
 import org.HdrHistogram.Recorder;
 import org.apache.pulsar.client.api.ClientConfiguration;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerConfiguration;
-import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
 import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.EncryptionKeyInfo;
 import org.apache.pulsar.client.api.Message;
@@ -49,7 +45,6 @@ import org.apache.pulsar.client.api.MessageListener;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
-import org.apache.pulsar.common.api.proto.PulsarApi.KeyValue;
 import org.apache.pulsar.common.naming.DestinationName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,7 +62,7 @@ public class PerformanceConsumer {
     private static final LongAdder bytesReceived = new LongAdder();
     private static final DecimalFormat dec = new DecimalFormat("0.000");
 
-    private static Recorder recorder = new Recorder(TimeUnit.SECONDS.toMillis(120000), 5);
+    private static Recorder recorder = new Recorder(TimeUnit.DAYS.toMillis(90), 5);
 
     static class Arguments {
 

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.testclient;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -203,8 +204,8 @@ public class PerformanceConsumer {
                     limiter.acquire();
                 }
 
-                long latencyMills = System.currentTimeMillis() - msg.getPublishTime();
-                recorder.recordValue(latencyMills);
+                long latencyMicros = MILLISECONDS.toMicros(System.currentTimeMillis() - msg.getPublishTime());
+                recorder.recordValue(latencyMicros);
 
                 consumer.acknowledgeAsync(msg);
             }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -206,9 +206,9 @@ public class PerformanceConsumer {
                     limiter.acquire();
                 }
 
-                long latencyMicros = MILLISECONDS.toMicros(System.currentTimeMillis() - msg.getPublishTime());
-                recorder.recordValue(latencyMicros);
-                cumulativeRecorder.recordValue(latencyMicros);
+                long latencyMillis = System.currentTimeMillis() - msg.getPublishTime();
+                recorder.recordValue(latencyMillis);
+                cumulativeRecorder.recordValue(latencyMillis);
 
                 consumer.acknowledgeAsync(msg);
             }
@@ -313,13 +313,13 @@ public class PerformanceConsumer {
             log.info(
                     "Throughput received: {}  msg/s -- {} Mbit/s --- Latency: mean: {} ms - med: {} - 95pct: {} - 99pct: {} - 99.9pct: {} - 99.99pct: {} - Max: {}",
                     dec.format(rate), dec.format(throughput),
-                    dec.format(reportHistogram.getMean() / 1000.0),
-                    dec.format(reportHistogram.getValueAtPercentile(50) / 1000.0),
-                    dec.format(reportHistogram.getValueAtPercentile(95) / 1000.0),
-                    dec.format(reportHistogram.getValueAtPercentile(99) / 1000.0),
-                    dec.format(reportHistogram.getValueAtPercentile(99.9) / 1000.0),
-                    dec.format(reportHistogram.getValueAtPercentile(99.99) / 1000.0),
-                    dec.format(reportHistogram.getMaxValue() / 1000.0));
+                    dec.format(reportHistogram.getMean()),
+                    dec.format(reportHistogram.getValueAtPercentile(50)),
+                    dec.format(reportHistogram.getValueAtPercentile(95)),
+                    dec.format(reportHistogram.getValueAtPercentile(99)),
+                    dec.format(reportHistogram.getValueAtPercentile(99.9)),
+                    dec.format(reportHistogram.getValueAtPercentile(99.99)),
+                    dec.format(reportHistogram.getMaxValue()));
 
             reportHistogram.reset();
             oldTime = now;
@@ -333,13 +333,13 @@ public class PerformanceConsumer {
         log.info(
                 "Aggregated latency stats --- Latency: mean: {} ms - med: {} - 95pct: {} - 99pct: {} - 99.9pct: {} - 99.99pct: {} - 99.999pct: {} - Max: {}",
                 dec.format(reportHistogram.getMean() / 1000.0),
-                dec.format(reportHistogram.getValueAtPercentile(50) / 1000.0),
-                dec.format(reportHistogram.getValueAtPercentile(95) / 1000.0),
-                dec.format(reportHistogram.getValueAtPercentile(99) / 1000.0),
-                dec.format(reportHistogram.getValueAtPercentile(99.9) / 1000.0),
-                dec.format(reportHistogram.getValueAtPercentile(99.99) / 1000.0),
-                dec.format(reportHistogram.getValueAtPercentile(99.999) / 1000.0),
-                dec.format(reportHistogram.getMaxValue() / 1000.0));
+                dec.format(reportHistogram.getValueAtPercentile(50)),
+                dec.format(reportHistogram.getValueAtPercentile(95)),
+                dec.format(reportHistogram.getValueAtPercentile(99)),
+                dec.format(reportHistogram.getValueAtPercentile(99.9)),
+                dec.format(reportHistogram.getValueAtPercentile(99.99)),
+                dec.format(reportHistogram.getValueAtPercentile(99.999)),
+                dec.format(reportHistogram.getMaxValue()));
     }
 
     private static final Logger log = LoggerFactory.getLogger(PerformanceConsumer.class);

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -62,7 +62,7 @@ public class PerformanceConsumer {
     private static final LongAdder bytesReceived = new LongAdder();
     private static final DecimalFormat dec = new DecimalFormat("0.000");
 
-    private static Recorder recorder = new Recorder(TimeUnit.DAYS.toMillis(90), 5);
+    private static Recorder recorder = new Recorder(TimeUnit.DAYS.toMillis(10), 5);
 
     static class Arguments {
 
@@ -203,8 +203,8 @@ public class PerformanceConsumer {
                     limiter.acquire();
                 }
 
-                long latencyMicros = NANOSECONDS.toMicros(System.nanoTime() - msg.getPublishTime());
-                recorder.recordValue(latencyMicros);
+                long latencyMills = System.currentTimeMillis() - msg.getPublishTime();
+                recorder.recordValue(latencyMills);
 
                 consumer.acknowledgeAsync(msg);
             }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -349,9 +349,9 @@ public class PerformanceProducer {
                             messagesSent.increment();
                             bytesSent.add(payloadData.length);
 
-                            long latencyMicros = NANOSECONDS.toMicros(System.nanoTime() - sendTime);
-                            recorder.recordValue(latencyMicros);
-                            cumulativeRecorder.recordValue(latencyMicros);
+                            long latencyMillis = NANOSECONDS.toMillis(System.nanoTime() - sendTime);
+                            recorder.recordValue(latencyMillis);
+                            cumulativeRecorder.recordValue(latencyMillis);
                         }).exceptionally(ex -> {
                             log.warn("Write error on message", ex);
                             System.exit(-1);

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -349,9 +349,9 @@ public class PerformanceProducer {
                             messagesSent.increment();
                             bytesSent.add(payloadData.length);
 
-                            long latencyMillis = NANOSECONDS.toMillis(System.nanoTime() - sendTime);
-                            recorder.recordValue(latencyMillis);
-                            cumulativeRecorder.recordValue(latencyMillis);
+                            long latencyMicros = NANOSECONDS.toMicros(System.nanoTime() - sendTime);
+                            recorder.recordValue(latencyMicros);
+                            cumulativeRecorder.recordValue(latencyMicros);
                         }).exceptionally(ex -> {
                             log.warn("Write error on message", ex);
                             System.exit(-1);


### PR DESCRIPTION
### Motivation

add end to end latency in performance consumer to see the e2e latency, besides fix typos in discoveryService

### Modifications

add end to end latency in PerformanceConsumer and change log out in DiscoveryService 

### Result

e2e latency in PerformanceConsumer and right log out in DiscoveryService
