### PR TITLE
Fix authentication logic in WebSocketWebResource

### DIFF
--- a/pulsar-websocket/pom.xml
+++ b/pulsar-websocket/pom.xml
@@ -65,6 +65,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-servlet-core</artifactId>
     </dependency>

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/admin/WebSocketWebResource.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/admin/WebSocketWebResource.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.websocket.admin;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
 import javax.naming.AuthenticationException;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
@@ -62,14 +64,15 @@ public class WebSocketWebResource {
      * @return the web service caller identification
      */
     public String clientAppId() {
-        if (clientId != null && service().getConfig().isAuthenticationEnabled()) {
+        if (isBlank(clientId) && service().getConfig().isAuthenticationEnabled()) {
             try {
                 clientId = service().getAuthenticationService().authenticateHttpRequest(httpRequest);
             } catch (AuthenticationException e) {
                 throw new RestException(Status.UNAUTHORIZED, "Failed to get clientId from request");
             }
-        } else {
-            throw new RestException(Status.UNAUTHORIZED, "Failed to get auth data from the request");
+            if (isBlank(clientId)) {
+                throw new RestException(Status.UNAUTHORIZED, "Failed to get auth data from the request");
+            }
         }
         return clientId;
     }

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/admin/WebSocketWebResource.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/admin/WebSocketWebResource.java
@@ -64,13 +64,16 @@ public class WebSocketWebResource {
      * @return the web service caller identification
      */
     public String clientAppId() {
-        if (isBlank(clientId) && service().getConfig().isAuthenticationEnabled()) {
+        if (isBlank(clientId)) {
             try {
                 clientId = service().getAuthenticationService().authenticateHttpRequest(httpRequest);
             } catch (AuthenticationException e) {
-                throw new RestException(Status.UNAUTHORIZED, "Failed to get clientId from request");
+                if (service().getConfig().isAuthenticationEnabled()) {
+                    throw new RestException(Status.UNAUTHORIZED, "Failed to get clientId from request");
+                }
             }
-            if (isBlank(clientId)) {
+
+            if (isBlank(clientId) && service().getConfig().isAuthenticationEnabled()) {
                 throw new RestException(Status.UNAUTHORIZED, "Failed to get auth data from the request");
             }
         }


### PR DESCRIPTION
### Motivation

When authentication of WebSocket Proxy is enabled, any HTTP request to proxy stats API is rejected.
I think it is because an authentication logic in WebSocketWebResource class is incorrect.

### Modifications

Fix the authentication logic in WebSocketWebResource class.

### Result

We can access proxy stats API even when authentication is enabled.