### PR TITLE
BUG: Fix ProtocolBuffer output directory when building the C++ client

### DIFF
--- a/pulsar-client-cpp/lib/CMakeLists.txt
+++ b/pulsar-client-cpp/lib/CMakeLists.txt
@@ -26,7 +26,7 @@ set (CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -D_PULSAR_VERSION_=\\\"${PV}\\\"")
 # Using custom command for now
 ADD_CUSTOM_COMMAND(
          OUTPUT PulsarApi.pb.h PulsarApi.pb.cc
-         COMMAND protoc -I ../../pulsar-common/src/main/proto ../../pulsar-common/src/main/proto/PulsarApi.proto --cpp_out=${CMAKE_CURRENT_BINARY_DIR}
+         COMMAND protoc -I ../../pulsar-common/src/main/proto ../../pulsar-common/src/main/proto/PulsarApi.proto --cpp_out=${CMAKE_SOURCE_DIR}/lib
          DEPENDS
          ../../pulsar-common/src/main/proto/PulsarApi.proto
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
### Motivation

C++ client build failure when running CMake at any directory except `pulsar-client-cpp/` because the `protoc` output location is wrong.

### Modifications

Change the `protoc` output location to `pulsar-client-cpp/lib`.

### Result

We can build at any location.
