### PR TITLE
ENH: Add C++ code auto-formatting option

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -4,11 +4,3 @@ Copyright 2017 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
-
-
-This product includes software from the Arrow project (Apache 2.0)
-https://github.com/apache/arrow
-
-
-This product includes software from the LLVM project
- * distributed under the University of Illinois Open Source

--- a/NOTICE
+++ b/NOTICE
@@ -4,3 +4,11 @@ Copyright 2017 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+
+This product includes software from the Arrow project (Apache 2.0)
+https://github.com/apache/arrow
+
+
+This product includes software from the LLVM project
+ * distributed under the University of Illinois Open Source

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update
 RUN apt-get install -y maven tig g++ cmake libssl-dev libcurl4-openssl-dev \
                 liblog4cxx-dev libprotobuf-dev libboost-all-dev  libgtest-dev \
                 libjsoncpp-dev libxml2-utils protobuf-compiler wget \
-                curl doxygen openjdk-8-jdk-headless
+                curl doxygen openjdk-8-jdk-headless clang-format-4.0
 
 # Compile and install gtest
 RUN cd /usr/src/gtest && cmake . && make && cp libgtest.a /usr/lib

--- a/pulsar-client-cpp/.clang-format
+++ b/pulsar-client-cpp/.clang-format
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+BasedOnStyle: Google
+ColumnLimit: 90

--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -19,6 +19,7 @@
 
 cmake_minimum_required(VERSION 2.8)
 project (pulsar-cpp)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake_modules")
 
 option(LINK_STATIC "Link against static libraries" OFF)
 MESSAGE(STATUS "LINK_STATIC:  " ${LINK_STATIC})
@@ -195,3 +196,24 @@ add_subdirectory(perf)
 add_subdirectory(examples)
 add_subdirectory(tests)
 add_subdirectory(python)
+
+# `make format` option
+set(CLANG_FORMAT_VERSION "4.0")
+find_package(ClangTools)
+set(BUILD_SUPPORT_DIR "${CMAKE_SOURCE_DIR}/build-support")
+add_custom_target(format ${BUILD_SUPPORT_DIR}/run_clang_format.py
+        ${CLANG_FORMAT_BIN}
+        0
+        ${BUILD_SUPPORT_DIR}/clang_format_exclusions.txt
+        ${CMAKE_SOURCE_DIR}/lib
+        ${CMAKE_SOURCE_DIR}/tests
+        ${CMAKE_SOURCE_DIR}/include)
+
+# `make check-format` option (for CI test)
+add_custom_target(check-format ${BUILD_SUPPORT_DIR}/run_clang_format.py
+        ${CLANG_FORMAT_BIN}
+        1
+        ${BUILD_SUPPORT_DIR}/clang_format_exclusions.txt
+        ${CMAKE_SOURCE_DIR}/lib
+        ${CMAKE_SOURCE_DIR}/tests
+        ${CMAKE_SOURCE_DIR}/include)

--- a/pulsar-client-cpp/build-support/run_clang_format.py
+++ b/pulsar-client-cpp/build-support/run_clang_format.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Original: https://github.com/apache/arrow/blob/4dbce607d50031a405af39d36e08cd03c5ffc764/cpp/build-support/run_clang_format.py
+# ChangeLog:
+#     2018-01-08: Accept multiple source directories (@Licht-T)
+
+import fnmatch
+import os
+import subprocess
+import sys
+
+if len(sys.argv) < 5:
+    sys.stderr.write("Usage: %s $CLANG_FORMAT $CHECK_FORMAT exclude_globs.txt "
+                     "$source_dir1 $source_dir2\n" %
+                     sys.argv[0])
+    sys.exit(1)
+
+CLANG_FORMAT = sys.argv[1]
+CHECK_FORMAT = int(sys.argv[2]) == 1
+EXCLUDE_GLOBS_FILENAME = sys.argv[3]
+SOURCE_DIRS = sys.argv[4:]
+
+exclude_globs = [line.strip() for line in open(EXCLUDE_GLOBS_FILENAME, "r")]
+
+files_to_format = []
+matches = []
+for source_dir in SOURCE_DIRS:
+    for directory, subdirs, files in os.walk(source_dir):
+        for name in files:
+            name = os.path.join(directory, name)
+            if not (name.endswith('.h') or name.endswith('.cc')):
+                continue
+
+            excluded = False
+            for g in exclude_globs:
+                if fnmatch.fnmatch(name, g):
+                    excluded = True
+                    break
+            if not excluded:
+                files_to_format.append(name)
+
+if CHECK_FORMAT:
+    output = subprocess.check_output([CLANG_FORMAT, '-output-replacements-xml']
+                                     + files_to_format,
+                                     stderr=subprocess.STDOUT).decode('utf8')
+
+    to_fix = []
+    for line in output.split('\n'):
+        if 'offset' in line:
+            to_fix.append(line)
+
+    if len(to_fix) > 0:
+        print("clang-format checks failed, run 'make format' to fix")
+        sys.exit(-1)
+else:
+    try:
+        cmd = [CLANG_FORMAT, '-i'] + files_to_format
+        subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+    except Exception as e:
+        print(e)
+        print(' '.join(cmd))
+        raise

