### PR TITLE
RawReader allows futures to be cancelled

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
@@ -115,7 +115,10 @@ public class RawReaderImpl implements RawReader {
             if (future == null) {
                 assert(messageAndCnx == null);
             } else {
-                future.complete(messageAndCnx.msg);
+                if (!future.complete(messageAndCnx.msg)) {
+                    messageAndCnx.msg.close();
+                    closeAsync();
+                }
 
                 ClientCnx currentCnx = cnx();
                 if (currentCnx == messageAndCnx.cnx) {
@@ -137,10 +140,14 @@ public class RawReaderImpl implements RawReader {
                 while (!pendingRawReceives.isEmpty()) {
                     toError.add(pendingRawReceives.remove());
                 }
+                RawMessageAndCnx m = incomingRawMessages.poll();
+                while (m != null) {
+                    m.msg.close();
+                    m = incomingRawMessages.poll();
+                }
                 incomingRawMessages.clear();
             }
-            toError.forEach((f) -> f.completeExceptionally(
-                                    new PulsarClientException.ConsumerBusyException("Sought while reading")));
+            toError.forEach((f) -> f.cancel(false));
         }
 
         @Override


### PR DESCRIPTION
RawReader#readNextAsync returns a Future<RawMessage> to the user, which includes a
retained ByteBuf. If the user is no longer interested in the result of
the read call, it should be able to cancel to ensure that the ByteBuf
is released.

Cancellation messes up the state of a stream (if you cancel a read, should the subsequent read get the message that read would have received, or the message after it?), so it should only occur when a you are about to close a reader or seek to a new position.

The return value of a call to cancel must be checked, as if it fails the future may have completes successfully. If this is the case, the returned RawMessage needs to be closed to avoid leaking ByteBufs.