### PR TITLE
Introduce config to skip non-recoverable data-ledger

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -300,6 +300,9 @@ managedLedgerMaxUnackedRangesToPersist=10000
 # zookeeper.
 managedLedgerMaxUnackedRangesToPersistInZooKeeper=1000
 
+# Skip reading non-recoverable/unreadable data-ledger under managed-ledger's list. It helps when data-ledgers gets
+# corrupted at bookkeeper and managed-cursor is stuck at that ledger.
+autoSkipNonRecoverableData=false
 
 ### --- Load balancer --- ###
 

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -266,6 +266,9 @@ managedLedgerMaxUnackedRangesToPersist=10000
 # zookeeper.
 managedLedgerMaxUnackedRangesToPersistInZooKeeper=1000
 
+# Skip reading non-recoverable/unreadable data-ledger under managed-ledger's list. It helps when data-ledgers gets
+# corrupted at bookkeeper and managed-cursor is stuck at that ledger.
+autoSkipNonRecoverableData=false
 
 ### --- Load balancer --- ###
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
@@ -51,6 +51,7 @@ public class ManagedLedgerConfig {
     private double throttleMarkDelete = 0;
     private long retentionTimeMs = 0;
     private long retentionSizeInMB = 0;
+    private boolean autoSkipNonRecoverableData;
 
     private DigestType digestType = DigestType.MAC;
     private byte[] password = "".getBytes(Charsets.UTF_8);
@@ -351,6 +352,20 @@ public class ManagedLedgerConfig {
      */
     public long getRetentionSizeInMB() {
         return retentionSizeInMB;
+    }
+
+    /**
+     * Skip reading non-recoverable/unreadable data-ledger under managed-ledger's list. It helps when data-ledgers gets
+     * corrupted at bookkeeper and managed-cursor is stuck at that ledger.
+     * 
+     * @param autoSkipNonRecoverableData
+     */
+    public boolean isAutoSkipNonRecoverableData() {
+        return autoSkipNonRecoverableData;
+    }
+
+    public void setAutoSkipNonRecoverableData(boolean skipNonRecoverableData) {
+        this.autoSkipNonRecoverableData = skipNonRecoverableData;
     }
 
     /**

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerException.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerException.java
@@ -31,6 +31,13 @@ public class ManagedLedgerException extends Exception {
         super(e);
     }
 
+    public static ManagedLedgerException getManagedLedgerException(Throwable e) {
+        if (e instanceof ManagedLedgerException) {
+            return (ManagedLedgerException) e;
+        }
+        return new ManagedLedgerException(e);
+    }
+    
     public static class MetaStoreException extends ManagedLedgerException {
         public MetaStoreException(Exception e) {
             super(e);
@@ -85,6 +92,12 @@ public class ManagedLedgerException extends Exception {
 
     public static class TooManyRequestsException extends ManagedLedgerException {
         public TooManyRequestsException(String msg) {
+            super(msg);
+        }
+    }
+
+    public static class NonRecoverableLedgerException extends ManagedLedgerException {
+        public NonRecoverableLedgerException(String msg) {
             super(msg);
         }
     }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheManager.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheManager.java
@@ -18,6 +18,7 @@
  */
 package org.apache.bookkeeper.mledger.impl;
 
+import static org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.createManagedLedgerException;
 import static org.apache.bookkeeper.mledger.util.SafeRun.safeRun;
 
 import java.util.Enumeration;
@@ -197,7 +198,7 @@ public class EntryCacheManager {
             lh.asyncReadEntries(firstEntry, lastEntry, new ReadCallback() {
                 public void readComplete(int rc, LedgerHandle lh, Enumeration<LedgerEntry> seq, Object bkctx) {
                     if (rc != BKException.Code.OK) {
-                        callback.readEntriesFailed(new ManagedLedgerException(BKException.create(rc)), ctx);
+                        callback.readEntriesFailed(createManagedLedgerException(rc), ctx);
                         return;
                     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerFactoryImpl.java
@@ -71,6 +71,7 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.Maps;
 
 import io.netty.util.concurrent.DefaultThreadFactory;
+import static org.apache.bookkeeper.mledger.ManagedLedgerException.getManagedLedgerException;
 
 public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
     private final MetaStore store;
@@ -432,7 +433,7 @@ public class ManagedLedgerFactoryImpl implements ManagedLedgerFactory {
                             // Completed all the cursors info
                             callback.getInfoComplete(info, ctx);
                         }).exceptionally((ex) -> {
-                            callback.getInfoFailed(new ManagedLedgerException(ex), ctx);
+                            callback.getInfoFailed(getManagedLedgerException(ex.getCause()), ctx);
                             return null;
                         });
                     }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntriesCallback;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.bookkeeper.mledger.ManagedLedgerException.NonRecoverableLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.TooManyRequestsException;
 import org.apache.bookkeeper.mledger.Position;
 import org.slf4j.Logger;
@@ -80,7 +81,7 @@ public class OpReadEntry implements ReadEntriesCallback {
     }
 
     @Override
-    public void readEntriesFailed(ManagedLedgerException status, Object ctx) {
+    public void readEntriesFailed(ManagedLedgerException exception, Object ctx) {
         cursor.readOperationCompleted();
 
         if (!entries.isEmpty()) {
@@ -89,10 +90,24 @@ public class OpReadEntry implements ReadEntriesCallback {
                 callback.readEntriesComplete(entries, ctx);
                 recycle();
             }));
+        } else if (cursor.config.isAutoSkipNonRecoverableData() && exception instanceof NonRecoverableLedgerException) {
+            log.warn("[{}][{}] read failed from ledger at position:{} : {}", cursor.ledger.getName(), cursor.getName(),
+                    readPosition, exception.getMessage());
+            // try to find and move to next valid ledger
+            final Position nexReadPosition = cursor.getNextLedgerPosition(readPosition.getLedgerId());
+            // fail callback if it couldn't find next valid ledger
+            if (nexReadPosition == null) {
+                callback.readEntriesFailed(exception, ctx);
+                cursor.ledger.mbean.recordReadEntriesError();
+                recycle();
+                return;
+            }
+            updateReadPosition(nexReadPosition);
+            checkReadCompletion();
         } else {
-            if (!(status instanceof TooManyRequestsException)) {
-                log.warn("[{}][{}] read failed from ledger at position:{} : {}", cursor.ledger.getName(), cursor.getName(),
-                        readPosition, status.getMessage());
+            if (!(exception instanceof TooManyRequestsException)) {
+                log.warn("[{}][{}] read failed from ledger at position:{} : {}", cursor.ledger.getName(),
+                        cursor.getName(), readPosition, exception.getMessage());
             } else {
                 if (log.isDebugEnabled()) {
                     log.debug("[{}][{}] read throttled failed from ledger at position:{}", cursor.ledger.getName(),
@@ -100,7 +115,7 @@ public class OpReadEntry implements ReadEntriesCallback {
                 }
             }
 
-            callback.readEntriesFailed(status, ctx);
+            callback.readEntriesFailed(exception, ctx);
             cursor.ledger.mbean.recordReadEntriesError();
             recycle();
         }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -285,6 +285,10 @@ public class ServiceConfiguration implements PulsarConfiguration {
     // than this limit then broker will persist unacked ranges into bookkeeper to avoid additional data overhead into
     // zookeeper.
     private int managedLedgerMaxUnackedRangesToPersistInZooKeeper = 1000;
+    // Skip reading non-recoverable/unreadable data-ledger under managed-ledger's list. It helps when data-ledgers gets
+    // corrupted at bookkeeper and managed-cursor is stuck at that ledger.
+    @FieldContext(dynamic = true)
+    private boolean autoSkipNonRecoverableData = false;
 
     /*** --- Load balancer --- ****/
     // Enable load balancer
@@ -1031,6 +1035,14 @@ public class ServiceConfiguration implements PulsarConfiguration {
     public void setManagedLedgerMaxUnackedRangesToPersistInZooKeeper(
             int managedLedgerMaxUnackedRangesToPersistInZookeeper) {
         this.managedLedgerMaxUnackedRangesToPersistInZooKeeper = managedLedgerMaxUnackedRangesToPersistInZookeeper;
+    }
+
+    public boolean isAutoSkipNonRecoverableData() {
+        return autoSkipNonRecoverableData;
+    }
+
+    public void setAutoSkipNonRecoverableData(boolean skipNonRecoverableLedger) {
+        this.autoSkipNonRecoverableData = skipNonRecoverableLedger;
     }
 
     public boolean isLoadBalancerEnabled() {

--- a/site/_data/config/broker.yaml
+++ b/site/_data/config/broker.yaml
@@ -206,6 +206,9 @@ configs:
   default: '1000'
   description: |
     Max number of "acknowledgment holes" that are going to be persistently stored. When acknowledging out of order, a consumer will leave holes that are supposed to be quickly filled by acking all the messages. The information of which messages are acknowledged is persisted by compressing in "ranges" of messages that were acknowledged. After the max number of ranges is reached, the information will only be tracked in memory and messages will be redelivered in case of crashes.
+- name: autoSkipNonRecoverableData
+  default: 'false'
+  description: Skip reading non-recoverable/unreadable data-ledger under managed-ledger's list.It helps when data-ledgers gets corrupted at bookkeeper and managed-cursor is stuck at that ledger.
 - name: loadBalancerEnabled
   default: 'true'
   description: Enable load balancer

--- a/site/_data/config/standalone.yaml
+++ b/site/_data/config/standalone.yaml
@@ -155,6 +155,8 @@ configs:
   default: '50000'
 - name: managedLedgerCursorRolloverTimeInSeconds
   default: '14400'
+- name: autoSkipNonRecoverableData
+  default: 'false'
 - name: loadBalancerEnabled
   default: 'false'
 - name: loadBalancerPlacementStrategy


### PR DESCRIPTION
### Motivation

Recently, we have seen that due to unexpected ledger deletion at BK, Broker was seeing NoSuchEntryException/NoLedgerException while reading data-ledger.

```
22:14:22.833 [BookKeeperClientWorker-20-1] WARN  o.a.b.mledger.impl.OpReadEntry       - [prop1/global/ns/persistent/topic1][sub1] read failed from ledger at position:5422597082:9745 : No such ledger exists
22:14:33.806 [BookKeeperClientWorker-20-1] WARN  o.a.b.mledger.impl.OpReadEntry       - [prop1/global/ns/persistent/topic2][sub1] read failed from ledger at position:5422670450:5149 : No such entry
:
```
In this case, it requires manual cleanup to delete those ledgers from managed-ledger list and performing it for large number of topics across many brokers will be very complicated. In this case, those ledgers are not recoverable so, there should be a mechanism to skip non-recoverable data-ledgers from managed-ledger list.

### Modifications

- Introduced a dynamic configuration to skip non-recoverable data-ledger
- Skip reading non-recoverable data-ledger

### Result

Broker will be more resilient when it is not able to read non-recoverable data-ledger and it can avoid manual cleanup in cluster.
