### PR TITLE
Fix status code when partitioned-topic unsubscribe fails

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -756,6 +756,15 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
 
         assertEquals(admin.persistentTopics().getSubscriptions(partitionedTopicName), Lists.newArrayList("my-sub"));
 
+        try {
+            admin.persistentTopics().deleteSubscription(partitionedTopicName, "my-sub");
+            fail("should have failed");
+        } catch (PulsarAdminException.PreconditionFailedException e) {
+            // ok
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+
         Consumer consumer1 = client.subscribe(partitionedTopicName, "my-sub-1", conf);
 
         assertEquals(Sets.newHashSet(admin.persistentTopics().getSubscriptions(partitionedTopicName)),


### PR DESCRIPTION
### Motivation

Admin API returns 500 when partitioned-topic unsubscribe fails even though NOT_FOUND or PRECONDITION_FAILED (subscription has active connected consumers) cases.

### Modifications

Modify `PersistentTopics` to return appropriate status code according to exceptions.

### Result

Admin API can return NOT_FOUND or PRECONDITION_FAILED when partitioned-topic unsubscribe fails.