### PR TITLE
Avoid logging stacktrace for exclusive consumer-busy exception

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -37,6 +37,7 @@ import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.bookkeeper.mledger.util.SafeRun;
 import org.apache.pulsar.broker.authentication.AuthenticationDataCommand;
+import org.apache.pulsar.broker.service.BrokerServiceException.ConsumerBusyException;
 import org.apache.pulsar.broker.service.BrokerServiceException.ServiceUnitNotReadyException;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -415,7 +416,9 @@ public class ServerCnx extends PulsarHandler {
                         }) //
                         .exceptionally(exception -> {
                             log.warn("[{}][{}][{}] Failed to create consumer: {}", remoteAddress, topicName,
-                                    subscriptionName, exception.getCause().getMessage(), exception);
+                                    subscriptionName, exception.getCause().getMessage(),
+                                    exception.getCause() instanceof ConsumerBusyException ? null
+                                            : exception.getCause());
 
                             // If client timed out, the future would have been completed by subsequent close. Send error
                             // back to client, only if not completed already.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -415,10 +415,17 @@ public class ServerCnx extends PulsarHandler {
 
                         }) //
                         .exceptionally(exception -> {
-                            log.warn("[{}][{}][{}] Failed to create consumer: {}", remoteAddress, topicName,
-                                    subscriptionName, exception.getCause().getMessage(),
-                                    exception.getCause() instanceof ConsumerBusyException ? null
-                                            : exception.getCause());
+                            if (exception.getCause() instanceof ConsumerBusyException) {
+                                if (log.isDebugEnabled()) {
+                                    log.debug(
+                                            "[{}][{}][{}] Failed to create consumer because exclusive consumer is already connected: {}",
+                                            remoteAddress, topicName, subscriptionName,
+                                            exception.getCause().getMessage());
+                                }
+                            } else {
+                                log.warn("[{}][{}][{}] Failed to create consumer: {}", remoteAddress, topicName,
+                                        subscriptionName, exception.getCause().getMessage(), exception);
+                            }
 
                             // If client timed out, the future would have been completed by subsequent close. Send error
                             // back to client, only if not completed already.


### PR DESCRIPTION
### Motivation

Right now, due to few clients which try to connect consumers on already connected exclusive subscription, that consumer is keep trying to reconnect and it pollutes broker's log with below exception stacktrace
```
00:00:03.270 [pulsar-io-64-25] WARN  o.a.pulsar.broker.service.ServerCnx  - [persistent://prop/cluster/ns/topic] Failed to create consumer: Exclusive consumer is already connected
java.util.concurrent.CompletionException: org.apache.pulsar.broker.service.BrokerServiceException$ConsumerBusyException: Exclusive consumer is already connected
        at java.util.concurrent.CompletableFuture.encodeRelay(CompletableFuture.java:326) ~[na:1.8.0_131]
        at java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:984) ~[na:1.8.0_131]
        at java.util.concurrent.CompletableFuture.thenCompose(CompletableFuture.java:2124) ~[na:1.8.0_131]
        at org.apache.pulsar.broker.service.ServerCnx.lambda$4(ServerCnx.java:385) [pulsar-broker-1.19.2-incubating-yahoo.jar:1.19.2-incubating-yahoo]
        at java.util.concurrent.CompletableFuture.uniApply(CompletableFuture.java:602) ~[na:1.8.0_131]
        at java.util.concurrent.CompletableFuture.uniApplyStage(CompletableFuture.java:614) ~[na:1.8.0_131]
        at java.util.concurrent.CompletableFuture.thenApply(CompletableFuture.java:1983) ~[na:1.8.0_131]
        at org.apache.pulsar.broker.service.ServerCnx.handleSubscribe(ServerCnx.java:354) [pulsar-broker-1.19.2-incubating-yahoo.jar:1.19.2-incubating-yahoo]
        at org.apache.pulsar.common.api.PulsarDecoder.channelRead(PulsarDecoder.java:192) ~[pulsar-common-1.19.2-incubating-yahoo.jar:1.19.2-incubating-yahoo]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:356) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:342) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:335) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:295) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:269) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:356) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:342) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:335) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1294) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:356) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:342) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:911) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:934) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:397) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:302) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:131) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.util.concurrent.DefaultThreadFactory$DefaultRunnableDecorator.run(DefaultThreadFactory.java:144) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_131]
Caused by: org.apache.pulsar.broker.service.BrokerServiceException$ConsumerBusyException: Exclusive consumer is already connected
        at org.apache.pulsar.broker.service.AbstractDispatcherSingleActiveConsumer.addConsumer(AbstractDispatcherSingleActiveConsumer.java:106) ~[pulsar-broker-1.19.2-incubating-yahoo.jar:1.19.2-incubating-yahoo]
        at org.apache.pulsar.broker.service.persistent.PersistentSubscription.addConsumer(PersistentSubscription.java:135) ~[pulsar-broker-1.19.2-incubating-yahoo.jar:1.19.2-incubating-yahoo]
        at org.apache.pulsar.broker.service.persistent.PersistentTopic.lambda$7(PersistentTopic.java:411) ~[pulsar-broker-1.19.2-incubating-yahoo.jar:1.19.2-incubating-yahoo]
        at java.util.concurrent.CompletableFuture.uniAccept(CompletableFuture.java:656) ~[na:1.8.0_131]
        at java.util.concurrent.CompletableFuture.uniAcceptStage(CompletableFuture.java:669) ~[na:1.8.0_131]
        at java.util.concurrent.CompletableFuture.thenAccept(CompletableFuture.java:1997) ~[na:1.8.0_131]
        at org.apache.pulsar.broker.service.persistent.PersistentTopic.subscribe(PersistentTopic.java:407) ~[pulsar-broker-1.19.2-incubating-yahoo.jar:1.19.2-incubating-yahoo]
        at org.apache.pulsar.broker.service.ServerCnx.lambda$8(ServerCnx.java:385) [pulsar-broker-1.19.2-incubating-yahoo.jar:1.19.2-incubating-yahoo]
        at java.util.concurrent.CompletableFuture.uniComposeStage(CompletableFuture.java:981) ~[na:1.8.0_131]
        ... 25 common frames omitted
```

### Modifications

Avoid logging stacktrace for `ConsumerBusyException` for exclusive consumer.

### Result

It will try to keep log clean from `ConsumerBusyException-stacktrace`.
