### PR TITLE
Make load-balancer shedding dynamic configurable

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -291,6 +291,9 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private int loadBalancerReportUpdateMaxIntervalMinutes = 15;
     // Frequency of report to collect
     private int loadBalancerHostUsageCheckIntervalMinutes = 1;
+    // Enable/disable automatic bundle unloading for load-shedding 
+    @FieldContext(dynamic = true)
+    private boolean loadBalancerSheddingEnabled = true;
     // Load shedding interval. Broker periodically checks whether some traffic should be offload from some over-loaded
     // broker to other under-loaded brokers
     private int loadBalancerSheddingIntervalMinutes = 5;
@@ -1028,6 +1031,14 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     public void setLoadBalancerHostUsageCheckIntervalMinutes(int loadBalancerHostUsageCheckIntervalMinutes) {
         this.loadBalancerHostUsageCheckIntervalMinutes = loadBalancerHostUsageCheckIntervalMinutes;
+    }
+
+    public boolean isLoadBalancerSheddingEnabled() {
+        return loadBalancerSheddingEnabled;
+    }
+
+    public void setLoadBalancerSheddingEnabled(boolean loadBalancerSheddingEnabled) {
+        this.loadBalancerSheddingEnabled = loadBalancerSheddingEnabled;
     }
 
     public int getLoadBalancerSheddingIntervalMinutes() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -69,7 +69,6 @@ import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
 public abstract class AdminResource extends PulsarWebResource {
     private static final Logger log = LoggerFactory.getLogger(AdminResource.class);
     private static final String POLICIES_READONLY_FLAG_PATH = "/admin/flags/policies-readonly";
-    public static final String LOAD_SHEDDING_UNLOAD_DISABLED_FLAG_PATH = "/admin/flags/load-shedding-unload-disabled";
     public static final String PARTITIONED_TOPIC_PATH_ZNODE = "partitioned-topics";
 
     protected ZooKeeper globalZk() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
@@ -203,25 +203,13 @@ public class LoadManagerShared {
     }
 
     /**
-     * If load balancing is enabled, load shedding is enabled by default unless forced off by setting a flag in global
-     * zk /admin/flags/load-shedding-unload-disabled
+     * If load balancing is enabled, load shedding is enabled by default unless forced off by dynamic configuration
      *
-     * @return false by default, unload is allowed in load shedding true if zk flag is set, unload is disabled
+     * @return true by default
      */
-    public static boolean isUnloadDisabledInLoadShedding(final PulsarService pulsar) {
-        if (!pulsar.getConfiguration().isLoadBalancerEnabled()) {
-            return true;
-        }
-
-        boolean unloadDisabledInLoadShedding = false;
-        try {
-            unloadDisabledInLoadShedding = pulsar.getGlobalZkCache()
-                    .exists(AdminResource.LOAD_SHEDDING_UNLOAD_DISABLED_FLAG_PATH);
-        } catch (Exception e) {
-            log.warn("Unable to fetch contents of [{}] from global zookeeper",
-                    AdminResource.LOAD_SHEDDING_UNLOAD_DISABLED_FLAG_PATH, e);
-        }
-        return unloadDisabledInLoadShedding;
+    public static boolean isLoadSheddingEnabled(final PulsarService pulsar) {
+        return pulsar.getConfiguration().isLoadBalancerEnabled()
+                && pulsar.getConfiguration().isLoadBalancerSheddingEnabled();
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -554,7 +554,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
      */
     @Override
     public synchronized void doLoadShedding() {
-        if (LoadManagerShared.isUnloadDisabledInLoadShedding(pulsar)) {
+        if (!LoadManagerShared.isLoadSheddingEnabled(pulsar)) {
             return;
         }
         if (getAvailableBrokers().size() <= 1) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
@@ -1318,7 +1318,7 @@ public class SimpleLoadManagerImpl implements LoadManager, ZooKeeperCacheListene
             String bundleName = bundle.getValue();
             try {
                 if (unloadedHotNamespaceCache.getIfPresent(bundleName) == null) {
-                    if (!LoadManagerShared.isUnloadDisabledInLoadShedding(pulsar)) {
+                    if (LoadManagerShared.isLoadSheddingEnabled(pulsar)) {
                         log.info("Unloading namespace {} from overloaded broker {}", bundleName, brokerName);
                         pulsar.getAdminClient().namespaces().unloadNamespaceBundle(
                                 LoadManagerShared.getNamespaceNameFromBundleName(bundleName),


### PR DESCRIPTION
### Motivation

Right now, enabling/disabling load-shedding for load-manager is controlled by manually creating/deleting znode under global zk: `/admin/flags/load-shedding-unload-disabled` which is not user friendly and it should be dynamically configurable.

