### PR TITLE
Added more log messages for SLA Namespace acquisition

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -352,14 +352,17 @@ public class PulsarService implements AutoCloseable {
     private void acquireSLANamespace() {
         try {
             // Namespace not created hence no need to unload it
+            String nsName = NamespaceService.getSLAMonitorNamespace(getAdvertisedAddress(), config);
             if (!this.globalZkCache.exists(
-                    AdminResource.path(POLICIES) + "/" + NamespaceService.getSLAMonitorNamespace(getAdvertisedAddress(), config))) {
+                    AdminResource.path(POLICIES) + "/" + nsName)) {
+                LOG.info("SLA Namespace = {} doesn't exist.", nsName);
                 return;
             }
 
             boolean acquiredSLANamespace;
             try {
                 acquiredSLANamespace = nsservice.registerSLANamespace();
+                LOG.info("Register SLA Namespace = {}, returned - {}.", nsName, acquiredSLANamespace);
             } catch (PulsarServerException e) {
                 acquiredSLANamespace = false;
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -236,7 +236,6 @@ public class NamespaceService {
         try {
             NamespaceName nsname = new NamespaceName(namespace);
 
-            // [Bug 6504511] Enable writing with JSON format
             String otherUrl = null;
             NamespaceBundle nsFullBundle = null;
 
@@ -759,18 +758,18 @@ public class NamespaceService {
         PulsarAdmin adminClient = null;
         String namespaceName = getSLAMonitorNamespace(host, config);
 
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Trying to unload SLA namespace {}", namespaceName);
-        }
+        LOG.info("Trying to unload SLA namespace {}", namespaceName);
 
         NamespaceBundle nsFullBundle = getFullBundle(new NamespaceName(namespaceName));
         if (!getOwner(nsFullBundle).isPresent()) {
             // No one owns the namespace so no point trying to unload it
+            // Next lookup will assign the bundle to this broker.
+            LOG.info("No one owns SLA namespace {}. Aborting unload", namespaceName);
             return;
         }
         adminClient = pulsar.getAdminClient();
         adminClient.namespaces().unload(namespaceName);
-        LOG.debug("Namespace {} unloaded successfully", namespaceName);
+        LOG.info("Namespace {} unloaded successfully", namespaceName);
     }
 
     public static String getHeartbeatNamespace(String host, ServiceConfiguration config) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -758,15 +758,16 @@ public class NamespaceService {
         PulsarAdmin adminClient = null;
         String namespaceName = getSLAMonitorNamespace(host, config);
 
-        LOG.info("Trying to unload SLA namespace {}", namespaceName);
+        LOG.info("Checking owner for SLA namespace {}", namespaceName);
 
         NamespaceBundle nsFullBundle = getFullBundle(new NamespaceName(namespaceName));
         if (!getOwner(nsFullBundle).isPresent()) {
             // No one owns the namespace so no point trying to unload it
             // Next lookup will assign the bundle to this broker.
-            LOG.info("No one owns SLA namespace {}. Aborting unload", namespaceName);
             return;
         }
+
+	LOG.info("Trying to unload SLA namespace {}", namespaceName);
         adminClient = pulsar.getAdminClient();
         adminClient.namespaces().unload(namespaceName);
         LOG.info("Namespace {} unloaded successfully", namespaceName);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -767,7 +767,7 @@ public class NamespaceService {
             return;
         }
 
-	LOG.info("Trying to unload SLA namespace {}", namespaceName);
+        LOG.info("Trying to unload SLA namespace {}", namespaceName);
         adminClient = pulsar.getAdminClient();
         adminClient.namespaces().unload(namespaceName);
         LOG.info("Namespace {} unloaded successfully", namespaceName);


### PR DESCRIPTION
During a one-off production incident, one of the brokers was restarted and it *should* have reacquired the SLA namespace at startup but instead, according to the logs, it looks like the broker didn't even attempt to reacquire the SLA namespace or failed silently. 

Currently, I don't have enough details in the log to get to the root cause - hence adding some more log messages so that the next time it happens we can analyze it.

Since reacquiring the namespace happens only at startup - I have effectively added just three small log lines more of messages per startup