### PR TITLE
Add NoSuchEntryException as not-recoverable error for cursor-recovery

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -2230,6 +2230,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         case BKException.Code.NoSuchLedgerExistsException:
         case BKException.Code.ReadException:
         case BKException.Code.LedgerRecoveryException:
+        case BKException.Code.NoSuchEntryException:
             return true;
 
         default:


### PR DESCRIPTION
### Motivation

Recently, we have seen that due to unexpected ledger deletion at BK, Broker was seeing `NoSuchEntryException` while recovering cursor and it is non-recoverable error while recovering the cursor.

### Modifications

Adding `NoSuchEntryException` as not-recoverable exception.

### Result

Broker will be able to recover cursor when it receives below `NoSuchEntryException` while recovering it.

```
15:19:41.168 [main-EventThread] WARN  o.a.b.mledger.impl.ManagedCursorImpl - [prop/global/ns/persistent/topic] Error reading from metadata ledger 5361778007 for consumer cons: No such entry
```
  