### PR TITLE
Support Url Encode in Athenz auth params

### DIFF
--- a/pulsar-client-auth-athenz/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationAthenz.java
+++ b/pulsar-client-auth-athenz/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationAthenz.java
@@ -107,7 +107,9 @@ public class AuthenticationAthenz implements Authentication, EncodedAuthenticati
         // Convert JSON to Map
         try {
             ObjectMapper jsonMapper = ObjectMapperFactory.create();
-            Map<String, String> authParamsMap = jsonMapper.readValue(encodedAuthParamString, new TypeReference<HashMap<String, String>>() {});
+            Map<String, String> authParamsMap = jsonMapper.readValue(encodedAuthParamString,
+                    new TypeReference<HashMap<String, String>>() {
+                    });
             setAuthParams(authParamsMap);
         } catch (IOException e) {
             throw new IllegalArgumentException("Failed to parse authParams");
@@ -119,7 +121,7 @@ public class AuthenticationAthenz implements Authentication, EncodedAuthenticati
         setAuthParams(authParams);
     }
 
-    private void setAuthParams(Map<String, String> authParams){
+    private void setAuthParams(Map<String, String> authParams) {
         this.tenantDomain = authParams.get("tenantDomain");
         this.tenantService = authParams.get("tenantService");
         this.providerDomain = authParams.get("providerDomain");
@@ -129,11 +131,11 @@ public class AuthenticationAthenz implements Authentication, EncodedAuthenticati
         } else {
             this.privateKey = loadPrivateKey(authParams.get("privateKey"));
         }
-        
-        if(this.privateKey == null) {
+
+        if (this.privateKey == null) {
             throw new IllegalArgumentException("Failed to load private key from privateKey or privateKeyPath field");
         }
-        
+
         this.keyId = authParams.getOrDefault("keyId", "0");
         if (authParams.containsKey("athenzConfPath")) {
             System.setProperty("athenz.athenz_conf", authParams.get("athenzConfPath"));
@@ -172,15 +174,20 @@ public class AuthenticationAthenz implements Authentication, EncodedAuthenticati
                 privateKey = Crypto.loadPrivateKey(new File(privateKeyURL));
             } else if (uri.getScheme().equals("file")) {
                 privateKey = Crypto.loadPrivateKey(new File(uri.getPath()));
-            } else if(uri.getScheme().equals("data")) {
+            } else if (uri.getScheme().equals("data")) {
                 List<String> dataParts = Splitter.on(",").splitToList(uri.getSchemeSpecificPart());
-                if (dataParts.get(0).equals("application/x-pem-file;base64")) {
+                // Support Urlencode but not decode here because already decoded by URI class.
+                if (dataParts.get(0).equals("application/x-pem-file")) {
+                    privateKey = Crypto.loadPrivateKey(dataParts.get(1));
+                // Support base64
+                } else if (dataParts.get(0).equals("application/x-pem-file;base64")) {
                     privateKey = Crypto.loadPrivateKey(new String(Base64.getDecoder().decode(dataParts.get(1))));
                 } else {
-                    throw new IllegalArgumentException("Unsupported media type or encoding format: " + dataParts.get(0));
+                    throw new IllegalArgumentException(
+                            "Unsupported media type or encoding format: " + dataParts.get(0));
                 }
             }
-        } catch(URISyntaxException e) {
+        } catch (URISyntaxException e) {
             throw new IllegalArgumentException("Invalid privateKey format");
         }
         return privateKey;

--- a/pulsar-client-auth-athenz/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationAthenz.java
+++ b/pulsar-client-auth-athenz/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationAthenz.java
@@ -52,6 +52,9 @@ import com.yahoo.athenz.auth.util.Crypto;
 
 public class AuthenticationAthenz implements Authentication, EncodedAuthenticationParameterSupport {
 
+    private static final String APPLICATION_X_PEM_FILE = "application/x-pem-file";
+    private static final String APPLICATION_X_PEM_FILE_BASE64 = "application/x-pem-file;base64";
+
     private transient ZTSClient ztsClient = null;
     private String tenantDomain;
     private String tenantService;
@@ -177,10 +180,10 @@ public class AuthenticationAthenz implements Authentication, EncodedAuthenticati
             } else if (uri.getScheme().equals("data")) {
                 List<String> dataParts = Splitter.on(",").splitToList(uri.getSchemeSpecificPart());
                 // Support Urlencode but not decode here because already decoded by URI class.
-                if (dataParts.get(0).equals("application/x-pem-file")) {
+                if (dataParts.get(0).equals(APPLICATION_X_PEM_FILE)) {
                     privateKey = Crypto.loadPrivateKey(dataParts.get(1));
                 // Support base64
-                } else if (dataParts.get(0).equals("application/x-pem-file;base64")) {
+                } else if (dataParts.get(0).equals(APPLICATION_X_PEM_FILE_BASE64)) {
                     privateKey = Crypto.loadPrivateKey(new String(Base64.getDecoder().decode(dataParts.get(1))));
                 } else {
                     throw new IllegalArgumentException(

--- a/pulsar-client-auth-athenz/src/test/java/org/apache/pulsar/client/impl/auth/AuthenticationAthenzTest.java
+++ b/pulsar-client-auth-athenz/src/test/java/org/apache/pulsar/client/impl/auth/AuthenticationAthenzTest.java
@@ -19,20 +19,29 @@
 package org.apache.pulsar.client.impl.auth;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 import org.testng.annotations.Test;
-import org.apache.pulsar.client.api.AuthenticationDataProvider;
 import org.apache.pulsar.client.impl.auth.AuthenticationAthenz;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
+import static org.apache.pulsar.common.util.Codec.encode;
+import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 
+import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.security.PrivateKey;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yahoo.athenz.auth.util.Crypto;
 import com.yahoo.athenz.zts.RoleToken;
 import com.yahoo.athenz.zts.ZTSClient;
 
@@ -41,24 +50,12 @@ public class AuthenticationAthenzTest {
     private AuthenticationAthenz auth;
     private static final String TENANT_DOMAIN = "test_tenant";
     private static final String TENANT_SERVICE = "test_service";
-    private static final String PROVIDER_DOMAIN = "test_provider";
-    private static final String PRIVATE_KEY_PATH = "./src/test/resources/tenant_private.pem";
 
     @BeforeClass
     public void setup() throws Exception {
-
-        // Configure parameters
-        Map<String, String> params = new HashMap<String, String>() {
-            {
-                put("tenantDomain", TENANT_DOMAIN);
-                put("tenantService", TENANT_SERVICE);
-                put("providerDomain", PROVIDER_DOMAIN);
-                put("privateKeyPath", PRIVATE_KEY_PATH);
-            }
-        };
+        String paramsStr = new String(Files.readAllBytes(Paths.get("./src/test/resources/authParams.json")));
         auth = new AuthenticationAthenz();
-        auth.configure(params);
-
+        auth.configure(paramsStr);
         // Set mock ztsClient which returns fixed token instead of fetching from ZTS server
         Field field = auth.getClass().getDeclaredField("ztsClient");
         field.setAccessible(true);
@@ -111,5 +108,59 @@ public class AuthenticationAthenzTest {
             }
         }
         assertEquals(count, 1);
+    }
+
+    @Test
+    public void testLoadPrivateKeyBase64() throws Exception {
+        try {
+            String paramsStr = new String(Files.readAllBytes(Paths.get("./src/test/resources/authParams.json")));
+
+            // load privatekey and encode it using base64
+            ObjectMapper jsonMapper = ObjectMapperFactory.create();
+            Map<String, String> authParamsMap = jsonMapper.readValue(paramsStr,
+                    new TypeReference<HashMap<String, String>>() {
+                    });
+            String privateKeyContents = new String(Files.readAllBytes(Paths.get(authParamsMap.get("privateKey"))));
+            authParamsMap.put("privateKey", "data:application/x-pem-file;base64,"
+                    + new String(Base64.getEncoder().encode(privateKeyContents.getBytes())));
+
+            AuthenticationAthenz authBase64 = new AuthenticationAthenz();
+            authBase64.configure(jsonMapper.writeValueAsString(authParamsMap));
+
+            PrivateKey privateKey = Crypto.loadPrivateKey(new File("./src/test/resources/tenant_private.pem"));
+            Field field = authBase64.getClass().getDeclaredField("privateKey");
+            field.setAccessible(true);
+            PrivateKey key = (PrivateKey) field.get(authBase64);
+            assertTrue(privateKey.equals(key));
+        } catch (Exception e) {
+            Assert.fail();
+        }
+    }
+
+    @Test
+    public void testLoadPrivateKeyUrlEncode() throws Exception {
+        try {
+            String paramsStr = new String(Files.readAllBytes(Paths.get("./src/test/resources/authParams.json")));
+
+            // load privatekey and encode it using url encoding
+            ObjectMapper jsonMapper = ObjectMapperFactory.create();
+            Map<String, String> authParamsMap = jsonMapper.readValue(paramsStr,
+                    new TypeReference<HashMap<String, String>>() {
+                    });
+            String privateKeyContents = new String(Files.readAllBytes(Paths.get(authParamsMap.get("privateKey"))));
+            authParamsMap.put("privateKey",
+                    "data:application/x-pem-file," + new String(encode(privateKeyContents).replace("+", "%20")));
+
+            AuthenticationAthenz authEncode = new AuthenticationAthenz();
+            authEncode.configure(jsonMapper.writeValueAsString(authParamsMap));
+
+            PrivateKey privateKey = Crypto.loadPrivateKey(new File("./src/test/resources/tenant_private.pem"));
+            Field field = authEncode.getClass().getDeclaredField("privateKey");
+            field.setAccessible(true);
+            PrivateKey key = (PrivateKey) field.get(authEncode);
+            assertTrue(privateKey.equals(key));
+        } catch (Exception e) {
+            Assert.fail();
+        }
     }
 }

--- a/pulsar-client-auth-athenz/src/test/resources/authParams.json
+++ b/pulsar-client-auth-athenz/src/test/resources/authParams.json
@@ -1,0 +1,6 @@
+{
+	"tenantService": "test_service",
+	"privateKey": "./src/test/resources/tenant_private.pem",
+	"providerDomain": "test_provider",
+	"tenantDomain": "test_tenant"
+}


### PR DESCRIPTION
### Motivation
Currently, only support base64 for privatekey encoding format.

### Modifications
 - Support url encode, too.
 - And Fixed deprecated method in unit test. (use `configure(String encodedAuthParamString)` intead of`configure(Map<String, String> authParams)`)

### Result
Users can use url encode to encode privatekey contents.
