### PR TITLE
Issue 1014: Rename "global zookeeper" to "global configuration zookeeper"

### DIFF
--- a/bin/pulsar
+++ b/bin/pulsar
@@ -24,7 +24,8 @@ PULSAR_HOME=`cd $BINDIR/..;pwd`
 DEFAULT_BROKER_CONF=$PULSAR_HOME/conf/broker.conf
 DEFAULT_BOOKKEEPER_CONF=$PULSAR_HOME/conf/bookkeeper.conf
 DEFAULT_ZK_CONF=$PULSAR_HOME/conf/zookeeper.conf
-DEFAULT_GLOBAL_ZK_CONF=$PULSAR_HOME/conf/global_zookeeper.conf
+DEFAULT_GLOBAL_ZK_CONF=$PULSAR_HOME/conf/global_configuration_zookeeper.conf
+DEFAULT_GLOBAL_CONFIGURATION_ZK_CONF=$PULSAR_HOME/conf/global_configuration_zookeeper.conf
 DEFAULT_DISCOVERY_CONF=$PULSAR_HOME/conf/discovery.conf
 DEFAULT_PROXY_CONF=$PULSAR_HOME/conf/proxy.conf
 DEFAULT_STANDALONE_CONF=$PULSAR_HOME/conf/standalone.conf
@@ -70,7 +71,8 @@ where command is one of:
     broker              Run a broker server
     bookie              Run a bookie server
     zookeeper           Run a zookeeper server
-    global-zookeeper    Run a global-zookeeper server
+    global-zookeeper    Deprecated. Run a global-configuration-zookeeper server
+    global-configuration-zookeeper    Run a global-configuration-zookeeper server
     discovery           Run a discovery server
     proxy               Run a pulsar proxy
     websocket           Run a web socket proxy server
@@ -88,7 +90,8 @@ Environment variables:
    PULSAR_BROKER_CONF            Configuration file for broker (default: $DEFAULT_BROKER_CONF)
    PULSAR_BOOKKEEPER_CONF        Configuration file for bookie (default: $DEFAULT_BOOKKEEPER_CONF)
    PULSAR_ZK_CONF                Configuration file for zookeeper (default: $DEFAULT_ZK_CONF)
-   PULSAR_GLOBAL_ZK_CONF         Configuration file for global zookeeper (default: $DEFAULT_GLOBAL_ZK_CONF)
+   PULSAR_GLOBAL_ZK_CONF         Deprecated. Configuration file for global configuration zookeeper (default: $DEFAULT_GLOBAL_ZK_CONF)
+   PULSAR_GLOBAL_CONFIGURATION_ZK_CONF         Configuration file for global configuration zookeeper (default: $DEFAULT_GLOBAL_CONFIGURATION_ZK_CONF)
    PULSAR_DISCOVERY_CONF         Configuration file for discovery service (default: $DEFAULT_DISCOVERY_CONF)
    PULSAR_WEBSOCKET_CONF         Configuration file for websocket proxy (default: $DEFAULT_WEBSOCKET_CONF)
    PULSAR_PROXY_CONF             Configuration file for Pulsar proxy (default: $DEFAULT_PROXY_CONF)
@@ -151,6 +154,10 @@ if [ -z "$PULSAR_GLOBAL_ZK_CONF" ]; then
     PULSAR_GLOBAL_ZK_CONF=$DEFAULT_GLOBAL_ZK_CONF
 fi
 
+if [ -z "$PULSAR_GLOBAL_CONFIGURATION_ZK_CONF" ]; then
+    PULSAR_GLOBAL_CONFIGURATION_ZK_CONF=$DEFAULT_GLOBAL_CONFIGURATION_ZK_CONF
+fi
+
 if [ -z "$PULSAR_DISCOVERY_CONF" ]; then
     PULSAR_DISCOVERY_CONF=$DEFAULT_DISCOVERY_CONF
 fi
@@ -208,6 +215,11 @@ elif [ $COMMAND == "global-zookeeper" ]; then
     # Allow global ZK to turn into read-only mode when it cannot reach the quorum
     OPTS="${OPTS} -Dreadonlymode.enabled=true"
     exec $JAVA $OPTS -Dpulsar.log.file=$PULSAR_LOG_FILE org.apache.pulsar.zookeeper.GlobalZooKeeperStarter $PULSAR_GLOBAL_ZK_CONF $@
+elif [ $COMMAND == "global-configuration-zookeeper" ]; then
+    PULSAR_LOG_FILE=${PULSAR_LOG_FILE:-"global-configuration-zookeeper.log"}
+    # Allow global ZK to turn into read-only mode when it cannot reach the quorum
+    OPTS="${OPTS} -Dreadonlymode.enabled=true"
+    exec $JAVA $OPTS -Dpulsar.log.file=$PULSAR_LOG_FILE org.apache.pulsar.zookeeper.GlobalConfigurationZooKeeperStarter $PULSAR_GLOBAL_CONFIGURATION_ZK_CONF $@
 elif [ $COMMAND == "discovery" ]; then
     PULSAR_LOG_FILE=${PULSAR_LOG_FILE:-"discovery.log"}
     exec $JAVA $OPTS -Dpulsar.log.file=$PULSAR_LOG_FILE org.apache.pulsar.discovery.service.server.DiscoveryServiceStarter $PULSAR_DISCOVERY_CONF $@

--- a/bin/pulsar-daemon
+++ b/bin/pulsar-daemon
@@ -7,9 +7,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -25,7 +25,8 @@ where command is one of:
     broker           Run a broker server
     bookie           Run a bookie server
     zookeeper        Run a zookeeper server
-    global-zookeeper Run a global-zookeeper server
+    global-zookeeper Deprecated. Run a global-configuration-zookeeper server
+    global-configuration-zookeeper Run a global-configuration-zookeeper server
     discovery        Run a discovery server
     websocket        Run a websocket proxy server
     standalone       Run a standalone Pulsar service
@@ -71,6 +72,9 @@ case $command in
         echo "doing $startStop $command ..."
         ;;
     (global-zookeeper)
+        echo "doing $startStop $command ..."
+        ;;
+    (global-configuration-zookeeper)
         echo "doing $startStop $command ..."
         ;;
     (discovery)

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -22,8 +22,11 @@
 # Zookeeper quorum connection string
 zookeeperServers=
 
