### PR TITLE
Handle and log uncaught exception

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -511,7 +511,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                         config.getAckQuorumSize(), config.getDigestType(), config.getPassword(), this, ctx);
             }
         } else {
-            checkArgument(state == State.LedgerOpened);
+            checkArgument(state == State.LedgerOpened, "ledger=%s is not opened", state);
 
             // Write into lastLedger
             addOperation.setLedger(currentLedger);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -106,7 +106,11 @@ class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallback {
 
     @Override
     public void addComplete(int rc, final LedgerHandle lh, long entryId, Object ctx) {
-        checkArgument(ledger.getId() == lh.getId());
+        if (ledger.getId() != lh.getId()) {
+            log.warn("[{}] ledgerId {} doesn't match with acked ledgerId {}", ml.getName(), ledger.getId(), lh.getId());
+        }
+        checkArgument(ledger.getId() == lh.getId(), "ledgerId %s doesn't match with acked ledgerId %s", ledger.getId(),
+                lh.getId());
         checkArgument(this.ctx == ctx);
 
         this.entryId = entryId;
@@ -173,7 +177,8 @@ class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallback {
 
     @Override
     public void closeComplete(int rc, LedgerHandle lh, Object ctx) {
-        checkArgument(ledger.getId() == lh.getId());
+        checkArgument(ledger.getId() == lh.getId(), "ledgerId %s doesn't match with acked ledgerId %s", ledger.getId(),
+                lh.getId());
 
         if (rc == BKException.Code.OK) {
             log.debug("Successfuly closed ledger {}", lh.getId());

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/StatsBuckets.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/util/StatsBuckets.java
@@ -102,7 +102,9 @@ public class StatsBuckets {
     }
 
     public void addAll(StatsBuckets other) {
-        checkArgument(boundaries.length == other.boundaries.length);
+        checkArgument(boundaries.length == other.boundaries.length,
+                "boundaries size %s doesn't match with given boundaries size %s", boundaries.length,
+                other.boundaries.length);
 
         for (int i = 0; i < buckets.length; i++) {
             buckets[i].add(other.values[i]);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -215,7 +215,7 @@ public abstract class AdminResource extends PulsarWebResource {
         String brokerUrl = String.format("http://%s", broker);
         if (!pulsar().getWebServiceAddress().equals(brokerUrl)) {
             String[] parts = broker.split(":");
-            checkArgument(parts.length == 2);
+            checkArgument(parts.length == 2, "Invalid broker url %s", broker);
             String host = parts[0];
             int port = Integer.parseInt(parts[1]);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -776,7 +776,7 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
 
     public void checkGC(int gcIntervalInSeconds) {
         topics.forEach((n, t) -> {
-            Topic topic = t.getNow(null);
+            Topic topic = t.isCompletedExceptionally() ? null : t.getNow(null);
             if (topic != null) {
                 topic.checkGC(gcIntervalInSeconds);
             }


### PR DESCRIPTION
### Motivation

1. Recently we have seen following uncaught exception with unexpected ledgerId when BK-client complete addEntry callback. So, adding more context to `IllegalArgumentException` to understand actual behavior.

```
16:32:13.412 [BookKeeperClientWorker-23-1] ERROR o.a.bookkeeper.client.PendingAddOp   - Write of ledger entry to quorum failed: L197140149 E3
16:32:13.414 [BookKeeperClientWorker-23-1] ERROR o.a.bookkeeper.client.PendingAddOp   - Write of ledger entry to quorum failed: L197140149 E4
:
16:32:13.419 [BookKeeperClientWorker-23-1] ERROR o.a.bookkeeper.util.SafeRunnable     - Unexpected throwable caught 
java.lang.IllegalArgumentException: null
        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:77) ~[guava-15.0.jar:na]
        at org.apache.bookkeeper.mledger.impl.OpAddEntry.addComplete(OpAddEntry.java:110) ~[managed-ledger-1.19.2-incubating-yahoo.jar:1.19.2-incubating-yahoo]
        at org.apache.bookkeeper.client.PendingAddOp.submitCallback(PendingAddOp.java:256) ~[bookkeeper-server-4.3.1.56-yahoo.jar:4.3.1.56-yahoo]
        at org.apache.bookkeeper.client.LedgerHandle.errorOutPendingAdds(LedgerHandle.java:865) ~[bookkeeper-server-4.3.1.56-yahoo.jar:4.3.1.56-yahoo]
        at org.apache.bookkeeper.client.LedgerHandle$2.safeRun(LedgerHandle.java:355) ~[bookkeeper-server-4.3.1.56-yahoo.jar:4.3.1.56-yahoo]
        at org.apache.bookkeeper.util.SafeRunnable.run(SafeRunnable.java:31) ~[bookkeeper-server-4.3.1.56-yahoo.jar:4.3.1.56-yahoo]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_131]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_131]
        at io.netty.util.concurrent.DefaultThreadFactory$DefaultRunnableDecorator.run(DefaultThreadFactory.java:144) [netty-all-4.0.46.Final.jar:4.0.46.Final]

```
2. Uncaught exception at `checkGC()` if topic is completed with exception and not yet removed from cache.
```
16:32:23.357 [pulsar-inactivity-monitor-66-1] ERROR o.a.bookkeeper.util.SafeRunnable     - Unexpected throwable caught 
java.util.concurrent.CompletionException: org.apache.pulsar.broker.service.BrokerServiceException$ServiceUnitNotReadyException: Namespace is being unloaded, cannot add topic persistent://xobni/ne1/jedi-events/mailevents-partition-274
        at java.util.concurrent.CompletableFuture.reportJoin(CompletableFuture.java:375) ~[na:1.8.0_131]
        at java.util.concurrent.CompletableFuture.getNow(CompletableFuture.java:1949) ~[na:1.8.0_131]
        at org.apache.pulsar.broker.service.BrokerService.lambda$17(BrokerService.java:767) ~[pulsar-broker-1.19.2-incubating-yahoo.jar:1.19.2-incubating-yahoo]
        at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section.forEach(ConcurrentOpenHashMap.java:386) ~[pulsar-common-1.19.2-incubating-yahoo.jar:1.19.2-incubating-yahoo]
        at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap.forEach(ConcurrentOpenHashMap.java:160) ~[pulsar-common-1.19.2-incubating-yahoo.jar:1.19.2-incubating-yahoo]
        at org.apache.pulsar.broker.service.BrokerService.checkGC(BrokerService.java:766) ~[pulsar-broker-1.19.2-incubating-yahoo.jar:1.19.2-incubating-yahoo]
        at org.apache.pulsar.broker.service.BrokerService.lambda$1(BrokerService.java:314) ~[pulsar-broker-1.19.2-incubating-yahoo.jar:1.19.2-incubating-yahoo]
        at org.apache.bookkeeper.mledger.util.SafeRun$1.safeRun(SafeRun.java:30) ~[managed-ledger-1.19.2-incubating-yahoo.jar:1.19.2-incubating-yahoo]
        at org.apache.bookkeeper.util.SafeRunnable.run(SafeRunnable.java:31) ~[bookkeeper-server-4.3.1.56-yahoo.jar:4.3.1.56-yahoo]

```

### Modifications

- add more context info when broker sees ledgerId discrepancy while getting addEntry-ack.
- handle uncaught exception in `checkGC()`

