### PR TITLE
Issue 1061: Consumers in failover subscription stops consuming after restart

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -238,6 +238,12 @@ public final class PersistentDispatcherSingleActiveConsumer extends AbstractDisp
 
     @Override
     protected void readMoreEntries(Consumer consumer) {
+        // consumer can be null when all consumers are disconnected from broker.
+        // so skip reading more entries if currently there is no active consumer.
+        if (null == consumer) {
+            return;
+        }
+
         int availablePermits = consumer.getAvailablePermits();
 
         if (availablePermits > 0) {


### PR DESCRIPTION

### Motivation

consumers can be stuck in failover subscription as described in #1061 

### Modifications

skip read more entries if there is no active consumer, to avoid NPE

### Result
It fixes #1061 