-# Global Zookeeper quorum connection string
+# Deprecated. Global Zookeeper quorum connection string
 globalZookeeperServers=
+
+# Global Configuration Zookeeper quorum connection string
+globalConfigurationZookeeperServers=
 
 # Broker data port
 brokerServicePort=6650

--- a/conf/discovery.conf
+++ b/conf/discovery.conf
@@ -20,8 +20,11 @@
 # Zookeeper quorum connection string (comma-separated)
 zookeeperServers=
 
-# Global zookeeper quorum connection string (comma-separated)
+# Deprecated. Global zookeeper quorum connection string (comma-separated)
 globalZookeeperServers=
+
+# Global Configuration Zookeeper quorum connection string (comma-separated)
+globalConfigurationZookeeperServers=
 
 # ZooKeeper session timeout
 zookeeperSessionTimeoutMs=30000

--- a/conf/global_configuration_zookeeper.conf
+++ b/conf/global_configuration_zookeeper.conf
@@ -26,7 +26,7 @@ initLimit=10
 # sending a request and getting an acknowledgement
 syncLimit=5
 # the directory where the snapshot is stored.
-dataDir=data/global-zookeeper
+dataDir=data/global-configuration-zookeeper
 # the port at which the clients will connect
 clientPort=2184
 # the maximum number of client connections.

--- a/conf/proxy.conf
+++ b/conf/proxy.conf
@@ -20,8 +20,11 @@
 # Zookeeper quorum connection string (comma-separated)
 zookeeperServers=
 
-# Global zookeeper quorum connection string (comma-separated)
+# Deprecated. Global zookeeper quorum connection string (comma-separated)
 globalZookeeperServers=
+
+# Global Configuration Zookeeper quorum connection string (comma-separated)
+globalConfigurationZookeeperServers=
 
 # ZooKeeper session timeout
 zookeeperSessionTimeoutMs=30000

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -22,8 +22,11 @@
 # Zookeeper quorum connection string
 zookeeperServers=
 
-# Global Zookeeper quorum connection string
+# Deprecated. Global Zookeeper quorum connection string
 globalZookeeperServers=
+
+# Global Configuration Zookeeper quorum connection string
+globalConfigurationZookeeperServers=
 
 brokerServicePort=6650
 

--- a/conf/websocket.conf
+++ b/conf/websocket.conf
@@ -19,13 +19,16 @@
 
 ### --- Web Socket proxy settings --- ###
 
-# Global Zookeeper quorum connection string
+# Deprecated. Global zookeeper quorum connection string
 globalZookeeperServers=
+
+# Global Configuration Zookeeper quorum connection string
+globalConfigurationZookeeperServers=
 
 # Zookeeper session timeout in milliseconds
 zooKeeperSessionTimeoutMillis=30000
 
-# Pulsar cluster url to connect to broker (optional if globalZookeeperServers present)
+# Pulsar cluster url to connect to broker (optional if globalConfigurationZookeeperServers present)
 serviceUrl=
 serviceUrlTls=
 brokerServiceUrl=

--- a/deploy/dcos/PulsarGroups.json
+++ b/deploy/dcos/PulsarGroups.json
@@ -182,7 +182,7 @@
             "// Notice": "add PULSAR_MEM, PULSAR_GC, according to your environment.",
             "webServicePort": "8082",
             "zookeeperServers":  "master.mesos:2181",
-            "globalZookeeperServers":  "master.mesos:2181",
+            "globalConfigurationZookeeperServers":  "master.mesos:2181",
             "clusterName": "pulsar-dcos"
           },
 
@@ -223,7 +223,7 @@
           "env": {
             "webServicePort": "8082",
             "zookeeperServers":  "master.mesos:2181",
-            "globalZookeeperServers":  "master.mesos:2181",
+            "globalConfigurationZookeeperServers":  "master.mesos:2181",
             "clusterName": "pulsar-dcos",
             "webServiceUrl": "http://broker.brokers.pulsar.marathon.mesos:8082",
             "brokerServiceUrl":  "pulsar://broker.brokers.pulsar.marathon.mesos:6650"

--- a/deployment/terraform-ansible/deploy-pulsar.yaml
+++ b/deployment/terraform-ansible/deploy-pulsar.yaml
@@ -88,7 +88,7 @@
         state: directory
       with_items:
         - data/zookeeper
-    - name: Add pulsar_env.sh configuration file 
+    - name: Add pulsar_env.sh configuration file
       template:
         src: "../templates/pulsar_env.sh"
         dest: "/opt/pulsar/conf/pulsar_env.sh"
@@ -114,7 +114,7 @@
         bin/pulsar initialize-cluster-metadata \
           --cluster {{ cluster_name }} \
           --zookeeper localhost:2181 \
-          --global-zookeeper localhost:2181 \
+          --global-configuration-zookeeper localhost:2181 \
           --web-service-url {{ http_url }} \
           --broker-service-url {{ service_url }}
       args:
@@ -169,7 +169,7 @@
       args:
         chdir: /opt/pulsar
       when: groups['zookeeper'][0] == inventory_hostname
-      
+
 - name:  Hosts addresses
   hosts: localhost
   become: false

--- a/kubernetes/generic/broker.yaml
+++ b/kubernetes/generic/broker.yaml
@@ -27,7 +27,7 @@ data:
     # better GC behavior at high throughput
     PULSAR_MEM: "\" -Xms1g -Xmx1g -XX:MaxDirectMemorySize=1g\""
     zookeeperServers: zk-0.zookeeper,zk-1.zookeeper,zk-2.zookeeper
-    globalZookeeperServers: zk-0.zookeeper,zk-1.zookeeper,zk-2.zookeeper
+    globalConfigurationZookeeperServers: zk-0.zookeeper,zk-1.zookeeper,zk-2.zookeeper
     clusterName: us-central
 ---
 ##

--- a/kubernetes/google-kubernetes-engine/broker.yaml
+++ b/kubernetes/google-kubernetes-engine/broker.yaml
@@ -26,7 +26,7 @@ data:
     PULSAR_MEM: "\" -Xms8g -Xmx8g -XX:MaxDirectMemorySize=4g\""
     PULSAR_GC: "\" -XX:+UseG1GC \""
     zookeeperServers: zk-0.zookeeper,zk-1.zookeeper,zk-2.zookeeper
-    globalZookeeperServers: zk-0.zookeeper,zk-1.zookeeper,zk-2.zookeeper
+    globalConfigurationZookeeperServers: zk-0.zookeeper,zk-1.zookeeper,zk-2.zookeeper
     clusterName: pulsar-gke
 ---
 ##

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -40,8 +40,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(required = true)
     private String zookeeperServers;
     // Global Zookeeper quorum connection string
+    @Deprecated
     @FieldContext(required = false)
     private String globalZookeeperServers;
+    // Global Zookeeper quorum connection string
+    @FieldContext(required = false)
+    private String globalConfigurationZookeeperServers;
     private int brokerServicePort = 6650;
     private int brokerServicePortTls = 6651;
     // Port to use to server HTTP request
@@ -381,6 +385,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
         this.zookeeperServers = zookeeperServers;
     }
 
