### PR TITLE
Update maven compiler plugin to newest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -741,7 +741,7 @@ flexible messaging model and an intuitive client API.</description>
         </plugin>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>2.3.2</version>
+          <version>3.7.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -246,7 +246,6 @@
         </configuration>
         <executions>
           <execution>
-            <phase>process-sources</phase>
             <goals>
               <goal>compile</goal>
             </goals>

--- a/pulsar-zookeeper/pom.xml
+++ b/pulsar-zookeeper/pom.xml
@@ -97,7 +97,6 @@
         </configuration>
         <executions>
           <execution>
-            <phase>process-sources</phase>
             <goals>
               <goal>compile</goal>
             </goals>


### PR DESCRIPTION
The previously used version doesn't handle the errors from newer jdk
versions, so if there's a error you can't see what's actually wrong.
