### PR TITLE
Fix: failed producer creation leak

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -654,6 +654,7 @@ public class ConsumerImpl extends ConsumerBase {
     void connectionFailed(PulsarClientException exception) {
         if (System.currentTimeMillis() > subscribeTimeout && subscribeFuture.completeExceptionally(exception)) {
             setState(State.Failed);
+            log.info("[{}] Consumer creation failed for consumer {}", topic, consumerId);
             client.cleanupConsumer(this);
         }
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -898,6 +898,7 @@ public class ProducerImpl extends ProducerBase implements TimerTask {
         if (System.currentTimeMillis() > createProducerTimeout
                 && producerCreatedFuture.completeExceptionally(exception)) {
             log.info("[{}] Producer creation failed for producer {}", topic, producerId);
+            client.cleanupProducer(this);
             setState(State.Failed);
         }
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -898,8 +898,8 @@ public class ProducerImpl extends ProducerBase implements TimerTask {
         if (System.currentTimeMillis() > createProducerTimeout
                 && producerCreatedFuture.completeExceptionally(exception)) {
             log.info("[{}] Producer creation failed for producer {}", topic, producerId);
-            client.cleanupProducer(this);
             setState(State.Failed);
+            client.cleanupProducer(this);
         }
     }
 


### PR DESCRIPTION
### Motivation

Recently, we have seen that due to invalid replication-cluster configuration, replication producers failed to do lookup and it producer creation failed. But, client doesn't clean up failed producer which creates a leak and creates too many live producer objects. So, PulsarClient should clean up producer if producer creation failed.

### Modifications

Clean up failed producers from pulsar-client's producer-map.

### Result

It prevents leak when producer creation fails.