--- a/pulsar-client-cpp/cmake_modules/FindClangTools.cmake
+++ b/pulsar-client-cpp/cmake_modules/FindClangTools.cmake
@@ -1,0 +1,100 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Tries to find the clang-tidy and clang-format modules
+#
+# Usage of this module as follows:
+#
+#  find_package(ClangTools)
+#
+# Variables used by this module, they can change the default behaviour and need
+# to be set before calling find_package:
+#
+#  ClangToolsBin_HOME -
+#   When set, this path is inspected instead of standard library binary locations
+#   to find clang-tidy and clang-format
+#
+# This module defines
+#  CLANG_TIDY_BIN, The  path to the clang tidy binary
+#  CLANG_TIDY_FOUND, Whether clang tidy was found
+#  CLANG_FORMAT_BIN, The path to the clang format binary
+#  CLANG_TIDY_FOUND, Whether clang format was found
+
+find_program(CLANG_TIDY_BIN
+        NAMES clang-tidy-4.0
+        clang-tidy-3.9
+        clang-tidy-3.8
+        clang-tidy-3.7
+        clang-tidy-3.6
+        clang-tidy
+        PATHS ${ClangTools_PATH} $ENV{CLANG_TOOLS_PATH} /usr/local/bin /usr/bin
+        NO_DEFAULT_PATH
+        )
+
+if ( "${CLANG_TIDY_BIN}" STREQUAL "CLANG_TIDY_BIN-NOTFOUND" )
+    set(CLANG_TIDY_FOUND 0)
+    message("clang-tidy not found")
+else()
+    set(CLANG_TIDY_FOUND 1)
+    message("clang-tidy found at ${CLANG_TIDY_BIN}")
+endif()
+
+if (CLANG_FORMAT_VERSION)
+    find_program(CLANG_FORMAT_BIN
+            NAMES clang-format-${CLANG_FORMAT_VERSION}
+            PATHS
+            ${ClangTools_PATH}
+            $ENV{CLANG_TOOLS_PATH}
+            /usr/local/bin /usr/bin
+            NO_DEFAULT_PATH
+            )
+
+    # If not found yet, search alternative locations
+    if (("${CLANG_FORMAT_BIN}" STREQUAL "CLANG_FORMAT_BIN-NOTFOUND") AND APPLE)
+        # Homebrew ships older LLVM versions in /usr/local/opt/llvm@version/
+        STRING(REGEX REPLACE "^([0-9]+)\\.[0-9]+" "\\1" CLANG_FORMAT_MAJOR_VERSION "${CLANG_FORMAT_VERSION}")
+        STRING(REGEX REPLACE "^[0-9]+\\.([0-9]+)" "\\1" CLANG_FORMAT_MINOR_VERSION "${CLANG_FORMAT_VERSION}")
+        if ("${CLANG_FORMAT_MINOR_VERSION}" STREQUAL "0")
+            find_program(CLANG_FORMAT_BIN
+                    NAMES clang-format
+                    PATHS /usr/local/opt/llvm@${CLANG_FORMAT_MAJOR_VERSION}/bin
+                    NO_DEFAULT_PATH
+                    )
+        else()
+            find_program(CLANG_FORMAT_BIN
+                    NAMES clang-format
+                    PATHS /usr/local/opt/llvm@${CLANG_FORMAT_VERSION}/bin
+                    NO_DEFAULT_PATH
+                    )
+        endif()
+    endif()
+else()
+    find_program(CLANG_FORMAT_BIN
+            NAMES clang-format-4.0
+            clang-format-3.9
+            clang-format-3.8
+            clang-format-3.7
+            clang-format-3.6
+            clang-format
+            PATHS ${ClangTools_PATH} $ENV{CLANG_TOOLS_PATH} /usr/local/bin /usr/bin
+            NO_DEFAULT_PATH
+            )
+endif()
+
+if ( "${CLANG_FORMAT_BIN}" STREQUAL "CLANG_FORMAT_BIN-NOTFOUND" )
+    set(CLANG_FORMAT_FOUND 0)
+    message("clang-format not found")
+else()
+    set(CLANG_FORMAT_FOUND 1)
+    message("clang-format found at ${CLANG_FORMAT_BIN}")
+endif()

--- a/pulsar-client-cpp/docs/MainPage.md
+++ b/pulsar-client-cpp/docs/MainPage.md
@@ -169,3 +169,12 @@ config.setAuth(auth);
 
 Client client("pulsar+ssl://my-broker.com:6651",config);
 ```
+
+## Code formatting
+After you changed code, run auto-formatting by the following command.
+
+```bash
+make format
+```
+You need to have the following installed to use the auto-formatting.
+* [clang-format 4.0](https://clang.llvm.org/)


### PR DESCRIPTION
### Motivation

This closes https://github.com/apache/incubator-pulsar/issues/1034.
C++ source codes are not well-formatted. Also, there is no code-formatting settings. We want to make codes formatted before sending PR, but we can't.

### Modifications

- Introduce `make format`
- Introduce `make check-format` for CI testing

### Result

C++ source codes are well-formatted.

  
  