### PR TITLE
Fixed getting the position in PulsarKafkaConsumer when we don't have an offset yet

### DIFF
--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
@@ -456,7 +456,8 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
 
     @Override
     public long position(TopicPartition partition) {
-        return lastReceivedOffset.get(partition);
+        Long offset = lastReceivedOffset.get(partition);
+        return offset != null ? offset : -1l;
     }
 
     @Override


### PR DESCRIPTION
### Motivation

Avoid NullPointerException when trying to get current position before starting getting messages.