### PR TITLE
Fail broker start if broker-znode created by other zk-session

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerImplTest.java
@@ -44,15 +44,15 @@ import org.apache.bookkeeper.test.PortManager;
 import org.apache.bookkeeper.util.ZkUtils;
 import org.apache.pulsar.broker.BrokerData;
 import org.apache.pulsar.broker.BundleData;
+import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.TimeAverageMessageData;
-import org.apache.pulsar.broker.loadbalance.LoadData;
 import org.apache.pulsar.broker.loadbalance.impl.LoadManagerShared;
+import org.apache.pulsar.broker.loadbalance.impl.LoadManagerShared.BrokerTopicLoadingPredicate;
 import org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl;
 import org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerWrapper;
 import org.apache.pulsar.broker.loadbalance.impl.SimpleResourceAllocationPolicies;
-import org.apache.pulsar.broker.loadbalance.impl.LoadManagerShared.BrokerTopicLoadingPredicate;
 import org.apache.pulsar.client.admin.Namespaces;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.Authentication;
@@ -64,7 +64,6 @@ import org.apache.pulsar.common.naming.ServiceUnitId;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.NamespaceIsolationData;
 import org.apache.pulsar.common.policies.data.PropertyAdmin;
-import org.apache.pulsar.common.policies.impl.NamespaceIsolationPolicies;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
 import org.apache.pulsar.policies.data.loadbalancer.NamespaceBundleStats;
@@ -551,5 +550,35 @@ public class ModularLoadManagerImplTest {
                 availableBrokers, brokerTopicLoadingPredicate);
         assertEquals(brokerCandidateCache.size(), 0);
 
+    }
+    
+    /**
+     * It verifies that pulsar-service fails if load-manager tries to create ephemeral znode for broker which is already
+     * created by other zk-session-id.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testOwnBrokerZnodeByMultipleBroker() throws Exception {
+
+        ServiceConfiguration config = new ServiceConfiguration();
+        config.setLoadManagerClassName(ModularLoadManagerImpl.class.getName());
+        config.setClusterName("use");
+        int brokerWebServicePort = PortManager.nextFreePort();
+        int brokerServicePort = PortManager.nextFreePort();
+        config.setWebServicePort(brokerWebServicePort);
+        config.setZookeeperServers("127.0.0.1" + ":" + ZOOKEEPER_PORT);
+        config.setBrokerServicePort(brokerServicePort);
+        PulsarService pulsar = new PulsarService(config);
+        // create znode using different zk-session
+        final String brokerZnode = LoadManager.LOADBALANCE_BROKERS_ROOT + "/" + pulsar.getAdvertisedAddress() + ":"
+                + brokerWebServicePort;
+        ZkUtils.createFullPathOptimistic(pulsar1.getZkClient(), brokerZnode, "".getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE,
+                CreateMode.EPHEMERAL);
+        try {
+            pulsar.start();
+        } catch (PulsarServerException e) {
+            //Ok.
+        }
     }
 }


### PR DESCRIPTION
### Motivation

Sometimes, broker restarts without completing clean shutdown which may miss to delete broker-registration-znode (`/loadbalance/brokers/<broker>`). And when broker restarts, it sees broker's ephemeral znode is already present as previous broker-zk-session is not expired yet and it starts pulsar-service successfully. But after sometime, previous zk-session expires and broker-znode gets deleted that removes broker from available list and current broker logs following exceptions while writing load-report.
```
18:41:07.966 [pulsar-load-manager-11-1] WARN  o.a.p.b.l.i.ModularLoadManagerImpl   - Error writing broker data on ZooKeeper: {}
org.apache.zookeeper.KeeperException$NoNodeException: KeeperErrorCode = NoNode for /loadbalance/brokers/broker:4080
        at org.apache.zookeeper.KeeperException.create(KeeperException.java:111) ~[zookeeper-3.4.6.jar:3.4.6-1569965]
        at org.apache.zookeeper.KeeperException.create(KeeperException.java:51) ~[zookeeper-3.4.6.jar:3.4.6-1569965]
        at org.apache.zookeeper.ZooKeeper.setData(ZooKeeper.java:1270) ~[zookeeper-3.4.6.jar:3.4.6-1569965]
        at org.apache.bookkeeper.zookeeper.ZooKeeperClient.access$2501(ZooKeeperClient.java:60) ~[bookkeeper-server-4.3.1.56-yahoo.jar:4.3.1.56-yahoo]
        at org.apache.bookkeeper.zookeeper.ZooKeeperClient$20.call(ZooKeeperClient.java:800) ~[bookkeeper-server-4.3.1.56-yahoo.jar:4.3.1.56-yahoo]
        at org.apache.bookkeeper.zookeeper.ZooKeeperClient$20.call(ZooKeeperClient.java:794) ~[bookkeeper-server-4.3.1.56-yahoo.jar:4.3.1.56-yahoo]
        at org.apache.bookkeeper.zookeeper.ZooWorker.syncCallWithRetries(ZooWorker.java:122) ~[bookkeeper-server-4.3.1.56-yahoo.jar:4.3.1.56-yahoo]
        at org.apache.bookkeeper.zookeeper.ZooKeeperClient.setData(ZooKeeperClient.java:794) ~[bookkeeper-server-4.3.1.56-yahoo.jar:4.3.1.56-yahoo]
        at org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl.writeBrokerDataOnZooKeeper(ModularLoadManagerImpl.java:739) ~[pulsar-broker-1.19.2-incubating-yahoo.jar:1.19.2-incubating-yahoo]
        at org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerWrapper.writeLoadReportOnZookeeper(ModularLoadManagerWrapper.java:105) [pulsar-broker-1.19.2-incubating-yahoo.jar:1.19.2-incubating-yahoo]
        at org.apache.pulsar.broker.loadbalance.LoadReportUpdaterTask.run(LoadReportUpdaterTask.java:41) [pulsar-broker-1.19.2-incubating-yahoo.jar:1.19.2-incubating-yahoo]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [na:1.8.0_131]
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) [na:1.8.0_131]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) [na:1.8.0_131]
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) [na:1.8.0_131]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_131]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_131]
```

### Modifications

Fail broker start if ephemeral broker-znode is created by other zk-session.

### Result

It will prevent broker to go in condition where it becomes unavailable after successfully restarted.
