### PR TITLE
Retry on failure of ledger-deletion and avoid running callback in executor

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -267,7 +267,7 @@ public class ManagedCursorImpl implements ManagedCursor {
             // Read the last entry in the ledger
             lh.asyncReadLastEntry((rc1, lh1, seq, ctx1) -> {
                 if (log.isDebugEnabled()) {
-                    log.debug("readComplete rc={} entryId={}", rc1, lh1.getLastAddConfirmed());
+                    log.debug("[{}} readComplete rc={} entryId={}", ledger.getName(), rc1, lh1.getLastAddConfirmed());
                 }
                 if (isBkErrorNotRecoverable(rc1)) {
                     log.error("[{}] Error reading from metadata ledger {} for consumer {}: {}", ledger.getName(),
@@ -984,7 +984,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         long allEntries = ledger.getNumberOfEntries(range);
 
         if (log.isDebugEnabled()) {
-            log.debug("getNumberOfEntries. {} allEntries: {}", range, allEntries);
+            log.debug("[{}] getNumberOfEntries. {} allEntries: {}", ledger.getName(), range, allEntries);
         }
 
         long deletedEntries = 0;
@@ -1007,7 +1007,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         }
 
         if (log.isDebugEnabled()) {
-            log.debug("Found {} entries - deleted: {}", allEntries - deletedEntries, deletedEntries);
+            log.debug("[{}] Found {} entries - deleted: {}", ledger.getName(), allEntries - deletedEntries, deletedEntries);
         }
         return allEntries - deletedEntries;
     }
@@ -1235,7 +1235,7 @@ public class ManagedCursorImpl implements ManagedCursor {
             readPosition = ledger.getNextValidPosition(newMarkDeletePosition);
 
             if (log.isDebugEnabled()) {
-                log.debug("Moved read position from: {} to: {}", oldReadPosition, readPosition);
+                log.debug("[{}] Moved read position from: {} to: {}", ledger.getName(), oldReadPosition, readPosition);
             }
         }
 
@@ -1258,8 +1258,8 @@ public class ManagedCursorImpl implements ManagedCursor {
             }
 
             if (log.isDebugEnabled()) {
-                log.debug("Moved ack position from: {} to: {} -- skipped: {}", oldMarkDeletePosition,
-                        newMarkDeletePosition, skippedEntries);
+                log.debug("[{}] Moved ack position from: {} to: {} -- skipped: {}", ledger.getName(),
+                        oldMarkDeletePosition, newMarkDeletePosition, skippedEntries);
             }
             messagesConsumedCounter += skippedEntries;
         }
@@ -1664,7 +1664,7 @@ public class ManagedCursorImpl implements ManagedCursor {
             PositionImpl newReadPosition = ledger.getNextValidPosition(markDeletePosition);
             PositionImpl oldReadPosition = readPosition;
 
-            log.info("[{}] Rewind from {} to {}", name, oldReadPosition, newReadPosition);
+            log.info("[{}-{}] Rewind from {} to {}", ledger.getName(), name, oldReadPosition, newReadPosition);
 
             readPosition = newReadPosition;
         } finally {
@@ -2156,47 +2156,55 @@ public class ManagedCursorImpl implements ManagedCursor {
     }
 
     void asyncDeleteLedger(final LedgerHandle lh) {
-        if (lh == null) {
+        asyncDeleteLedger(lh, 3);
+    }
+    
+    private void asyncDeleteLedger(final LedgerHandle lh, int retry) {
+        if (lh == null || retry <= 0) {
             return;
         }
 
         ledger.mbean.startCursorLedgerDeleteOp();
         bookkeeper.asyncDeleteLedger(lh.getId(), (rc, ctx) -> {
-            ledger.getExecutor().submit(safeRun(() -> {
-                ledger.mbean.endCursorLedgerDeleteOp();
-                if (rc != BKException.Code.OK) {
-                    log.warn("[{}] Failed to delete ledger {}: {}", ledger.getName(), lh.getId(),
-                            BKException.getMessage(rc));
-                    return;
-                } else {
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}][{}] Successfully closed&deleted ledger {} in cursor", ledger.getName(), name,
-                                lh.getId());
-                    }
+            ledger.mbean.endCursorLedgerDeleteOp();
+            if (rc != BKException.Code.OK) {
+                log.warn("[{}] Failed to delete ledger {}: {}", ledger.getName(), lh.getId(),
+                        BKException.getMessage(rc));
+                if (rc != BKException.Code.NoSuchLedgerExistsException) {
+                    asyncDeleteLedger(lh, retry - 1);
                 }
-            }));
+                return;
+            } else {
+                log.info("[{}][{}] Successfully closed & deleted ledger {} in cursor", ledger.getName(), name,
+                        lh.getId());
+            }
         }, null);
     }
 
     void asyncDeleteCursorLedger() {
+        asyncDeleteCursorLedger(3);
+    }
+    
+    private void asyncDeleteCursorLedger(int retry) {
         STATE_UPDATER.set(this, State.Closed);
 
-        if (cursorLedger == null) {
+        if (cursorLedger == null || retry <= 0) {
             // No ledger was created
             return;
         }
 
         ledger.mbean.startCursorLedgerDeleteOp();
         bookkeeper.asyncDeleteLedger(cursorLedger.getId(), (rc, ctx) -> {
-            ledger.getExecutor().submit(safeRun(() -> {
-                ledger.mbean.endCursorLedgerDeleteOp();
-                if (rc == BKException.Code.OK) {
-                    log.debug("[{}][{}] Deleted cursor ledger", cursorLedger.getId());
-                } else {
-                    log.warn("[{}][{}] Failed to delete ledger {}: {}", ledger.getName(), name, cursorLedger.getId(),
-                            BKException.getMessage(rc));
+            ledger.mbean.endCursorLedgerDeleteOp();
+            if (rc == BKException.Code.OK) {
+                log.info("[{}][{}] Deleted cursor ledger {}", ledger.getName(), name, cursorLedger.getId());
+            } else {
+                log.warn("[{}][{}] Failed to delete ledger {}: {}", ledger.getName(), name, cursorLedger.getId(),
+                        BKException.getMessage(rc));
+                if (rc != BKException.Code.NoSuchLedgerExistsException) {
+                    asyncDeleteCursorLedger(retry - 1);
                 }
-            }));
+            }
         }, null);
     }
 


### PR DESCRIPTION
### Motivation

- Right now, when cursor ledger deletion fails then broker doesn't retry 
- and if it is successfully deleted then broker should log it as info to help debugging into leak cursor ledger.
- also delete-ledger callback doesn't process much so, it should not be run on executor to avoid context switch.
- add ml-name into info log

Recently, we have seen large number of cursor ledger leaks with below behavior
```
eg:
Leaked Orphan-ledger: `5868811882`

00:00:12.215 [bookkeeper-ml-workers-49-1] INFO  o.a.b.mledger.impl.ManagedCursorImpl - [prop/cluster/ns/persistent/topic] Updated cursor cms.repl.prod2-gq1 with ledger id 5867534842 md-position=5867470268:0 rd-position=5867470268:1
:
00:28:23.221 [bookkeeper-ml-workers-47-1] INFO  o.a.b.mledger.impl.ManagedCursorImpl - [prop/cluster/ns/persistent/topic] Updated cursor cms.repl.prod2-gq1 with ledger id 5868811882 md-position=5868513467:0 rd-position=5868513467:1
:
00:52:31.135 [bookkeeper-ml-workers-48-1] INFO  o.a.b.mledger.impl.ManagedCursorImpl - [prop/cluster/ns/persistent/topic] Updated cursor cms.repl.prod2-gq1 with ledger id 5869626192 md-position=5869588859:1 rd-position=5869588859:2
```

[We don't see any logs after this, but this thread should have deleted previous cursor-ledger : `5868811882` but still it was leaking
So, with this PR, we can see info log once ledger is successfully deleted and can learn more about broker/BK behavior]

### Result

- it retries if cursor-ledger deletion fails and logs it on successful deletion. 
