### PR TITLE
Check whether the property exists at the beginning of `validateAdminAccessOnProperty`

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -169,6 +169,16 @@ public abstract class PulsarWebResource {
     }
 
     protected static void validateAdminAccessOnProperty(PulsarService pulsar, String clientAppId, String property) throws RestException, Exception{
+        PropertyAdmin propertyAdmin;
+
+        try {
+            propertyAdmin = pulsar.getConfigurationCache().propertiesCache().get(path(POLICIES, property))
+                    .orElseThrow(() -> new RestException(Status.NOT_FOUND, "Property does not exist"));
+        } catch (KeeperException.NoNodeException e) {
+            log.warn("Failed to get property admin data for non existing property {}", property);
+            throw new RestException(Status.NOT_FOUND, "Property does not exist");
+        }
+
         if (pulsar.getConfiguration().isAuthenticationEnabled() && pulsar.getConfiguration().isAuthorizationEnabled()) {
             log.debug("check admin access on property: {} - Authenticated: {} -- role: {}", property,
                     (isClientAuthenticated(clientAppId)), clientAppId);
@@ -181,15 +191,6 @@ public abstract class PulsarWebResource {
                 // Super-user has access to configure all the policies
                 log.debug("granting access to super-user {} on property {}", clientAppId, property);
             } else {
-                PropertyAdmin propertyAdmin;
-
-                try {
-                    propertyAdmin = pulsar.getConfigurationCache().propertiesCache().get(path(POLICIES, property))
-                            .orElseThrow(() -> new RestException(Status.UNAUTHORIZED, "Property does not exist"));
-                } catch (KeeperException.NoNodeException e) {
-                    log.warn("Failed to get property admin data for non existing property {}", property);
-                    throw new RestException(Status.UNAUTHORIZED, "Property does not exist");
-                }
 
                 if (!propertyAdmin.getAdminRoles().contains(clientAppId)) {
                     throw new RestException(Status.UNAUTHORIZED,

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
@@ -159,6 +159,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         doReturn(Sets.newTreeSet(Lists.newArrayList("use", "usw", "usc"))).when(persistentTopics).clusters();
         doNothing().when(persistentTopics).validateAdminAccessOnProperty("my-property");
         doNothing().when(persistentTopics).validateAdminAccessOnProperty("other-property");
+        doNothing().when(persistentTopics).validateAdminAccessOnProperty("prop-xyz");
 
         resourceQuotas = spy(new ResourceQuotas());
         resourceQuotas.setServletContext(new MockServletContext());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ResendRequestTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ResendRequestTest.java
@@ -38,6 +38,7 @@ import org.apache.pulsar.client.api.ProducerConfiguration;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.ProducerConfiguration.MessageRoutingMode;
 import org.apache.pulsar.client.impl.ConsumerBase;
+import org.apache.pulsar.common.policies.data.PropertyAdmin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
@@ -412,6 +413,7 @@ public class ResendRequestTest extends BrokerTestBase {
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 10;
         final int numberOfPartitions = 4;
+        admin.properties().createProperty("prop", new PropertyAdmin());
         admin.persistentTopics().createPartitionedTopic(topicName, numberOfPartitions);
         // Special step to create partitioned topic
 
@@ -466,6 +468,7 @@ public class ResendRequestTest extends BrokerTestBase {
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 10;
         final int numberOfPartitions = 3;
+        admin.properties().createProperty("prop", new PropertyAdmin());
         admin.persistentTopics().createPartitionedTopic(topicName, numberOfPartitions);
         Random rn = new Random();
         // Special step to create partitioned topic
@@ -563,6 +566,7 @@ public class ResendRequestTest extends BrokerTestBase {
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 10;
         final int numberOfPartitions = 3;
+        admin.properties().createProperty("prop", new PropertyAdmin());
         admin.persistentTopics().createPartitionedTopic(topicName, numberOfPartitions);
         Random rn = new Random();
         // Special step to create partitioned topic

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PerMessageUnAcknowledgedRedeliveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PerMessageUnAcknowledgedRedeliveryTest.java
@@ -32,6 +32,7 @@ import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.ProducerConfiguration.MessageRoutingMode;
 import org.apache.pulsar.client.impl.ConsumerImpl;
 import org.apache.pulsar.client.impl.PartitionedConsumerImpl;
+import org.apache.pulsar.common.policies.data.PropertyAdmin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
@@ -359,6 +360,7 @@ public class PerMessageUnAcknowledgedRedeliveryTest extends BrokerTestBase {
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 15;
         final int numberOfPartitions = 3;
+        admin.properties().createProperty("prop", new PropertyAdmin());
         admin.persistentTopics().createPartitionedTopic(topicName, numberOfPartitions);
 
         // 1. producer connect

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/UnAcknowledgedMessagesTimeoutTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/UnAcknowledgedMessagesTimeoutTest.java
@@ -35,6 +35,7 @@ import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.ProducerConfiguration.MessageRoutingMode;
 import org.apache.pulsar.client.impl.ConsumerImpl;
 import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.apache.pulsar.common.policies.data.PropertyAdmin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -169,6 +170,7 @@ public class UnAcknowledgedMessagesTimeoutTest extends BrokerTestBase {
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 20;
         final int numberOfPartitions = 3;
+        admin.properties().createProperty("prop", new PropertyAdmin());
         admin.persistentTopics().createPartitionedTopic(topicName, numberOfPartitions);
         // Special step to create partitioned topic
 
@@ -258,6 +260,7 @@ public class UnAcknowledgedMessagesTimeoutTest extends BrokerTestBase {
         final String messagePredicate = "my-message-" + key + "-";
         final int totalMessages = 10;
         final int numberOfPartitions = 3;
+        admin.properties().createProperty("prop", new PropertyAdmin());
         admin.persistentTopics().createPartitionedTopic(topicName, numberOfPartitions);
         // Special step to create partitioned topic
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/discovery/service/web/DiscoveryServiceWebTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/discovery/service/web/DiscoveryServiceWebTest.java
@@ -100,7 +100,7 @@ public class DiscoveryServiceWebTest extends ProducerConsumerBase {
          **/
 
         assertEquals(hitBrokerService(HttpMethod.POST, postRequestUrl, Lists.newArrayList("use")),
-                "Cannot set replication on a non-global namespace");
+                "Property does not exist");
         assertEquals(hitBrokerService(HttpMethod.PUT, putRequestUrl, new BundlesData(1)), "Property does not exist");
         assertEquals(hitBrokerService(HttpMethod.GET, getRequestUrl, null), "Property does not exist");
 

--- a/pulsar-client-cpp/run-unit-tests.sh
+++ b/pulsar-client-cpp/run-unit-tests.sh
@@ -35,7 +35,11 @@ PULSAR_STANDALONE_CONF=$PWD/test-conf/standalone-ssl.conf pulsar-dist/bin/pulsar
 auth_pid=$!;
 sleep 10
 
-PULSAR_CLIENT_CONF=$PWD/test-conf/client.conf pulsar-dist/bin/pulsar-admin clusters create \
+# create property for test
+PULSAR_CLIENT_CONF=$PWD/test-conf/client.conf pulsar-dist/bin/pulsar-admin properties create prop -r "" -c "unit"
+PULSAR_CLIENT_CONF=$PWD/test-conf/client.conf pulsar-dist/bin/pulsar-admin properties create property -r "" -c "cluster"
+
+PULSAR_CLIENT_CONF=$PWD/test-conf/client-ssl.conf pulsar-dist/bin/pulsar-admin clusters create \
         --url http://localhost:9765/ --url-secure https://localhost:9766/ \
         --broker-url pulsar://localhost:9885/ --broker-url-secure pulsar+ssl://localhost:9886/ \
         cluster

--- a/pulsar-client-cpp/test-conf/client-ssl.conf
+++ b/pulsar-client-cpp/test-conf/client-ssl.conf
@@ -18,10 +18,10 @@
 #
 
 # Pulsar Client configuration
-webServiceUrl=http://localhost:8765/
-brokerServiceUrl=pulsar://localhost:8885/
-#authPlugin=
-#authParams=
-#useTls=
-#tlsAllowInsecureConnection
-#tlsTrustCertsFilePath
+webServiceUrl=https://localhost:9766/
+brokerServiceUrl=pulsar+ssl://localhost:9886/
+useTls=true
+tlsAllowInsecureConnection=true
+tlsTrustCertsFilePath=/pulsar/pulsar-broker/src/test/resources/authentication/tls/cacert.pem
+authPlugin=org.apache.pulsar.client.impl.auth.AuthenticationTls
+authParams=tlsCertFile:/pulsar/pulsar-broker/src/test/resources/authentication/tls/client-cert.pem,tlsKeyFile:/pulsar/pulsar-broker/src/test/resources/authentication/tls/client-key.pem

--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/test/java/org/apache/pulsar/client/kafka/compat/tests/KafkaConsumerTest.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/test/java/org/apache/pulsar/client/kafka/compat/tests/KafkaConsumerTest.java
@@ -40,6 +40,7 @@ import org.apache.pulsar.client.api.MessageBuilder;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerConfiguration;
 import org.apache.pulsar.client.api.ProducerConfiguration.MessageRoutingMode;
+import org.apache.pulsar.common.policies.data.PropertyAdmin;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -190,6 +191,7 @@ public class KafkaConsumerTest extends BrokerTestBase {
         String topic = "persistent://sample/standalone/ns/testPartitions";
 
         // Create 8 partitions in topic
+        admin.properties().createProperty("sample", new PropertyAdmin());
         admin.persistentTopics().createPartitionedTopic(topic, 8);
 
         Properties props = new Properties();

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
@@ -30,6 +30,7 @@ import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.cli.PulsarClientTool;
+import org.apache.pulsar.common.policies.data.PropertyAdmin;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -51,11 +52,12 @@ public class PulsarClientToolTest extends BrokerTestBase {
     }
 
     @Test(timeOut = 10000)
-    public void testInitialzation() throws MalformedURLException, InterruptedException, ExecutionException {
+    public void testInitialzation() throws MalformedURLException, InterruptedException, ExecutionException, PulsarAdminException {
         Properties properties = new Properties();
         properties.setProperty("serviceUrl", brokerUrl.toString());
         properties.setProperty("useTls", "false");
 
+        admin.properties().createProperty("property", new PropertyAdmin());
         String topicName = "persistent://property/ns/topic-scale-ns-0/topic";
 
         int numberOfMessages = 10;

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTest.java
@@ -32,6 +32,7 @@ import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerConfiguration;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.ProducerConfiguration.MessageRoutingMode;
+import org.apache.pulsar.common.policies.data.PropertyAdmin;
 import org.mockito.Mockito;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -101,6 +102,7 @@ public class ProxyTest extends MockedPulsarServiceBaseTest {
 
     @Test
     public void testPartitions() throws Exception {
+        admin.properties().createProperty("sample", new PropertyAdmin());
         PulsarClient client = PulsarClient.create("pulsar://localhost:" + proxyConfig.getServicePort());
         admin.persistentTopics().createPartitionedTopic("persistent://sample/test/local/partitioned-topic", 2);
 

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTlsTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTlsTest.java
@@ -32,6 +32,7 @@ import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerConfiguration;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.ProducerConfiguration.MessageRoutingMode;
+import org.apache.pulsar.common.policies.data.PropertyAdmin;
 import org.mockito.Mockito;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -98,6 +99,7 @@ public class ProxyTlsTest extends MockedPulsarServiceBaseTest {
         conf.setTlsTrustCertsFilePath(TLS_TRUST_CERT_FILE_PATH);
 
         PulsarClient client = PulsarClient.create("pulsar://localhost:" + proxyConfig.getServicePortTls(), conf);
+        admin.properties().createProperty("sample", new PropertyAdmin());
         admin.persistentTopics().createPartitionedTopic("persistent://sample/test/local/partitioned-topic", 2);
 
         ProducerConfiguration producerConf = new ProducerConfiguration();


### PR DESCRIPTION
### Motivation
It is not checked whether the property exists in `validateAdminAccessOnProperty` when Authentication or Authorization disabled or The client role is the super user.
It causes the problem that invalid zk node is created when creating namespace in a property which does not exist.

### Modifications
Checking whether the property exists at the beginning of `validateAdminAccessOnProperty`.

### Result
Resolved things mentioned above.