### PR TITLE
Acknowledgement with properties for RawReader

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.bookkeeper.mledger.Entry;
@@ -39,7 +40,7 @@ public interface Subscription {
 
     void consumerFlow(Consumer consumer, int additionalNumberOfMessages);
 
-    void acknowledgeMessage(PositionImpl position, AckType ackType);
+    void acknowledgeMessage(PositionImpl position, AckType ackType, Map<String,Long> properties);
 
     String getDestination();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.service.nonpersistent;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
@@ -138,7 +139,7 @@ public class NonPersistentSubscription implements Subscription {
     }
 
     @Override
-    public void acknowledgeMessage(PositionImpl position, AckType ackType) {
+    public void acknowledgeMessage(PositionImpl position, AckType ackType, Map<String,Long> properties) {
         // No-op
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.service.persistent;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
@@ -175,12 +176,12 @@ public class PersistentSubscription implements Subscription {
     }
 
     @Override
-    public void acknowledgeMessage(PositionImpl position, AckType ackType) {
+    public void acknowledgeMessage(PositionImpl position, AckType ackType, Map<String,Long> properties) {
         if (ackType == AckType.Cumulative) {
             if (log.isDebugEnabled()) {
                 log.debug("[{}][{}] Cumulative ack on {}", topicName, subName, position);
             }
-            cursor.asyncMarkDelete(position, markDeleteCallback, position);
+            cursor.asyncMarkDelete(position, properties, markDeleteCallback, position);
         } else {
             if (log.isDebugEnabled()) {
                 log.debug("[{}][{}] Individual ack on {}", topicName, subName, position);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/api/RawReader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/api/RawReader.java
@@ -31,10 +31,9 @@ public interface RawReader {
     /**
      * Create a raw reader for a topic.
      */
-    public static CompletableFuture<RawReader> create(PulsarClient client, String subscription,
-                                                      String topic) {
+    public static CompletableFuture<RawReader> create(PulsarClient client, String topic, String subscription) {
         CompletableFuture<Consumer> future = new CompletableFuture<>();
-        RawReader r = new RawReaderImpl((PulsarClientImpl)client, subscription, topic, future);
+        RawReader r = new RawReaderImpl((PulsarClientImpl)client, topic, subscription, future);
         return future.thenCompose((consumer) -> r.seekAsync(MessageId.earliest)).thenApply((ignore) -> r);
     }
 
@@ -52,11 +51,14 @@ public interface RawReader {
     CompletableFuture<RawMessage> readNextAsync();
 
     /**
-     * Acknowledge all messages as read up until <i>messageId</i>.
+     * Acknowledge all messages as read up until <i>messageId</i>. The properties are stored
+     * with the individual acknowledgement, so later acknowledgements will overwrite all
+     * properties from previous acknowledgements.
+     *
      * @param messageId to cumulatively acknowledge to
      * @param properties a map of properties which will be stored with the acknowledgement
      */
-    CompletableFuture<Void> acknowledgeAsync(MessageId messageId, Map<String,Long> properties);
+    CompletableFuture<Void> acknowledgeCumulativeAsync(MessageId messageId, Map<String,Long> properties);
 
     /**
      * Close the raw reader.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/api/RawReader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/api/RawReader.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.api;
 
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
@@ -30,9 +31,10 @@ public interface RawReader {
     /**
      * Create a raw reader for a topic.
      */
-    public static CompletableFuture<RawReader> create(PulsarClient client, String topic) {
+    public static CompletableFuture<RawReader> create(PulsarClient client, String subscription,
+                                                      String topic) {
         CompletableFuture<Consumer> future = new CompletableFuture<>();
-        RawReader r = new RawReaderImpl((PulsarClientImpl)client, topic, future);
+        RawReader r = new RawReaderImpl((PulsarClientImpl)client, subscription, topic, future);
         return future.thenCompose((consumer) -> r.seekAsync(MessageId.earliest)).thenApply((ignore) -> r);
     }
 
@@ -48,6 +50,13 @@ public interface RawReader {
      * @return a completable future which will return the next RawMessage in the topic.
      */
     CompletableFuture<RawMessage> readNextAsync();
+
+    /**
+     * Acknowledge all messages as read up until <i>messageId</i>.
+     * @param messageId to cumulatively acknowledge to
+     * @param properties a map of properties which will be stored with the acknowledgement
+     */
+    CompletableFuture<Void> acknowledgeAsync(MessageId messageId, Map<String,Long> properties);
 
     /**
      * Close the raw reader.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.client.impl;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 import java.util.UUID;
 import java.util.concurrent.BlockingQueue;
@@ -38,6 +39,7 @@ import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.ConsumerImpl.SubscriptionMode;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData;
+import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType;
 import org.apache.pulsar.common.util.collections.GrowableArrayBlockingQueue;
 import io.netty.buffer.ByteBuf;
 import org.slf4j.Logger;
@@ -52,11 +54,11 @@ public class RawReaderImpl implements RawReader {
     private final ConsumerConfiguration consumerConfiguration;
     private RawConsumerImpl consumer;
 
-    public RawReaderImpl(PulsarClientImpl client, String topic, CompletableFuture<Consumer> consumerFuture) {
+    public RawReaderImpl(PulsarClientImpl client, String subscription,
+                         String topic, CompletableFuture<Consumer> consumerFuture) {
         this.client = client;
+        this.subscription = subscription;
         this.topic = topic;
-
-        subscription = "raw-reader";
 
         consumerConfiguration = new ConsumerConfiguration();
         consumerConfiguration.setSubscriptionType(SubscriptionType.Exclusive);
@@ -74,6 +76,11 @@ public class RawReaderImpl implements RawReader {
     @Override
     public CompletableFuture<RawMessage> readNextAsync() {
         return consumer.receiveRawAsync();
+    }
+
+    @Override
+    public CompletableFuture<Void> acknowledgeAsync(MessageId messageId, Map<String,Long> properties) {
+        return consumer.doAcknowledge(messageId, AckType.Cumulative, properties);
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
@@ -54,8 +54,8 @@ public class RawReaderImpl implements RawReader {
     private final ConsumerConfiguration consumerConfiguration;
     private RawConsumerImpl consumer;
 
-    public RawReaderImpl(PulsarClientImpl client, String subscription,
-                         String topic, CompletableFuture<Consumer> consumerFuture) {
+    public RawReaderImpl(PulsarClientImpl client, String topic, String subscription,
+                         CompletableFuture<Consumer> consumerFuture) {
         this.client = client;
         this.subscription = subscription;
         this.topic = topic;
@@ -79,7 +79,7 @@ public class RawReaderImpl implements RawReader {
     }
 
     @Override
-    public CompletableFuture<Void> acknowledgeAsync(MessageId messageId, Map<String,Long> properties) {
+    public CompletableFuture<Void> acknowledgeCumulativeAsync(MessageId messageId, Map<String,Long> properties) {
         return consumer.doAcknowledge(messageId, AckType.Cumulative, properties);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -36,6 +36,7 @@ import static org.testng.Assert.assertTrue;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -1168,7 +1169,7 @@ public class ServerCnxTest {
         PositionImpl pos = new PositionImpl(0, 0);
 
         clientCommand = Commands.newAck(1 /* consumer id */, pos.getLedgerId(), pos.getEntryId(), AckType.Individual,
-                null);
+                                        null, Collections.emptyMap());
         channel.writeInbound(clientCommand);
 
         // verify nothing is sent out on the wire after ack

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/RawReaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/RawReaderTest.java
@@ -110,7 +110,7 @@ public class RawReaderTest extends MockedPulsarServiceBaseTest {
 
         Set<String> keys = publishMessages(topic, numKeys);
 
-        RawReader reader = RawReader.create(pulsarClient, subscription, topic).get();
+        RawReader reader = RawReader.create(pulsarClient, topic, subscription).get();
         try {
             while (true) { // should break out with TimeoutException
                 try (RawMessage m = reader.readNextAsync().get(1, TimeUnit.SECONDS)) {
@@ -132,7 +132,7 @@ public class RawReaderTest extends MockedPulsarServiceBaseTest {
         publishMessages(topic, numKeys);
 
         Set<String> readKeys = new HashSet<>();
-        RawReader reader = RawReader.create(pulsarClient, subscription, topic).get();
+        RawReader reader = RawReader.create(pulsarClient, topic, subscription).get();
         try {
             while (true) { // should break out with TimeoutException
                 try (RawMessage m = reader.readNextAsync().get(1, TimeUnit.SECONDS)) {
@@ -167,7 +167,7 @@ public class RawReaderTest extends MockedPulsarServiceBaseTest {
         publishMessages(topic, numKeys);
 
         Set<String> readKeys = new HashSet<>();
-        RawReader reader = RawReader.create(pulsarClient, subscription, topic).get();
+        RawReader reader = RawReader.create(pulsarClient, topic, subscription).get();
         int i = 0;
         MessageId seekTo = null;
         try {
@@ -212,7 +212,7 @@ public class RawReaderTest extends MockedPulsarServiceBaseTest {
 
         publishMessages(topic, numMessages);
 
-        RawReader reader = RawReader.create(pulsarClient, subscription, topic).get();
+        RawReader reader = RawReader.create(pulsarClient, topic, subscription).get();
         List<Future<RawMessage>> futures = new ArrayList<>();
         Set<String> keys = new HashSet<>();
 
@@ -242,7 +242,7 @@ public class RawReaderTest extends MockedPulsarServiceBaseTest {
         Set<String> keys = publishMessages(topic, numKeys);
 
         MessageId lastMessageId = null;
-        RawReader reader = RawReader.create(pulsarClient, subscription, topic).get();
+        RawReader reader = RawReader.create(pulsarClient, topic, subscription).get();
         try {
             while (true) { // should break out with TimeoutException
                 try (RawMessage m = reader.readNextAsync().get(1, TimeUnit.SECONDS)) {
@@ -258,7 +258,7 @@ public class RawReaderTest extends MockedPulsarServiceBaseTest {
 
         Map<String,Long> properties = new HashMap<>();
         properties.put("foobar", 0xdeadbeefdecaL);
-        reader.acknowledgeAsync(lastMessageId, properties).get(5, TimeUnit. SECONDS);
+        reader.acknowledgeCumulativeAsync(lastMessageId, properties).get(5, TimeUnit.SECONDS);
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topic);
         ManagedLedger ledger = topicRef.getManagedLedger();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/RawReaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/RawReaderTest.java
@@ -26,13 +26,19 @@ import com.google.common.collect.Sets;
 import io.netty.buffer.ByteBuf;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.bookkeeper.mledger.ManagedLedger;
+
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.common.api.Commands;
 import org.apache.pulsar.client.api.MessageBuilder;
 import org.apache.pulsar.client.api.MessageId;
@@ -41,7 +47,6 @@ import org.apache.pulsar.client.api.ProducerConfiguration;
 import org.apache.pulsar.client.api.RawMessage;
 import org.apache.pulsar.client.api.RawReader;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
-import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.PropertyAdmin;
 
@@ -54,6 +59,7 @@ import org.testng.annotations.Test;
 
 public class RawReaderTest extends MockedPulsarServiceBaseTest {
     private static final Logger log = LoggerFactory.getLogger(RawReaderTest.class);
+    private static final String subscription = "foobar-sub";
 
     @BeforeMethod
     @Override
@@ -104,7 +110,7 @@ public class RawReaderTest extends MockedPulsarServiceBaseTest {
 
         Set<String> keys = publishMessages(topic, numKeys);
 
-        RawReader reader = RawReader.create(pulsarClient, topic).get();
+        RawReader reader = RawReader.create(pulsarClient, subscription, topic).get();
         try {
             while (true) { // should break out with TimeoutException
                 try (RawMessage m = reader.readNextAsync().get(1, TimeUnit.SECONDS)) {
@@ -126,7 +132,7 @@ public class RawReaderTest extends MockedPulsarServiceBaseTest {
         publishMessages(topic, numKeys);
 
         Set<String> readKeys = new HashSet<>();
-        RawReader reader = RawReader.create(pulsarClient, topic).get();
+        RawReader reader = RawReader.create(pulsarClient, subscription, topic).get();
         try {
             while (true) { // should break out with TimeoutException
                 try (RawMessage m = reader.readNextAsync().get(1, TimeUnit.SECONDS)) {
@@ -161,7 +167,7 @@ public class RawReaderTest extends MockedPulsarServiceBaseTest {
         publishMessages(topic, numKeys);
 
         Set<String> readKeys = new HashSet<>();
-        RawReader reader = RawReader.create(pulsarClient, topic).get();
+        RawReader reader = RawReader.create(pulsarClient, subscription, topic).get();
         int i = 0;
         MessageId seekTo = null;
         try {
@@ -206,7 +212,7 @@ public class RawReaderTest extends MockedPulsarServiceBaseTest {
 
         publishMessages(topic, numMessages);
 
-        RawReader reader = RawReader.create(pulsarClient, topic).get();
+        RawReader reader = RawReader.create(pulsarClient, subscription, topic).get();
         List<Future<RawMessage>> futures = new ArrayList<>();
         Set<String> keys = new HashSet<>();
 
@@ -226,4 +232,44 @@ public class RawReaderTest extends MockedPulsarServiceBaseTest {
         Assert.assertEquals(timeouts, 1);
         Assert.assertEquals(keys.size(), numMessages);
     }
+
+    @Test
+    public void testAcknowledgeWithProperties() throws Exception {
+        int numKeys = 10;
+
+        String topic = "persistent://my-property/use/my-ns/my-raw-topic";
+
+        Set<String> keys = publishMessages(topic, numKeys);
+
+        MessageId lastMessageId = null;
+        RawReader reader = RawReader.create(pulsarClient, subscription, topic).get();
+        try {
+            while (true) { // should break out with TimeoutException
+                try (RawMessage m = reader.readNextAsync().get(1, TimeUnit.SECONDS)) {
+                    lastMessageId = m.getMessageId();
+                    Assert.assertTrue(keys.remove(extractKey(m)));
+                }
+            }
+        } catch (TimeoutException te) {
+            // ok
+        }
+
+        Assert.assertTrue(keys.isEmpty());
+
+        Map<String,Long> properties = new HashMap<>();
+        properties.put("foobar", 0xdeadbeefdecaL);
+        reader.acknowledgeAsync(lastMessageId, properties).get(5, TimeUnit. SECONDS);
+
+        PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topic);
+        ManagedLedger ledger = topicRef.getManagedLedger();
+        for (int i = 0; i < 30; i++) {
+            if (ledger.openCursor(subscription).getProperties().get("foobar") == Long.valueOf(0xdeadbeefdecaL)) {
+                break;
+            }
+            Thread.sleep(100);
+        }
+        Assert.assertEquals(ledger.openCursor(subscription).getProperties().get("foobar"),
+                Long.valueOf(0xdeadbeefdecaL));
+    }
+
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.client.impl;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
@@ -225,7 +227,7 @@ public abstract class ConsumerBase extends HandlerBase implements Consumer {
 
     @Override
     public CompletableFuture<Void> acknowledgeAsync(MessageId messageId) {
-        return doAcknowledge(messageId, AckType.Individual);
+        return doAcknowledge(messageId, AckType.Individual, Collections.emptyMap());
     }
 
     @Override
@@ -235,10 +237,11 @@ public abstract class ConsumerBase extends HandlerBase implements Consumer {
                     "Cannot use cumulative acks on a non-exclusive subscription"));
         }
 
-        return doAcknowledge(messageId, AckType.Cumulative);
+        return doAcknowledge(messageId, AckType.Cumulative, Collections.emptyMap());
     }
 
-    abstract protected CompletableFuture<Void> doAcknowledge(MessageId messageId, AckType ackType);
+    abstract protected CompletableFuture<Void> doAcknowledge(MessageId messageId, AckType ackType,
+                                                             Map<String,Long> properties);
 
     @Override
     public void unsubscribe() throws PulsarClientException {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -28,7 +28,9 @@ import static org.apache.pulsar.common.api.Commands.readChecksum;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.BitSet;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.Set;
@@ -322,7 +324,8 @@ public class ConsumerImpl extends ConsumerBase {
 
     // we may not be able to ack message being acked by client. However messages in prior
     // batch may be ackable
-    private void ackMessagesInEarlierBatch(BatchMessageIdImpl batchMessageId, MessageIdImpl message) {
+    private void ackMessagesInEarlierBatch(BatchMessageIdImpl batchMessageId, MessageIdImpl message,
+                                           Map<String,Long> properties) {
         // get entry before this message and ack that message on broker
         MessageIdImpl lowerKey = batchMessageAckTracker.lowerKey(message);
         if (lowerKey != null) {
@@ -334,7 +337,7 @@ public class ConsumerImpl extends ConsumerBase {
                 log.debug("[{}] [{}] ack prior message {} to broker on cumulative ack for message {}", subscription,
                         consumerId, lowerKey, batchMessageId);
             }
-            sendAcknowledge(lowerKey, AckType.Cumulative);
+            sendAcknowledge(lowerKey, AckType.Cumulative, properties);
         } else {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] [{}] no messages prior to message {}", subscription, consumerId, batchMessageId);
@@ -342,7 +345,8 @@ public class ConsumerImpl extends ConsumerBase {
         }
     }
 
-    boolean markAckForBatchMessage(BatchMessageIdImpl batchMessageId, AckType ackType) {
+    boolean markAckForBatchMessage(BatchMessageIdImpl batchMessageId, AckType ackType,
+                                   Map<String,Long> properties) {
         // we keep track of entire batch and so need MessageIdImpl and cannot use BatchMessageIdImpl
         MessageIdImpl message = new MessageIdImpl(batchMessageId.getLedgerId(), batchMessageId.getEntryId(),
                 batchMessageId.getPartitionIndex());
@@ -396,7 +400,7 @@ public class ConsumerImpl extends ConsumerBase {
         } else {
             // we cannot ack this message to broker. but prior message may be ackable
             if (ackType == AckType.Cumulative) {
-                ackMessagesInEarlierBatch(batchMessageId, message);
+                ackMessagesInEarlierBatch(batchMessageId, message, properties);
             }
             if (log.isDebugEnabled()) {
                 log.debug("[{}] [{}] cannot ack message to broker {}, acktype {}, pending acks - {}", subscription,
@@ -439,7 +443,8 @@ public class ConsumerImpl extends ConsumerBase {
     }
 
     @Override
-    protected CompletableFuture<Void> doAcknowledge(MessageId messageId, AckType ackType) {
+    protected CompletableFuture<Void> doAcknowledge(MessageId messageId, AckType ackType,
+                                                    Map<String,Long> properties) {
         checkArgument(messageId instanceof MessageIdImpl);
         if (getState() != State.Ready && getState() != State.Connecting) {
             stats.incrementNumAcksFailed();
@@ -447,7 +452,7 @@ public class ConsumerImpl extends ConsumerBase {
         }
 
         if (messageId instanceof BatchMessageIdImpl) {
-            if (markAckForBatchMessage((BatchMessageIdImpl) messageId, ackType)) {
+            if (markAckForBatchMessage((BatchMessageIdImpl) messageId, ackType, properties)) {
                 // all messages in batch have been acked so broker can be acked via sendAcknowledge()
                 if (log.isDebugEnabled()) {
                     log.debug("[{}] [{}] acknowledging message - {}, acktype {}", subscription, consumerName, messageId,
@@ -463,12 +468,14 @@ public class ConsumerImpl extends ConsumerBase {
         if (ackType == AckType.Cumulative && !(messageId instanceof BatchMessageIdImpl)) {
             updateBatchAckTracker((MessageIdImpl) messageId, ackType);
         }
-        return sendAcknowledge(messageId, ackType);
+        return sendAcknowledge(messageId, ackType, properties);
     }
 
-    private CompletableFuture<Void> sendAcknowledge(MessageId messageId, AckType ackType) {
+    private CompletableFuture<Void> sendAcknowledge(MessageId messageId, AckType ackType,
+                                                    Map<String,Long> properties) {
         MessageIdImpl msgId = (MessageIdImpl) messageId;
-        final ByteBuf cmd = Commands.newAck(consumerId, msgId.getLedgerId(), msgId.getEntryId(), ackType, null);
+        final ByteBuf cmd = Commands.newAck(consumerId, msgId.getLedgerId(), msgId.getEntryId(),
+                                            ackType, null, properties);
 
         // There's no actual response from ack messages
         final CompletableFuture<Void> ackFuture = new CompletableFuture<Void>();
@@ -1094,7 +1101,7 @@ public class ConsumerImpl extends ConsumerBase {
 
     private void discardMessage(MessageIdData messageId, ClientCnx currentCnx, ValidationError validationError) {
         ByteBuf cmd = Commands.newAck(consumerId, messageId.getLedgerId(), messageId.getEntryId(), AckType.Individual,
-                validationError);
+                                      validationError, Collections.emptyMap());
         currentCnx.ctx().writeAndFlush(cmd, currentCnx.ctx().voidPromise());
         increaseAvailablePermits(currentCnx);
         stats.incrementNumReceiveFailed();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedConsumerImpl.java
@@ -236,7 +236,8 @@ public class PartitionedConsumerImpl extends ConsumerBase {
     }
 
     @Override
-    protected CompletableFuture<Void> doAcknowledge(MessageId messageId, AckType ackType) {
+    protected CompletableFuture<Void> doAcknowledge(MessageId messageId, AckType ackType,
+                                                    Map<String,Long> properties) {
         checkArgument(messageId instanceof MessageIdImpl);
 
         if (getState() != State.Ready) {
@@ -249,7 +250,7 @@ public class PartitionedConsumerImpl extends ConsumerBase {
         } else {
 
             ConsumerImpl consumer = consumers.get(((MessageIdImpl) messageId).getPartitionIndex());
-            return consumer.doAcknowledge(messageId, ackType).thenRun(() ->
+            return consumer.doAcknowledge(messageId, ackType, properties).thenRun(() ->
                     unAckedMessageTracker.remove((MessageIdImpl) messageId));
         }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/Commands.java
@@ -23,6 +23,7 @@ import static org.apache.pulsar.checksum.utils.Crc32cChecksum.resumeChecksum;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.pulsar.common.api.proto.PulsarApi;
 import org.apache.pulsar.common.api.proto.PulsarApi.AuthMethod;
@@ -512,7 +513,7 @@ public class Commands {
     }
 
     public static ByteBuf newAck(long consumerId, long ledgerId, long entryId, AckType ackType,
-            ValidationError validationError) {
+                                 ValidationError validationError, Map<String,Long> properties) {
         CommandAck.Builder ackBuilder = CommandAck.newBuilder();
         ackBuilder.setConsumerId(consumerId);
         ackBuilder.setAckType(ackType);
@@ -523,6 +524,10 @@ public class Commands {
         ackBuilder.setMessageId(messageIdData);
         if (validationError != null) {
             ackBuilder.setValidationError(validationError);
+        }
+        for (Map.Entry<String,Long> e : properties.entrySet()) {
+            ackBuilder.addProperties(
+                    PulsarApi.KeyLongValue.newBuilder().setKey(e.getKey()).setValue(e.getValue()).build());
         }
         CommandAck ack = ackBuilder.build();
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
@@ -270,13 +270,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements MessageIdDataOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use MessageIdData.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<MessageIdData> handle;
-    private MessageIdData(io.netty.util.Recycler.Handle<MessageIdData> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private MessageIdData(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<MessageIdData> RECYCLER = new io.netty.util.Recycler<MessageIdData>() {
-            protected MessageIdData newObject(Handle<MessageIdData> handle) {
+            protected MessageIdData newObject(Handle handle) {
               return new MessageIdData(handle);
             }
           };
@@ -286,12 +286,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private MessageIdData(boolean noInit) {
-        this.handle = null;
-    }
+    private MessageIdData(boolean noInit) {}
     
     private static final MessageIdData defaultInstance;
     public static MessageIdData getDefaultInstance() {
@@ -499,20 +497,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.MessageIdDataOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -771,13 +769,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements KeyValueOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use KeyValue.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<KeyValue> handle;
-    private KeyValue(io.netty.util.Recycler.Handle<KeyValue> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private KeyValue(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<KeyValue> RECYCLER = new io.netty.util.Recycler<KeyValue>() {
-            protected KeyValue newObject(Handle<KeyValue> handle) {
+            protected KeyValue newObject(Handle handle) {
               return new KeyValue(handle);
             }
           };
@@ -787,12 +785,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private KeyValue(boolean noInit) {
-        this.handle = null;
-    }
+    private KeyValue(boolean noInit) {}
     
     private static final KeyValue defaultInstance;
     public static KeyValue getDefaultInstance() {
@@ -1008,20 +1004,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.KeyValue, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.KeyValueOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.KeyValue.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -1225,6 +1221,436 @@ public final class PulsarApi {
     // @@protoc_insertion_point(class_scope:pulsar.proto.KeyValue)
   }
   
+  public interface KeyLongValueOrBuilder
+      extends com.google.protobuf.MessageLiteOrBuilder {
+    
+    // required string key = 1;
+    boolean hasKey();
+    String getKey();
+    
+    // required uint64 value = 2;
+    boolean hasValue();
+    long getValue();
+  }
+  public static final class KeyLongValue extends
+      com.google.protobuf.GeneratedMessageLite
+      implements KeyLongValueOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
+    // Use KeyLongValue.newBuilder() to construct.
+    private io.netty.util.Recycler.Handle handle;
+    private KeyLongValue(io.netty.util.Recycler.Handle handle) {
+      this.handle = handle;
+    }
+    
+     private static final io.netty.util.Recycler<KeyLongValue> RECYCLER = new io.netty.util.Recycler<KeyLongValue>() {
+            protected KeyLongValue newObject(Handle handle) {
+              return new KeyLongValue(handle);
+            }
+          };
+        
+        public void recycle() {
+            this.initFields();
+            this.memoizedIsInitialized = -1;
+            this.bitField0_ = 0;
+            this.memoizedSerializedSize = -1;
+            if (handle != null) { RECYCLER.recycle(this, handle); }
+        }
+         
+    private KeyLongValue(boolean noInit) {}
+    
+    private static final KeyLongValue defaultInstance;
+    public static KeyLongValue getDefaultInstance() {
+      return defaultInstance;
+    }
+    
+    public KeyLongValue getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+    
+    private int bitField0_;
+    // required string key = 1;
+    public static final int KEY_FIELD_NUMBER = 1;
+    private java.lang.Object key_;
+    public boolean hasKey() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    public String getKey() {
+      java.lang.Object ref = key_;
+      if (ref instanceof String) {
+        return (String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        String s = bs.toStringUtf8();
+        if (com.google.protobuf.Internal.isValidUtf8(bs)) {
+          key_ = s;
+        }
+        return s;
+      }
+    }
+    private com.google.protobuf.ByteString getKeyBytes() {
+      java.lang.Object ref = key_;
+      if (ref instanceof String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8((String) ref);
+        key_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+    
+    // required uint64 value = 2;
+    public static final int VALUE_FIELD_NUMBER = 2;
+    private long value_;
+    public boolean hasValue() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    public long getValue() {
+      return value_;
+    }
+    
+    private void initFields() {
+      key_ = "";
+      value_ = 0L;
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized != -1) return isInitialized == 1;
+      
+      if (!hasKey()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      if (!hasValue()) {
+        memoizedIsInitialized = 0;
+        return false;
+      }
+      memoizedIsInitialized = 1;
+      return true;
+    }
+    
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+        throw new RuntimeException("Cannot use CodedOutputStream");
+    }
+    
+    public void writeTo(org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeBytes(1, getKeyBytes());
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeUInt64(2, value_);
+      }
+    }
+    
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+    
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBytesSize(1, getKeyBytes());
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeUInt64Size(2, value_);
+      }
+      memoizedSerializedSize = size;
+      return size;
+    }
+    
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+    
+    public static org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+         throw new RuntimeException("Disabled");
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+         throw new RuntimeException("Disabled");
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data).buildParsed();
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input).buildParsed();
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      Builder builder = newBuilder();
+      if (builder.mergeDelimitedFrom(input)) {
+        return builder.buildParsed();
+      } else {
+        return null;
+      }
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      Builder builder = newBuilder();
+      if (builder.mergeDelimitedFrom(input, extensionRegistry)) {
+        return builder.buildParsed();
+      } else {
+        return null;
+      }
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input).buildParsed();
+    }
+    public static org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input, extensionRegistry)
+               .buildParsed();
+    }
+    
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+    
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageLite.Builder<
+          org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue, Builder>
+        implements org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValueOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
+      // Construct using org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue.newBuilder()
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
+        this.handle = handle;
+        maybeForceBuilderInitialization();
+      }
+      private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+               return new Builder(handle);
+             }
+            };
+      
+       public void recycle() {
+                clear();
+                if (handle != null) {RECYCLER.recycle(this, handle);}
+            }
+      
+      private void maybeForceBuilderInitialization() {
+      }
+      private static Builder create() {
+        return RECYCLER.get();
+      }
+      
+      public Builder clear() {
+        super.clear();
+        key_ = "";
+        bitField0_ = (bitField0_ & ~0x00000001);
+        value_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+      
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+      
+      public org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue getDefaultInstanceForType() {
+        return org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue.getDefaultInstance();
+      }
+      
+      public org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue build() {
+        org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+      
+      private org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue buildParsed()
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(
+            result).asInvalidProtocolBufferException();
+        }
+        return result;
+      }
+      
+      public org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue buildPartial() {
+        org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue result = org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue.RECYCLER.get();
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.key_ = key_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.value_ = value_;
+        result.bitField0_ = to_bitField0_;
+        return result;
+      }
+      
+      public Builder mergeFrom(org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue other) {
+        if (other == org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue.getDefaultInstance()) return this;
+        if (other.hasKey()) {
+          setKey(other.getKey());
+        }
+        if (other.hasValue()) {
+          setValue(other.getValue());
+        }
+        return this;
+      }
+      
+      public final boolean isInitialized() {
+        if (!hasKey()) {
+          
+          return false;
+        }
+        if (!hasValue()) {
+          
+          return false;
+        }
+        return true;
+      }
+      
+      public Builder mergeFrom(com.google.protobuf.CodedInputStream input,
+                              com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                              throws java.io.IOException {
+         throw new java.io.IOException("Merge from CodedInputStream is disabled");
+                              }
+      public Builder mergeFrom(
+          org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        while (true) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              
+              return this;
+            default: {
+              if (!input.skipField(tag)) {
+                
+                return this;
+              }
+              break;
+            }
+            case 10: {
+              bitField0_ |= 0x00000001;
+              key_ = input.readBytes();
+              break;
+            }
+            case 16: {
+              bitField0_ |= 0x00000002;
+              value_ = input.readUInt64();
+              break;
+            }
+          }
+        }
+      }
+      
+      private int bitField0_;
+      
+      // required string key = 1;
+      private java.lang.Object key_ = "";
+      public boolean hasKey() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      public String getKey() {
+        java.lang.Object ref = key_;
+        if (!(ref instanceof String)) {
+          String s = ((com.google.protobuf.ByteString) ref).toStringUtf8();
+          key_ = s;
+          return s;
+        } else {
+          return (String) ref;
+        }
+      }
+      public Builder setKey(String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        key_ = value;
+        
+        return this;
+      }
+      public Builder clearKey() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        key_ = getDefaultInstance().getKey();
+        
+        return this;
+      }
+      void setKey(com.google.protobuf.ByteString value) {
+        bitField0_ |= 0x00000001;
+        key_ = value;
+        
+      }
+      
+      // required uint64 value = 2;
+      private long value_ ;
+      public boolean hasValue() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      public long getValue() {
+        return value_;
+      }
+      public Builder setValue(long value) {
+        bitField0_ |= 0x00000002;
+        value_ = value;
+        
+        return this;
+      }
+      public Builder clearValue() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        value_ = 0L;
+        
+        return this;
+      }
+      
+      // @@protoc_insertion_point(builder_scope:pulsar.proto.KeyLongValue)
+    }
+    
+    static {
+      defaultInstance = new KeyLongValue(true);
+      defaultInstance.initFields();
+    }
+    
+    // @@protoc_insertion_point(class_scope:pulsar.proto.KeyLongValue)
+  }
+  
   public interface EncryptionKeysOrBuilder
       extends com.google.protobuf.MessageLiteOrBuilder {
     
@@ -1246,13 +1672,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements EncryptionKeysOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use EncryptionKeys.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<EncryptionKeys> handle;
-    private EncryptionKeys(io.netty.util.Recycler.Handle<EncryptionKeys> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private EncryptionKeys(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<EncryptionKeys> RECYCLER = new io.netty.util.Recycler<EncryptionKeys>() {
-            protected EncryptionKeys newObject(Handle<EncryptionKeys> handle) {
+            protected EncryptionKeys newObject(Handle handle) {
               return new EncryptionKeys(handle);
             }
           };
@@ -1262,12 +1688,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private EncryptionKeys(boolean noInit) {
-        this.handle = null;
-    }
+    private EncryptionKeys(boolean noInit) {}
     
     private static final EncryptionKeys defaultInstance;
     public static EncryptionKeys getDefaultInstance() {
@@ -1496,20 +1920,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.EncryptionKeys, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.EncryptionKeysOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.EncryptionKeys.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -1887,13 +2311,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements MessageMetadataOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use MessageMetadata.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<MessageMetadata> handle;
-    private MessageMetadata(io.netty.util.Recycler.Handle<MessageMetadata> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private MessageMetadata(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<MessageMetadata> RECYCLER = new io.netty.util.Recycler<MessageMetadata>() {
-            protected MessageMetadata newObject(Handle<MessageMetadata> handle) {
+            protected MessageMetadata newObject(Handle handle) {
               return new MessageMetadata(handle);
             }
           };
@@ -1903,12 +2327,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private MessageMetadata(boolean noInit) {
-        this.handle = null;
-    }
+    private MessageMetadata(boolean noInit) {}
     
     private static final MessageMetadata defaultInstance;
     public static MessageMetadata getDefaultInstance() {
@@ -2431,20 +2853,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadataOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -3343,13 +3765,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements SingleMessageMetadataOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use SingleMessageMetadata.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<SingleMessageMetadata> handle;
-    private SingleMessageMetadata(io.netty.util.Recycler.Handle<SingleMessageMetadata> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private SingleMessageMetadata(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<SingleMessageMetadata> RECYCLER = new io.netty.util.Recycler<SingleMessageMetadata>() {
-            protected SingleMessageMetadata newObject(Handle<SingleMessageMetadata> handle) {
+            protected SingleMessageMetadata newObject(Handle handle) {
               return new SingleMessageMetadata(handle);
             }
           };
@@ -3359,12 +3781,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private SingleMessageMetadata(boolean noInit) {
-        this.handle = null;
-    }
+    private SingleMessageMetadata(boolean noInit) {}
     
     private static final SingleMessageMetadata defaultInstance;
     public static SingleMessageMetadata getDefaultInstance() {
@@ -3589,20 +4009,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.SingleMessageMetadata, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.SingleMessageMetadataOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.SingleMessageMetadata.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -3940,13 +4360,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandConnectOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandConnect.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<CommandConnect> handle;
-    private CommandConnect(io.netty.util.Recycler.Handle<CommandConnect> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private CommandConnect(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandConnect> RECYCLER = new io.netty.util.Recycler<CommandConnect>() {
-            protected CommandConnect newObject(Handle<CommandConnect> handle) {
+            protected CommandConnect newObject(Handle handle) {
               return new CommandConnect(handle);
             }
           };
@@ -3956,12 +4376,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private CommandConnect(boolean noInit) {
-        this.handle = null;
-    }
+    private CommandConnect(boolean noInit) {}
     
     private static final CommandConnect defaultInstance;
     public static CommandConnect getDefaultInstance() {
@@ -4307,20 +4725,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandConnect, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandConnectOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandConnect.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -4750,13 +5168,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandConnectedOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandConnected.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<CommandConnected> handle;
-    private CommandConnected(io.netty.util.Recycler.Handle<CommandConnected> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private CommandConnected(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandConnected> RECYCLER = new io.netty.util.Recycler<CommandConnected>() {
-            protected CommandConnected newObject(Handle<CommandConnected> handle) {
+            protected CommandConnected newObject(Handle handle) {
               return new CommandConnected(handle);
             }
           };
@@ -4766,12 +5184,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private CommandConnected(boolean noInit) {
-        this.handle = null;
-    }
+    private CommandConnected(boolean noInit) {}
     
     private static final CommandConnected defaultInstance;
     public static CommandConnected getDefaultInstance() {
@@ -4961,20 +5377,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandConnected, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandConnectedOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandConnected.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -5202,13 +5618,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandSubscribeOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandSubscribe.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<CommandSubscribe> handle;
-    private CommandSubscribe(io.netty.util.Recycler.Handle<CommandSubscribe> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private CommandSubscribe(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandSubscribe> RECYCLER = new io.netty.util.Recycler<CommandSubscribe>() {
-            protected CommandSubscribe newObject(Handle<CommandSubscribe> handle) {
+            protected CommandSubscribe newObject(Handle handle) {
               return new CommandSubscribe(handle);
             }
           };
@@ -5218,12 +5634,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private CommandSubscribe(boolean noInit) {
-        this.handle = null;
-    }
+    private CommandSubscribe(boolean noInit) {}
     
     private static final CommandSubscribe defaultInstance;
     public static CommandSubscribe getDefaultInstance() {
@@ -5649,20 +6063,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribeOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -6193,13 +6607,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandPartitionedTopicMetadataOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandPartitionedTopicMetadata.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<CommandPartitionedTopicMetadata> handle;
-    private CommandPartitionedTopicMetadata(io.netty.util.Recycler.Handle<CommandPartitionedTopicMetadata> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private CommandPartitionedTopicMetadata(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandPartitionedTopicMetadata> RECYCLER = new io.netty.util.Recycler<CommandPartitionedTopicMetadata>() {
-            protected CommandPartitionedTopicMetadata newObject(Handle<CommandPartitionedTopicMetadata> handle) {
+            protected CommandPartitionedTopicMetadata newObject(Handle handle) {
               return new CommandPartitionedTopicMetadata(handle);
             }
           };
@@ -6209,12 +6623,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private CommandPartitionedTopicMetadata(boolean noInit) {
-        this.handle = null;
-    }
+    private CommandPartitionedTopicMetadata(boolean noInit) {}
     
     private static final CommandPartitionedTopicMetadata defaultInstance;
     public static CommandPartitionedTopicMetadata getDefaultInstance() {
@@ -6408,20 +6820,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandPartitionedTopicMetadata, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandPartitionedTopicMetadataOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandPartitionedTopicMetadata.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -6637,13 +7049,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandPartitionedTopicMetadataResponseOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandPartitionedTopicMetadataResponse.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<CommandPartitionedTopicMetadataResponse> handle;
-    private CommandPartitionedTopicMetadataResponse(io.netty.util.Recycler.Handle<CommandPartitionedTopicMetadataResponse> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private CommandPartitionedTopicMetadataResponse(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandPartitionedTopicMetadataResponse> RECYCLER = new io.netty.util.Recycler<CommandPartitionedTopicMetadataResponse>() {
-            protected CommandPartitionedTopicMetadataResponse newObject(Handle<CommandPartitionedTopicMetadataResponse> handle) {
+            protected CommandPartitionedTopicMetadataResponse newObject(Handle handle) {
               return new CommandPartitionedTopicMetadataResponse(handle);
             }
           };
@@ -6653,12 +7065,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private CommandPartitionedTopicMetadataResponse(boolean noInit) {
-        this.handle = null;
-    }
+    private CommandPartitionedTopicMetadataResponse(boolean noInit) {}
     
     private static final CommandPartitionedTopicMetadataResponse defaultInstance;
     public static CommandPartitionedTopicMetadataResponse getDefaultInstance() {
@@ -6943,20 +7353,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandPartitionedTopicMetadataResponse, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandPartitionedTopicMetadataResponseOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandPartitionedTopicMetadataResponse.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -7279,13 +7689,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandLookupTopicOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandLookupTopic.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<CommandLookupTopic> handle;
-    private CommandLookupTopic(io.netty.util.Recycler.Handle<CommandLookupTopic> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private CommandLookupTopic(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandLookupTopic> RECYCLER = new io.netty.util.Recycler<CommandLookupTopic>() {
-            protected CommandLookupTopic newObject(Handle<CommandLookupTopic> handle) {
+            protected CommandLookupTopic newObject(Handle handle) {
               return new CommandLookupTopic(handle);
             }
           };
@@ -7295,12 +7705,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private CommandLookupTopic(boolean noInit) {
-        this.handle = null;
-    }
+    private CommandLookupTopic(boolean noInit) {}
     
     private static final CommandLookupTopic defaultInstance;
     public static CommandLookupTopic getDefaultInstance() {
@@ -7512,20 +7920,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandLookupTopic, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandLookupTopicOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandLookupTopic.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -7788,13 +8196,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandLookupTopicResponseOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandLookupTopicResponse.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<CommandLookupTopicResponse> handle;
-    private CommandLookupTopicResponse(io.netty.util.Recycler.Handle<CommandLookupTopicResponse> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private CommandLookupTopicResponse(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandLookupTopicResponse> RECYCLER = new io.netty.util.Recycler<CommandLookupTopicResponse>() {
-            protected CommandLookupTopicResponse newObject(Handle<CommandLookupTopicResponse> handle) {
+            protected CommandLookupTopicResponse newObject(Handle handle) {
               return new CommandLookupTopicResponse(handle);
             }
           };
@@ -7804,12 +8212,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private CommandLookupTopicResponse(boolean noInit) {
-        this.handle = null;
-    }
+    private CommandLookupTopicResponse(boolean noInit) {}
     
     private static final CommandLookupTopicResponse defaultInstance;
     public static CommandLookupTopicResponse getDefaultInstance() {
@@ -8195,20 +8601,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandLookupTopicResponse, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandLookupTopicResponseOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandLookupTopicResponse.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -8670,13 +9076,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandProducerOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandProducer.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<CommandProducer> handle;
-    private CommandProducer(io.netty.util.Recycler.Handle<CommandProducer> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private CommandProducer(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandProducer> RECYCLER = new io.netty.util.Recycler<CommandProducer>() {
-            protected CommandProducer newObject(Handle<CommandProducer> handle) {
+            protected CommandProducer newObject(Handle handle) {
               return new CommandProducer(handle);
             }
           };
@@ -8686,12 +9092,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private CommandProducer(boolean noInit) {
-        this.handle = null;
-    }
+    private CommandProducer(boolean noInit) {}
     
     private static final CommandProducer defaultInstance;
     public static CommandProducer getDefaultInstance() {
@@ -8947,20 +9351,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandProducer, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandProducerOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandProducer.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -9257,13 +9661,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandSendOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandSend.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<CommandSend> handle;
-    private CommandSend(io.netty.util.Recycler.Handle<CommandSend> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private CommandSend(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandSend> RECYCLER = new io.netty.util.Recycler<CommandSend>() {
-            protected CommandSend newObject(Handle<CommandSend> handle) {
+            protected CommandSend newObject(Handle handle) {
               return new CommandSend(handle);
             }
           };
@@ -9273,12 +9677,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private CommandSend(boolean noInit) {
-        this.handle = null;
-    }
+    private CommandSend(boolean noInit) {}
     
     private static final CommandSend defaultInstance;
     public static CommandSend getDefaultInstance() {
@@ -9468,20 +9870,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandSend, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandSendOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandSend.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -9709,13 +10111,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandSendReceiptOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandSendReceipt.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<CommandSendReceipt> handle;
-    private CommandSendReceipt(io.netty.util.Recycler.Handle<CommandSendReceipt> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private CommandSendReceipt(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandSendReceipt> RECYCLER = new io.netty.util.Recycler<CommandSendReceipt>() {
-            protected CommandSendReceipt newObject(Handle<CommandSendReceipt> handle) {
+            protected CommandSendReceipt newObject(Handle handle) {
               return new CommandSendReceipt(handle);
             }
           };
@@ -9725,12 +10127,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private CommandSendReceipt(boolean noInit) {
-        this.handle = null;
-    }
+    private CommandSendReceipt(boolean noInit) {}
     
     private static final CommandSendReceipt defaultInstance;
     public static CommandSendReceipt getDefaultInstance() {
@@ -9926,20 +10326,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandSendReceipt, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandSendReceiptOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandSendReceipt.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -10204,13 +10604,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandSendErrorOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandSendError.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<CommandSendError> handle;
-    private CommandSendError(io.netty.util.Recycler.Handle<CommandSendError> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private CommandSendError(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandSendError> RECYCLER = new io.netty.util.Recycler<CommandSendError>() {
-            protected CommandSendError newObject(Handle<CommandSendError> handle) {
+            protected CommandSendError newObject(Handle handle) {
               return new CommandSendError(handle);
             }
           };
@@ -10220,12 +10620,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private CommandSendError(boolean noInit) {
-        this.handle = null;
-    }
+    private CommandSendError(boolean noInit) {}
     
     private static final CommandSendError defaultInstance;
     public static CommandSendError getDefaultInstance() {
@@ -10463,20 +10861,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandSendError, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandSendErrorOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandSendError.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -10765,13 +11163,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandMessageOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandMessage.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<CommandMessage> handle;
-    private CommandMessage(io.netty.util.Recycler.Handle<CommandMessage> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private CommandMessage(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandMessage> RECYCLER = new io.netty.util.Recycler<CommandMessage>() {
-            protected CommandMessage newObject(Handle<CommandMessage> handle) {
+            protected CommandMessage newObject(Handle handle) {
               return new CommandMessage(handle);
             }
           };
@@ -10781,12 +11179,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private CommandMessage(boolean noInit) {
-        this.handle = null;
-    }
+    private CommandMessage(boolean noInit) {}
     
     private static final CommandMessage defaultInstance;
     public static CommandMessage getDefaultInstance() {
@@ -10962,20 +11358,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandMessage, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandMessageOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandMessage.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -11198,18 +11594,24 @@ public final class PulsarApi {
     // optional .pulsar.proto.CommandAck.ValidationError validation_error = 4;
     boolean hasValidationError();
     org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.ValidationError getValidationError();
+    
+    // repeated .pulsar.proto.KeyLongValue properties = 5;
+    java.util.List<org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue> 
+        getPropertiesList();
+    org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue getProperties(int index);
+    int getPropertiesCount();
   }
   public static final class CommandAck extends
       com.google.protobuf.GeneratedMessageLite
       implements CommandAckOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandAck.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<CommandAck> handle;
-    private CommandAck(io.netty.util.Recycler.Handle<CommandAck> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private CommandAck(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandAck> RECYCLER = new io.netty.util.Recycler<CommandAck>() {
-            protected CommandAck newObject(Handle<CommandAck> handle) {
+            protected CommandAck newObject(Handle handle) {
               return new CommandAck(handle);
             }
           };
@@ -11219,12 +11621,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private CommandAck(boolean noInit) {
-        this.handle = null;
-    }
+    private CommandAck(boolean noInit) {}
     
     private static final CommandAck defaultInstance;
     public static CommandAck getDefaultInstance() {
@@ -11367,11 +11767,33 @@ public final class PulsarApi {
       return validationError_;
     }
     
+    // repeated .pulsar.proto.KeyLongValue properties = 5;
+    public static final int PROPERTIES_FIELD_NUMBER = 5;
+    private java.util.List<org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue> properties_;
+    public java.util.List<org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue> getPropertiesList() {
+      return properties_;
+    }
+    public java.util.List<? extends org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValueOrBuilder> 
+        getPropertiesOrBuilderList() {
+      return properties_;
+    }
+    public int getPropertiesCount() {
+      return properties_.size();
+    }
+    public org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue getProperties(int index) {
+      return properties_.get(index);
+    }
+    public org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValueOrBuilder getPropertiesOrBuilder(
+        int index) {
+      return properties_.get(index);
+    }
+    
     private void initFields() {
       consumerId_ = 0L;
       ackType_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType.Individual;
       messageId_ = org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.getDefaultInstance();
       validationError_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.ValidationError.UncompressedSizeCorruption;
+      properties_ = java.util.Collections.emptyList();
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -11393,6 +11815,12 @@ public final class PulsarApi {
       if (!getMessageId().isInitialized()) {
         memoizedIsInitialized = 0;
         return false;
+      }
+      for (int i = 0; i < getPropertiesCount(); i++) {
+        if (!getProperties(i).isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
       }
       memoizedIsInitialized = 1;
       return true;
@@ -11418,6 +11846,9 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         output.writeEnum(4, validationError_.getNumber());
       }
+      for (int i = 0; i < properties_.size(); i++) {
+        output.writeMessage(5, properties_.get(i));
+      }
     }
     
     private int memoizedSerializedSize = -1;
@@ -11441,6 +11872,10 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         size += com.google.protobuf.CodedOutputStream
           .computeEnumSize(4, validationError_.getNumber());
+      }
+      for (int i = 0; i < properties_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(5, properties_.get(i));
       }
       memoizedSerializedSize = size;
       return size;
@@ -11531,20 +11966,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandAck, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandAckOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -11563,6 +11998,8 @@ public final class PulsarApi {
         bitField0_ = (bitField0_ & ~0x00000004);
         validationError_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.ValidationError.UncompressedSizeCorruption;
         bitField0_ = (bitField0_ & ~0x00000008);
+        properties_ = java.util.Collections.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000010);
         return this;
       }
       
@@ -11612,6 +12049,11 @@ public final class PulsarApi {
           to_bitField0_ |= 0x00000008;
         }
         result.validationError_ = validationError_;
+        if (((bitField0_ & 0x00000010) == 0x00000010)) {
+          properties_ = java.util.Collections.unmodifiableList(properties_);
+          bitField0_ = (bitField0_ & ~0x00000010);
+        }
+        result.properties_ = properties_;
         result.bitField0_ = to_bitField0_;
         return result;
       }
@@ -11629,6 +12071,16 @@ public final class PulsarApi {
         }
         if (other.hasValidationError()) {
           setValidationError(other.getValidationError());
+        }
+        if (!other.properties_.isEmpty()) {
+          if (properties_.isEmpty()) {
+            properties_ = other.properties_;
+            bitField0_ = (bitField0_ & ~0x00000010);
+          } else {
+            ensurePropertiesIsMutable();
+            properties_.addAll(other.properties_);
+          }
+          
         }
         return this;
       }
@@ -11649,6 +12101,12 @@ public final class PulsarApi {
         if (!getMessageId().isInitialized()) {
           
           return false;
+        }
+        for (int i = 0; i < getPropertiesCount(); i++) {
+          if (!getProperties(i).isInitialized()) {
+            
+            return false;
+          }
         }
         return true;
       }
@@ -11706,6 +12164,12 @@ public final class PulsarApi {
                 bitField0_ |= 0x00000008;
                 validationError_ = value;
               }
+              break;
+            }
+            case 42: {
+              org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue.Builder subBuilder = org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue.newBuilder();
+              input.readMessage(subBuilder, extensionRegistry);
+              addProperties(subBuilder.buildPartial());
               break;
             }
           }
@@ -11826,6 +12290,95 @@ public final class PulsarApi {
         return this;
       }
       
+      // repeated .pulsar.proto.KeyLongValue properties = 5;
+      private java.util.List<org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue> properties_ =
+        java.util.Collections.emptyList();
+      private void ensurePropertiesIsMutable() {
+        if (!((bitField0_ & 0x00000010) == 0x00000010)) {
+          properties_ = new java.util.ArrayList<org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue>(properties_);
+          bitField0_ |= 0x00000010;
+         }
+      }
+      
+      public java.util.List<org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue> getPropertiesList() {
+        return java.util.Collections.unmodifiableList(properties_);
+      }
+      public int getPropertiesCount() {
+        return properties_.size();
+      }
+      public org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue getProperties(int index) {
+        return properties_.get(index);
+      }
+      public Builder setProperties(
+          int index, org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        ensurePropertiesIsMutable();
+        properties_.set(index, value);
+        
+        return this;
+      }
+      public Builder setProperties(
+          int index, org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue.Builder builderForValue) {
+        ensurePropertiesIsMutable();
+        properties_.set(index, builderForValue.build());
+        
+        return this;
+      }
+      public Builder addProperties(org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        ensurePropertiesIsMutable();
+        properties_.add(value);
+        
+        return this;
+      }
+      public Builder addProperties(
+          int index, org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        ensurePropertiesIsMutable();
+        properties_.add(index, value);
+        
+        return this;
+      }
+      public Builder addProperties(
+          org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue.Builder builderForValue) {
+        ensurePropertiesIsMutable();
+        properties_.add(builderForValue.build());
+        
+        return this;
+      }
+      public Builder addProperties(
+          int index, org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue.Builder builderForValue) {
+        ensurePropertiesIsMutable();
+        properties_.add(index, builderForValue.build());
+        
+        return this;
+      }
+      public Builder addAllProperties(
+          java.lang.Iterable<? extends org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue> values) {
+        ensurePropertiesIsMutable();
+        super.addAll(values, properties_);
+        
+        return this;
+      }
+      public Builder clearProperties() {
+        properties_ = java.util.Collections.emptyList();
+        bitField0_ = (bitField0_ & ~0x00000010);
+        
+        return this;
+      }
+      public Builder removeProperties(int index) {
+        ensurePropertiesIsMutable();
+        properties_.remove(index);
+        
+        return this;
+      }
+      
       // @@protoc_insertion_point(builder_scope:pulsar.proto.CommandAck)
     }
     
@@ -11852,13 +12405,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandFlowOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandFlow.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<CommandFlow> handle;
-    private CommandFlow(io.netty.util.Recycler.Handle<CommandFlow> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private CommandFlow(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandFlow> RECYCLER = new io.netty.util.Recycler<CommandFlow>() {
-            protected CommandFlow newObject(Handle<CommandFlow> handle) {
+            protected CommandFlow newObject(Handle handle) {
               return new CommandFlow(handle);
             }
           };
@@ -11868,12 +12421,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private CommandFlow(boolean noInit) {
-        this.handle = null;
-    }
+    private CommandFlow(boolean noInit) {}
     
     private static final CommandFlow defaultInstance;
     public static CommandFlow getDefaultInstance() {
@@ -12045,20 +12596,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandFlow, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandFlowOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandFlow.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -12247,13 +12798,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandUnsubscribeOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandUnsubscribe.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<CommandUnsubscribe> handle;
-    private CommandUnsubscribe(io.netty.util.Recycler.Handle<CommandUnsubscribe> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private CommandUnsubscribe(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandUnsubscribe> RECYCLER = new io.netty.util.Recycler<CommandUnsubscribe>() {
-            protected CommandUnsubscribe newObject(Handle<CommandUnsubscribe> handle) {
+            protected CommandUnsubscribe newObject(Handle handle) {
               return new CommandUnsubscribe(handle);
             }
           };
@@ -12263,12 +12814,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private CommandUnsubscribe(boolean noInit) {
-        this.handle = null;
-    }
+    private CommandUnsubscribe(boolean noInit) {}
     
     private static final CommandUnsubscribe defaultInstance;
     public static CommandUnsubscribe getDefaultInstance() {
@@ -12440,20 +12989,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandUnsubscribe, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandUnsubscribeOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandUnsubscribe.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -12646,13 +13195,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandSeekOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandSeek.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<CommandSeek> handle;
-    private CommandSeek(io.netty.util.Recycler.Handle<CommandSeek> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private CommandSeek(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandSeek> RECYCLER = new io.netty.util.Recycler<CommandSeek>() {
-            protected CommandSeek newObject(Handle<CommandSeek> handle) {
+            protected CommandSeek newObject(Handle handle) {
               return new CommandSeek(handle);
             }
           };
@@ -12662,12 +13211,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private CommandSeek(boolean noInit) {
-        this.handle = null;
-    }
+    private CommandSeek(boolean noInit) {}
     
     private static final CommandSeek defaultInstance;
     public static CommandSeek getDefaultInstance() {
@@ -12863,20 +13410,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -13129,13 +13676,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandReachedEndOfTopicOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandReachedEndOfTopic.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<CommandReachedEndOfTopic> handle;
-    private CommandReachedEndOfTopic(io.netty.util.Recycler.Handle<CommandReachedEndOfTopic> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private CommandReachedEndOfTopic(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandReachedEndOfTopic> RECYCLER = new io.netty.util.Recycler<CommandReachedEndOfTopic>() {
-            protected CommandReachedEndOfTopic newObject(Handle<CommandReachedEndOfTopic> handle) {
+            protected CommandReachedEndOfTopic newObject(Handle handle) {
               return new CommandReachedEndOfTopic(handle);
             }
           };
@@ -13145,12 +13692,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private CommandReachedEndOfTopic(boolean noInit) {
-        this.handle = null;
-    }
+    private CommandReachedEndOfTopic(boolean noInit) {}
     
     private static final CommandReachedEndOfTopic defaultInstance;
     public static CommandReachedEndOfTopic getDefaultInstance() {
@@ -13300,20 +13845,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopicOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -13463,13 +14008,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandCloseProducerOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandCloseProducer.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<CommandCloseProducer> handle;
-    private CommandCloseProducer(io.netty.util.Recycler.Handle<CommandCloseProducer> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private CommandCloseProducer(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandCloseProducer> RECYCLER = new io.netty.util.Recycler<CommandCloseProducer>() {
-            protected CommandCloseProducer newObject(Handle<CommandCloseProducer> handle) {
+            protected CommandCloseProducer newObject(Handle handle) {
               return new CommandCloseProducer(handle);
             }
           };
@@ -13479,12 +14024,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private CommandCloseProducer(boolean noInit) {
-        this.handle = null;
-    }
+    private CommandCloseProducer(boolean noInit) {}
     
     private static final CommandCloseProducer defaultInstance;
     public static CommandCloseProducer getDefaultInstance() {
@@ -13656,20 +14199,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandCloseProducer, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandCloseProducerOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandCloseProducer.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -13858,13 +14401,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandCloseConsumerOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandCloseConsumer.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<CommandCloseConsumer> handle;
-    private CommandCloseConsumer(io.netty.util.Recycler.Handle<CommandCloseConsumer> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private CommandCloseConsumer(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandCloseConsumer> RECYCLER = new io.netty.util.Recycler<CommandCloseConsumer>() {
-            protected CommandCloseConsumer newObject(Handle<CommandCloseConsumer> handle) {
+            protected CommandCloseConsumer newObject(Handle handle) {
               return new CommandCloseConsumer(handle);
             }
           };
@@ -13874,12 +14417,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private CommandCloseConsumer(boolean noInit) {
-        this.handle = null;
-    }
+    private CommandCloseConsumer(boolean noInit) {}
     
     private static final CommandCloseConsumer defaultInstance;
     public static CommandCloseConsumer getDefaultInstance() {
@@ -14051,20 +14592,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandCloseConsumer, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandCloseConsumerOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandCloseConsumer.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -14255,13 +14796,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandRedeliverUnacknowledgedMessagesOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandRedeliverUnacknowledgedMessages.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<CommandRedeliverUnacknowledgedMessages> handle;
-    private CommandRedeliverUnacknowledgedMessages(io.netty.util.Recycler.Handle<CommandRedeliverUnacknowledgedMessages> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private CommandRedeliverUnacknowledgedMessages(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandRedeliverUnacknowledgedMessages> RECYCLER = new io.netty.util.Recycler<CommandRedeliverUnacknowledgedMessages>() {
-            protected CommandRedeliverUnacknowledgedMessages newObject(Handle<CommandRedeliverUnacknowledgedMessages> handle) {
+            protected CommandRedeliverUnacknowledgedMessages newObject(Handle handle) {
               return new CommandRedeliverUnacknowledgedMessages(handle);
             }
           };
@@ -14271,12 +14812,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private CommandRedeliverUnacknowledgedMessages(boolean noInit) {
-        this.handle = null;
-    }
+    private CommandRedeliverUnacknowledgedMessages(boolean noInit) {}
     
     private static final CommandRedeliverUnacknowledgedMessages defaultInstance;
     public static CommandRedeliverUnacknowledgedMessages getDefaultInstance() {
@@ -14461,20 +15000,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandRedeliverUnacknowledgedMessages, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandRedeliverUnacknowledgedMessagesOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandRedeliverUnacknowledgedMessages.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -14738,13 +15277,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandSuccessOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandSuccess.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<CommandSuccess> handle;
-    private CommandSuccess(io.netty.util.Recycler.Handle<CommandSuccess> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private CommandSuccess(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandSuccess> RECYCLER = new io.netty.util.Recycler<CommandSuccess>() {
-            protected CommandSuccess newObject(Handle<CommandSuccess> handle) {
+            protected CommandSuccess newObject(Handle handle) {
               return new CommandSuccess(handle);
             }
           };
@@ -14754,12 +15293,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private CommandSuccess(boolean noInit) {
-        this.handle = null;
-    }
+    private CommandSuccess(boolean noInit) {}
     
     private static final CommandSuccess defaultInstance;
     public static CommandSuccess getDefaultInstance() {
@@ -14909,20 +15446,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandSuccess, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandSuccessOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandSuccess.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -15076,13 +15613,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandProducerSuccessOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandProducerSuccess.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<CommandProducerSuccess> handle;
-    private CommandProducerSuccess(io.netty.util.Recycler.Handle<CommandProducerSuccess> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private CommandProducerSuccess(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandProducerSuccess> RECYCLER = new io.netty.util.Recycler<CommandProducerSuccess>() {
-            protected CommandProducerSuccess newObject(Handle<CommandProducerSuccess> handle) {
+            protected CommandProducerSuccess newObject(Handle handle) {
               return new CommandProducerSuccess(handle);
             }
           };
@@ -15092,12 +15629,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private CommandProducerSuccess(boolean noInit) {
-        this.handle = null;
-    }
+    private CommandProducerSuccess(boolean noInit) {}
     
     private static final CommandProducerSuccess defaultInstance;
     public static CommandProducerSuccess getDefaultInstance() {
@@ -15309,20 +15844,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandProducerSuccess, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandProducerSuccessOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandProducerSuccess.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -15565,13 +16100,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandErrorOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandError.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<CommandError> handle;
-    private CommandError(io.netty.util.Recycler.Handle<CommandError> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private CommandError(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandError> RECYCLER = new io.netty.util.Recycler<CommandError>() {
-            protected CommandError newObject(Handle<CommandError> handle) {
+            protected CommandError newObject(Handle handle) {
               return new CommandError(handle);
             }
           };
@@ -15581,12 +16116,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private CommandError(boolean noInit) {
-        this.handle = null;
-    }
+    private CommandError(boolean noInit) {}
     
     private static final CommandError defaultInstance;
     public static CommandError getDefaultInstance() {
@@ -15802,20 +16335,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandError, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandErrorOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandError.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -16057,13 +16590,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandPingOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandPing.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<CommandPing> handle;
-    private CommandPing(io.netty.util.Recycler.Handle<CommandPing> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private CommandPing(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandPing> RECYCLER = new io.netty.util.Recycler<CommandPing>() {
-            protected CommandPing newObject(Handle<CommandPing> handle) {
+            protected CommandPing newObject(Handle handle) {
               return new CommandPing(handle);
             }
           };
@@ -16072,12 +16605,10 @@ public final class PulsarApi {
             this.initFields();
             this.memoizedIsInitialized = -1;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private CommandPing(boolean noInit) {
-        this.handle = null;
-    }
+    private CommandPing(boolean noInit) {}
     
     private static final CommandPing defaultInstance;
     public static CommandPing getDefaultInstance() {
@@ -16204,20 +16735,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandPing, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandPingOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandPing.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -16316,13 +16847,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandPongOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandPong.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<CommandPong> handle;
-    private CommandPong(io.netty.util.Recycler.Handle<CommandPong> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private CommandPong(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandPong> RECYCLER = new io.netty.util.Recycler<CommandPong>() {
-            protected CommandPong newObject(Handle<CommandPong> handle) {
+            protected CommandPong newObject(Handle handle) {
               return new CommandPong(handle);
             }
           };
@@ -16331,12 +16862,10 @@ public final class PulsarApi {
             this.initFields();
             this.memoizedIsInitialized = -1;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private CommandPong(boolean noInit) {
-        this.handle = null;
-    }
+    private CommandPong(boolean noInit) {}
     
     private static final CommandPong defaultInstance;
     public static CommandPong getDefaultInstance() {
@@ -16463,20 +16992,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandPong, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandPongOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandPong.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -16583,13 +17112,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandConsumerStatsOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandConsumerStats.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<CommandConsumerStats> handle;
-    private CommandConsumerStats(io.netty.util.Recycler.Handle<CommandConsumerStats> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private CommandConsumerStats(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandConsumerStats> RECYCLER = new io.netty.util.Recycler<CommandConsumerStats>() {
-            protected CommandConsumerStats newObject(Handle<CommandConsumerStats> handle) {
+            protected CommandConsumerStats newObject(Handle handle) {
               return new CommandConsumerStats(handle);
             }
           };
@@ -16599,12 +17128,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private CommandConsumerStats(boolean noInit) {
-        this.handle = null;
-    }
+    private CommandConsumerStats(boolean noInit) {}
     
     private static final CommandConsumerStats defaultInstance;
     public static CommandConsumerStats getDefaultInstance() {
@@ -16776,20 +17303,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandConsumerStats, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandConsumerStatsOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandConsumerStats.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -17030,13 +17557,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandConsumerStatsResponseOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandConsumerStatsResponse.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<CommandConsumerStatsResponse> handle;
-    private CommandConsumerStatsResponse(io.netty.util.Recycler.Handle<CommandConsumerStatsResponse> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private CommandConsumerStatsResponse(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandConsumerStatsResponse> RECYCLER = new io.netty.util.Recycler<CommandConsumerStatsResponse>() {
-            protected CommandConsumerStatsResponse newObject(Handle<CommandConsumerStatsResponse> handle) {
+            protected CommandConsumerStatsResponse newObject(Handle handle) {
               return new CommandConsumerStatsResponse(handle);
             }
           };
@@ -17046,12 +17573,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private CommandConsumerStatsResponse(boolean noInit) {
-        this.handle = null;
-    }
+    private CommandConsumerStatsResponse(boolean noInit) {}
     
     private static final CommandConsumerStatsResponse defaultInstance;
     public static CommandConsumerStatsResponse getDefaultInstance() {
@@ -17563,20 +18088,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandConsumerStatsResponse, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandConsumerStatsResponseOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandConsumerStatsResponse.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {
@@ -18402,13 +18927,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements BaseCommandOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use BaseCommand.newBuilder() to construct.
-    private final io.netty.util.Recycler.Handle<BaseCommand> handle;
-    private BaseCommand(io.netty.util.Recycler.Handle<BaseCommand> handle) {
+    private io.netty.util.Recycler.Handle handle;
+    private BaseCommand(io.netty.util.Recycler.Handle handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<BaseCommand> RECYCLER = new io.netty.util.Recycler<BaseCommand>() {
-            protected BaseCommand newObject(Handle<BaseCommand> handle) {
+            protected BaseCommand newObject(Handle handle) {
               return new BaseCommand(handle);
             }
           };
@@ -18418,12 +18943,10 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            handle.recycle(this);
+            if (handle != null) { RECYCLER.recycle(this, handle); }
         }
          
-    private BaseCommand(boolean noInit) {
-        this.handle = null;
-    }
+    private BaseCommand(boolean noInit) {}
     
     private static final BaseCommand defaultInstance;
     public static BaseCommand getDefaultInstance() {
@@ -19325,20 +19848,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.BaseCommand, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.BaseCommandOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.BaseCommand.newBuilder()
-      private final io.netty.util.Recycler.Handle<Builder> handle;
-      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
+      private final io.netty.util.Recycler.Handle handle;
+      private Builder(io.netty.util.Recycler.Handle handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                handle.recycle(this);
+                if (handle != null) {RECYCLER.recycle(this, handle);}
             }
       
       private void maybeForceBuilderInitialization() {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
@@ -270,13 +270,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements MessageIdDataOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use MessageIdData.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private MessageIdData(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<MessageIdData> handle;
+    private MessageIdData(io.netty.util.Recycler.Handle<MessageIdData> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<MessageIdData> RECYCLER = new io.netty.util.Recycler<MessageIdData>() {
-            protected MessageIdData newObject(Handle handle) {
+            protected MessageIdData newObject(Handle<MessageIdData> handle) {
               return new MessageIdData(handle);
             }
           };
@@ -286,10 +286,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private MessageIdData(boolean noInit) {}
+    private MessageIdData(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final MessageIdData defaultInstance;
     public static MessageIdData getDefaultInstance() {
@@ -497,20 +499,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.MessageIdDataOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -769,13 +771,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements KeyValueOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use KeyValue.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private KeyValue(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<KeyValue> handle;
+    private KeyValue(io.netty.util.Recycler.Handle<KeyValue> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<KeyValue> RECYCLER = new io.netty.util.Recycler<KeyValue>() {
-            protected KeyValue newObject(Handle handle) {
+            protected KeyValue newObject(Handle<KeyValue> handle) {
               return new KeyValue(handle);
             }
           };
@@ -785,10 +787,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private KeyValue(boolean noInit) {}
+    private KeyValue(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final KeyValue defaultInstance;
     public static KeyValue getDefaultInstance() {
@@ -1004,20 +1008,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.KeyValue, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.KeyValueOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.KeyValue.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -1236,13 +1240,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements KeyLongValueOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use KeyLongValue.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private KeyLongValue(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<KeyLongValue> handle;
+    private KeyLongValue(io.netty.util.Recycler.Handle<KeyLongValue> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<KeyLongValue> RECYCLER = new io.netty.util.Recycler<KeyLongValue>() {
-            protected KeyLongValue newObject(Handle handle) {
+            protected KeyLongValue newObject(Handle<KeyLongValue> handle) {
               return new KeyLongValue(handle);
             }
           };
@@ -1252,10 +1256,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private KeyLongValue(boolean noInit) {}
+    private KeyLongValue(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final KeyLongValue defaultInstance;
     public static KeyLongValue getDefaultInstance() {
@@ -1449,20 +1455,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValueOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -1672,13 +1678,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements EncryptionKeysOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use EncryptionKeys.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private EncryptionKeys(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<EncryptionKeys> handle;
+    private EncryptionKeys(io.netty.util.Recycler.Handle<EncryptionKeys> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<EncryptionKeys> RECYCLER = new io.netty.util.Recycler<EncryptionKeys>() {
-            protected EncryptionKeys newObject(Handle handle) {
+            protected EncryptionKeys newObject(Handle<EncryptionKeys> handle) {
               return new EncryptionKeys(handle);
             }
           };
@@ -1688,10 +1694,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private EncryptionKeys(boolean noInit) {}
+    private EncryptionKeys(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final EncryptionKeys defaultInstance;
     public static EncryptionKeys getDefaultInstance() {
@@ -1920,20 +1928,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.EncryptionKeys, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.EncryptionKeysOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.EncryptionKeys.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -2311,13 +2319,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements MessageMetadataOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use MessageMetadata.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private MessageMetadata(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<MessageMetadata> handle;
+    private MessageMetadata(io.netty.util.Recycler.Handle<MessageMetadata> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<MessageMetadata> RECYCLER = new io.netty.util.Recycler<MessageMetadata>() {
-            protected MessageMetadata newObject(Handle handle) {
+            protected MessageMetadata newObject(Handle<MessageMetadata> handle) {
               return new MessageMetadata(handle);
             }
           };
@@ -2327,10 +2335,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private MessageMetadata(boolean noInit) {}
+    private MessageMetadata(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final MessageMetadata defaultInstance;
     public static MessageMetadata getDefaultInstance() {
@@ -2853,20 +2863,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadataOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -3765,13 +3775,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements SingleMessageMetadataOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use SingleMessageMetadata.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private SingleMessageMetadata(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<SingleMessageMetadata> handle;
+    private SingleMessageMetadata(io.netty.util.Recycler.Handle<SingleMessageMetadata> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<SingleMessageMetadata> RECYCLER = new io.netty.util.Recycler<SingleMessageMetadata>() {
-            protected SingleMessageMetadata newObject(Handle handle) {
+            protected SingleMessageMetadata newObject(Handle<SingleMessageMetadata> handle) {
               return new SingleMessageMetadata(handle);
             }
           };
@@ -3781,10 +3791,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private SingleMessageMetadata(boolean noInit) {}
+    private SingleMessageMetadata(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final SingleMessageMetadata defaultInstance;
     public static SingleMessageMetadata getDefaultInstance() {
@@ -4009,20 +4021,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.SingleMessageMetadata, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.SingleMessageMetadataOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.SingleMessageMetadata.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -4360,13 +4372,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandConnectOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandConnect.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandConnect(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandConnect> handle;
+    private CommandConnect(io.netty.util.Recycler.Handle<CommandConnect> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandConnect> RECYCLER = new io.netty.util.Recycler<CommandConnect>() {
-            protected CommandConnect newObject(Handle handle) {
+            protected CommandConnect newObject(Handle<CommandConnect> handle) {
               return new CommandConnect(handle);
             }
           };
@@ -4376,10 +4388,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandConnect(boolean noInit) {}
+    private CommandConnect(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandConnect defaultInstance;
     public static CommandConnect getDefaultInstance() {
@@ -4725,20 +4739,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandConnect, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandConnectOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandConnect.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -5168,13 +5182,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandConnectedOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandConnected.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandConnected(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandConnected> handle;
+    private CommandConnected(io.netty.util.Recycler.Handle<CommandConnected> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandConnected> RECYCLER = new io.netty.util.Recycler<CommandConnected>() {
-            protected CommandConnected newObject(Handle handle) {
+            protected CommandConnected newObject(Handle<CommandConnected> handle) {
               return new CommandConnected(handle);
             }
           };
@@ -5184,10 +5198,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandConnected(boolean noInit) {}
+    private CommandConnected(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandConnected defaultInstance;
     public static CommandConnected getDefaultInstance() {
@@ -5377,20 +5393,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandConnected, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandConnectedOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandConnected.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -5618,13 +5634,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandSubscribeOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandSubscribe.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandSubscribe(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandSubscribe> handle;
+    private CommandSubscribe(io.netty.util.Recycler.Handle<CommandSubscribe> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandSubscribe> RECYCLER = new io.netty.util.Recycler<CommandSubscribe>() {
-            protected CommandSubscribe newObject(Handle handle) {
+            protected CommandSubscribe newObject(Handle<CommandSubscribe> handle) {
               return new CommandSubscribe(handle);
             }
           };
@@ -5634,10 +5650,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandSubscribe(boolean noInit) {}
+    private CommandSubscribe(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandSubscribe defaultInstance;
     public static CommandSubscribe getDefaultInstance() {
@@ -6063,20 +6081,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribeOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -6607,13 +6625,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandPartitionedTopicMetadataOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandPartitionedTopicMetadata.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandPartitionedTopicMetadata(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandPartitionedTopicMetadata> handle;
+    private CommandPartitionedTopicMetadata(io.netty.util.Recycler.Handle<CommandPartitionedTopicMetadata> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandPartitionedTopicMetadata> RECYCLER = new io.netty.util.Recycler<CommandPartitionedTopicMetadata>() {
-            protected CommandPartitionedTopicMetadata newObject(Handle handle) {
+            protected CommandPartitionedTopicMetadata newObject(Handle<CommandPartitionedTopicMetadata> handle) {
               return new CommandPartitionedTopicMetadata(handle);
             }
           };
@@ -6623,10 +6641,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandPartitionedTopicMetadata(boolean noInit) {}
+    private CommandPartitionedTopicMetadata(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandPartitionedTopicMetadata defaultInstance;
     public static CommandPartitionedTopicMetadata getDefaultInstance() {
@@ -6820,20 +6840,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandPartitionedTopicMetadata, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandPartitionedTopicMetadataOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandPartitionedTopicMetadata.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -7049,13 +7069,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandPartitionedTopicMetadataResponseOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandPartitionedTopicMetadataResponse.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandPartitionedTopicMetadataResponse(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandPartitionedTopicMetadataResponse> handle;
+    private CommandPartitionedTopicMetadataResponse(io.netty.util.Recycler.Handle<CommandPartitionedTopicMetadataResponse> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandPartitionedTopicMetadataResponse> RECYCLER = new io.netty.util.Recycler<CommandPartitionedTopicMetadataResponse>() {
-            protected CommandPartitionedTopicMetadataResponse newObject(Handle handle) {
+            protected CommandPartitionedTopicMetadataResponse newObject(Handle<CommandPartitionedTopicMetadataResponse> handle) {
               return new CommandPartitionedTopicMetadataResponse(handle);
             }
           };
@@ -7065,10 +7085,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandPartitionedTopicMetadataResponse(boolean noInit) {}
+    private CommandPartitionedTopicMetadataResponse(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandPartitionedTopicMetadataResponse defaultInstance;
     public static CommandPartitionedTopicMetadataResponse getDefaultInstance() {
@@ -7353,20 +7375,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandPartitionedTopicMetadataResponse, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandPartitionedTopicMetadataResponseOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandPartitionedTopicMetadataResponse.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -7689,13 +7711,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandLookupTopicOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandLookupTopic.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandLookupTopic(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandLookupTopic> handle;
+    private CommandLookupTopic(io.netty.util.Recycler.Handle<CommandLookupTopic> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandLookupTopic> RECYCLER = new io.netty.util.Recycler<CommandLookupTopic>() {
-            protected CommandLookupTopic newObject(Handle handle) {
+            protected CommandLookupTopic newObject(Handle<CommandLookupTopic> handle) {
               return new CommandLookupTopic(handle);
             }
           };
@@ -7705,10 +7727,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandLookupTopic(boolean noInit) {}
+    private CommandLookupTopic(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandLookupTopic defaultInstance;
     public static CommandLookupTopic getDefaultInstance() {
@@ -7920,20 +7944,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandLookupTopic, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandLookupTopicOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandLookupTopic.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -8196,13 +8220,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandLookupTopicResponseOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandLookupTopicResponse.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandLookupTopicResponse(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandLookupTopicResponse> handle;
+    private CommandLookupTopicResponse(io.netty.util.Recycler.Handle<CommandLookupTopicResponse> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandLookupTopicResponse> RECYCLER = new io.netty.util.Recycler<CommandLookupTopicResponse>() {
-            protected CommandLookupTopicResponse newObject(Handle handle) {
+            protected CommandLookupTopicResponse newObject(Handle<CommandLookupTopicResponse> handle) {
               return new CommandLookupTopicResponse(handle);
             }
           };
@@ -8212,10 +8236,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandLookupTopicResponse(boolean noInit) {}
+    private CommandLookupTopicResponse(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandLookupTopicResponse defaultInstance;
     public static CommandLookupTopicResponse getDefaultInstance() {
@@ -8601,20 +8627,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandLookupTopicResponse, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandLookupTopicResponseOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandLookupTopicResponse.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -9076,13 +9102,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandProducerOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandProducer.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandProducer(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandProducer> handle;
+    private CommandProducer(io.netty.util.Recycler.Handle<CommandProducer> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandProducer> RECYCLER = new io.netty.util.Recycler<CommandProducer>() {
-            protected CommandProducer newObject(Handle handle) {
+            protected CommandProducer newObject(Handle<CommandProducer> handle) {
               return new CommandProducer(handle);
             }
           };
@@ -9092,10 +9118,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandProducer(boolean noInit) {}
+    private CommandProducer(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandProducer defaultInstance;
     public static CommandProducer getDefaultInstance() {
@@ -9351,20 +9379,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandProducer, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandProducerOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandProducer.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -9661,13 +9689,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandSendOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandSend.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandSend(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandSend> handle;
+    private CommandSend(io.netty.util.Recycler.Handle<CommandSend> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandSend> RECYCLER = new io.netty.util.Recycler<CommandSend>() {
-            protected CommandSend newObject(Handle handle) {
+            protected CommandSend newObject(Handle<CommandSend> handle) {
               return new CommandSend(handle);
             }
           };
@@ -9677,10 +9705,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandSend(boolean noInit) {}
+    private CommandSend(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandSend defaultInstance;
     public static CommandSend getDefaultInstance() {
@@ -9870,20 +9900,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandSend, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandSendOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandSend.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -10111,13 +10141,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandSendReceiptOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandSendReceipt.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandSendReceipt(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandSendReceipt> handle;
+    private CommandSendReceipt(io.netty.util.Recycler.Handle<CommandSendReceipt> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandSendReceipt> RECYCLER = new io.netty.util.Recycler<CommandSendReceipt>() {
-            protected CommandSendReceipt newObject(Handle handle) {
+            protected CommandSendReceipt newObject(Handle<CommandSendReceipt> handle) {
               return new CommandSendReceipt(handle);
             }
           };
@@ -10127,10 +10157,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandSendReceipt(boolean noInit) {}
+    private CommandSendReceipt(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandSendReceipt defaultInstance;
     public static CommandSendReceipt getDefaultInstance() {
@@ -10326,20 +10358,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandSendReceipt, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandSendReceiptOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandSendReceipt.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -10604,13 +10636,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandSendErrorOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandSendError.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandSendError(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandSendError> handle;
+    private CommandSendError(io.netty.util.Recycler.Handle<CommandSendError> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandSendError> RECYCLER = new io.netty.util.Recycler<CommandSendError>() {
-            protected CommandSendError newObject(Handle handle) {
+            protected CommandSendError newObject(Handle<CommandSendError> handle) {
               return new CommandSendError(handle);
             }
           };
@@ -10620,10 +10652,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandSendError(boolean noInit) {}
+    private CommandSendError(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandSendError defaultInstance;
     public static CommandSendError getDefaultInstance() {
@@ -10861,20 +10895,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandSendError, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandSendErrorOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandSendError.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -11163,13 +11197,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandMessageOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandMessage.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandMessage(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandMessage> handle;
+    private CommandMessage(io.netty.util.Recycler.Handle<CommandMessage> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandMessage> RECYCLER = new io.netty.util.Recycler<CommandMessage>() {
-            protected CommandMessage newObject(Handle handle) {
+            protected CommandMessage newObject(Handle<CommandMessage> handle) {
               return new CommandMessage(handle);
             }
           };
@@ -11179,10 +11213,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandMessage(boolean noInit) {}
+    private CommandMessage(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandMessage defaultInstance;
     public static CommandMessage getDefaultInstance() {
@@ -11358,20 +11394,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandMessage, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandMessageOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandMessage.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -11605,13 +11641,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandAckOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandAck.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandAck(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandAck> handle;
+    private CommandAck(io.netty.util.Recycler.Handle<CommandAck> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandAck> RECYCLER = new io.netty.util.Recycler<CommandAck>() {
-            protected CommandAck newObject(Handle handle) {
+            protected CommandAck newObject(Handle<CommandAck> handle) {
               return new CommandAck(handle);
             }
           };
@@ -11621,10 +11657,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandAck(boolean noInit) {}
+    private CommandAck(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandAck defaultInstance;
     public static CommandAck getDefaultInstance() {
@@ -11966,20 +12004,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandAck, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandAckOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -12405,13 +12443,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandFlowOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandFlow.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandFlow(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandFlow> handle;
+    private CommandFlow(io.netty.util.Recycler.Handle<CommandFlow> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandFlow> RECYCLER = new io.netty.util.Recycler<CommandFlow>() {
-            protected CommandFlow newObject(Handle handle) {
+            protected CommandFlow newObject(Handle<CommandFlow> handle) {
               return new CommandFlow(handle);
             }
           };
@@ -12421,10 +12459,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandFlow(boolean noInit) {}
+    private CommandFlow(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandFlow defaultInstance;
     public static CommandFlow getDefaultInstance() {
@@ -12596,20 +12636,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandFlow, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandFlowOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandFlow.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -12798,13 +12838,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandUnsubscribeOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandUnsubscribe.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandUnsubscribe(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandUnsubscribe> handle;
+    private CommandUnsubscribe(io.netty.util.Recycler.Handle<CommandUnsubscribe> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandUnsubscribe> RECYCLER = new io.netty.util.Recycler<CommandUnsubscribe>() {
-            protected CommandUnsubscribe newObject(Handle handle) {
+            protected CommandUnsubscribe newObject(Handle<CommandUnsubscribe> handle) {
               return new CommandUnsubscribe(handle);
             }
           };
@@ -12814,10 +12854,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandUnsubscribe(boolean noInit) {}
+    private CommandUnsubscribe(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandUnsubscribe defaultInstance;
     public static CommandUnsubscribe getDefaultInstance() {
@@ -12989,20 +13031,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandUnsubscribe, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandUnsubscribeOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandUnsubscribe.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -13195,13 +13237,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandSeekOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandSeek.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandSeek(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandSeek> handle;
+    private CommandSeek(io.netty.util.Recycler.Handle<CommandSeek> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandSeek> RECYCLER = new io.netty.util.Recycler<CommandSeek>() {
-            protected CommandSeek newObject(Handle handle) {
+            protected CommandSeek newObject(Handle<CommandSeek> handle) {
               return new CommandSeek(handle);
             }
           };
@@ -13211,10 +13253,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandSeek(boolean noInit) {}
+    private CommandSeek(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandSeek defaultInstance;
     public static CommandSeek getDefaultInstance() {
@@ -13410,20 +13454,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -13676,13 +13720,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandReachedEndOfTopicOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandReachedEndOfTopic.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandReachedEndOfTopic(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandReachedEndOfTopic> handle;
+    private CommandReachedEndOfTopic(io.netty.util.Recycler.Handle<CommandReachedEndOfTopic> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandReachedEndOfTopic> RECYCLER = new io.netty.util.Recycler<CommandReachedEndOfTopic>() {
-            protected CommandReachedEndOfTopic newObject(Handle handle) {
+            protected CommandReachedEndOfTopic newObject(Handle<CommandReachedEndOfTopic> handle) {
               return new CommandReachedEndOfTopic(handle);
             }
           };
@@ -13692,10 +13736,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandReachedEndOfTopic(boolean noInit) {}
+    private CommandReachedEndOfTopic(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandReachedEndOfTopic defaultInstance;
     public static CommandReachedEndOfTopic getDefaultInstance() {
@@ -13845,20 +13891,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopicOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -14008,13 +14054,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandCloseProducerOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandCloseProducer.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandCloseProducer(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandCloseProducer> handle;
+    private CommandCloseProducer(io.netty.util.Recycler.Handle<CommandCloseProducer> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandCloseProducer> RECYCLER = new io.netty.util.Recycler<CommandCloseProducer>() {
-            protected CommandCloseProducer newObject(Handle handle) {
+            protected CommandCloseProducer newObject(Handle<CommandCloseProducer> handle) {
               return new CommandCloseProducer(handle);
             }
           };
@@ -14024,10 +14070,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandCloseProducer(boolean noInit) {}
+    private CommandCloseProducer(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandCloseProducer defaultInstance;
     public static CommandCloseProducer getDefaultInstance() {
@@ -14199,20 +14247,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandCloseProducer, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandCloseProducerOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandCloseProducer.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -14401,13 +14449,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandCloseConsumerOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandCloseConsumer.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandCloseConsumer(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandCloseConsumer> handle;
+    private CommandCloseConsumer(io.netty.util.Recycler.Handle<CommandCloseConsumer> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandCloseConsumer> RECYCLER = new io.netty.util.Recycler<CommandCloseConsumer>() {
-            protected CommandCloseConsumer newObject(Handle handle) {
+            protected CommandCloseConsumer newObject(Handle<CommandCloseConsumer> handle) {
               return new CommandCloseConsumer(handle);
             }
           };
@@ -14417,10 +14465,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandCloseConsumer(boolean noInit) {}
+    private CommandCloseConsumer(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandCloseConsumer defaultInstance;
     public static CommandCloseConsumer getDefaultInstance() {
@@ -14592,20 +14642,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandCloseConsumer, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandCloseConsumerOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandCloseConsumer.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -14796,13 +14846,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandRedeliverUnacknowledgedMessagesOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandRedeliverUnacknowledgedMessages.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandRedeliverUnacknowledgedMessages(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandRedeliverUnacknowledgedMessages> handle;
+    private CommandRedeliverUnacknowledgedMessages(io.netty.util.Recycler.Handle<CommandRedeliverUnacknowledgedMessages> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandRedeliverUnacknowledgedMessages> RECYCLER = new io.netty.util.Recycler<CommandRedeliverUnacknowledgedMessages>() {
-            protected CommandRedeliverUnacknowledgedMessages newObject(Handle handle) {
+            protected CommandRedeliverUnacknowledgedMessages newObject(Handle<CommandRedeliverUnacknowledgedMessages> handle) {
               return new CommandRedeliverUnacknowledgedMessages(handle);
             }
           };
@@ -14812,10 +14862,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandRedeliverUnacknowledgedMessages(boolean noInit) {}
+    private CommandRedeliverUnacknowledgedMessages(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandRedeliverUnacknowledgedMessages defaultInstance;
     public static CommandRedeliverUnacknowledgedMessages getDefaultInstance() {
@@ -15000,20 +15052,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandRedeliverUnacknowledgedMessages, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandRedeliverUnacknowledgedMessagesOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandRedeliverUnacknowledgedMessages.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -15277,13 +15329,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandSuccessOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandSuccess.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandSuccess(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandSuccess> handle;
+    private CommandSuccess(io.netty.util.Recycler.Handle<CommandSuccess> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandSuccess> RECYCLER = new io.netty.util.Recycler<CommandSuccess>() {
-            protected CommandSuccess newObject(Handle handle) {
+            protected CommandSuccess newObject(Handle<CommandSuccess> handle) {
               return new CommandSuccess(handle);
             }
           };
@@ -15293,10 +15345,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandSuccess(boolean noInit) {}
+    private CommandSuccess(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandSuccess defaultInstance;
     public static CommandSuccess getDefaultInstance() {
@@ -15446,20 +15500,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandSuccess, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandSuccessOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandSuccess.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -15613,13 +15667,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandProducerSuccessOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandProducerSuccess.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandProducerSuccess(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandProducerSuccess> handle;
+    private CommandProducerSuccess(io.netty.util.Recycler.Handle<CommandProducerSuccess> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandProducerSuccess> RECYCLER = new io.netty.util.Recycler<CommandProducerSuccess>() {
-            protected CommandProducerSuccess newObject(Handle handle) {
+            protected CommandProducerSuccess newObject(Handle<CommandProducerSuccess> handle) {
               return new CommandProducerSuccess(handle);
             }
           };
@@ -15629,10 +15683,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandProducerSuccess(boolean noInit) {}
+    private CommandProducerSuccess(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandProducerSuccess defaultInstance;
     public static CommandProducerSuccess getDefaultInstance() {
@@ -15844,20 +15900,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandProducerSuccess, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandProducerSuccessOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandProducerSuccess.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -16100,13 +16156,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandErrorOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandError.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandError(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandError> handle;
+    private CommandError(io.netty.util.Recycler.Handle<CommandError> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandError> RECYCLER = new io.netty.util.Recycler<CommandError>() {
-            protected CommandError newObject(Handle handle) {
+            protected CommandError newObject(Handle<CommandError> handle) {
               return new CommandError(handle);
             }
           };
@@ -16116,10 +16172,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandError(boolean noInit) {}
+    private CommandError(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandError defaultInstance;
     public static CommandError getDefaultInstance() {
@@ -16335,20 +16393,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandError, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandErrorOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandError.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -16590,13 +16648,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandPingOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandPing.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandPing(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandPing> handle;
+    private CommandPing(io.netty.util.Recycler.Handle<CommandPing> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandPing> RECYCLER = new io.netty.util.Recycler<CommandPing>() {
-            protected CommandPing newObject(Handle handle) {
+            protected CommandPing newObject(Handle<CommandPing> handle) {
               return new CommandPing(handle);
             }
           };
@@ -16605,10 +16663,12 @@ public final class PulsarApi {
             this.initFields();
             this.memoizedIsInitialized = -1;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandPing(boolean noInit) {}
+    private CommandPing(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandPing defaultInstance;
     public static CommandPing getDefaultInstance() {
@@ -16735,20 +16795,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandPing, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandPingOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandPing.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -16847,13 +16907,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandPongOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandPong.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandPong(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandPong> handle;
+    private CommandPong(io.netty.util.Recycler.Handle<CommandPong> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandPong> RECYCLER = new io.netty.util.Recycler<CommandPong>() {
-            protected CommandPong newObject(Handle handle) {
+            protected CommandPong newObject(Handle<CommandPong> handle) {
               return new CommandPong(handle);
             }
           };
@@ -16862,10 +16922,12 @@ public final class PulsarApi {
             this.initFields();
             this.memoizedIsInitialized = -1;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandPong(boolean noInit) {}
+    private CommandPong(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandPong defaultInstance;
     public static CommandPong getDefaultInstance() {
@@ -16992,20 +17054,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandPong, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandPongOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandPong.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -17112,13 +17174,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandConsumerStatsOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandConsumerStats.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandConsumerStats(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandConsumerStats> handle;
+    private CommandConsumerStats(io.netty.util.Recycler.Handle<CommandConsumerStats> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandConsumerStats> RECYCLER = new io.netty.util.Recycler<CommandConsumerStats>() {
-            protected CommandConsumerStats newObject(Handle handle) {
+            protected CommandConsumerStats newObject(Handle<CommandConsumerStats> handle) {
               return new CommandConsumerStats(handle);
             }
           };
@@ -17128,10 +17190,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandConsumerStats(boolean noInit) {}
+    private CommandConsumerStats(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandConsumerStats defaultInstance;
     public static CommandConsumerStats getDefaultInstance() {
@@ -17303,20 +17367,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandConsumerStats, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandConsumerStatsOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandConsumerStats.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -17557,13 +17621,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandConsumerStatsResponseOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandConsumerStatsResponse.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandConsumerStatsResponse(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandConsumerStatsResponse> handle;
+    private CommandConsumerStatsResponse(io.netty.util.Recycler.Handle<CommandConsumerStatsResponse> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandConsumerStatsResponse> RECYCLER = new io.netty.util.Recycler<CommandConsumerStatsResponse>() {
-            protected CommandConsumerStatsResponse newObject(Handle handle) {
+            protected CommandConsumerStatsResponse newObject(Handle<CommandConsumerStatsResponse> handle) {
               return new CommandConsumerStatsResponse(handle);
             }
           };
@@ -17573,10 +17637,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandConsumerStatsResponse(boolean noInit) {}
+    private CommandConsumerStatsResponse(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandConsumerStatsResponse defaultInstance;
     public static CommandConsumerStatsResponse getDefaultInstance() {
@@ -18088,20 +18154,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandConsumerStatsResponse, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandConsumerStatsResponseOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandConsumerStatsResponse.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -18927,13 +18993,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements BaseCommandOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use BaseCommand.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private BaseCommand(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<BaseCommand> handle;
+    private BaseCommand(io.netty.util.Recycler.Handle<BaseCommand> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<BaseCommand> RECYCLER = new io.netty.util.Recycler<BaseCommand>() {
-            protected BaseCommand newObject(Handle handle) {
+            protected BaseCommand newObject(Handle<BaseCommand> handle) {
               return new BaseCommand(handle);
             }
           };
@@ -18943,10 +19009,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private BaseCommand(boolean noInit) {}
+    private BaseCommand(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final BaseCommand defaultInstance;
     public static BaseCommand getDefaultInstance() {
@@ -19848,20 +19916,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.BaseCommand, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.BaseCommandOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.BaseCommand.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -34,6 +34,11 @@ message KeyValue {
 	required string value = 2;
 }
 
+message KeyLongValue {
+        required string key = 1;
+        required uint64 value = 2;
+}
+
 message EncryptionKeys {
 	required string key = 1;
 	required bytes value = 2;
@@ -278,6 +283,7 @@ message CommandAck {
 	}
 
 	optional ValidationError validation_error = 4;
+        repeated KeyLongValue properties = 5;
 }
 
 message CommandFlow {


### PR DESCRIPTION
This will be used by the compactor to update the topic with the
compacted ledger. There will be a cursor/subscription owned by the
compactor which keeps track of where we have compacted until, and the
ID of the ledger into which the compacted data has been written.

This change exposes the cursor's String->Long properties map which is
already available for Producer sequence tracking. This is only exposed
through the RawReader, which is part of the broker module. Clients
will not be able to use it.
