### PR TITLE
Move zookeeper/bookkeeper from dependency management and only specify the dependency when they are used

### DIFF
--- a/managed-ledger/pom.xml
+++ b/managed-ledger/pom.xml
@@ -36,6 +36,21 @@
     <dependency>
       <groupId>org.apache.bookkeeper</groupId>
       <artifactId>bookkeeper-server</artifactId>
+      <version>${bookkeeper.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>slf4j-log4j12</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>log4j</artifactId>
+          <groupId>log4j</groupId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jboss.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -168,34 +168,8 @@ flexible messaging model and an intuitive client API.</description>
       <dependency>
         <groupId>org.apache.zookeeper</groupId>
         <artifactId>zookeeper</artifactId>
-        <version>${zookeeper.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.zookeeper</groupId>
-        <artifactId>zookeeper</artifactId>
         <classifier>tests</classifier>
         <version>${zookeeper.version}</version>
-        <exclusions>
-          <exclusion>
-            <artifactId>slf4j-log4j12</artifactId>
-            <groupId>org.slf4j</groupId>
-          </exclusion>
-          <exclusion>
-            <artifactId>log4j</artifactId>
-            <groupId>log4j</groupId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.jboss.netty</groupId>
-            <artifactId>netty</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.bookkeeper</groupId>
-        <artifactId>bookkeeper-server</artifactId>
-        <version>${bookkeeper.version}</version>
         <exclusions>
           <exclusion>
             <artifactId>slf4j-log4j12</artifactId>

--- a/pulsar-testclient/pom.xml
+++ b/pulsar-testclient/pom.xml
@@ -44,6 +44,7 @@
 		<dependency>
 			<groupId>org.apache.zookeeper</groupId>
 			<artifactId>zookeeper</artifactId>
+			<version>${zookeeper.version}</version>
 		</dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/pulsar-zookeeper-utils/pom.xml
+++ b/pulsar-zookeeper-utils/pom.xml
@@ -42,6 +42,21 @@
     <dependency>
       <groupId>org.apache.bookkeeper</groupId>
       <artifactId>bookkeeper-server</artifactId>
+      <version>${bookkeeper.version}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>slf4j-log4j12</artifactId>
+          <groupId>org.slf4j</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>log4j</artifactId>
+          <groupId>log4j</groupId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.jboss.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/pulsar-zookeeper/pom.xml
+++ b/pulsar-zookeeper/pom.xml
@@ -38,6 +38,7 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
+      <version>${zookeeper.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION

### Motivation

Currently zookeeper and bookkeeper are specified in dependency management. so a specific version of zookeeper and bookkeeper is enforced across the project. It would be good to move zk and bk away from dependency management and only specify the dependency when they are used. so it allows playing around with the new bookkeeper version in a separate module.

### Modifications

- move zk dependency to pulsar-zookeeper
- move bk dependency to managed-ledger

### Result

It allows me using the latest bookkeeper client in a separated module that I am working on.
