### PR TITLE
Start receiving messages after WebSocket session established

### DIFF
--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
@@ -40,6 +40,7 @@ import org.apache.pulsar.common.util.DateFormatter;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.websocket.data.ConsumerAck;
 import org.apache.pulsar.websocket.data.ConsumerMessage;
+import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.WriteCallback;
 import org.eclipse.jetty.websocket.servlet.ServletUpgradeResponse;
 import org.slf4j.Logger;
@@ -91,7 +92,6 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
                 log.warn("[{}:{}] Failed to add consumer handler for topic {}", request.getRemoteAddr(),
                         request.getRemotePort(), topic);
             }
-            receiveMessage();
         } catch (Exception e) {
             log.warn("[{}:{}] Failed in creating subscription {} on topic {}", request.getRemoteAddr(),
                     request.getRemotePort(), subscription, topic, e);
@@ -165,6 +165,12 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
         }).exceptionally(exception -> {
             return null;
         });
+    }
+
+    @Override
+    public void onWebSocketConnect(Session session) {
+        super.onWebSocketConnect(session);
+        receiveMessage();
     }
 
     @Override


### PR DESCRIPTION
### Motivation

In rare cases, WebSocket client that start consuming can not receive any messages from WebSocket Proxy even though messages are still in the backlog.
As a result of the investigation, I found that NullPointerException occurred at either of the following lines:

* https://github.com/apache/incubator-pulsar/blob/bcc74044288932acc9e83b04001bf1ced17d7780/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java#L118
* https://github.com/apache/incubator-pulsar/blob/bcc74044288932acc9e83b04001bf1ced17d7780/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java#L136

It seems that `getSession()` returns null because WebSocket session establishment has not been completed.

### Modifications

Move the first call of `receiveMessage()` from the constructor to `onWebSocketConnect()` in ConsumerHandler.

### Result

ConsumerHandler starts receiving messages after WebSocket session established.
Therefore, we can avoid NullPointerException.