### PR TITLE
Fail Pulsar storm spout/bolt init on consumer/producer creation failed

### DIFF
--- a/pulsar-storm/src/main/java/org/apache/pulsar/storm/PulsarBolt.java
+++ b/pulsar-storm/src/main/java/org/apache/pulsar/storm/PulsarBolt.java
@@ -39,6 +39,7 @@ import org.apache.storm.task.TopologyContext;
 import org.apache.storm.topology.OutputFieldsDeclarer;
 import org.apache.storm.topology.base.BaseRichBolt;
 import org.apache.storm.tuple.Tuple;
+import static java.lang.String.format;
 
 public class PulsarBolt extends BaseRichBolt implements IMetric {
     /**
@@ -90,6 +91,8 @@ public class PulsarBolt extends BaseRichBolt implements IMetric {
             LOG.info("[{}] Created a pulsar producer on topic {} to send messages", boltId, pulsarBoltConf.getTopic());
         } catch (PulsarClientException e) {
             LOG.error("[{}] Error initializing pulsar producer on topic {}", boltId, pulsarBoltConf.getTopic(), e);
+            throw new IllegalStateException(
+                    format("Failed to initialize producer for %s : %s", pulsarBoltConf.getTopic(), e.getMessage()), e);
         }
         context.registerMetric(String.format("PulsarBoltMetrics-%s-%s", componentId, context.getThisTaskIndex()), this,
                 pulsarBoltConf.getMetricsTimeIntervalInSecs());

--- a/pulsar-storm/src/main/java/org/apache/pulsar/storm/PulsarSpout.java
+++ b/pulsar-storm/src/main/java/org/apache/pulsar/storm/PulsarSpout.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.storm;
 
+import static java.lang.String.format;
+
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentMap;
@@ -213,6 +215,8 @@ public class PulsarSpout extends BaseRichSpout implements IMetric {
                     pulsarSpoutConf.getTopic(), pulsarSpoutConf.getSubscriptionName());
         } catch (PulsarClientException e) {
             LOG.error("[{}] Error creating pulsar consumer on topic {}", spoutId, pulsarSpoutConf.getTopic(), e);
+            throw new IllegalStateException(format("Failed to initialize consumer for %s-%s : %s",
+                    pulsarSpoutConf.getTopic(), pulsarSpoutConf.getSubscriptionName(), e.getMessage()), e);
         }
         context.registerMetric(String.format("PulsarSpoutMetrics-%s-%s", componentId, context.getThisTaskIndex()), this,
                 pulsarSpoutConf.getMetricsTimeIntervalInSecs());

--- a/pulsar-storm/src/test/java/org/apache/pulsar/storm/PulsarSpoutTest.java
+++ b/pulsar-storm/src/test/java/org/apache/pulsar/storm/PulsarSpoutTest.java
@@ -29,6 +29,7 @@ import org.apache.pulsar.storm.MessageToValuesMapper;
 import org.apache.pulsar.storm.PulsarSpout;
 import org.apache.pulsar.storm.PulsarSpoutConfiguration;
 import org.testng.Assert;
+import static org.testng.Assert.fail;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -321,5 +322,32 @@ public class PulsarSpoutTest extends ProducerConsumerBase {
         // test serializability with no auth
         PulsarSpout spoutWithNoAuth = new PulsarSpout(pulsarSpoutConf, new ClientConfiguration());
         TestUtil.testSerializability(spoutWithNoAuth);
+    }
+    
+    @Test
+    public void testFailedConsumer() throws Exception {
+        PulsarSpoutConfiguration pulsarSpoutConf = new PulsarSpoutConfiguration();
+        pulsarSpoutConf.setServiceUrl(serviceUrl);
+        pulsarSpoutConf.setTopic("persistent://invalidTopic");
+        pulsarSpoutConf.setSubscriptionName(subscriptionName);
+        pulsarSpoutConf.setMessageToValuesMapper(messageToValuesMapper);
+        pulsarSpoutConf.setFailedRetriesTimeout(1, TimeUnit.SECONDS);
+        pulsarSpoutConf.setMaxFailedRetries(2);
+        pulsarSpoutConf.setSharedConsumerEnabled(false);
+        pulsarSpoutConf.setMetricsTimeIntervalInSecs(60);
+        ConsumerConfiguration consumerConf = new ConsumerConfiguration();
+        consumerConf.setSubscriptionType(SubscriptionType.Shared);
+        PulsarSpout spout = new PulsarSpout(pulsarSpoutConf, new ClientConfiguration(), consumerConf);
+        MockSpoutOutputCollector mockCollector = new MockSpoutOutputCollector();
+        SpoutOutputCollector collector = new SpoutOutputCollector(mockCollector);
+        TopologyContext context = mock(TopologyContext.class);
+        when(context.getThisComponentId()).thenReturn("new-test" + methodName);
+        when(context.getThisTaskId()).thenReturn(0);
+        try {
+            spout.open(Maps.newHashMap(), context, collector);
+            fail("should have failed as consumer creation failed");
+        } catch (IllegalStateException e) {
+            // Ok
+        }
     }
 }


### PR DESCRIPTION
### Motivation

Sometime PulsarSpout/PulsarBolt fails to create consumer/producer due to `Authentication` and `invalid configuration` in that case Pulsar spout and bolt initialization should fail right away so, user can take appropriate action to fix it. Right now, user doesn't know about the consumer/producer failure and topology doesn't report any exception as well.

### Modifications

Fail pulsar spout/bolt init if consumer/producer creation failed.

### Result

Pulsar spout/bolt init fails if it wont be able to create appropriate consumer/producer in it.
