### PR TITLE
Avoid running duplicate ReplicatorTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTlsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTlsTest.java
@@ -30,7 +30,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
 
-public class ReplicatorTlsTest extends ReplicatorTest {
+public class ReplicatorTlsTest extends ReplicatorTestBase {
 
     @Override
     @BeforeClass


### PR DESCRIPTION
### Motivation

Right now, `ReplicatorTlsTest` also runs all the test of `ReplicatorTest` so, `ReplicatorTest's` runs multiple times.

### Modifications

- Replace base class of `ReplicatorTlsTest` to avoid running duplicate tests of `ReplicatorTest`.
- remove `BrokerService` shutdown multiple times that was causing below exception
```
ERROR org.apache.pulsar.broker.service.BrokerService - Failed to disable broker from loadbalancer list java.lang.NullPointerException
org.apache.pulsar.broker.PulsarServerException: java.lang.NullPointerException
	at org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl.disableBroker(ModularLoadManagerImpl.java:543)
	at org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerWrapper.disableBroker(ModularLoadManagerWrapper.java:47)
	at org.apache.pulsar.broker.service.BrokerService.unloadNamespaceBundlesGracefully(BrokerService.java:392)
	at org.apache.pulsar.broker.service.BrokerService.close(BrokerService.java:353)
	at org.apache.pulsar.broker.service.ReplicatorTestBase.shutdown(ReplicatorTestBase.java:255)
	at org.apache.pulsar.broker.service.ReplicatorTlsTest.shutdown(ReplicatorTlsTest.java:47)
```

### Result

`ReplicatorTest` test will not run multiple time.
