### PR TITLE
Remove some netty artifacts from bin package since they're already included in netty-all

### DIFF
--- a/all/src/assemble/bin.xml
+++ b/all/src/assemble/bin.xml
@@ -82,6 +82,10 @@
       <excludes>
         <!-- All these dependencies are already included in netty-all -->
         <exclude>io.netty:netty-common</exclude>
+        <exclude>io.netty:netty-resolver</exclude>
+        <exclude>io.netty:netty-resolver-dns</exclude>
+        <exclude>io.netty:netty-codec-dns</exclude>
+        <exclude>io.netty:netty-transport-native-unix-common</exclude>
         <exclude>io.netty:netty-buffer</exclude>
         <exclude>io.netty:netty-codec-http</exclude>
         <exclude>io.netty:netty-codec</exclude>


### PR DESCRIPTION
### Motivation

The binary package is including additional netty jars with different versions, while we already have netty-all included.

This is causing some problems on linux. In netty 4.0 we were already excluding these artifacts, though with 4.1 there are a few more to exclude.