### PR TITLE
Fix Incremental long crc32c

### DIFF
--- a/pulsar-checksum/src/main/java/com/scurrilous/circe/crc/ReflectedLongCrc.java
+++ b/pulsar-checksum/src/main/java/com/scurrilous/circe/crc/ReflectedLongCrc.java
@@ -36,8 +36,12 @@ final class ReflectedLongCrc extends AbstractLongCrc {
     }
 
     @Override
+    protected long initial() {
+        return reflect(super.initial());
+    }
+
+    @Override
     protected long resumeRaw(long crc, byte[] input, int index, int length) {
-        crc = reflect(crc);
         for (int i = 0; i < length; ++i)
             crc = table[(int) (crc ^ input[index + i]) & 0xff] ^ (crc >>> 8);
         return crc;

--- a/pulsar-checksum/src/test/java/com/scurrilous/circe/crc/CRCTest.java
+++ b/pulsar-checksum/src/test/java/com/scurrilous/circe/crc/CRCTest.java
@@ -26,6 +26,7 @@ import static com.scurrilous.circe.params.CrcParameters.CRC64;
 import static com.scurrilous.circe.params.CrcParameters.CRC64_XZ;
 import static org.testng.Assert.assertEquals;
 
+import com.scurrilous.circe.IncrementalLongHash;
 import java.nio.charset.Charset;
 
 import org.testng.annotations.Test;
@@ -163,18 +164,34 @@ public class CRCTest {
     }
     
     @Test
-    public void testCRC32CIncremental() {
+    public void testCRC32CIncrementalInt() {
         // reflected
-        testIncremental(PROVIDER.getIncrementalInt(CRC32C));
+        testIncrementalInt(PROVIDER.getIncrementalInt(CRC32C));
     }
 
-    private void testIncremental(IncrementalIntHash hash) {
+    private void testIncrementalInt(IncrementalIntHash hash) {
         final String data = "data";
         final String combined = data + data;
 
         final int dataChecksum = hash.calculate(data.getBytes(ASCII));
         final int combinedChecksum = hash.calculate(combined.getBytes(ASCII));
         final int incrementalChecksum = hash.resume(dataChecksum, data.getBytes(ASCII));
+        assertEquals(combinedChecksum, incrementalChecksum);
+    }
+
+    @Test
+    public void testCRC32CIncrementalLong() {
+        // reflected
+        testIncrementalLong(PROVIDER.getIncrementalLong(CRC32C));
+    }
+
+    private void testIncrementalLong(IncrementalLongHash hash) {
+        final String data = "data";
+        final String combined = data + data;
+
+        final long dataChecksum = hash.calculate(data.getBytes(ASCII));
+        final long combinedChecksum = hash.calculate(combined.getBytes(ASCII));
+        final long incrementalChecksum = hash.resume(dataChecksum, data.getBytes(ASCII));
         assertEquals(combinedChecksum, incrementalChecksum);
     }
 }


### PR DESCRIPTION
### Motivation

Integer based incremental crc32c works. However Long based incremental crc32c doesn't work.

### Modifications

The reflection in long crc32c should be on the initial value, not on each incremental resume. This fix is moving reflect to be on `initial()` only.

### Result

long crc32 supports incremental
