### PR TITLE
DoubleByteBuf fix for Netty > 4.1.12

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/DoubleByteBuf.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/DoubleByteBuf.java
@@ -383,7 +383,7 @@ public final class DoubleByteBuf extends AbstractReferenceCountedByteBuf {
 
     @Override
     public ByteBuffer nioBuffer(int index, int length) {
-        ByteBuffer dst = ByteBuffer.allocate(length);
+        ByteBuffer dst = isDirect() ? ByteBuffer.allocateDirect(length) : ByteBuffer.allocate(length);
         ByteBuf b = Unpooled.wrappedBuffer(dst);
         b.writerIndex(0);
         getBytes(index, b, length);


### PR DESCRIPTION
It seems `DoubleByteBuf` is not playing well when used with Native Transports.
Using @merlimat [test](https://gist.github.com/merlimat/799b8ba84b5987de369668a748aa0e32) I was able to reproduce this.
Switching from Epoll to Nio transport fixes the issue, so this has to be something with native transports.
Also, changing [this line](https://github.com/apache/incubator-pulsar/blob/master/pulsar-common/src/main/java/org/apache/pulsar/common/api/DoubleByteBuf.java#L386) to `allocateDirect` fixes the issue for both Epoll and Nio, but I don't know if it's the right thing to do. 
The most simple fix is not try to allocate a new `ByteBuffer` but return a concatenation of the components' nio buffers.

Therefore, I propose making `DoubleByteBuf.nioBuffers` return a concatenation of the two components' `nioBuffers` when index and length are not needed, this could prove be more efficient. Also make `nioBuffer` allocate a direct buffer if both components are direct, i believe this should be safe also.