### PR TITLE
Set error-message into RestException

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/RestException.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/RestException.java
@@ -48,7 +48,7 @@ public class RestException extends WebApplicationException {
     }
 
     public RestException(int code, String message) {
-        super(Response.status(code).entity(new ErrorData(message)).type(MediaType.APPLICATION_JSON).build());
+        super(message, Response.status(code).entity(new ErrorData(message)).type(MediaType.APPLICATION_JSON).build());
     }
 
     public RestException(Throwable t) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
@@ -626,4 +626,12 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         assertTrue(permission.isEmpty());
     }
 
+    @Test
+    public void testRestExceptionMessage() {
+        String message = "my-message";
+        RestException exception = new RestException(Status.PRECONDITION_FAILED, message);
+        assertEquals(exception.getMessage(), message);
+
+    }
+    
 }


### PR DESCRIPTION
### Motivation

Right now, `RestException(code, message)` doesn't set given message into the exception and `restException.getMessage()` doesn't return correct configured message-string which doesn't log correct information when broker tries to log message string using `restException.getMessage()`.

### Modifications

Set correct message-string into `RestException`.

### Result

`RestException.getMessage()` returns correct message-string.
