### PR TITLE
Exclude tests jar path from classpath.txt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -676,6 +676,7 @@ flexible messaging model and an intuitive client API.</description>
             </goals>
             <configuration>
               <outputFile>target/classpath.txt</outputFile>
+              <includeScope>runtime</includeScope>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
### Motivation
Now, when running bin files, they output logs like following.
```
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/Users/yushiga/.m2/repository/org/slf4j/slf4j-log4j12/1.7.25/slf4j-log4j12-1.7.25.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/Users/yushiga/.m2/repository/org/slf4j/slf4j-simple/1.7.25/slf4j-simple-1.7.25.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.impl.Log4jLoggerFactory]
```

The cause of them is that `classpath.txt` contains jars for both test and runtime.

### Modifications

- Added `includeScope` for `build-classpath`.

### Result
The logs will not be output.