### PR TITLE
Populate message properties after building a message

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -59,12 +59,7 @@ public class MessageImpl implements Message {
         msg.messageId = null;
         msg.cnx = null;
         msg.payload = Unpooled.wrappedBuffer(payload);
-        if (msgMetadataBuilder.getPropertiesCount() > 0) {
-            msg.properties = Collections.unmodifiableMap(msgMetadataBuilder.getPropertiesList().stream()
-                    .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue)));
-        } else {
-            msg.properties = Collections.emptyMap();
-        }
+        msg.properties = null;
         return msg;
     }
 
@@ -218,13 +213,21 @@ public class MessageImpl implements Message {
     }
 
     @Override
-    public Map<String, String> getProperties() {
-        return properties;
+    public synchronized Map<String, String> getProperties() {
+        if (this.properties == null) {
+            if (msgMetadataBuilder.getPropertiesCount() > 0) {
+                this.properties = Collections.unmodifiableMap(msgMetadataBuilder.getPropertiesList().stream()
+                        .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue)));
+            } else {
+                this.properties = Collections.emptyMap();
+            }
+        }
+        return this.properties;
     }
 
     @Override
     public boolean hasProperty(String name) {
-        return properties.containsKey(name);
+        return getProperties().containsKey(name);
     }
 
     @Override

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageBuilderTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageBuilderTest.java
@@ -21,9 +21,13 @@ package org.apache.pulsar.client.impl;
 
 import static org.testng.Assert.assertEquals;
 
+import java.util.Map;
+
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageBuilder;
 import org.testng.annotations.Test;
+
+import com.google.common.collect.Maps;
 
 /**
  * Unit test of {@link MessageBuilderImpl}.
@@ -60,4 +64,15 @@ public class MessageBuilderTest {
         assertEquals(0L, msg.getEventTime());
     }
 
+    @Test
+    public void testSetMessageProperties() {
+        MessageBuilder builder = MessageBuilder.create();
+        builder.setContent(new byte[0]);
+        Map<String, String> map = Maps.newHashMap();
+        map.put("key1", "value1");
+        builder.setProperties(map);
+        Message msg = builder.build();
+        assertEquals(map, msg.getProperties());
+    }
+    
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageBuilderTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageBuilderTest.java
@@ -73,6 +73,7 @@ public class MessageBuilderTest {
         builder.setProperties(map);
         Message msg = builder.build();
         assertEquals(map, msg.getProperties());
+        assertEquals("value1", msg.getProperty("key1"));
     }
     
 }


### PR DESCRIPTION
### Motivation

Some times user wants to read set properties after building a message. But right now, properties is not being populated while building message.

### Modifications

Populate properties while building a message.

### Result

User can read set properties after building a message.
