### PR TITLE
PIP-8: Introduce peer cluster for global namespace redirection

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -291,7 +291,11 @@ public abstract class AdminResource extends PulsarWebResource {
             String destination, boolean authoritative) {
         DestinationName dn = DestinationName.get(domain(), property, cluster, namespace, destination);
         validateClusterOwnership(dn.getCluster());
-
+        // validates global-namespace contains local/peer cluster: if peer/local cluster present then lookup can
+        // serve/redirect request else fail partitioned-metadata-request so, client fails while creating
+        // producer/consumer
+        validateGlobalNamespaceOwnership(dn.getNamespaceObject());
+        
         try {
             checkConnect(dn);
         } catch (WebApplicationException e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/Clusters.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/Clusters.java
@@ -18,9 +18,11 @@
  */
 package org.apache.pulsar.broker.admin;
 
+import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
+
 import java.io.IOException;
 import java.util.Collections;
-import java.util.List;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -40,7 +42,6 @@ import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.common.naming.NamedEntity;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.NamespaceIsolationData;
-import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.policies.impl.NamespaceIsolationPolicies;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.zookeeper.CreateMode;
@@ -52,13 +53,11 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.databind.JsonMappingException;
-import static com.google.common.base.Preconditions.checkArgument;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
 
 @Path("/clusters")
 @Api(value = "/clusters", description = "Cluster admin apis", tags = "clusters")
@@ -163,7 +162,7 @@ public class Clusters extends AdminResource {
             @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 412, message = "Peer cluster doesn't exist"),
             @ApiResponse(code = 404, message = "Cluster doesn't exist") })
