### PR TITLE
Partitioned Consumer UnAckedMessageTracker

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PerMessageUnAcknowledgedRedeliveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PerMessageUnAcknowledgedRedeliveryTest.java
@@ -348,7 +348,8 @@ public class PerMessageUnAcknowledgedRedeliveryTest extends BrokerTestBase {
     }
 
     private static long getUnackedMessagesCountInPartitionedConsumer(Consumer c) {
-        return ((PartitionedConsumerImpl) c).getConsumers().stream()
+        PartitionedConsumerImpl pc = (PartitionedConsumerImpl) c;
+        return pc.getUnAckedMessageTracker().size() + pc.getConsumers().stream()
                 .mapToLong(consumer -> consumer.getUnAckedMessageTracker().size()).sum();
     }
 
@@ -417,6 +418,7 @@ public class PerMessageUnAcknowledgedRedeliveryTest extends BrokerTestBase {
         assertEquals(received, 5);
 
         // 7. Simulate ackTimeout
+        ((PartitionedConsumerImpl) consumer).getUnAckedMessageTracker().toggle();
         ((PartitionedConsumerImpl) consumer).getConsumers().forEach(c -> c.getUnAckedMessageTracker().toggle());
 
         // 8. producer publish more messages

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -965,7 +965,12 @@ public class ConsumerImpl extends ConsumerBase {
             if (id instanceof BatchMessageIdImpl) {
                 id = new MessageIdImpl(id.getLedgerId(), id.getEntryId(), getPartitionIndex());
             }
-            unAckedMessageTracker.add(id);
+            if (partitionIndex != -1) {
+                // we should no longer track this message, PartitionedConsumerImpl will take care from now onwards
+                unAckedMessageTracker.remove(id);
+            } else {
+                unAckedMessageTracker.add(id);
+            }
         }
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -769,8 +769,8 @@ public class ConsumerImpl extends ConsumerBase {
             uncompressedPayload.release();
             msgMetadata.recycle();
 
+            lock.readLock().lock();
             try {
-                lock.readLock().lock();
                 // Enqueue the message so that it can be retrieved when application calls receive()
                 // if the conf.getReceiverQueueSize() is 0 then discard message if no one is waiting for it.
                 // if asyncReceive is waiting then notify callback without adding to incomingMessages queue
@@ -916,12 +916,15 @@ public class ConsumerImpl extends ConsumerBase {
                 final MessageImpl message = new MessageImpl(batchMessageIdImpl, msgMetadata,
                         singleMessageMetadataBuilder.build(), singleMessagePayload, cnx);
                 lock.readLock().lock();
-                if (pendingReceives.isEmpty()) {
-                    incomingMessages.add(message);
-                } else {
-                    notifyPendingReceivedCallback(message, null);
+                try {
+                    if (pendingReceives.isEmpty()) {
+                        incomingMessages.add(message);
+                    } else {
+                        notifyPendingReceivedCallback(message, null);
+                    }
+                } finally {
+                    lock.readLock().unlock();
                 }
-                lock.readLock().unlock();
                 singleMessagePayload.release();
                 singleMessageMetadataBuilder.recycle();
             }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedConsumerImpl.java
@@ -66,7 +66,7 @@ public class PartitionedConsumerImpl extends ConsumerBase {
 
     PartitionedConsumerImpl(PulsarClientImpl client, String topic, String subscription, ConsumerConfiguration conf,
             int numPartitions, ExecutorService listenerExecutor, CompletableFuture<Consumer> subscribeFuture) {
-        super(client, topic, subscription, conf, Math.max(numPartitions, conf.getReceiverQueueSize()), listenerExecutor,
+        super(client, topic, subscription, conf, Math.max(Math.max(2, numPartitions), conf.getReceiverQueueSize()), listenerExecutor,
                 subscribeFuture);
         this.consumers = Lists.newArrayListWithCapacity(numPartitions);
         this.pausedConsumers = new ConcurrentLinkedQueue<>();


### PR DESCRIPTION
Should fix #946 

I added UnAckedMessageTracker on `PartitionedConsumer` and made `ConsumerImpl`s stop tracking messages when they're handed to `PartitionedConsumerImpl`. This is kind of tricky, because `ConsumerImpl` will not increment permits for messages that are not in it's queue, this is why I made `PartitionedConsumerImpl` try to remove messages from it's queue and increment permits for the corresponding `ConsumerImpl`s.

There are also a few cases where we are accessing variables that should be wrapped in a read lock but are not. This also raised a few questions, there are at least two cases where we're modifying data while holding a read lock or not holding a lock at all, this could have consequences. [Here](https://github.com/apache/incubator-pulsar/blob/master/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedConsumerImpl.java#L137) we're modifying `pausedConsumers` which is usually guarded by locks. And [here](https://github.com/apache/incubator-pulsar/blob/master/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedConsumerImpl.java#L365) we're adding messages to the queue while holding a read lock, I realize having a write lock there could cause a deadlock, mostly when using queue size 1.
We could treat these in anothre PR, though.