### PR TITLE
ENH: Add RPC client/server sample in Python

### DIFF
--- a/pulsar-client-cpp/python/examples/rpc_client.py
+++ b/pulsar-client-cpp/python/examples/rpc_client.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+
+import pulsar
+import uuid
+
+
+DEFAULT_CLIENT_TOPIC = 'persistent://sample/standalone/ns/rpc-client-topic'
+DEFAULT_SERVER_TOPIC = 'persistent://sample/standalone/ns/rpc-server-topic'
+
+
+class RPCClient(object):
+
+    def __init__(self,
+                 client_topic=DEFAULT_CLIENT_TOPIC,
+                 server_topic=DEFAULT_SERVER_TOPIC):
+        self.client_topic = client_topic
+        self.server_topic = server_topic
+
+        self.response = None
+        self.partition_key = str(uuid.uuid4())
+        self.client = pulsar.Client('pulsar://localhost:6650')
+        self.producer = self.client.create_producer(server_topic)
+        self.consumer = \
+            self.client.subscribe(client_topic,
+                                  'rpc-client',
+                                  message_listener=self.on_response)
+
+        self.consumer.resume_message_listener()
+
+    def on_response(self, consumer, message):
+        if message.partition_key() == self.partition_key \
+           and consumer.topic() == self.client_topic:
+            print('Received: {0}'.format(message.data()))
+            self.response = message.data().decode()
+            consumer.acknowledge(message)
+
+    def call(self, message):
+        self.response = None
+        self.producer.send(message, partition_key=self.partition_key)
+
+        while self.response is None:
+            pass
+
+        return self.response
+
+
+msg = 'foo'
+rpc_client = RPCClient()
+ret = rpc_client.call(msg)
+
+print('RPCClient message sent: {0}, result: {1}'.format(msg, ret))

--- a/pulsar-client-cpp/python/examples/rpc_server.py
+++ b/pulsar-client-cpp/python/examples/rpc_server.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+
+import pulsar
+
+
+DEFAULT_CLIENT_TOPIC = 'persistent://sample/standalone/ns/rpc-client-topic'
+DEFAULT_SERVER_TOPIC = 'persistent://sample/standalone/ns/rpc-server-topic'
+
+
+class RPCServer(object):
+    def __init__(self,
+                 client_topic=DEFAULT_CLIENT_TOPIC,
+                 server_topic=DEFAULT_SERVER_TOPIC):
+        self.client_topic = client_topic
+        self.server_topic = server_topic
+
+        self.client = pulsar.Client('pulsar://localhost:6650')
+        self.producer = self.client.create_producer(client_topic)
+        self.consumer = \
+            self.client.subscribe(server_topic,
+                                  'rpc-server',
+                                  message_listener=self.on_response)
+
+    def on_response(self, consumer, message):
+        print('Received from {0}: {1}'.format(message.partition_key(),
+                                              message.data().decode()))
+
+        self.producer.send('{} bar'.format(message.data().decode()),
+                           partition_key=message.partition_key())
+        consumer.acknowledge(message)
+
+    def start(self):
+        self.consumer.resume_message_listener()
+
+
+rpc_server = RPCServer()
+rpc_server.start()
+
+try:
+    while True:
+        pass
+except KeyboardInterrupt:
+    print('Interrupted.')

--- a/pulsar-client-cpp/python/examples/rpc_server.py
+++ b/pulsar-client-cpp/python/examples/rpc_server.py
@@ -38,6 +38,7 @@ class RPCServer(object):
         self.consumer = \
             self.client.subscribe(server_topic,
                                   'rpc-server',
+                                  pulsar.ConsumerType.Shared,
                                   message_listener=self.on_response)
 
     def on_response(self, consumer, message):


### PR DESCRIPTION
### Motivation

RabbitMQ provides the RPC tutorial and example, but Pulsar doesn't. Also, there is no examples written in Python.
https://www.rabbitmq.com/tutorials/tutorial-six-python.html
https://github.com/rabbitmq/rabbitmq-tutorials/tree/d312d5e2a96d046d45f437f620e430208a0f2d1a/python

### Modifications

No mod., just added the example.

### Result

Made Pythonista friendly. ;-)
I'll add more examples in Python if you want!