+    @Deprecated
     public String getGlobalZookeeperServers() {
         if (this.globalZookeeperServers == null || this.globalZookeeperServers.isEmpty()) {
             // If the configuration is not set, assuming that the globalZK is not enabled and all data is in the same
@@ -390,8 +395,22 @@ public class ServiceConfiguration implements PulsarConfiguration {
         return globalZookeeperServers;
     }
 
+    @Deprecated
     public void setGlobalZookeeperServers(String globalZookeeperServers) {
         this.globalZookeeperServers = globalZookeeperServers;
+    }
+
+    public String getGlobalConfigurationZookeeperServers() {
+        if (this.globalConfigurationZookeeperServers == null || this.globalConfigurationZookeeperServers.isEmpty()) {
+            // If the configuration is not set, assuming that the globalZK is not enabled and all data is in the same
+            // ZooKeeper cluster
+            return this.getZookeeperServers();
+        }
+        return globalConfigurationZookeeperServers;
+    }
+
+    public void setGlobalConfigurationZookeeperServers(String globalConfigurationZookeeperServers) {
+        this.globalConfigurationZookeeperServers = globalConfigurationZookeeperServers;
     }
 
     public int getBrokerServicePort() {

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/common/configuration/PulsarConfigurationLoaderTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/common/configuration/PulsarConfigurationLoaderTest.java
@@ -40,7 +40,7 @@ public class PulsarConfigurationLoaderTest {
         private Properties properties = new Properties();
 
         private String zookeeperServers = "localhost:2181";
-        private String globalZookeeperServers = "localhost:2184";
+        private String globalConfigurationZookeeperServers = "localhost:2184";
         private int brokerServicePort = 7650;
         private int brokerServicePortTls = 7651;
         private int webServicePort = 9080;
@@ -65,7 +65,7 @@ public class PulsarConfigurationLoaderTest {
 
         // check whether converting correctly
         assertEquals(serviceConfiguration.getZookeeperServers(), "localhost:2181");
-        assertEquals(serviceConfiguration.getGlobalZookeeperServers(), "localhost:2184");
+        assertEquals(serviceConfiguration.getGlobalConfigurationZookeeperServers(), "localhost:2184");
         assertEquals(serviceConfiguration.getBrokerServicePort(), 7650);
         assertEquals(serviceConfiguration.getBrokerServicePortTls(), 7651);
         assertEquals(serviceConfiguration.getWebServicePort(), 9080);
@@ -89,7 +89,7 @@ public class PulsarConfigurationLoaderTest {
         final String zkServer = "z1.example.com,z2.example.com,z3.example.com";
         PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(new FileOutputStream(testConfigFile)));
         printWriter.println("zookeeperServers=" + zkServer);
-        printWriter.println("globalZookeeperServers=gz1.example.com,gz2.example.com,gz3.example.com/foo");
+        printWriter.println("globalConfigurationZookeeperServers=gz1.example.com,gz2.example.com,gz3.example.com/foo");
         printWriter.println("brokerDeleteInactiveTopicsEnabled=true");
         printWriter.println("statusFilePath=/tmp/status.html");
         printWriter.println("managedLedgerDefaultEnsembleSize=1");

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
@@ -69,9 +69,14 @@ public class PulsarClusterMetadataSetup {
                 "--zookeeper" }, description = "Local ZooKeeper quorum connection string", required = true)
         private String zookeeper;
 
+        @Deprecated
         @Parameter(names = { "-gzk",
                 "--global-zookeeper" }, description = "Global ZooKeeper quorum connection string", required = true)
         private String globalZookeeper;
+
+        @Parameter(names = { "-gczk",
+            "--global-configuration-zookeeper" }, description = "Global Configuration ZooKeeper quorum connection string", required = false)
+        private String globalConfigurationZookeeper;
 
         @Parameter(names = { "-h", "--help" }, description = "Show this help message")
         private boolean help = false;
@@ -92,8 +97,12 @@ public class PulsarClusterMetadataSetup {
             return;
         }
 
-        log.info("Setting up cluster {} with zk={} global-zk={}", arguments.cluster, arguments.zookeeper,
-                arguments.globalZookeeper);
+        if (arguments.globalConfigurationZookeeper == null) {
+            arguments.globalConfigurationZookeeper = arguments.globalZookeeper;
+        }
+
+        log.info("Setting up cluster {} with zk={} global-config-zk={}", arguments.cluster, arguments.zookeeper,
+                arguments.globalConfigurationZookeeper);
 
         // Format BookKeeper metadata
         ClientConfiguration bkConf = new ClientConfiguration();
@@ -105,7 +114,7 @@ public class PulsarClusterMetadataSetup {
 
         ZooKeeperClientFactory zkfactory = new ZookeeperClientFactoryImpl();
         ZooKeeper localZk = zkfactory.create(arguments.zookeeper, SessionType.ReadWrite, 30000).get();
-        ZooKeeper globalZk = zkfactory.create(arguments.globalZookeeper, SessionType.ReadWrite, 30000).get();
+        ZooKeeper globalZk = zkfactory.create(arguments.globalConfigurationZookeeper, SessionType.ReadWrite, 30000).get();
 
         localZk.create("/managed-ledgers", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
         localZk.create("/namespace", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
@@ -109,7 +109,7 @@ public class PulsarStandaloneStarter {
         PulsarConfigurationLoader.isComplete(config);
         // Set ZK server's host to localhost
         config.setZookeeperServers("127.0.0.1:" + zkPort);
-        config.setGlobalZookeeperServers("127.0.0.1:" + zkPort);
+        config.setGlobalConfigurationZookeeperServers("127.0.0.1:" + zkPort);
 
         if (advertisedAddress != null) {
             // Use advertised address from command line

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -404,7 +404,7 @@ public class PulsarService implements AutoCloseable {
 
         this.localZkCache = new LocalZooKeeperCache(getZkClient(), getOrderedExecutor(), this.cacheExecutor);
         this.globalZkCache = new GlobalZooKeeperCache(getZooKeeperClientFactory(),
-                (int) config.getZooKeeperSessionTimeoutMillis(), config.getGlobalZookeeperServers(),
+                (int) config.getZooKeeperSessionTimeoutMillis(), config.getGlobalConfigurationZookeeperServers(),
                 getOrderedExecutor(), this.cacheExecutor);
         try {
             this.globalZkCache.start();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/PulsarBrokerStarterTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/PulsarBrokerStarterTest.java
@@ -47,7 +47,7 @@ public class PulsarBrokerStarterTest {
         }
         PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(new FileOutputStream(testConfigFile)));
         printWriter.println("zookeeperServers=z1.example.com,z2.example.com,z3.example.com");
-        printWriter.println("globalZookeeperServers=gz1.example.com,gz2.example.com,gz3.example.com/foo");
+        printWriter.println("globalConfigurationZookeeperServers=gz1.example.com,gz2.example.com,gz3.example.com/foo");
         printWriter.println("brokerDeleteInactiveTopicsEnabled=false");
         printWriter.println("statusFilePath=/tmp/status.html");
         printWriter.println("managedLedgerDefaultEnsembleSize=1");
@@ -99,7 +99,7 @@ public class PulsarBrokerStarterTest {
         Assert.assertTrue(ServiceConfiguration.class.isInstance(returnValue));
         ServiceConfiguration serviceConfig = (ServiceConfiguration) returnValue;
         Assert.assertEquals(serviceConfig.getZookeeperServers(), "z1.example.com,z2.example.com,z3.example.com");
-        Assert.assertEquals(serviceConfig.getGlobalZookeeperServers(),
+        Assert.assertEquals(serviceConfig.getGlobalConfigurationZookeeperServers(),
                 "gz1.example.com,gz2.example.com,gz3.example.com/foo");
         Assert.assertFalse(serviceConfig.isBrokerDeleteInactiveTopicsEnabled());
         Assert.assertEquals(serviceConfig.getStatusFilePath(), "/tmp/status.html");
@@ -217,7 +217,7 @@ public class PulsarBrokerStarterTest {
         }
         PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(new FileOutputStream(testConfigFile)));
         printWriter.println("zookeeperServers=z1.example.com,z2.example.com,z3.example.com");
-        printWriter.println("globalZookeeperServers=");
+        printWriter.println("globalConfigurationZookeeperServers=");
         printWriter.println("brokerDeleteInactiveTopicsEnabled=false");
         printWriter.println("statusFilePath=/tmp/status.html");
         printWriter.println("managedLedgerDefaultEnsembleSize=1");
@@ -248,7 +248,7 @@ public class PulsarBrokerStarterTest {
         Assert.assertTrue(ServiceConfiguration.class.isInstance(returnValue));
         ServiceConfiguration serviceConfig = (ServiceConfiguration) returnValue;
         Assert.assertEquals(serviceConfig.getZookeeperServers(), "z1.example.com,z2.example.com,z3.example.com");
-        Assert.assertEquals(serviceConfig.getGlobalZookeeperServers(), "z1.example.com,z2.example.com,z3.example.com");
+        Assert.assertEquals(serviceConfig.getGlobalConfigurationZookeeperServers(), "z1.example.com,z2.example.com,z3.example.com");
         Assert.assertFalse(serviceConfig.isBrokerDeleteInactiveTopicsEnabled());
         Assert.assertEquals(serviceConfig.getStatusFilePath(), "/tmp/status.html");
         Assert.assertEquals(serviceConfig.getBacklogQuotaDefaultLimitGB(), 18);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTestBase.java
@@ -120,7 +120,7 @@ public class ReplicatorTestBase {
         config1.setWebServicePort(webServicePort1);
         config1.setWebServicePortTls(webServicePortTls1);
         config1.setZookeeperServers("127.0.0.1:" + zkPort1);
-        config1.setGlobalZookeeperServers("127.0.0.1:" + globalZKPort + "/foo");
+        config1.setGlobalConfigurationZookeeperServers("127.0.0.1:" + globalZKPort + "/foo");
         config1.setBrokerDeleteInactiveTopicsEnabled(isBrokerServicePurgeInactiveDestination());
         config1.setBrokerServicePurgeInactiveFrequencyInSeconds(
                 inSec(getBrokerServicePurgeInactiveFrequency(), TimeUnit.SECONDS));
@@ -152,7 +152,7 @@ public class ReplicatorTestBase {
         config2.setWebServicePort(webServicePort2);
         config2.setWebServicePortTls(webServicePortTls2);
         config2.setZookeeperServers("127.0.0.1:" + zkPort2);
-        config2.setGlobalZookeeperServers("127.0.0.1:" + globalZKPort + "/foo");
+        config2.setGlobalConfigurationZookeeperServers("127.0.0.1:" + globalZKPort + "/foo");
         config2.setBrokerDeleteInactiveTopicsEnabled(isBrokerServicePurgeInactiveDestination());
         config2.setBrokerServicePurgeInactiveFrequencyInSeconds(
                 inSec(getBrokerServicePurgeInactiveFrequency(), TimeUnit.SECONDS));
@@ -184,7 +184,7 @@ public class ReplicatorTestBase {
         config3.setWebServicePort(webServicePort3);
         config3.setWebServicePortTls(webServicePortTls3);
         config3.setZookeeperServers("127.0.0.1:" + zkPort3);
-        config3.setGlobalZookeeperServers("127.0.0.1:" + globalZKPort + "/foo");
+        config3.setGlobalConfigurationZookeeperServers("127.0.0.1:" + globalZKPort + "/foo");
         config3.setBrokerDeleteInactiveTopicsEnabled(isBrokerServicePurgeInactiveDestination());
         config3.setBrokerServicePurgeInactiveFrequencyInSeconds(
                 inSec(getBrokerServicePurgeInactiveFrequency(), TimeUnit.SECONDS));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
@@ -838,7 +838,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             config1.setClusterName("r1");
             config1.setWebServicePort(webServicePort1);
             config1.setZookeeperServers("127.0.0.1:" + zkPort1);
-            config1.setGlobalZookeeperServers("127.0.0.1:" + globalZKPort + "/foo");
+            config1.setGlobalConfigurationZookeeperServers("127.0.0.1:" + globalZKPort + "/foo");
             config1.setBrokerDeleteInactiveTopicsEnabled(isBrokerServicePurgeInactiveDestination());
             config1.setBrokerServicePurgeInactiveFrequencyInSeconds(
                     inSec(getBrokerServicePurgeInactiveFrequency(), TimeUnit.SECONDS));
@@ -863,7 +863,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             config2.setClusterName("r2");
             config2.setWebServicePort(webServicePort2);
             config2.setZookeeperServers("127.0.0.1:" + zkPort2);
-            config2.setGlobalZookeeperServers("127.0.0.1:" + globalZKPort + "/foo");
+            config2.setGlobalConfigurationZookeeperServers("127.0.0.1:" + globalZKPort + "/foo");
             config2.setBrokerDeleteInactiveTopicsEnabled(isBrokerServicePurgeInactiveDestination());
             config2.setBrokerServicePurgeInactiveFrequencyInSeconds(
                     inSec(getBrokerServicePurgeInactiveFrequency(), TimeUnit.SECONDS));
@@ -888,7 +888,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             config3.setClusterName("r3");
             config3.setWebServicePort(webServicePort3);
             config3.setZookeeperServers("127.0.0.1:" + zkPort3);
-            config3.setGlobalZookeeperServers("127.0.0.1:" + globalZKPort + "/foo");
+            config3.setGlobalConfigurationZookeeperServers("127.0.0.1:" + globalZKPort + "/foo");
             config3.setBrokerDeleteInactiveTopicsEnabled(isBrokerServicePurgeInactiveDestination());
             config3.setBrokerServicePurgeInactiveFrequencyInSeconds(
                     inSec(getBrokerServicePurgeInactiveFrequency(), TimeUnit.SECONDS));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyAuthenticationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyAuthenticationTest.java
@@ -56,7 +56,7 @@ import org.testng.annotations.Test;
 import com.google.common.collect.Sets;
 
 public class ProxyAuthenticationTest extends ProducerConsumerBase {
-    
+
     private int port;
     private ProxyServer proxyServer;
     private WebSocketService service;
@@ -73,7 +73,7 @@ public class ProxyAuthenticationTest extends ProducerConsumerBase {
         config.setAuthenticationEnabled(true);
         config.setAuthenticationProviders(
                 Sets.newHashSet("org.apache.pulsar.websocket.proxy.MockAuthenticationProvider"));
-        config.setGlobalZookeeperServers("dummy-zk-servers");
+        config.setGlobalConfigurationZookeeperServers("dummy-zk-servers");
         config.setSuperUserRoles(Sets.newHashSet("pulsar.super_user"));
         service = spy(new WebSocketService(config));
         doReturn(mockZooKeeperClientFactory).when(service).getZooKeeperClientFactory();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyAuthorizationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyAuthorizationTest.java
@@ -59,7 +59,7 @@ public class ProxyAuthorizationTest extends MockedPulsarServiceBaseTest {
         WebSocketProxyConfiguration config = new WebSocketProxyConfiguration();
         Set<String> superUser = Sets.newHashSet("");
         config.setAuthorizationEnabled(true);
-        config.setGlobalZookeeperServers("dummy-zk-servers");
+        config.setGlobalConfigurationZookeeperServers("dummy-zk-servers");
         config.setSuperUserRoles(superUser);
         config.setClusterName("c1");
         config.setWebServicePort(TEST_PORT);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeTest.java
@@ -79,7 +79,7 @@ public class ProxyPublishConsumeTest extends ProducerConsumerBase {
         WebSocketProxyConfiguration config = new WebSocketProxyConfiguration();
         config.setWebServicePort(port);
         config.setClusterName("use");
-        config.setGlobalZookeeperServers("dummy-zk-servers");
+        config.setGlobalConfigurationZookeeperServers("dummy-zk-servers");
         service = spy(new WebSocketService(config));
         doReturn(mockZooKeeperClientFactory).when(service).getZooKeeperClientFactory();
         proxyServer = new ProxyServer(config);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeTlsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyPublishConsumeTlsTest.java
@@ -69,7 +69,7 @@ public class ProxyPublishConsumeTlsTest extends TlsProducerConsumerBase {
         config.setTlsCertificateFilePath(TLS_SERVER_CERT_FILE_PATH);
         config.setTlsTrustCertsFilePath(TLS_TRUST_CERT_FILE_PATH);
         config.setClusterName("use");
-        config.setGlobalZookeeperServers("dummy-zk-servers");
+        config.setGlobalConfigurationZookeeperServers("dummy-zk-servers");
         service = spy(new WebSocketService(config));
         doReturn(mockZooKeeperClientFactory).when(service).getZooKeeperClientFactory();
         proxyServer = new ProxyServer(config);

--- a/pulsar-broker/src/test/resources/configurations/pulsar_broker_test.conf
+++ b/pulsar-broker/src/test/resources/configurations/pulsar_broker_test.conf
@@ -19,7 +19,7 @@
 
 applicationName="pulsar_broker"
 zookeeperServers="localhost"
-globalZookeeperServers="localhost"
+globalConfigurationZookeeperServers="localhost"
 brokerServicePort=6650
 brokerServicePortTls=6651
 webServicePort=8080

--- a/pulsar-client-cpp/test-conf/standalone-ssl.conf
+++ b/pulsar-client-cpp/test-conf/standalone-ssl.conf
@@ -22,8 +22,11 @@
 # Zookeeper quorum connection string
 zookeeperServers=
 
-# Global Zookeeper quorum connection string
+# Deprecated. Global zookeeper quorum connection string
 globalZookeeperServers=
+
+# Global Configuration Zookeeper quorum connection string
+globalConfigurationZookeeperServers=
 
 brokerServicePort=9885
 brokerServicePortTls=9886

--- a/pulsar-client-cpp/tests/authentication.conf
+++ b/pulsar-client-cpp/tests/authentication.conf
@@ -22,8 +22,11 @@
 # Zookeeper quorum connection string
 zookeeperServers=
 
-# Global Zookeeper quorum connection string
+# Deprecated. Global Zookeeper quorum connection string
 globalZookeeperServers=
+
+# Global Configuration Zookeeper quorum connection string
+globalConfigurationZookeeperServers=
 
 brokerServicePort=9885
 brokerServicePortTls=9886

--- a/pulsar-client-cpp/tests/standalone.conf
+++ b/pulsar-client-cpp/tests/standalone.conf
@@ -22,8 +22,11 @@
 # Zookeeper quorum connection string
 zookeeperServers=
 
-# Global Zookeeper quorum connection string
+# Deprecated. Global Zookeeper quorum connection string
 globalZookeeperServers=
+
+# Global Configuration Zookeeper quorum connection string
+globalConfigurationZookeeperServers=
 
 brokerServicePort=8885
 
@@ -60,13 +63,13 @@ brokerDeleteInactiveTopicsEnabled=true
 # How often to check for inactive topics
 brokerDeleteInactiveTopicsFrequencySeconds=60
 
-# How frequently to proactively check and purge expired messages 
+# How frequently to proactively check and purge expired messages
 messageExpiryCheckIntervalInMinutes=5
 
 # Enable check for minimum allowed client library version
 clientLibraryVersionCheckEnabled=false
 
-# Allow client libraries with no version information 
+# Allow client libraries with no version information
 clientLibraryVersionCheckAllowUnversioned=true
 
 # Path for the file used to determine the rotation status for the broker when responding
@@ -108,7 +111,7 @@ bookkeeperClientAuthenticationPlugin=
 bookkeeperClientAuthenticationParametersName=
 bookkeeperClientAuthenticationParameters=
 
-# Timeout for BK add / read operations 
+# Timeout for BK add / read operations
 bookkeeperClientTimeoutInSeconds=30
 
 # Speculative reads are initiated if a read request doesn't complete within a certain time
@@ -124,11 +127,11 @@ bookkeeperClientHealthCheckErrorThresholdPerInterval=5
 bookkeeperClientHealthCheckQuarantineTimeInSeconds=1800
 
 # Enable rack-aware bookie selection policy. BK will chose bookies from different racks when
-# forming a new bookie ensemble 
+# forming a new bookie ensemble
 bookkeeperClientRackawarePolicyEnabled=true
 
-# Enable bookie isolation by specifying a list of bookie groups to choose from. Any bookie 
-# outside the specified groups will not be used by the broker 
+# Enable bookie isolation by specifying a list of bookie groups to choose from. Any bookie
+# outside the specified groups will not be used by the broker
 bookkeeperClientIsolationGroups=
 
 ### --- Managed Ledger --- ###
@@ -144,7 +147,7 @@ managedLedgerDefaultAckQuorum=1
 
 # Amount of memory to use for caching data payload in managed ledger. This memory
 # is allocated from JVM direct memory and it's shared across all the topics
-# running  in the same broker 
+# running  in the same broker
 managedLedgerCacheSizeMB=1024
 
 # Threshold to which bring down the cache level when eviction is triggered
@@ -156,7 +159,7 @@ managedLedgerDefaultMarkDeleteRateLimit=0.1
 # Max number of entries to append to a ledger before triggering a rollover
 # A ledger rollover is triggered on these conditions
 #  * Either the max rollover time has been reached
-#  * or max entries have been written to the ledged and at least min-time 
+#  * or max entries have been written to the ledged and at least min-time
 #    has passed
 managedLedgerMaxEntriesPerLedger=50000
 
@@ -174,7 +177,7 @@ managedLedgerCursorRolloverTimeInSeconds=14400
 
 
 
-### --- Load balancer --- ### 
+### --- Load balancer --- ###
 
 # Enable load balancer
 loadBalancerEnabled=false
@@ -192,13 +195,13 @@ loadBalancerReportUpdateMaxIntervalMinutes=15
 loadBalancerHostUsageCheckIntervalMinutes=1
 
 # Load shedding interval. Broker periodically checks whether some traffic should be offload from
-# some over-loaded broker to other under-loaded brokers   
+# some over-loaded broker to other under-loaded brokers
 loadBalancerSheddingIntervalMinutes=30
 
-# Prevent the same topics to be shed and moved to other broker more that once within this timeframe 
+# Prevent the same topics to be shed and moved to other broker more that once within this timeframe
 loadBalancerSheddingGracePeriodMinutes=30
 
-# Usage threshold to determine a broker as under-loaded 
+# Usage threshold to determine a broker as under-loaded
 loadBalancerBrokerUnderloadedThresholdPercentage=1
 
 # Usage threshold to determine a broker as over-loaded
@@ -238,7 +241,7 @@ replicationMetricsEnabled=true
 
 # Max number of connections to open for each broker in a remote cluster
 # More connections host-to-host lead to better throughput over high-latency
-# links. 
+# links.
 replicationConnectionsPerBroker=16
 
 # Replicator producer queue size

--- a/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/BrokerDiscoveryProvider.java
+++ b/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/BrokerDiscoveryProvider.java
@@ -69,7 +69,7 @@ public class BrokerDiscoveryProvider implements Closeable {
             localZkCache = new ZookeeperCacheLoader(zkClientFactory, config.getZookeeperServers(),
                     config.getZookeeperSessionTimeoutMs());
             globalZkCache = new GlobalZooKeeperCache(zkClientFactory, config.getZookeeperSessionTimeoutMs(),
-                    config.getGlobalZookeeperServers(), orderedExecutor, scheduledExecutorScheduler);
+                    config.getGlobalConfigurationZookeeperServers(), orderedExecutor, scheduledExecutorScheduler);
             globalZkCache.start();
         } catch (Exception e) {
             LOG.error("Failed to start Zookkeeper {}", e.getMessage(), e);

--- a/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/server/DiscoveryServiceStarter.java
+++ b/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/server/DiscoveryServiceStarter.java
@@ -51,13 +51,17 @@ public class DiscoveryServiceStarter {
         // load config file
         final ServiceConfig config = PulsarConfigurationLoader.create(configFile, ServiceConfig.class);
         checkArgument(!isEmpty(config.getZookeeperServers()), "zookeeperServers must be provided");
-        checkArgument(!isEmpty(config.getGlobalZookeeperServers()), "global-zookeeperServers must be provided");
-        
+        if(!isEmpty(config.getGlobalZookeeperServers())) {
+            config.setGlobalConfigurationZookeeperServers(config.getGlobalZookeeperServers());
+        }
+        checkArgument(!isEmpty(config.getGlobalConfigurationZookeeperServers()),
+            "global-configuration-zookeeperServers must be provided");
+
         // create Discovery service
         DiscoveryService discoveryService = new DiscoveryService(config);
         // create a web-service
         final ServerManager server = new ServerManager(config);
-        
+
         Runtime.getRuntime().addShutdownHook(new Thread() {
             @Override
             public void run() {
@@ -69,7 +73,7 @@ public class DiscoveryServiceStarter {
                 }
             }
         });
-        
+
         discoveryService.start();
         startWebService(server, config);
     }

--- a/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/server/ServiceConfig.java
+++ b/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/server/ServiceConfig.java
@@ -35,7 +35,10 @@ public class ServiceConfig implements PulsarConfiguration {
     // Local-Zookeeper quorum connection string
     private String zookeeperServers;
     // Global-Zookeeper quorum connection string
+    @Deprecated
     private String globalZookeeperServers;
+    // Global-Configuration-Zookeeper quorum connection string
+    private String globalConfigurationZookeeperServers;
 
     // ZooKeeper session timeout
     private int zookeeperSessionTimeoutMs = 30_000;
@@ -90,12 +93,22 @@ public class ServiceConfig implements PulsarConfiguration {
         this.zookeeperServers = zookeeperServers;
     }
 
+    @Deprecated
     public String getGlobalZookeeperServers() {
         return globalZookeeperServers;
     }
 
+    @Deprecated
     public void setGlobalZookeeperServers(String globalZookeeperServers) {
         this.globalZookeeperServers = globalZookeeperServers;
+    }
+
+    public String getGlobalConfigurationZookeeperServers() {
+        return globalConfigurationZookeeperServers;
+    }
+
+    public void setGlobalConfigurationZookeeperServers(String globalConfigurationZookeeperServers) {
+        this.globalConfigurationZookeeperServers = globalConfigurationZookeeperServers;
     }
 
     public int getZookeeperSessionTimeoutMs() {

--- a/pulsar-discovery-service/src/test/java/org/apache/pulsar/discovery/service/server/DiscoveryServiceWebTest.java
+++ b/pulsar-discovery-service/src/test/java/org/apache/pulsar/discovery/service/server/DiscoveryServiceWebTest.java
@@ -40,7 +40,7 @@ import org.testng.annotations.Test;
  */
 public class DiscoveryServiceWebTest {
 
-    
+
     @Test
     public void testWebDiscoveryServiceStarter() throws Exception {
 
@@ -51,7 +51,7 @@ public class DiscoveryServiceWebTest {
         }
         PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(new FileOutputStream(testConfigFile)));
         printWriter.println("zookeeperServers=z1.pulsar.com,z2.pulsar.com,z3.pulsar.com");
-        printWriter.println("globalZookeeperServers=z1.pulsar.com,z2.pulsar.com,z3.pulsar.com");
+        printWriter.println("globalConfigurationZookeeperServers=z1.pulsar.com,z2.pulsar.com,z3.pulsar.com");
         printWriter.println("webServicePort=" + port);
         printWriter.close();
         testConfigFile.deleteOnExit();

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/BrokerDiscoveryProvider.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/BrokerDiscoveryProvider.java
@@ -69,7 +69,7 @@ public class BrokerDiscoveryProvider implements Closeable {
             localZkCache = new ZookeeperCacheLoader(zkClientFactory, config.getZookeeperServers(),
                     config.getZookeeperSessionTimeoutMs());
             globalZkCache = new GlobalZooKeeperCache(zkClientFactory, config.getZookeeperSessionTimeoutMs(),
-                    config.getGlobalZookeeperServers(), orderedExecutor, scheduledExecutorScheduler);
+                    config.getGlobalConfigurationZookeeperServers(), orderedExecutor, scheduledExecutorScheduler);
             globalZkCache.start();
         } catch (Exception e) {
             LOG.error("Failed to start Zookkeeper {}", e.getMessage(), e);

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -29,8 +29,12 @@ public class ProxyConfiguration implements PulsarConfiguration {
 
     // Local-Zookeeper quorum connection string
     private String zookeeperServers;
+    @Deprecated
     // Global-Zookeeper quorum connection string
     private String globalZookeeperServers;
+
+    // Global-Configuration-Zookeeper quorum connection string
+    private String globalConfigurationZookeeperServers;
 
     // ZooKeeper session timeout
     private int zookeeperSessionTimeoutMs = 30_000;
@@ -86,12 +90,22 @@ public class ProxyConfiguration implements PulsarConfiguration {
         this.zookeeperServers = zookeeperServers;
     }
 
+    @Deprecated
     public String getGlobalZookeeperServers() {
         return globalZookeeperServers;
     }
 
+    @Deprecated
     public void setGlobalZookeeperServers(String globalZookeeperServers) {
         this.globalZookeeperServers = globalZookeeperServers;
+    }
+
+    public String getGlobalConfigurationZookeeperServers() {
+        return globalConfigurationZookeeperServers;
+    }
+
+    public void setGlobalCongigurationZookeeperServers(String globalConfigurationZookeeperServers) {
+        this.globalConfigurationZookeeperServers = globalConfigurationZookeeperServers;
     }
 
     public int getZookeeperSessionTimeoutMs() {

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyServiceStarter.java
@@ -48,8 +48,13 @@ public class ProxyServiceStarter {
     @Parameter(names = { "-zk", "--zookeeper-servers" }, description = "Local zookeeper connection string")
     private String zookeeperServers = "";
 
+    @Deprecated
     @Parameter(names = { "-gzk", "--global-zookeeper-servers" }, description = "Global zookeeper connection string")
     private String globalZookeeperServers = "";
+
+    @Parameter(names = { "-gczk", "--global-configuration-zookeeper-servers" },
+        description = "Global configuration zookeeper connection string")
+    private String globalConfigurationZookeeperServers = "";
 
     @Parameter(names = { "-h", "--help" }, description = "Show this help message")
     private boolean help = false;
@@ -85,11 +90,15 @@ public class ProxyServiceStarter {
 
         if (!isBlank(globalZookeeperServers)) {
             // Use globalZookeeperServers from command line
-            config.setGlobalZookeeperServers(globalZookeeperServers);
+            config.setGlobalCongigurationZookeeperServers(globalZookeeperServers);
+        }
+        if (!isBlank(globalConfigurationZookeeperServers)) {
+            // Use globalConfigurationZookeeperServers from command line
+            config.setGlobalCongigurationZookeeperServers(globalZookeeperServers);
         }
 
         checkArgument(!isEmpty(config.getZookeeperServers()), "zookeeperServers must be provided");
-        checkArgument(!isEmpty(config.getGlobalZookeeperServers()), "globalZookeeperServers must be provided");
+        checkArgument(!isEmpty(config.getGlobalConfigurationZookeeperServers()), "globalConfigurationZookeeperServers must be provided");
 
         // create broker service
         ProxyService discoveryService = new ProxyService(config);

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketService.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketService.java
@@ -99,9 +99,9 @@ public class WebSocketService implements Closeable {
     public void start() throws PulsarServerException, PulsarClientException, MalformedURLException, ServletException,
             DeploymentException {
 
-        if (isNotBlank(config.getGlobalZookeeperServers())) {
+        if (isNotBlank(config.getGlobalConfigurationZookeeperServers())) {
             this.globalZkCache = new GlobalZooKeeperCache(getZooKeeperClientFactory(),
-                    (int) config.getZooKeeperSessionTimeoutMillis(), config.getGlobalZookeeperServers(),
+                    (int) config.getZooKeeperSessionTimeoutMillis(), config.getGlobalConfigurationZookeeperServers(),
                     this.orderedExecutor, this.executor);
             try {
                 this.globalZkCache.start();
@@ -116,7 +116,7 @@ public class WebSocketService implements Closeable {
         if (config.isAuthorizationEnabled()) {
             if (configurationCacheService == null) {
                 throw new PulsarServerException(
-                        "Failed to initialize authorization manager due to empty GlobalZookeeperServers");
+                        "Failed to initialize authorization manager due to empty GlobalConfigurationZookeeperServers");
             }
             authorizationManager = new AuthorizationManager(this.config, configurationCacheService);
         }
@@ -214,7 +214,8 @@ public class WebSocketService implements Closeable {
 
     private ClusterData retrieveClusterData() throws PulsarServerException {
         if (configurationCacheService == null) {
-            throw new PulsarServerException("Failed to retrieve Cluster data due to empty GlobalZookeeperServers");
+            throw new PulsarServerException(
+                "Failed to retrieve Cluster data due to empty GlobalConfigurationZookeeperServers");
         }
         try {
             String path = "/admin/clusters/" + config.getClusterName();

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
@@ -38,15 +38,17 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     // Name of the cluster to which this broker belongs to
     @FieldContext(required = true)
     private String clusterName;
-    
-    // Pulsar cluster url to connect to broker (optional if globalZookeeperServers present)
+
+    // Pulsar cluster url to connect to broker (optional if globalConfigurationZookeeperServers present)
     private String serviceUrl;
     private String serviceUrlTls;
     private String brokerServiceUrl;
     private String brokerServiceUrlTls;
 
     // Global Zookeeper quorum connection string
+    @Deprecated
     private String globalZookeeperServers;
+    private String globalConfigurationZookeeperServers;
     // Zookeeper session timeout in milliseconds
     private long zooKeeperSessionTimeoutMillis = 30000;
 
@@ -92,7 +94,7 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     private String tlsTrustCertsFilePath = "";
     // Accept untrusted TLS certificate from client
     private boolean tlsAllowInsecureConnection = false;
-    
+
     private Properties properties = new Properties();
 
     public String getClusterName() {
@@ -102,7 +104,7 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     public void setClusterName(String clusterName) {
         this.clusterName = clusterName;
     }
-    
+
     public String getServiceUrl() {
         return serviceUrl;
     }
@@ -135,12 +137,22 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
         this.brokerServiceUrlTls = brokerServiceUrlTls;
     }
 
+    @Deprecated
     public String getGlobalZookeeperServers() {
         return globalZookeeperServers;
     }
 
+    @Deprecated
     public void setGlobalZookeeperServers(String globalZookeeperServers) {
         this.globalZookeeperServers = globalZookeeperServers;
+    }
+
+    public String getGlobalConfigurationZookeeperServers() {
+        return globalConfigurationZookeeperServers;
+    }
+
+    public void setGlobalConfigurationZookeeperServers(String globalConfigurationZookeeperServers) {
+        this.globalConfigurationZookeeperServers = globalConfigurationZookeeperServers;
     }
 
     public long getZooKeeperSessionTimeoutMillis() {
@@ -278,7 +290,7 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     public void setTlsAllowInsecureConnection(boolean tlsAllowInsecureConnection) {
         this.tlsAllowInsecureConnection = tlsAllowInsecureConnection;
     }
-    
+
     public Properties getProperties() {
         return properties;
     }

--- a/pulsar-zookeeper/src/main/java/org/apache/pulsar/zookeeper/GlobalConfigurationZooKeeperStarter.java
+++ b/pulsar-zookeeper/src/main/java/org/apache/pulsar/zookeeper/GlobalConfigurationZooKeeperStarter.java
@@ -21,11 +21,10 @@ package org.apache.pulsar.zookeeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Deprecated
-public class GlobalZooKeeperStarter extends ZooKeeperStarter {
+public class GlobalConfigurationZooKeeperStarter extends ZooKeeperStarter {
     public static void main(String[] args) throws Exception {
         start(args, "8001");
     }
 
-    private static final Logger log = LoggerFactory.getLogger(GlobalZooKeeperStarter.class);
+    private static final Logger log = LoggerFactory.getLogger(GlobalConfigurationZooKeeperStarter.class);
 }


### PR DESCRIPTION
### Motivation
We learned from our customers that 'global-zookeeper' is a bit confusing. people feels that the global zookeeper is the single point of failure, when it is down, pulsar is not functionable. since it is mostly used for configuration/policies, it is better to rename it to make the meaning more clear, so people will know directly that it is used for storing configurations/policies and they will not be freak out, or having other bad impressions.

It would be good to rename "global zookeeper" to "global configuration zookeeper".

### Modifications
- rename "global zookeeper" to "global configuration zookeeper" in code and cli command.
- mark old "global zookeeper" as "Deprecated".
- Add new "global configuration zookeeper" to replace "global zookeeper".

### Result
Since old "global zookeeper" is marked as deprecated, so it still OK to run as old way. Maybe finally removed in next release.
Encourage user to use new "global configuration zookeeper".