-    public void setPeerClusterNames(@PathParam("cluster") String cluster, List<String> peerClusterNames) {
+    public void setPeerClusterNames(@PathParam("cluster") String cluster, LinkedHashSet<String> peerClusterNames) {
         validateSuperUserAccess();
         validatePoliciesReadOnlyAccess();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/Namespaces.java
@@ -24,9 +24,11 @@ import static org.apache.pulsar.broker.cache.LocalZooKeeperCacheService.LOCAL_PO
 
 import java.net.URI;
 import java.net.URL;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -80,11 +82,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.google.common.collect.Sets.SetView;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+
 import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
 
 @Path("/namespaces")
@@ -538,6 +543,7 @@ public class Namespaces extends AdminResource {
     @ApiOperation(value = "Set the replication clusters for a namespace.")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Property or cluster or namespace doesn't exist"),
+            @ApiResponse(code = 409, message = "Peer-cluster can't be part of replication-cluster"),
             @ApiResponse(code = 412, message = "Namespace is not global or invalid cluster ids") })
     public void setNamespaceReplicationClusters(@PathParam("property") String property,
             @PathParam("cluster") String cluster, @PathParam("namespace") String namespace, List<String> clusterIds) {
@@ -558,6 +564,7 @@ public class Namespaces extends AdminResource {
             if (!clusters.contains(clusterId)) {
                 throw new RestException(Status.FORBIDDEN, "Invalid cluster id: " + clusterId);
             }
+            validatePeerClusterConflict(clusterId, clusters);
         }
 
         for (String clusterId : clusterIds) {
@@ -1495,5 +1502,35 @@ public class Namespaces extends AdminResource {
         }
     }
 
+    /**
+     * It validates that peer-clusters can't coexist in replication-clusters
+     * 
+     * @param clusterName:
+     *            given cluster whose peer-clusters can't be present into replication-cluster list
+     * @param clusters:
+     *            replication-cluster list
+     */
+    private void validatePeerClusterConflict(String clusterName, Set<String> clusters) {
+        try {
+            Optional<ClusterData> clusterData = clustersCache().get(path("clusters", clusterName));
+            if (clusterData.isPresent()) {
+                LinkedHashSet<String> peerClusters = clusterData.get().getPeerClusterNames();
+                if (peerClusters != null && !peerClusters.isEmpty()) {
+                    SetView<String> conflictPeerClusters = Sets.intersection(peerClusters, clusters);
+                    if (!conflictPeerClusters.isEmpty()) {
+                        log.warn("[{}] {}'s peer cluster can't be part of replication clusters {}", clientAppId(),
+                                clusterName, conflictPeerClusters);
+                        throw new RestException(Status.CONFLICT, clusterName
+                                + "'s peer-clusters can't be part of replication-clusters " + conflictPeerClusters);
+                    }
+                }
+            }
+        } catch (RestException re) {
+            throw re;
+        } catch (Exception e) {
+            log.warn("[{}] Failed to get cluster-data for {}", clientAppId(), clusterName, e);
+        }
+    }
+    
     private static final Logger log = LoggerFactory.getLogger(Namespaces.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/Namespaces.java
@@ -361,6 +361,7 @@ public class Namespaces extends AdminResource {
 
         // ensure that non-global namespace is directed to the correct cluster
         validateClusterOwnership(cluster);
+
         Policies policies = getNamespacePolicies(property, cluster, namespace);
         // ensure the local cluster is the only cluster for the global namespace configuration
         try {
@@ -777,6 +778,9 @@ public class Namespaces extends AdminResource {
         if (!cluster.equals(Namespaces.GLOBAL_CLUSTER)) {
             validateClusterOwnership(cluster);
             validateClusterForProperty(property, cluster);
+        } else {
+            // check cluster ownership for a given global namespace: redirect if peer-cluster owns it
+            validateGlobalNamespaceOwnership(new NamespaceName(property, cluster, namespace));
         }
 
         Policies policies = getNamespacePolicies(property, cluster, namespace);
@@ -813,6 +817,9 @@ public class Namespaces extends AdminResource {
         if (!cluster.equals(Namespaces.GLOBAL_CLUSTER)) {
             validateClusterOwnership(cluster);
             validateClusterForProperty(property, cluster);
+        } else {
+            // check cluster ownership for a given global namespace: redirect if peer-cluster owns it
+            validateGlobalNamespaceOwnership(new NamespaceName(property, cluster, namespace));
         }
 
         NamespaceName fqnn = new NamespaceName(property, cluster, namespace);
@@ -851,6 +858,9 @@ public class Namespaces extends AdminResource {
         if (!cluster.equals(Namespaces.GLOBAL_CLUSTER)) {
             validateClusterOwnership(cluster);
             validateClusterForProperty(property, cluster);
+        } else {
+            // check cluster ownership for a given global namespace: redirect if peer-cluster owns it
+            validateGlobalNamespaceOwnership(new NamespaceName(property, cluster, namespace));
         }
 
         NamespaceName fqnn = new NamespaceName(property, cluster, namespace);
@@ -1264,6 +1274,9 @@ public class Namespaces extends AdminResource {
         if (!cluster.equals(Namespaces.GLOBAL_CLUSTER)) {
             validateClusterOwnership(cluster);
             validateClusterForProperty(property, cluster);
+        } else {
+            // check cluster ownership  for a given global namespace: redirect if peer-cluster owns it
+            validateGlobalNamespaceOwnership(new NamespaceName(property, cluster, namespace));
         }
 
         NamespaceName nsName = new NamespaceName(property, cluster, namespace);
@@ -1336,6 +1349,9 @@ public class Namespaces extends AdminResource {
         if (!cluster.equals(Namespaces.GLOBAL_CLUSTER)) {
             validateClusterOwnership(cluster);
             validateClusterForProperty(property, cluster);
+        } else {
+            // check cluster ownership  for a given global namespace: redirect if peer-cluster owns it
+            validateGlobalNamespaceOwnership(new NamespaceName(property, cluster, namespace));
         }
 
         NamespaceName nsName = new NamespaceName(property, cluster, namespace);
@@ -1406,6 +1422,9 @@ public class Namespaces extends AdminResource {
         if (!cluster.equals(Namespaces.GLOBAL_CLUSTER)) {
             validateClusterOwnership(cluster);
             validateClusterForProperty(property, cluster);
+        } else {
+            // check cluster ownership for a given global namespace: redirect if peer-cluster owns it
+            validateGlobalNamespaceOwnership(new NamespaceName(property, cluster, namespace));
         }
 
         NamespaceName nsName = new NamespaceName(property, cluster, namespace);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/NonPersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/NonPersistentTopics.java
@@ -36,6 +36,7 @@ import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.nonpersistent.NonPersistentTopic;
 import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.common.naming.DestinationName;
+import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.NonPersistentTopicStats;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
@@ -141,6 +142,9 @@ public class NonPersistentTopics extends PersistentTopics {
         log.info("[{}] Unloading topic {}/{}/{}/{}", clientAppId(), property, cluster, namespace, destination);
         destination = decode(destination);
         DestinationName dn = DestinationName.get(domain(), property, cluster, namespace, destination);
+        if (cluster.equals(Namespaces.GLOBAL_CLUSTER)) {
+            validateGlobalNamespaceOwnership(new NamespaceName(property, cluster, namespace));
+        }
         unloadTopic(dn, authoritative);
     }
     

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/PersistentTopics.java
@@ -89,6 +89,7 @@ import org.apache.pulsar.common.compression.CompressionCodec;
 import org.apache.pulsar.common.compression.CompressionCodecProvider;
 import org.apache.pulsar.common.naming.DestinationDomain;
 import org.apache.pulsar.common.naming.DestinationName;
+import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.AuthPolicies;
@@ -557,6 +558,9 @@ public class PersistentTopics extends AdminResource {
         log.info("[{}] Unloading topic {}/{}/{}/{}", clientAppId(), property, cluster, namespace, destination);
         destination = decode(destination);
         DestinationName dn = DestinationName.get(domain(), property, cluster, namespace, destination);
+        if (cluster.equals(Namespaces.GLOBAL_CLUSTER)) {
+            validateGlobalNamespaceOwnership(new NamespaceName(property, cluster, namespace));
+        }
         unloadTopic(dn, authoritative);
     }
 
@@ -602,6 +606,9 @@ public class PersistentTopics extends AdminResource {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         destination = decode(destination);
         DestinationName dn = DestinationName.get(domain(), property, cluster, namespace, destination);
+        if (cluster.equals(Namespaces.GLOBAL_CLUSTER)) {
+            validateGlobalNamespaceOwnership(new NamespaceName(property, cluster, namespace));
+        } 
         List<String> subscriptions = Lists.newArrayList();
         PartitionedTopicMetadata partitionMetadata = getPartitionedTopicMetadata(property, cluster, namespace,
                 destination, authoritative);
@@ -640,6 +647,9 @@ public class PersistentTopics extends AdminResource {
         destination = decode(destination);
         DestinationName dn = DestinationName.get(domain(), property, cluster, namespace, destination);
         validateAdminAndClientPermission(dn);
+        if (cluster.equals(Namespaces.GLOBAL_CLUSTER)) {
+            validateGlobalNamespaceOwnership(new NamespaceName(property, cluster, namespace));
+        } 
         validateDestinationOwnership(dn, authoritative);
         Topic topic = getTopicReference(dn);
         return topic.getStats();
@@ -657,6 +667,9 @@ public class PersistentTopics extends AdminResource {
         destination = decode(destination);
         DestinationName dn = DestinationName.get(domain(), property, cluster, namespace, destination);
         validateAdminAndClientPermission(dn);
+        if (cluster.equals(Namespaces.GLOBAL_CLUSTER)) {
+            validateGlobalNamespaceOwnership(new NamespaceName(property, cluster, namespace));
+        } 
         validateDestinationOwnership(dn, authoritative);
         Topic topic = getTopicReference(dn);
         return topic.getInternalStats();
@@ -673,7 +686,9 @@ public class PersistentTopics extends AdminResource {
         destination = decode(destination);
         DestinationName dn = DestinationName.get(domain(), property, cluster, namespace, destination);
         validateAdminAccessOnProperty(dn.getProperty());
-
+        if (cluster.equals(Namespaces.GLOBAL_CLUSTER)) {
+            validateGlobalNamespaceOwnership(new NamespaceName(property, cluster, namespace));
+        }
         String managedLedger = dn.getPersistenceNamingEncoding();
         pulsar().getManagedLedgerFactory().asyncGetManagedLedgerInfo(managedLedger, new ManagedLedgerInfoCallback() {
             @Override
@@ -706,6 +721,9 @@ public class PersistentTopics extends AdminResource {
         if (partitionMetadata.partitions == 0) {
             throw new RestException(Status.NOT_FOUND, "Partitioned Topic not found");
         }
+        if (cluster.equals(Namespaces.GLOBAL_CLUSTER)) {
+            validateGlobalNamespaceOwnership(new NamespaceName(property, cluster, namespace));
+        }
         PartitionedTopicStats stats = new PartitionedTopicStats(partitionMetadata);
         try {
             for (int i = 0; i < partitionMetadata.partitions; i++) {
@@ -732,6 +750,9 @@ public class PersistentTopics extends AdminResource {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         destination = decode(destination);
         DestinationName dn = DestinationName.get(domain(), property, cluster, namespace, destination);
+        if (cluster.equals(Namespaces.GLOBAL_CLUSTER)) {
+            validateGlobalNamespaceOwnership(new NamespaceName(property, cluster, namespace));
+        }
         PartitionedTopicMetadata partitionMetadata = getPartitionedTopicMetadata(property, cluster, namespace,
                 destination, authoritative);
         if (partitionMetadata.partitions > 0) {
@@ -778,6 +799,9 @@ public class PersistentTopics extends AdminResource {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         destination = decode(destination);
         DestinationName dn = DestinationName.get(domain(), property, cluster, namespace, destination);
+        if (cluster.equals(Namespaces.GLOBAL_CLUSTER)) {
+            validateGlobalNamespaceOwnership(new NamespaceName(property, cluster, namespace));
+        }
         PartitionedTopicMetadata partitionMetadata = getPartitionedTopicMetadata(property, cluster, namespace,
                 destination, authoritative);
         if (partitionMetadata.partitions > 0) {
@@ -825,6 +849,9 @@ public class PersistentTopics extends AdminResource {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         destination = decode(destination);
         DestinationName dn = DestinationName.get(domain(), property, cluster, namespace, destination);
+        if (cluster.equals(Namespaces.GLOBAL_CLUSTER)) {
+            validateGlobalNamespaceOwnership(new NamespaceName(property, cluster, namespace));
+        }
         PartitionedTopicMetadata partitionMetadata = getPartitionedTopicMetadata(property, cluster, namespace,
                 destination, authoritative);
         if (partitionMetadata.partitions > 0) {
@@ -876,6 +903,9 @@ public class PersistentTopics extends AdminResource {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         final String destination = decode(destinationName);
         DestinationName dn = DestinationName.get(domain(), property, cluster, namespace, destination);
+        if (cluster.equals(Namespaces.GLOBAL_CLUSTER)) {
+            validateGlobalNamespaceOwnership(new NamespaceName(property, cluster, namespace));
+        }
         PartitionedTopicMetadata partitionMetadata = getPartitionedTopicMetadata(property, cluster, namespace,
                 destination, authoritative);
         if (partitionMetadata.partitions > 0) {
@@ -914,6 +944,9 @@ public class PersistentTopics extends AdminResource {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         destination = decode(destination);
         DestinationName dn = DestinationName.get(domain(), property, cluster, namespace, destination);
+        if (cluster.equals(Namespaces.GLOBAL_CLUSTER)) {
+            validateGlobalNamespaceOwnership(new NamespaceName(property, cluster, namespace));
+        }
         PartitionedTopicMetadata partitionMetadata = getPartitionedTopicMetadata(property, cluster, namespace,
                 destination, authoritative);
 
@@ -989,6 +1022,9 @@ public class PersistentTopics extends AdminResource {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative, MessageIdImpl messageId) {
         destination = decode(destination);
         DestinationName dn = DestinationName.get(domain(), property, cluster, namespace, destination);
+        if (cluster.equals(Namespaces.GLOBAL_CLUSTER)) {
+            validateGlobalNamespaceOwnership(new NamespaceName(property, cluster, namespace));
+        }
         log.info("[{}][{}] received reset cursor on subscription {} to position {}", clientAppId(), destination,
                 subName, messageId);
 
@@ -1038,6 +1074,9 @@ public class PersistentTopics extends AdminResource {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         destination = decode(destination);
         DestinationName dn = DestinationName.get(domain(), property, cluster, namespace, destination);
+        if (cluster.equals(Namespaces.GLOBAL_CLUSTER)) {
+            validateGlobalNamespaceOwnership(new NamespaceName(property, cluster, namespace));
+        }
         PartitionedTopicMetadata partitionMetadata = getPartitionedTopicMetadata(property, cluster, namespace,
                 destination, authoritative);
         if (partitionMetadata.partitions > 0) {
@@ -1128,6 +1167,9 @@ public class PersistentTopics extends AdminResource {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         destination = decode(destination);
         validateAdminAccessOnProperty(property);
+        if (cluster.equals(Namespaces.GLOBAL_CLUSTER)) {
+            validateGlobalNamespaceOwnership(new NamespaceName(property, cluster, namespace));
+        }
         // Validate that namespace exists, throw 404 if it doesn't exist
         // note that we do not want to load the topic and hence skip validateAdminOperationOnDestination()
         try {
@@ -1176,6 +1218,9 @@ public class PersistentTopics extends AdminResource {
             @QueryParam("authoritative") @DefaultValue("false") boolean authoritative) {
         destination = decode(destination);
         DestinationName dn = DestinationName.get(domain(), property, cluster, namespace, destination);
+        if (cluster.equals(Namespaces.GLOBAL_CLUSTER)) {
+            validateGlobalNamespaceOwnership(new NamespaceName(property, cluster, namespace));
+        }
         PartitionedTopicMetadata partitionMetadata = getPartitionedTopicMetadata(property, cluster, namespace,
                 destination, authoritative);
         if (partitionMetadata.partitions > 0) {
@@ -1194,6 +1239,9 @@ public class PersistentTopics extends AdminResource {
     public void expireMessages(String property, String cluster, String namespace, String destination, String subName,
             int expireTimeInSeconds, boolean authoritative) {
         DestinationName dn = DestinationName.get(domain(), property, cluster, namespace, destination);
+        if (cluster.equals(Namespaces.GLOBAL_CLUSTER)) {
+            validateGlobalNamespaceOwnership(new NamespaceName(property, cluster, namespace));
+        }
         PartitionedTopicMetadata partitionMetadata = getPartitionedTopicMetadata(property, cluster, namespace,
                 destination, authoritative);
         if (partitionMetadata.partitions > 0) {
@@ -1260,18 +1308,24 @@ public class PersistentTopics extends AdminResource {
                         dn.toString(), ex.getMessage(), ex);
                 throw ex;
             }
+            
             String path = path(PARTITIONED_TOPIC_PATH_ZNODE, dn.getProperty(), dn.getCluster(),
                     dn.getNamespacePortion(), "persistent", dn.getEncodedLocalName());
-            fetchPartitionedTopicMetadataAsync(pulsar, path).thenAccept(metadata -> {
-                if (log.isDebugEnabled()) {
-                    log.debug("[{}] Total number of partitions for topic {} is {}", clientAppId, dn,
-                            metadata.partitions);
-                }
-                metadataFuture.complete(metadata);
-            }).exceptionally(ex -> {
-                metadataFuture.completeExceptionally(ex);
-                return null;
-            });
+            
+            // validates global-namespace contains local/peer cluster: if peer/local cluster present then lookup can
+            // serve/redirect request else fail partitioned-metadata-request so, client fails while creating
+            // producer/consumer
+            checkLocalOrGetPeerReplicationCluster(pulsar, dn.getNamespaceObject())
+                    .thenCompose(res -> fetchPartitionedTopicMetadataAsync(pulsar, path)).thenAccept(metadata -> {
+                        if (log.isDebugEnabled()) {
+                            log.debug("[{}] Total number of partitions for topic {} is {}", clientAppId, dn,
+                                    metadata.partitions);
+                        }
+                        metadataFuture.complete(metadata);
+                    }).exceptionally(ex -> {
+                        metadataFuture.completeExceptionally(ex.getCause());
+                        return null;
+                    });
         } catch (Exception ex) {
             metadataFuture.completeExceptionally(ex);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -38,7 +38,7 @@ import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.bookkeeper.mledger.util.SafeRun;
 import org.apache.pulsar.broker.authentication.AuthenticationDataCommand;
 import org.apache.pulsar.broker.service.BrokerServiceException.ServiceUnitNotReadyException;
-import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.BatchMessageIdImpl;
 import org.apache.pulsar.client.impl.MessageIdImpl;
@@ -223,8 +223,11 @@ public class ServerCnx extends PulsarHandler {
                                     } else {
                                         log.warn("Failed to get Partitioned Metadata [{}] {}: {}", remoteAddress, topic,
                                                 ex.getMessage(), ex);
-                                        ctx.writeAndFlush(Commands.newPartitionMetadataResponse(
-                                                ServerError.ServiceNotReady, ex.getMessage(), requestId));
+                                        ServerError error = (ex instanceof RestException)
+                                                && ((RestException) ex).getResponse().getStatus() < 500
+                                                        ? ServerError.MetadataError : ServerError.ServiceNotReady;
+                                        ctx.writeAndFlush(Commands.newPartitionMetadataResponse(error, ex.getMessage(),
+                                                requestId));
                                     }
                                 }
                                 lookupSemaphore.release();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/RestException.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/RestException.java
@@ -48,7 +48,7 @@ public class RestException extends WebApplicationException {
     }
 
     public RestException(int code, String message) {
-        super(Response.status(code).entity(new ErrorData(message)).type(MediaType.APPLICATION_JSON).build());
+        super(message, Response.status(code).entity(new ErrorData(message)).type(MediaType.APPLICATION_JSON).build());
     }
 
     public RestException(Throwable t) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PeerReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PeerReplicatorTest.java
@@ -1,0 +1,154 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.client.api.ClientConfiguration;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.common.policies.data.PersistentTopicStats;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.testng.collections.Lists;
+
+public class PeerReplicatorTest extends ReplicatorTestBase {
+
+    @Override
+    @BeforeClass
+    void setup() throws Exception {
+        super.setup();
+    }
+
+    @Override
+    @AfterClass
+    void shutdown() throws Exception {
+        super.shutdown();
+    }
+
+    @DataProvider(name = "lookupType")
+    public Object[][] codecProvider() {
+        return new Object[][] { { "http" }, { "binary" } };
+    }
+
+    /**
+     * It verifies that lookup/admin requests for global-namespace would be redirected to peer-cluster if local cluster
+     * doesn't own it and peer-cluster owns it, else request will be failed.
+     * <pre>
+     * 1. Create global-namespace ns1 for replication cluster-r1
+     * 2. Try to create producer using broker in cluster r3
+     * 3. Reject lookup: "r3" receives request and doesn't find namespace in local/peer cluster
+     * 4. Add "r1" as a peer-cluster into "r3"
+     * 5. Try to create producer using broker in cluster r3
+     * 6. Success : "r3" finds "r1" in peer cluster which owns n1 and redirects to "r1"
+     * 7. call admin-api to "r3" which redirects request to "r1"
+     * 
+     * </pre>
+     * 
+     * @param protocol
+     * @throws Exception
+     */
+    @Test(dataProvider = "lookupType")
+    public void testPeerClusterTopicLookup(String protocol) throws Exception {
+
+        final String serviceUrl = protocol.equalsIgnoreCase("http") ? pulsar3.getWebServiceAddress()
+                : pulsar3.getBrokerServiceUrl();
+        final String namespace1 = "pulsar/global/peer1-" + protocol;
+        final String namespace2 = "pulsar/global/peer2-" + protocol;
+        admin1.namespaces().createNamespace(namespace1);
+        admin1.namespaces().createNamespace(namespace2);
+        // add replication cluster
+        admin1.namespaces().setNamespaceReplicationClusters(namespace1, Lists.newArrayList("r1"));
+        admin1.namespaces().setNamespaceReplicationClusters(namespace2, Lists.newArrayList("r2"));
+        admin1.clusters().updatePeerClusterNames("r3", null);
+        // disable tls as redirection url is prepared according tls configuration
+        pulsar1.getConfiguration().setTlsEnabled(false);
+        pulsar2.getConfiguration().setTlsEnabled(false);
+        pulsar3.getConfiguration().setTlsEnabled(false);
+
+        final String topic1 = "persistent://" + namespace1 + "/topic1";
+        final String topic2 = "persistent://" + namespace2 + "/topic2";
+        ClientConfiguration conf = new ClientConfiguration();
+        conf.setStatsInterval(0, TimeUnit.SECONDS);
+
+        PulsarClient client3 = PulsarClient.create(serviceUrl, conf);
+        Producer producer;
+        try {
+            // try to create producer for topic1 (part of cluster: r1) by calling cluster: r3
+            producer = client3.createProducer(topic1);
+            fail("should have failed as cluster:r3 doesn't own namespace");
+        } catch (PulsarClientException e) {
+            // Ok
+        }
+
+        try {
+            // try to create producer for topic2 (part of cluster: r2) by calling cluster: r3
+            producer = client3.createProducer(topic2);
+            fail("should have failed as cluster:r3 doesn't own namespace");
+        } catch (PulsarClientException e) {
+            // Ok
+        }
+
+        // set peer-clusters : r3->r1
+        admin1.clusters().updatePeerClusterNames("r3", Lists.newArrayList("r1"));
+        producer = client3.createProducer(topic1);
+        PersistentTopic topic = (PersistentTopic) pulsar1.getBrokerService().getTopic(topic1).get();
+        assertNotNull(topic);
+        pulsar1.getBrokerService().updateRates();
+        // get stats for topic1 using cluster-r3's admin3
+        PersistentTopicStats stats = admin1.persistentTopics().getStats(topic1);
+        assertNotNull(stats);
+        assertEquals(stats.publishers.size(), 1);
+        stats = admin3.persistentTopics().getStats(topic1);
+        assertNotNull(stats);
+        assertEquals(stats.publishers.size(), 1);
+        producer.close();
+
+        // set peer-clusters : r3->r2
+        admin2.clusters().updatePeerClusterNames("r3", Lists.newArrayList("r2"));
+        producer = client3.createProducer(topic2);
+        topic = (PersistentTopic) pulsar2.getBrokerService().getTopic(topic2).get();
+        assertNotNull(topic);
+        pulsar2.getBrokerService().updateRates();
+        // get stats for topic1 using cluster-r3's admin3
+        stats = admin3.persistentTopics().getStats(topic2);
+        assertNotNull(stats);
+        assertEquals(stats.publishers.size(), 1);
+        stats = admin3.persistentTopics().getStats(topic2);
+        assertNotNull(stats);
+        assertEquals(stats.publishers.size(), 1);
+        producer.close();
+
+        client3.close();
+
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(PeerReplicatorTest.class);
+
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PeerReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PeerReplicatorTest.java
@@ -38,6 +38,8 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
 
+import com.google.common.collect.Sets;
+
 public class PeerReplicatorTest extends ReplicatorTestBase {
 
     @Override
@@ -116,7 +118,7 @@ public class PeerReplicatorTest extends ReplicatorTestBase {
         }
 
         // set peer-clusters : r3->r1
-        admin1.clusters().updatePeerClusterNames("r3", Lists.newArrayList("r1"));
+        admin1.clusters().updatePeerClusterNames("r3", Sets.newLinkedHashSet(Lists.newArrayList("r1")));
         producer = client3.createProducer(topic1);
         PersistentTopic topic = (PersistentTopic) pulsar1.getBrokerService().getTopic(topic1).get();
         assertNotNull(topic);
@@ -131,7 +133,7 @@ public class PeerReplicatorTest extends ReplicatorTestBase {
         producer.close();
 
         // set peer-clusters : r3->r2
-        admin2.clusters().updatePeerClusterNames("r3", Lists.newArrayList("r2"));
+        admin2.clusters().updatePeerClusterNames("r3", Sets.newLinkedHashSet(Lists.newArrayList("r2")));
         producer = client3.createProducer(topic2);
         topic = (PersistentTopic) pulsar2.getBrokerService().getTopic(topic2).get();
         assertNotNull(topic);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -182,7 +182,10 @@ public class ReplicatorTest extends ReplicatorTestBase {
 
         log.info("--- Starting ReplicatorTest::testConcurrentReplicator ---");
 
-        final DestinationName dest = DestinationName.get(String.format("persistent://pulsar/global/ns1/topic-%d", 0));
+        final String namespace = "pulsar/global/concurrent";
+        admin1.namespaces().createNamespace(namespace);
+        admin1.namespaces().setNamespaceReplicationClusters(namespace, Lists.newArrayList("r1", "r2"));
+        final DestinationName dest = DestinationName.get(String.format("persistent://" + namespace + "/topic-%d", 0));
         ClientConfiguration conf = new ClientConfiguration();
         conf.setStatsInterval(0, TimeUnit.SECONDS);
         Producer producer = PulsarClient.create(url1.toString(), conf).createProducer(dest.toString());
@@ -200,6 +203,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
                 .get(pulsar1.getBrokerService());
         replicationClients.put("r3", pulsarClient);
 
+        admin1.namespaces().setNamespaceReplicationClusters(namespace, Lists.newArrayList("r1", "r2", "r3"));
         ExecutorService executor = Executors.newFixedThreadPool(5);
         for (int i = 0; i < 5; i++) {
             executor.submit(() -> {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTestBase.java
@@ -224,16 +224,7 @@ public class ReplicatorTestBase {
         assertEquals(admin2.clusters().getCluster("r1").getBrokerServiceUrl(), pulsar1.getBrokerServiceUrl());
         assertEquals(admin2.clusters().getCluster("r2").getBrokerServiceUrl(), pulsar2.getBrokerServiceUrl());
         assertEquals(admin2.clusters().getCluster("r3").getBrokerServiceUrl(), pulsar3.getBrokerServiceUrl());
-        /*
-         * assertEquals(admin2.clusters().getCluster("global").getServiceUrl(), "http://global:8080");
-         * assertEquals(admin2.properties().getPropertyAdmin("pulsar").getAdminRoles(), Lists.newArrayList("appid1",
-         * "appid2")); assertEquals(admin2.namespaces().getPolicies("pulsar/global/ns").replication_clusters,
-         * Lists.newArrayList("r1", "r2", "r3"));
-         *
-         * admin1.namespaces().createNamespace("pulsar/global/ns2");
-         * admin1.namespaces().setNamespaceReplicationClusters("pulsar/global/ns2", Lists.newArrayList("r1", "r2",
-         * "r3"));
-         */
+
         Thread.sleep(100);
         log.info("--- ReplicatorTestBase::setup completed ---");
 
@@ -252,13 +243,8 @@ public class ReplicatorTestBase {
         admin3.close();
 
         pulsar3.close();
-        ns3.close();
-
         pulsar2.close();
-        ns2.close();
-
         pulsar1.close();
-        ns1.close();
 
         bkEnsemble1.stop();
         bkEnsemble2.stop();

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Clusters.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Clusters.java
@@ -112,6 +112,25 @@ public interface Clusters {
      *             Unexpected error
      */
     void updateCluster(String cluster, ClusterData clusterData) throws PulsarAdminException;
+    
+    /**
+     * Update peer cluster names.
+     * <p>
+     * This operation requires Pulsar super-user privileges.
+     *
+     * @param cluster
+     *            Cluster name
+     * @param peerClusterNames
+     *            list of peer cluster names
+     *
+     * @throws NotAuthorizedException
+     *             You don't have admin permission to create the cluster
+     * @throws NotFoundException
+     *             Cluster doesn't exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void updatePeerClusterNames(String cluster, List<String> peerClusterNames) throws PulsarAdminException;
 
     /**
      * Delete an existing cluster

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Clusters.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Clusters.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.admin;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -130,7 +131,7 @@ public interface Clusters {
      * @throws PulsarAdminException
      *             Unexpected error
      */
-    void updatePeerClusterNames(String cluster, List<String> peerClusterNames) throws PulsarAdminException;
+    void updatePeerClusterNames(String cluster, LinkedHashSet<String> peerClusterNames) throws PulsarAdminException;
 
     /**
      * Delete an existing cluster

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ClustersImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ClustersImpl.java
@@ -82,6 +82,17 @@ public class ClustersImpl extends BaseResource implements Clusters {
     }
 
     @Override
+    public void updatePeerClusterNames(String cluster, List<String> peerClusterNames) throws PulsarAdminException {
+        try {
+            request(clusters.path(cluster).path("peers")).post(Entity.entity(peerClusterNames, MediaType.APPLICATION_JSON),
+                    ErrorData.class);
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+        
+    }
+
+    @Override
     public void deleteCluster(String cluster) throws PulsarAdminException {
         try {
             request(clusters.path(cluster)).delete(ErrorData.class);

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ClustersImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ClustersImpl.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.admin.internal;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -82,7 +83,7 @@ public class ClustersImpl extends BaseResource implements Clusters {
     }
 
     @Override
-    public void updatePeerClusterNames(String cluster, List<String> peerClusterNames) throws PulsarAdminException {
+    public void updatePeerClusterNames(String cluster, LinkedHashSet<String> peerClusterNames) throws PulsarAdminException {
         try {
             request(clusters.path(cluster).path("peers")).post(Entity.entity(peerClusterNames, MediaType.APPLICATION_JSON),
                     ErrorData.class);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
@@ -18,12 +18,14 @@
  */
 package org.apache.pulsar.admin.cli;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.policies.data.ClusterData;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
+import com.beust.jcommander.internal.Lists;
 
 @Parameters(commandDescription = "Operations about clusters")
 public class CmdClusters extends CmdBase {
@@ -105,6 +107,22 @@ public class CmdClusters extends CmdBase {
         }
     }
 
+    @Parameters(commandDescription = "Update peer cluster names")
+    private class UpdatePeerClusters extends CliCommand {
+        @Parameter(description = "cluster-name\n", required = true)
+        private java.util.List<String> params;
+
+        @Parameter(names = "--peer-clusters", description = "Comma separated peer-cluster names [Pass empty string \"\" to delete list]", required = true)
+        private String peerClusterNames;
+
+        void run() throws PulsarAdminException {
+            String cluster = getOneArgument(params);
+            java.util.List<String> clusters = StringUtils.isBlank(peerClusterNames) ? null
+                    : Lists.newArrayList(peerClusterNames.split(","));
+            admin.clusters().updatePeerClusterNames(cluster, clusters);
+        }
+    }
+
     public CmdClusters(PulsarAdmin admin) {
         super("clusters", admin);
         jcommander.addCommand("get", new Get());
@@ -112,6 +130,7 @@ public class CmdClusters extends CmdBase {
         jcommander.addCommand("update", new Update());
         jcommander.addCommand("delete", new Delete());
         jcommander.addCommand("list", new List());
+        jcommander.addCommand("update-peer-clusters", new UpdatePeerClusters());
     }
 
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.admin.cli;
 
+import java.util.Arrays;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -25,7 +27,7 @@ import org.apache.pulsar.common.policies.data.ClusterData;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
-import com.beust.jcommander.internal.Lists;
+import com.google.common.collect.Sets;
 
 @Parameters(commandDescription = "Operations about clusters")
 public class CmdClusters extends CmdBase {
@@ -117,8 +119,8 @@ public class CmdClusters extends CmdBase {
 
         void run() throws PulsarAdminException {
             String cluster = getOneArgument(params);
-            java.util.List<String> clusters = StringUtils.isBlank(peerClusterNames) ? null
-                    : Lists.newArrayList(peerClusterNames.split(","));
+            java.util.LinkedHashSet<String> clusters = StringUtils.isBlank(peerClusterNames) ? null
+                    : Sets.newLinkedHashSet(Arrays.asList(peerClusterNames.split(",")));
             admin.clusters().updatePeerClusterNames(cluster, clusters);
         }
     }

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -148,6 +148,9 @@ public class PulsarAdminToolTest {
 
         clusters.run(split("delete my-cluster"));
         verify(mockClusters).deleteCluster("my-cluster");
+
+        clusters.run(split("update-peer-clusters my-cluster --peer-clusters c1,c2"));
+        verify(mockClusters).updatePeerClusterNames("my-cluster", Lists.newArrayList("c1", "c2"));
     }
 
     @Test

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -150,7 +150,7 @@ public class PulsarAdminToolTest {
         verify(mockClusters).deleteCluster("my-cluster");
 
         clusters.run(split("update-peer-clusters my-cluster --peer-clusters c1,c2"));
-        verify(mockClusters).updatePeerClusterNames("my-cluster", Lists.newArrayList("c1", "c2"));
+        verify(mockClusters).updatePeerClusterNames("my-cluster", Sets.newLinkedHashSet(Lists.newArrayList("c1", "c2")));
     }
 
     @Test

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterData.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterData.java
@@ -120,21 +120,9 @@ public class ClusterData {
 
     @Override
     public String toString() {
-        StringBuilder str = new StringBuilder();
-        str.append(serviceUrl);
-        if (serviceUrlTls != null && !serviceUrlTls.isEmpty()) {
-            str.append(",");
-            str.append(serviceUrlTls);
-        }
-        if (brokerServiceUrl != null && !brokerServiceUrl.isEmpty()) {
-            str.append(",");
-            str.append(brokerServiceUrl);
-        }
-        if (brokerServiceUrlTls != null && !brokerServiceUrlTls.isEmpty()) {
-            str.append(",");
-            str.append(brokerServiceUrlTls);
-        }
-        return str.toString();
+        return Objects.toStringHelper(this).add("serviceUrl", serviceUrl).add("serviceUrlTls", serviceUrlTls)
+                .add("brokerServiceUrl", brokerServiceUrl).add("brokerServiceUrlTls", brokerServiceUrlTls)
+                .add("peerClusterNames", peerClusterNames).toString();
     }
     
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterData.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterData.java
@@ -18,13 +18,19 @@
  */
 package org.apache.pulsar.common.policies.data;
 
+import java.util.List;
+
 import com.google.common.base.Objects;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 public class ClusterData {
     private String serviceUrl;
     private String serviceUrlTls;
     private String brokerServiceUrl;
     private String brokerServiceUrlTls;
+    // For given Cluster1(us-west1, us-east1) and Cluster2(us-west2, us-east2)
+    // Peer: [us-west1 -> us-west2] and [us-east1 -> us-east2]
+    private List<String> peerClusterNames;
 
     public ClusterData() {
     }
@@ -45,6 +51,14 @@ public class ClusterData {
         this.brokerServiceUrlTls = brokerServiceUrlTls;
     }
 
+    public void update(ClusterData other) {
+        checkNotNull(other);
+        this.serviceUrl = other.serviceUrl;
+        this.serviceUrlTls = other.serviceUrlTls;
+        this.brokerServiceUrl = other.brokerServiceUrl;
+        this.brokerServiceUrlTls = other.brokerServiceUrlTls;
+    }
+    
     public String getServiceUrl() {
         return serviceUrl;
     }
@@ -75,6 +89,14 @@ public class ClusterData {
 
     public void setBrokerServiceUrlTls(String brokerServiceUrlTls) {
         this.brokerServiceUrlTls = brokerServiceUrlTls;
+    }
+
+    public List<String> getPeerClusterNames() {
+        return peerClusterNames;
+    }
+
+    public void setPeerClusterNames(List<String> peerClusterNames) {
+        this.peerClusterNames = peerClusterNames;
     }
 
     @Override

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterData.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ClusterData.java
@@ -18,10 +18,12 @@
  */
 package org.apache.pulsar.common.policies.data;
 
-import java.util.List;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.LinkedHashSet;
+import java.util.SortedSet;
 
 import com.google.common.base.Objects;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 public class ClusterData {
     private String serviceUrl;
@@ -30,7 +32,7 @@ public class ClusterData {
     private String brokerServiceUrlTls;
     // For given Cluster1(us-west1, us-east1) and Cluster2(us-west2, us-east2)
     // Peer: [us-west1 -> us-west2] and [us-east1 -> us-east2]
-    private List<String> peerClusterNames;
+    private LinkedHashSet<String> peerClusterNames;
 
     public ClusterData() {
     }
@@ -91,11 +93,11 @@ public class ClusterData {
         this.brokerServiceUrlTls = brokerServiceUrlTls;
     }
 
-    public List<String> getPeerClusterNames() {
+    public LinkedHashSet<String> getPeerClusterNames() {
         return peerClusterNames;
     }
 
-    public void setPeerClusterNames(List<String> peerClusterNames) {
+    public void setPeerClusterNames(LinkedHashSet<String> peerClusterNames) {
         this.peerClusterNames = peerClusterNames;
     }
 


### PR DESCRIPTION
### Motivation

As described in [PIP-8](https://github.com/apache/incubator-pulsar/wiki/PIP-8-Pulsar-beyond-1M-topics), introducing a "peer-group" which can help a broker to redirect a lookup/admin request for global-namespace to appropriate cluster that actually owns (cluster part of replication-clusters) the namespace.

So, if a cluster cluster-A receives a lookup/admin request for a global-namespace for which cluster-A is not part of replication-clusters then cluster-A will check with peer which is part of replication-clusters and redirects request to that appropriate peer cluster. 

It can help to partition namespaces across multiple clusters and with peer-group abstraction,  client can access them with a single service-url.

### Modifications

- Admin API: to add/update/get peer-clusters
- Lookups (Http/BinaryProto): Partitioned-metadata and Topic lookup supports request redirection to appropriate peer-cluster for a global namespace
- Admin-API : `namespaces` and `persistent/non-persistent` supports peer-group for a global namespace 
- CLI tool : add cli-tool commands
- Validation on PartitionedMetadata-Lookup: Fail request if global namespace's replication-clusters doesn't contain current/peer-clusters (Earlier this validation was only present at lookup only). So, client can't create producer/consumer object and don't do internal retry for lookup. 

### Result

It will support peer-group described on [PIP-8](https://github.com/apache/incubator-pulsar/wiki/PIP-8-Pulsar-beyond-1M-topics).
Note: I will create a separate PR for admin-api doc after reviewing/merging this one.