### PR TITLE
Enable usage of KQueue in MacOS

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/netty/EventLoopUtil.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/netty/EventLoopUtil.java
@@ -29,6 +29,11 @@ import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.epoll.EpollMode;
 import io.netty.channel.epoll.EpollServerSocketChannel;
 import io.netty.channel.epoll.EpollSocketChannel;
+import io.netty.channel.kqueue.KQueue;
+import io.netty.channel.kqueue.KQueueDatagramChannel;
+import io.netty.channel.kqueue.KQueueEventLoopGroup;
+import io.netty.channel.kqueue.KQueueServerSocketChannel;
+import io.netty.channel.kqueue.KQueueSocketChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.ServerSocketChannel;
@@ -45,6 +50,8 @@ public class EventLoopUtil {
     public static EventLoopGroup newEventLoopGroup(int nThreads, ThreadFactory threadFactory) {
         if (Epoll.isAvailable()) {
             return new EpollEventLoopGroup(nThreads, threadFactory);
+        } else if (KQueue.isAvailable()) {
+            return new KQueueEventLoopGroup(nThreads, threadFactory);
         } else {
             // Fallback to NIO
             return new NioEventLoopGroup(nThreads, threadFactory);
@@ -60,6 +67,8 @@ public class EventLoopUtil {
     public static Class<? extends SocketChannel> getClientSocketChannelClass(EventLoopGroup eventLoopGroup) {
         if (eventLoopGroup instanceof EpollEventLoopGroup) {
             return EpollSocketChannel.class;
+        } else if (eventLoopGroup instanceof KQueueEventLoopGroup) {
+            return KQueueSocketChannel.class;
         } else {
             return NioSocketChannel.class;
         }
@@ -68,6 +77,8 @@ public class EventLoopUtil {
     public static Class<? extends ServerSocketChannel> getServerSocketChannelClass(EventLoopGroup eventLoopGroup) {
         if (eventLoopGroup instanceof EpollEventLoopGroup) {
             return EpollServerSocketChannel.class;
+        } else if (eventLoopGroup instanceof KQueueEventLoopGroup) {
+            return KQueueServerSocketChannel.class;
         } else {
             return NioServerSocketChannel.class;
         }
@@ -76,6 +87,8 @@ public class EventLoopUtil {
     public static Class<? extends DatagramChannel> getDatagramChannelClass(EventLoopGroup eventLoopGroup) {
         if (eventLoopGroup instanceof EpollEventLoopGroup) {
             return EpollDatagramChannel.class;
+        } else if (eventLoopGroup instanceof KQueueEventLoopGroup) {
+            return KQueueDatagramChannel.class;
         } else {
             return NioDatagramChannel.class;
         }


### PR DESCRIPTION
### Motivation

KQueue is now supported in Netty-4.1. A good reason to use it is that it is much closer to Epoll in Linux than the NIO based event loop.