### PR TITLE
Fix SHA extension

### DIFF
--- a/src/sign-release.sh
+++ b/src/sign-release.sh
@@ -29,5 +29,5 @@ do
    gpg --print-md MD5 $FILE > $FILE.md5
 
    # SHA-512 signature
-   gpg --print-md SHA512 $FILE > $FILE.sha
+   gpg --print-md SHA512 $FILE > $FILE.sha512
 done


### PR DESCRIPTION
### Motivation

http://www.apache.org/dev/release-distribution#sigs-and-sums
We should use ".sha512" extension instead of ".sha".