### PR TITLE
Load-balancer consider max-topic threshold on broker-ownership selection

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -313,6 +313,9 @@ loadBalancerSheddingIntervalMinutes=5
 # Prevent the same topics to be shed and moved to other broker more that once within this timeframe
 loadBalancerSheddingGracePeriodMinutes=30
 
+# Usage threshold to allocate max number of topics to broker
+loadBalancerBrokerMaxTopics=50000
+
 # Interval to flush dynamic resource quota to ZooKeeper
 loadBalancerResourceQuotaUpdateIntervalMinutes=15
 

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -285,6 +285,9 @@ loadBalancerSheddingIntervalMinutes=5
 # Prevent the same topics to be shed and moved to other broker more that once within this timeframe
 loadBalancerSheddingGracePeriodMinutes=30
 
+# Usage threshold to allocate max number of topics to broker
+loadBalancerBrokerMaxTopics=50000
+
 # Interval to flush dynamic resource quota to ZooKeeper
 loadBalancerResourceQuotaUpdateIntervalMinutes=15
 

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -300,8 +300,10 @@ public class ServiceConfiguration implements PulsarConfiguration {
     // Usage threshold to determine a broker as under-loaded (only used by SimpleLoadManagerImpl)
     @Deprecated
     private int loadBalancerBrokerUnderloadedThresholdPercentage = 50;
-    // Usage threshold to determine a broker as over-loaded (only used by SimpleLoadManagerImpl)
-    @Deprecated
+    // Usage threshold to allocate max number of topics to broker
+    @FieldContext(dynamic = true)
+    private int loadBalancerBrokerMaxTopics = 50000;
+    // Usage threshold to determine a broker as over-loaded
     private int loadBalancerBrokerOverloadedThresholdPercentage = 85;
     // Interval to flush dynamic resource quota to ZooKeeper
     private int loadBalancerResourceQuotaUpdateIntervalMinutes = 15;
@@ -1065,6 +1067,14 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     public int getLoadBalancerBrokerOverloadedThresholdPercentage() {
         return loadBalancerBrokerOverloadedThresholdPercentage;
+    }
+
+    public int getLoadBalancerBrokerMaxTopics() {
+        return loadBalancerBrokerMaxTopics;
+    }
+
+    public void setLoadBalancerBrokerMaxTopics(int loadBalancerBrokerMaxTopics) {
+        this.loadBalancerBrokerMaxTopics = loadBalancerBrokerMaxTopics;
     }
 
     public void setLoadBalancerNamespaceBundleMaxTopics(int topics) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/BundleData.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/BundleData.java
@@ -34,6 +34,9 @@ public class BundleData extends JSONWritable {
     // by the number of long term samples
     // and the bundle update period.
     private TimeAverageMessageData longTermData;
+    
+    // number of topics present under this bundle
+    private int topics;
 
     // For JSON only.
     public BundleData() {
@@ -77,6 +80,7 @@ public class BundleData extends JSONWritable {
     public void update(final NamespaceBundleStats newSample) {
         shortTermData.update(newSample);
         longTermData.update(newSample);
+        this.topics = (int) newSample.topics;
     }
 
     public TimeAverageMessageData getShortTermData() {
@@ -93,5 +97,13 @@ public class BundleData extends JSONWritable {
 
     public void setLongTermData(TimeAverageMessageData longTermData) {
         this.longTermData = longTermData;
+    }
+
+    public int getTopics() {
+        return topics;
+    }
+
+    public void setTopics(int topics) {
+        this.topics = topics;
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastLongTermMessageRate.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LeastLongTermMessageRate.java
@@ -52,17 +52,20 @@ public class LeastLongTermMessageRate implements ModularLoadManagerStrategy {
     // Any broker at (or above) the overload threshold will have a score of POSITIVE_INFINITY.
     private static double getScore(final BrokerData brokerData, final ServiceConfiguration conf) {
         final double overloadThreshold = conf.getLoadBalancerBrokerOverloadedThresholdPercentage() / 100.0;
-        double totalMessageRate = 0;
-        for (BundleData bundleData : brokerData.getPreallocatedBundleData().values()) {
-            final TimeAverageMessageData longTermData = bundleData.getLongTermData();
-            totalMessageRate += longTermData.getMsgRateIn() + longTermData.getMsgRateOut();
-        }
-        final TimeAverageBrokerData timeAverageData = brokerData.getTimeAverageData();
         final double maxUsage = brokerData.getLocalData().getMaxResourceUsage();
         if (maxUsage > overloadThreshold) {
             log.warn("Broker {} is overloaded: max usage={}", brokerData.getLocalData().getWebServiceUrl(), maxUsage);
             return Double.POSITIVE_INFINITY;
         }
+        
+        double totalMessageRate = 0;
+        for (BundleData bundleData : brokerData.getPreallocatedBundleData().values()) {
+            final TimeAverageMessageData longTermData = bundleData.getLongTermData();
+            totalMessageRate += longTermData.getMsgRateIn() + longTermData.getMsgRateOut();
+        }
+
+        // calculate estimated score
+        final TimeAverageBrokerData timeAverageData = brokerData.getTimeAverageData();
         final double timeAverageLongTermMessageRate = timeAverageData.getLongTermMsgRateIn()
                 + timeAverageData.getLongTermMsgRateOut();
         final double totalMessageRateEstimate = totalMessageRate + timeAverageLongTermMessageRate;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
@@ -27,10 +27,13 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
+import org.apache.pulsar.broker.BrokerData;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.admin.AdminResource;
 import org.apache.pulsar.broker.loadbalance.BrokerHostUsage;
+import org.apache.pulsar.broker.loadbalance.LoadData;
 import org.apache.pulsar.broker.stats.metrics.JvmMetrics;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.NamespaceName;
@@ -277,5 +280,32 @@ public class LoadManagerShared {
         boolean isEnablePersistentTopics(String brokerUrl);
 
         boolean isEnableNonPersistentTopics(String brokerUrl);
+    }
+
+    /**
+     * It filters out brokers which owns topic higher than configured threshold at
+     * {@link ServiceConfiguration.loadBalancerBrokerMaxTopics}. <br/>
+     * if all the brokers own topic higher than threshold then it resets the list with original broker candidates
+     * 
+     * @param brokerCandidateCache
+     * @param loadData
+     * @param loadBalancerBrokerMaxTopics
+     */
+    public static void filterBrokersWithLargeTopicCount(Set<String> brokerCandidateCache, LoadData loadData,
+            int loadBalancerBrokerMaxTopics) {
+        Set<String> filteredBrokerCandidates = brokerCandidateCache.stream().filter((broker) -> {
+            BrokerData brokerData = loadData.getBrokerData().get(broker);
+            long totalTopics = brokerData != null && brokerData.getPreallocatedBundleData() != null
+                    ? brokerData.getPreallocatedBundleData().values().stream()
+                            .mapToLong((preAllocatedBundle) -> preAllocatedBundle.getTopics()).sum()
+                            + brokerData.getLocalData().getNumTopics()
+                    : 0;
+            return totalTopics <= loadBalancerBrokerMaxTopics;
+        }).collect(Collectors.toSet());
+
+        if (!filteredBrokerCandidates.isEmpty()) {
+            brokerCandidateCache.clear();
+            brokerCandidateCache.addAll(filteredBrokerCandidates);
+        }
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.apache.bookkeeper.util.ZkUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -658,6 +659,9 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
             brokerCandidateCache.clear();
             LoadManagerShared.applyPolicies(serviceUnit, policies, brokerCandidateCache, getAvailableBrokers(),
                     brokerTopicLoadingPredicate);
+            // filter brokers which owns topic higher than threshold
+            LoadManagerShared.filterBrokersWithLargeTopicCount(brokerCandidateCache, loadData,
+                    conf.getLoadBalancerBrokerMaxTopics());
             LoadManagerShared.removeMostServicingBrokersForNamespace(serviceUnit.toString(), brokerCandidateCache,
                     brokerToNamespaceToBundleRange);
             log.info("{} brokers being considered for assignment of {}", brokerCandidateCache.size(), bundle);

--- a/site/_data/config/broker.yaml
+++ b/site/_data/config/broker.yaml
@@ -227,6 +227,9 @@ configs:
 - name: loadBalancerSheddingGracePeriodMinutes
   default: '30'
   description: Prevent the same topics to be shed and moved to other broker more that once within this timeframe
+- name: loadBalancerBrokerMaxTopics
+  default: '50000'
+  description: Usage threshold to allocate max number of topics to broker
 - name: loadBalancerBrokerUnderloadedThresholdPercentage
   default: '1'
   description: Usage threshold to determine a broker as under-loaded

--- a/site/_data/config/standalone.yaml
+++ b/site/_data/config/standalone.yaml
@@ -169,6 +169,8 @@ configs:
   default: '30'
 - name: loadBalancerSheddingGracePeriodMinutes
   default: '30'
+- name: loadBalancerBrokerMaxTopics
+  default: '50000'
 - name: loadBalancerBrokerUnderloadedThresholdPercentage
   default: '1'
 - name: loadBalancerBrokerOverloadedThresholdPercentage


### PR DESCRIPTION
### Motivation

Right now, load-manager doesn't consider number of topics owned by a broker while selecting bundle ownership and it overloads few of the brokers with large number of brokers.
eg:
if cluster has 2 brokers: b1 and b2. where b2 owns few bundles and traffic and b1 not. Now, if load-manager receives lookup requests for 10K different bundles at the same time then 
- load-manager has data that b2 is having higher load than b1 
- but load-manager doesn't consider number of topics in those bundles and as b1 has lower load than b2 so, all 10K bundles will be assigned to broker b1.

Now, if broker owns topic higher than certain number (eg: 60K) then it requires to allocate fix set of objects (eg: rate, locks, stats, producers, consumers) per topic which majorly impacts broker GC so, load-manager should consider max-topics count while selecting broker.

Note: load-manager has load-shedding task but sometimes we want broker to prevent bundle unloading so, load-manager should do this work while selecting broker.

### Modifications

- store number of topics under bundle-resource quota
- consider number of topics for a bundle while selecting broker

### Result

Load-manager should not overload broker with topics higher than max-limit.
