### PR TITLE
Remove `apache-rat:check` from travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ install:
 
 script:
     # Build Java and C++
-    - mvn license:check apache-rat:check test package && sudo bash -x $TRAVIS_BUILD_DIR/pulsar-client-cpp/travis-build.sh $HOME/pulsar-dep $TRAVIS_BUILD_DIR compile
+    - mvn license:check test package && sudo bash -x $TRAVIS_BUILD_DIR/pulsar-client-cpp/travis-build.sh $HOME/pulsar-dep $TRAVIS_BUILD_DIR compile
     # Build docker images
     - docker/build.sh
     # Generate website


### PR DESCRIPTION
### Motivation

Be able to use travis to verify builds

### Modifications

Remove `apache-rat:check`.

### Result

Travis CI can build correctly.