### PR TITLE
Don't create client when authentication fails on websocket proxy

### DIFF
--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/AbstractWebSocketHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/AbstractWebSocketHandler.java
@@ -46,6 +46,7 @@ public abstract class AbstractWebSocketHandler extends WebSocketAdapter implemen
 
     protected final String topic;
     protected final Map<String, String> queryParams;
+    protected final boolean authResult;
 
     public AbstractWebSocketHandler(WebSocketService service, HttpServletRequest request, ServletUpgradeResponse response) {
         this.service = service;
@@ -57,10 +58,10 @@ public abstract class AbstractWebSocketHandler extends WebSocketAdapter implemen
             queryParams.put(key, values[0]);
         });
 
-        checkAuth(response);
+        authResult = checkAuth(response);
     }
 
-    private void checkAuth(ServletUpgradeResponse response) {
+    private boolean checkAuth(ServletUpgradeResponse response) {
         String authRole = "<none>";
         if (service.isAuthenticationEnabled()) {
             try {
@@ -77,7 +78,7 @@ public abstract class AbstractWebSocketHandler extends WebSocketAdapter implemen
                     log.warn("[{}:{}] Failed to send error: {}", request.getRemoteAddr(), request.getRemotePort(),
                             e1.getMessage(), e1);
                 }
-                return;
+                return false;
             }
         }
 
@@ -87,7 +88,7 @@ public abstract class AbstractWebSocketHandler extends WebSocketAdapter implemen
                     log.warn("[{}:{}] WebSocket Client [{}] is not authorized on topic {}", request.getRemoteAddr(),
                             request.getRemotePort(), authRole, topic);
                     response.sendError(HttpServletResponse.SC_FORBIDDEN, "Not authorized");
-                    return;
+                    return false;
                 }
             } catch (Exception e) {
                 log.warn("[{}:{}] Got an exception when authorizing WebSocket client {} on topic {} on: {}",
@@ -98,10 +99,10 @@ public abstract class AbstractWebSocketHandler extends WebSocketAdapter implemen
                     log.warn("[{}:{}] Failed to send error: {}", request.getRemoteAddr(), request.getRemotePort(),
                             e1.getMessage(), e1);
                 }
-                return;
+                return false;
             }
         }
-
+        return true;
     }
 
     @Override

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ConsumerHandler.java
@@ -86,6 +86,10 @@ public class ConsumerHandler extends AbstractWebSocketHandler {
         this.numBytesDelivered = new LongAdder();
         this.numMsgsAcked = new LongAdder();
 
+        if (!authResult) {
+            return;
+        }
+
         try {
             this.consumer = service.getPulsarClient().subscribe(topic, subscription, conf);
             if (!this.service.addConsumer(this)) {

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ProducerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ProducerHandler.java
@@ -86,6 +86,10 @@ public class ProducerHandler extends AbstractWebSocketHandler {
         this.numMsgsFailed = new LongAdder();
         this.publishLatencyStatsUSec = new StatsBuckets(ENTRY_LATENCY_BUCKETS_USEC);
 
+        if (!authResult) {
+            return;
+        }
+
         try {
             ProducerConfiguration conf = getProducerConfiguration();
             this.producer = service.getPulsarClient().createProducer(topic, conf);

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ReaderHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ReaderHandler.java
@@ -81,6 +81,10 @@ public class ReaderHandler extends AbstractWebSocketHandler {
         this.numMsgsDelivered = new LongAdder();
         this.numBytesDelivered = new LongAdder();
 
+        if (!authResult) {
+            return;
+        }
+
         try {
             this.reader = service.getPulsarClient().createReader(topic, getMessageId(), conf);
             this.subscription = ((ReaderImpl)this.reader).getConsumer().getSubscription();


### PR DESCRIPTION
## Motivation
Websocket proxy create producer/consumer even though authentication fails and they remains until proxy is restart.

### Modifications
Proxy doesn't create producer/consumer when authentication fails.

### Result
producer/consumer doesn't increase when authentication fails.