### PR TITLE
Bookies pods in kubernetes need to use hostPort

### DIFF
--- a/kubernetes/generic/bookie.yaml
+++ b/kubernetes/generic/bookie.yaml
@@ -66,6 +66,7 @@ spec:
                     bin/pulsar bookie
                 ports:
                   - containerPort: 3181
+                    hostPort: 3181
                     name: client
                 envFrom:
                   - configMapRef:

--- a/kubernetes/google-kubernetes-engine/bookie.yaml
+++ b/kubernetes/google-kubernetes-engine/bookie.yaml
@@ -67,6 +67,7 @@ spec:
                     bin/pulsar bookie
                 ports:
                   - containerPort: 3181
+                    hostPort: 3181
                     name: client
                 envFrom:
                   - configMapRef:


### PR DESCRIPTION
### Motivation

Bookies pods need to use `hostPort` in Kubernetes because they are advertising the host IP.