### PR TITLE
Fix: broker-zookeeper latency-metrics's dimension-name

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/BrokerOperabilityMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/BrokerOperabilityMetrics.java
@@ -90,6 +90,9 @@ public class BrokerOperabilityMetrics {
 
     public void reset() {
         metricsList.clear();
+        topicLoadStats.reset();
+        zkWriteLatencyStats.reset();
+        zkReadLatencyStats.reset();
     }
 
     public void recordTopicLoadTimeValue(long topicLoadLatencyMs) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/BrokerOperabilityMetrics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/BrokerOperabilityMetrics.java
@@ -62,11 +62,11 @@ public class BrokerOperabilityMetrics {
     }
 
     Metrics getZkWriteLatencyMetrics() {
-        return getDimensionMetrics("zk_write_latency", "zk_write_latency", zkWriteLatencyStats);
+        return getDimensionMetrics("zk_write_latency", "zk_write", zkWriteLatencyStats);
     }
 
     Metrics getZkReadLatencyMetrics() {
-        return getDimensionMetrics("zk_read_latency", "zk_read_latency", zkReadLatencyStats);
+        return getDimensionMetrics("zk_read_latency", "zk_read", zkReadLatencyStats);
     }
 
     Metrics getDimensionMetrics(String metricsName, String dimensionName, DimensionStats stats) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/DimensionStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/DimensionStats.java
@@ -102,6 +102,10 @@ public class DimensionStats {
         return defaultRegistry.getSampleValue(dimensionCountLabel).doubleValue();
     }
 
+    public void reset() {
+        summary.clear();
+    }
+
     private double getQuantile(double q) {
         return defaultRegistry.getSampleValue(name, QUANTILE_LABEL, new String[] { Collector.doubleToGoString(q) })
                 .doubleValue();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ZooKeeperClientAspectJTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ZooKeeperClientAspectJTest.java
@@ -185,23 +185,23 @@ public class ZooKeeperClientAspectJTest {
             pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic1");
             Metrics zkOpMetric = getMetric(pulsar, "zk_write_latency");
             Assert.assertNotNull(zkOpMetric);
-            Assert.assertTrue(zkOpMetric.getMetrics().containsKey("brk_zk_write_latency_rate_s"));
-            Assert.assertTrue(zkOpMetric.getMetrics().containsKey("brk_zk_write_latency_time_95percentile_ms"));
-            Assert.assertTrue(zkOpMetric.getMetrics().containsKey("brk_zk_write_latency_time_99_99_percentile_ms"));
-            Assert.assertTrue(zkOpMetric.getMetrics().containsKey("brk_zk_write_latency_time_99_9_percentile_ms"));
-            Assert.assertTrue(zkOpMetric.getMetrics().containsKey("brk_zk_write_latency_time_99_percentile_ms"));
-            Assert.assertTrue(zkOpMetric.getMetrics().containsKey("brk_zk_write_latency_time_mean_ms"));
-            Assert.assertTrue(zkOpMetric.getMetrics().containsKey("brk_zk_write_latency_time_median_ms"));
+            Assert.assertTrue(zkOpMetric.getMetrics().containsKey("brk_zk_write_rate_s"));
+            Assert.assertTrue(zkOpMetric.getMetrics().containsKey("brk_zk_write_time_95percentile_ms"));
+            Assert.assertTrue(zkOpMetric.getMetrics().containsKey("brk_zk_write_time_99_99_percentile_ms"));
+            Assert.assertTrue(zkOpMetric.getMetrics().containsKey("brk_zk_write_time_99_9_percentile_ms"));
+            Assert.assertTrue(zkOpMetric.getMetrics().containsKey("brk_zk_write_time_99_percentile_ms"));
+            Assert.assertTrue(zkOpMetric.getMetrics().containsKey("brk_zk_write_time_mean_ms"));
+            Assert.assertTrue(zkOpMetric.getMetrics().containsKey("brk_zk_write_time_median_ms"));
 
             zkOpMetric = getMetric(pulsar, "zk_read_latency");
             Assert.assertNotNull(zkOpMetric);
-            Assert.assertTrue(zkOpMetric.getMetrics().containsKey("brk_zk_read_latency_rate_s"));
-            Assert.assertTrue(zkOpMetric.getMetrics().containsKey("brk_zk_read_latency_time_95percentile_ms"));
-            Assert.assertTrue(zkOpMetric.getMetrics().containsKey("brk_zk_read_latency_time_99_99_percentile_ms"));
-            Assert.assertTrue(zkOpMetric.getMetrics().containsKey("brk_zk_read_latency_time_99_9_percentile_ms"));
-            Assert.assertTrue(zkOpMetric.getMetrics().containsKey("brk_zk_read_latency_time_99_percentile_ms"));
-            Assert.assertTrue(zkOpMetric.getMetrics().containsKey("brk_zk_read_latency_time_mean_ms"));
-            Assert.assertTrue(zkOpMetric.getMetrics().containsKey("brk_zk_read_latency_time_median_ms"));
+            Assert.assertTrue(zkOpMetric.getMetrics().containsKey("brk_zk_read_rate_s"));
+            Assert.assertTrue(zkOpMetric.getMetrics().containsKey("brk_zk_read_time_95percentile_ms"));
+            Assert.assertTrue(zkOpMetric.getMetrics().containsKey("brk_zk_read_time_99_99_percentile_ms"));
+            Assert.assertTrue(zkOpMetric.getMetrics().containsKey("brk_zk_read_time_99_9_percentile_ms"));
+            Assert.assertTrue(zkOpMetric.getMetrics().containsKey("brk_zk_read_time_99_percentile_ms"));
+            Assert.assertTrue(zkOpMetric.getMetrics().containsKey("brk_zk_read_time_mean_ms"));
+            Assert.assertTrue(zkOpMetric.getMetrics().containsKey("brk_zk_read_time_median_ms"));
 
             CountDownLatch createLatch = new CountDownLatch(1);
             CountDownLatch deleteLatch = new CountDownLatch(1);


### PR DESCRIPTION
### Motivation

- Right now, broker-zk read/write metric's total-event-count (`brk_zk_write_latency_rate_s/brk_zk_read_latency_rate_s`) name is confusing.
So, it should be `brk_zk_write_rate_s` instead `brk_zk_write_latency_rate_s` and `brk_zk_read_rate_s` instead `brk_zk_read_latency_rate_s`.
eg:
```
 "metrics": {
    "brk_zk_write_latency_rate_s": 3049871.0,
    "brk_zk_write_latency_time_75percentile_ms": 1.0,
    "brk_zk_write_latency_time_95percentile_ms": 1.0,
    "brk_zk_write_latency_time_99_99_percentile_ms": 116.0,
    "brk_zk_write_latency_time_99_9_percentile_ms": 116.0,
    "brk_zk_write_latency_time_99_percentile_ms": 114.0,
    "brk_zk_write_latency_time_mean_ms": 14.840268653985692,
    "brk_zk_write_latency_time_median_ms": 1.0
```
- Also, it is not reseting metrics.

### Result

- It will change event-count dimension name on brk-zk metrics: `brk_zk_write_rate_s` and `brk_zk_read_rate_s`
- It will also remove `latency` token from all zk-broker-latency metrics.
- It will also reset metrics when stats triggers `reset()` which shows stats for specific intervals only.

```
 "metrics": {
    "brk_zk_write_rate_s": 300,
    "brk_zk_write_time_75percentile_ms": 1.0,
    "brk_zk_write_time_95percentile_ms": 1.0,
    "brk_zk_write_time_99_99_percentile_ms": 116.0,
    "brk_zk_write_time_99_9_percentile_ms": 116.0,
    "brk_zk_write_time_99_percentile_ms": 114.0,
    "brk_zk_write_time_mean_ms": 14.840268653985692,
    "brk_zk_write_time_median_ms": 1.0
```
