### PR TITLE
Fix format of Athenz auth parameters written in document

### DIFF
--- a/site/docs/latest/admin/Authz.md
+++ b/site/docs/latest/admin/Authz.md
@@ -237,7 +237,7 @@ serviceUrl=https://broker.example.com:8443/
 
 # Set Athenz auth plugin and its parameters
 authPlugin=org.apache.pulsar.client.impl.auth.AuthenticationAthenz
-authParams=tenantDomain:shopping,tenantService:some_app,providerDomain:pulsar,privateKeyPath:/path/to/private.pem,keyId:v1
+authParams={"tenantDomain":"shopping","tenantService":"some_app","providerDomain":"pulsar","privateKey":"file:///path/to/private.pem","keyId":"v1"}
 
 # Enable TLS
 useTls=true


### PR DESCRIPTION
### Motivation

A format of Athenz auth parameters written in document is old.

### Modifications

* Change the format to JSON (#793)
* Use `privateKey` parameter instead of `privateKeyPath` (#672)

### Result

Users will be able to set the auth parameters of Athenz correctly.