### PR TITLE
Re-implement DoubleByteBuf as a simple holder of a pair of buffers

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -2133,7 +2133,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         headers.writeInt(msgMetadataSize);
         messageData.writeTo(outStream);
         outStream.recycle();
-        return DoubleByteBuf.get(headers, payload);
+        return DoubleByteBuf.get(headers, payload).coalesce();
     }
 
 }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -66,7 +66,7 @@ import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo;
 import org.apache.bookkeeper.mledger.util.Pair;
 import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
-import org.apache.pulsar.common.api.DoubleByteBuf;
+import org.apache.pulsar.common.api.ByteBufPair;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
 import org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream;
 import org.apache.zookeeper.CreateMode;
@@ -2133,7 +2133,7 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         headers.writeInt(msgMetadataSize);
         messageData.writeTo(outStream);
         outStream.recycle();
-        return DoubleByteBuf.get(headers, payload).coalesce();
+        return ByteBufPair.coalesce(ByteBufPair.get(headers, payload));
     }
 
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarChannelInitializer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarChannelInitializer.java
@@ -21,7 +21,7 @@ package org.apache.pulsar.broker.service;
 import java.io.File;
 
 import org.apache.pulsar.broker.ServiceConfiguration;
-import org.apache.pulsar.common.api.DoubleByteBuf;
+import org.apache.pulsar.common.api.ByteBufPair;
 import org.apache.pulsar.common.api.PulsarDecoder;
 
 import io.netty.channel.ChannelInitializer;
@@ -72,7 +72,7 @@ public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> 
             ch.pipeline().addLast(TLS_HANDLER, sslCtx.newHandler(ch.alloc()));
         }
 
-        ch.pipeline().addLast("DoubleByteBufEncoder", DoubleByteBuf.ENCODER);
+        ch.pipeline().addLast("ByteBufPairEncoder", ByteBufPair.ENCODER);
         ch.pipeline().addLast("frameDecoder", new LengthFieldBasedFrameDecoder(PulsarDecoder.MaxFrameSize, 0, 4, 0, 4));
         ch.pipeline().addLast("handler", new ServerCnx(brokerService));
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarChannelInitializer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarChannelInitializer.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.service;
 import java.io.File;
 
 import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.common.api.DoubleByteBuf;
 import org.apache.pulsar.common.api.PulsarDecoder;
 
 import io.netty.channel.ChannelInitializer;
@@ -70,6 +71,8 @@ public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> 
             SslContext sslCtx = builder.clientAuth(ClientAuth.OPTIONAL).build();
             ch.pipeline().addLast(TLS_HANDLER, sslCtx.newHandler(ch.alloc()));
         }
+
+        ch.pipeline().addLast("DoubleByteBufEncoder", DoubleByteBuf.ENCODER);
         ch.pipeline().addLast("frameDecoder", new LengthFieldBasedFrameDecoder(PulsarDecoder.MaxFrameSize, 0, 4, 0, 4));
         ch.pipeline().addLast("handler", new ServerCnx(brokerService));
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/api/RawMessage.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/api/RawMessage.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.client.api;
 
-import org.apache.pulsar.common.api.DoubleByteBuf;
+import org.apache.pulsar.common.api.ByteBufPair;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData;
 
 import io.netty.buffer.ByteBuf;
@@ -46,10 +46,10 @@ public interface RawMessage extends AutoCloseable {
     ByteBuf getHeadersAndPayload();
 
     /**
-     * Serialize a raw message to a ByteBuf. The caller is responsible for releasing
-     * the returned ByteBuf.
+     * Serialize a raw message to a ByteBufPair. The caller is responsible for releasing
+     * the returned ByteBufPair.
      */
-    DoubleByteBuf serialize();
+    ByteBufPair serialize();
 
     @Override
     void close();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/api/RawMessage.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/api/RawMessage.java
@@ -18,9 +18,10 @@
  */
 package org.apache.pulsar.client.api;
 
-import io.netty.buffer.ByteBuf;
-import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.common.api.DoubleByteBuf;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData;
+
+import io.netty.buffer.ByteBuf;
 
 /**
  * A representation of a message in a topic in its raw form (i.e. as it is stored in a managed ledger).
@@ -48,7 +49,7 @@ public interface RawMessage extends AutoCloseable {
      * Serialize a raw message to a ByteBuf. The caller is responsible for releasing
      * the returned ByteBuf.
      */
-    ByteBuf serialize();
+    DoubleByteBuf serialize();
 
     @Override
     void close();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawMessageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawMessageImpl.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.RawMessage;
-import org.apache.pulsar.common.api.DoubleByteBuf;
+import org.apache.pulsar.common.api.ByteBufPair;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData;
 import org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream;
 import org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream;
@@ -65,7 +65,7 @@ public class RawMessageImpl implements RawMessage {
     }
 
     @Override
-    public DoubleByteBuf serialize() {
+    public ByteBufPair serialize() {
         // Format: [IdSize][Id][PayloadAndMetadataSize][PayloadAndMetadata]
         int idSize = id.getSerializedSize();
         int headerSize = 4 /* IdSize */ + idSize + 4 /* PayloadAndMetadataSize */;
@@ -83,7 +83,7 @@ public class RawMessageImpl implements RawMessage {
         }
         headers.writeInt(headersAndPayload.readableBytes());
 
-        return DoubleByteBuf.get(headers, headersAndPayload);
+        return ByteBufPair.get(headers, headersAndPayload);
     }
 
     static public RawMessage deserializeFrom(ByteBuf buffer) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawMessageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawMessageImpl.java
@@ -20,19 +20,17 @@ package org.apache.pulsar.client.impl;
 
 import java.io.IOException;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.PooledByteBufAllocator;
-
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.RawMessage;
 import org.apache.pulsar.common.api.DoubleByteBuf;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData;
-import org.apache.pulsar.client.impl.BatchMessageIdImpl;
 import org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream;
 import org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
 
 public class RawMessageImpl implements RawMessage {
     private static final Logger log = LoggerFactory.getLogger(RawMessageImpl.class);
@@ -67,7 +65,7 @@ public class RawMessageImpl implements RawMessage {
     }
 
     @Override
-    public ByteBuf serialize() {
+    public DoubleByteBuf serialize() {
         // Format: [IdSize][Id][PayloadAndMetadataSize][PayloadAndMetadata]
         int idSize = id.getSerializedSize();
         int headerSize = 4 /* IdSize */ + idSize + 4 /* PayloadAndMetadataSize */;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
@@ -68,7 +68,7 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
         ByteBufCodedOutputStream outStream = ByteBufCodedOutputStream.get(headers);
         headers.writeInt(msgMetadataSize);
         messageMetadata.writeTo(outStream);
-        ByteBuf headersAndPayload = DoubleByteBuf.get(headers, data);
+        ByteBuf headersAndPayload = DoubleByteBuf.get(headers, data).coalesce();
         byte[] byteMessage = headersAndPayload.nioBuffer().array();
         headersAndPayload.release();
         return byteMessage;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
@@ -39,7 +39,7 @@ import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl;
 import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
 import org.apache.pulsar.broker.service.persistent.PersistentMessageExpiryMonitor;
 import org.apache.pulsar.broker.service.persistent.PersistentMessageFinder;
-import org.apache.pulsar.common.api.DoubleByteBuf;
+import org.apache.pulsar.common.api.ByteBufPair;
 import org.apache.pulsar.common.api.proto.PulsarApi;
 import org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream;
 import org.testng.annotations.Test;
@@ -68,7 +68,7 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
         ByteBufCodedOutputStream outStream = ByteBufCodedOutputStream.get(headers);
         headers.writeInt(msgMetadataSize);
         messageMetadata.writeTo(outStream);
-        ByteBuf headersAndPayload = DoubleByteBuf.get(headers, data).coalesce();
+        ByteBuf headersAndPayload = ByteBufPair.coalesce(ByteBufPair.get(headers, data));
         byte[] byteMessage = headersAndPayload.nioBuffer().array();
         headersAndPayload.release();
         return byteMessage;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -73,6 +73,7 @@ import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.ServerCnx.State;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.broker.service.utils.ClientChannelHelper;
+import org.apache.pulsar.common.api.ByteBufPair;
 import org.apache.pulsar.common.api.Commands;
 import org.apache.pulsar.common.api.PulsarHandler;
 import org.apache.pulsar.common.api.Commands.ChecksumType;
@@ -571,7 +572,7 @@ public class ServerCnxTest {
                 .setProducerName("prod-name").setSequenceId(0).build();
         ByteBuf data = Unpooled.buffer(1024);
 
-        clientCommand = Commands.newSend(1, 0, 1, ChecksumType.None, messageMetadata, data).coalesce();
+        clientCommand = ByteBufPair.coalesce(Commands.newSend(1, 0, 1, ChecksumType.None, messageMetadata, data));
         channel.writeInbound(Unpooled.copiedBuffer(clientCommand));
         clientCommand.release();
 
@@ -1292,7 +1293,7 @@ public class ServerCnxTest {
                 .build();
         ByteBuf data = Unpooled.buffer(1024);
 
-        clientCommand = Commands.newSend(1, 0, 1, ChecksumType.None, messageMetadata, data).coalesce();
+        clientCommand = ByteBufPair.coalesce(Commands.newSend(1, 0, 1, ChecksumType.None, messageMetadata, data));
         channel.writeInbound(Unpooled.copiedBuffer(clientCommand));
         clientCommand.release();
         assertTrue(getResponse() instanceof CommandSendReceipt);
@@ -1326,7 +1327,7 @@ public class ServerCnxTest {
                 .build();
         ByteBuf data = Unpooled.buffer(1024);
 
-        clientCommand = Commands.newSend(1, 0, 1, ChecksumType.None, messageMetadata, data).coalesce();
+        clientCommand = ByteBufPair.coalesce(Commands.newSend(1, 0, 1, ChecksumType.None, messageMetadata, data));
         channel.writeInbound(Unpooled.copiedBuffer(clientCommand));
         clientCommand.release();
         assertTrue(getResponse() instanceof CommandSendError);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -158,7 +158,7 @@ public class ServerCnxTest {
         doReturn(Optional.empty()).when(zkDataCache).get(anyObject());
         doReturn(zkDataCache).when(configCacheService).policiesCache();
         doReturn(configCacheService).when(pulsar).getConfigurationCache();
-        
+
         LocalZooKeeperCacheService zkCache = mock(LocalZooKeeperCacheService.class);
         doReturn(CompletableFuture.completedFuture(Optional.empty())).when(zkDataCache).getAsync(any());
         doReturn(zkDataCache).when(zkCache).policiesCache();
@@ -571,7 +571,7 @@ public class ServerCnxTest {
                 .setProducerName("prod-name").setSequenceId(0).build();
         ByteBuf data = Unpooled.buffer(1024);
 
-        clientCommand = Commands.newSend(1, 0, 1, ChecksumType.None, messageMetadata, data);
+        clientCommand = Commands.newSend(1, 0, 1, ChecksumType.None, messageMetadata, data).coalesce();
         channel.writeInbound(Unpooled.copiedBuffer(clientCommand));
         clientCommand.release();
 
@@ -1292,7 +1292,7 @@ public class ServerCnxTest {
                 .build();
         ByteBuf data = Unpooled.buffer(1024);
 
-        clientCommand = Commands.newSend(1, 0, 1, ChecksumType.None, messageMetadata, data);
+        clientCommand = Commands.newSend(1, 0, 1, ChecksumType.None, messageMetadata, data).coalesce();
         channel.writeInbound(Unpooled.copiedBuffer(clientCommand));
         clientCommand.release();
         assertTrue(getResponse() instanceof CommandSendReceipt);
@@ -1326,7 +1326,7 @@ public class ServerCnxTest {
                 .build();
         ByteBuf data = Unpooled.buffer(1024);
 
-        clientCommand = Commands.newSend(1, 0, 1, ChecksumType.None, messageMetadata, data);
+        clientCommand = Commands.newSend(1, 0, 1, ChecksumType.None, messageMetadata, data).coalesce();
         channel.writeInbound(Unpooled.copiedBuffer(clientCommand));
         clientCommand.release();
         assertTrue(getResponse() instanceof CommandSendError);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageIdTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageIdTest.java
@@ -53,7 +53,7 @@ import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.ProducerImpl.OpSendMsg;
 import org.apache.pulsar.common.api.Commands;
 import org.apache.pulsar.common.api.Commands.ChecksumType;
-import org.apache.pulsar.common.api.DoubleByteBuf;
+import org.apache.pulsar.common.api.ByteBufPair;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata.Builder;
 import org.slf4j.Logger;
@@ -472,7 +472,7 @@ public class MessageIdTest extends BrokerTestBase {
         Builder metadataBuilder = ((MessageImpl) msg).getMessageBuilder();
         MessageMetadata msgMetadata = metadataBuilder.setProducerName("test").setSequenceId(1).setPublishTime(10L)
                 .build();
-        DoubleByteBuf cmd = Commands.newSend(producerId, 1, 1, ChecksumType.Crc32c, msgMetadata, payload);
+        ByteBufPair cmd = Commands.newSend(producerId, 1, 1, ChecksumType.Crc32c, msgMetadata, payload);
         // (a) create OpSendMsg with message-data : "message-1"
         OpSendMsg op = OpSendMsg.create(((MessageImpl) msg), cmd, 1, null);
         // a.verify: as message is not corrupt: no need to update checksum

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageIdTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageIdTest.java
@@ -53,6 +53,7 @@ import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.ProducerImpl.OpSendMsg;
 import org.apache.pulsar.common.api.Commands;
 import org.apache.pulsar.common.api.Commands.ChecksumType;
+import org.apache.pulsar.common.api.DoubleByteBuf;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata.Builder;
 import org.slf4j.Logger;
@@ -471,7 +472,7 @@ public class MessageIdTest extends BrokerTestBase {
         Builder metadataBuilder = ((MessageImpl) msg).getMessageBuilder();
         MessageMetadata msgMetadata = metadataBuilder.setProducerName("test").setSequenceId(1).setPublishTime(10L)
                 .build();
-        ByteBuf cmd = Commands.newSend(producerId, 1, 1, ChecksumType.Crc32c, msgMetadata, payload);
+        DoubleByteBuf cmd = Commands.newSend(producerId, 1, 1, ChecksumType.Crc32c, msgMetadata, payload);
         // (a) create OpSendMsg with message-data : "message-1"
         OpSendMsg op = OpSendMsg.create(((MessageImpl) msg), cmd, 1, null);
         // a.verify: as message is not corrupt: no need to update checksum

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/RawMessageSerDeserTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/RawMessageSerDeserTest.java
@@ -19,17 +19,16 @@
 package org.apache.pulsar.client.impl;
 
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-
 import org.apache.pulsar.client.api.RawMessage;
+import org.apache.pulsar.common.api.DoubleByteBuf;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 
 public class RawMessageSerDeserTest {
     static final Logger log = LoggerFactory.getLogger(RawMessageSerDeserTest.class);
@@ -45,7 +44,7 @@ public class RawMessageSerDeserTest {
             .setPartition(10).setBatchIndex(20).build();
 
         RawMessage m = new RawMessageImpl(id, headersAndPayload);
-        ByteBuf serialized = m.serialize();
+        ByteBuf serialized = m.serialize().coalesce();
         byte[] bytes = new byte[serialized.readableBytes()];
         serialized.readBytes(bytes);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/RawMessageSerDeserTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/RawMessageSerDeserTest.java
@@ -20,7 +20,7 @@ package org.apache.pulsar.client.impl;
 
 
 import org.apache.pulsar.client.api.RawMessage;
-import org.apache.pulsar.common.api.DoubleByteBuf;
+import org.apache.pulsar.common.api.ByteBufPair;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,7 +44,7 @@ public class RawMessageSerDeserTest {
             .setPartition(10).setBatchIndex(20).build();
 
         RawMessage m = new RawMessageImpl(id, headersAndPayload);
-        ByteBuf serialized = m.serialize().coalesce();
+        ByteBuf serialized = ByteBufPair.coalesce(m.serialize());
         byte[] bytes = new byte[serialized.readableBytes()];
         serialized.readBytes(bytes);
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ConcurrentMap;
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
 import org.apache.pulsar.client.api.ClientConfiguration;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.common.api.DoubleByteBuf;
 import org.apache.pulsar.common.util.netty.EventLoopUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -107,6 +108,8 @@ public class ConnectionPool implements Closeable {
                     SslContext sslCtx = builder.build();
                     ch.pipeline().addLast(TLS_HANDLER, sslCtx.newHandler(ch.alloc()));
                 }
+
+                ch.pipeline().addLast("DoubleByteBufEncoder", DoubleByteBuf.ENCODER);
                 ch.pipeline().addLast("frameDecoder", new LengthFieldBasedFrameDecoder(MaxMessageSize, 0, 4, 0, 4));
                 ch.pipeline().addLast("handler", new ClientCnx(conf, eventLoopGroup));
             }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionPool.java
@@ -34,7 +34,7 @@ import java.util.concurrent.ConcurrentMap;
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
 import org.apache.pulsar.client.api.ClientConfiguration;
 import org.apache.pulsar.client.api.PulsarClientException;
-import org.apache.pulsar.common.api.DoubleByteBuf;
+import org.apache.pulsar.common.api.ByteBufPair;
 import org.apache.pulsar.common.util.netty.EventLoopUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -109,7 +109,7 @@ public class ConnectionPool implements Closeable {
                     ch.pipeline().addLast(TLS_HANDLER, sslCtx.newHandler(ch.alloc()));
                 }
 
-                ch.pipeline().addLast("DoubleByteBufEncoder", DoubleByteBuf.ENCODER);
+                ch.pipeline().addLast("ByteBufPairEncoder", ByteBufPair.ENCODER);
                 ch.pipeline().addLast("frameDecoder", new LengthFieldBasedFrameDecoder(MaxMessageSize, 0, 4, 0, 4));
                 ch.pipeline().addLast("handler", new ClientCnx(conf, eventLoopGroup));
             }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -98,7 +98,7 @@ public class ProducerImpl extends ProducerBase implements TimerTask {
 
     private volatile long lastSequenceIdPublished;
     private MessageCrypto msgCrypto = null;
-    
+
     private ScheduledFuture<?> keyGeneratorTask = null;
 
     private final Map<String, String> metadata;
@@ -129,7 +129,7 @@ public class ProducerImpl extends ProducerBase implements TimerTask {
 
         if (conf.isEncryptionEnabled()) {
             String logCtx = "[" + topic + "] [" + producerName + "] [" + producerId + "]";
-            this.msgCrypto = new MessageCrypto(logCtx , true);
+            this.msgCrypto = new MessageCrypto(logCtx, true);
 
             // Regenerate data key cipher at fixed interval
             keyGeneratorTask = client.eventLoopGroup().scheduleWithFixedDelay(() -> {
@@ -261,7 +261,8 @@ public class ProducerImpl extends ProducerBase implements TimerTask {
         if (compressedSize > PulsarDecoder.MaxMessageSize) {
             compressedPayload.release();
             String compressedStr = (!isBatchMessagingEnabled() && conf.getCompressionType() != CompressionType.NONE)
-                    ? "Compressed" : "";
+                    ? "Compressed"
+                    : "";
             callback.sendComplete(new PulsarClientException.InvalidMessageException(
                     format("%s Message payload size %d cannot exceed %d bytes", compressedStr, compressedSize,
                             PulsarDecoder.MaxMessageSize)));
@@ -311,7 +312,7 @@ public class ProducerImpl extends ProducerBase implements TimerTask {
                     }
                 } else {
                     ByteBuf encryptedPayload = encryptMessage(msgMetadata, compressedPayload);
-                    ByteBuf cmd = sendMessage(producerId, sequenceId, 1, msgMetadata.build(), encryptedPayload);
+                    DoubleByteBuf cmd = sendMessage(producerId, sequenceId, 1, msgMetadata.build(), encryptedPayload);
                     msgMetadata.recycle();
 
                     final OpSendMsg op = OpSendMsg.create(msg, cmd, sequenceId, callback);
@@ -350,14 +351,16 @@ public class ProducerImpl extends ProducerBase implements TimerTask {
         }
     }
 
-    private ByteBuf encryptMessage(MessageMetadata.Builder msgMetadata, ByteBuf compressedPayload) throws PulsarClientException {
+    private ByteBuf encryptMessage(MessageMetadata.Builder msgMetadata, ByteBuf compressedPayload)
+            throws PulsarClientException {
 
         ByteBuf encryptedPayload = compressedPayload;
         if (!conf.isEncryptionEnabled() || msgCrypto == null) {
             return encryptedPayload;
         }
         try {
-            encryptedPayload = msgCrypto.encrypt(conf.getEncryptionKeys(), conf.getCryptoKeyReader(), msgMetadata, compressedPayload);
+            encryptedPayload = msgCrypto.encrypt(conf.getEncryptionKeys(), conf.getCryptoKeyReader(), msgMetadata,
+                    compressedPayload);
         } catch (PulsarClientException e) {
             // Unless config is set to explicitly publish un-encrypted message upon failure, fail the request
             if (conf.getCryptoFailureAction() == ProducerCryptoFailureAction.SEND) {
@@ -370,7 +373,7 @@ public class ProducerImpl extends ProducerBase implements TimerTask {
         return encryptedPayload;
     }
 
-    private ByteBuf sendMessage(long producerId, long sequenceId, int numMessages, MessageMetadata msgMetadata,
+    private DoubleByteBuf sendMessage(long producerId, long sequenceId, int numMessages, MessageMetadata msgMetadata,
             ByteBuf compressedPayload) throws IOException {
         ChecksumType checksumType;
 
@@ -696,11 +699,10 @@ public class ProducerImpl extends ProducerBase implements TimerTask {
      *         return false that means that message is corrupted. Returns true if checksum is not present.
      */
     protected boolean verifyLocalBufferIsNotCorrupted(OpSendMsg op) {
-        DoubleByteBuf msg = getDoubleByteBuf(op.cmd);
+        DoubleByteBuf msg = op.cmd;
 
         if (msg != null) {
             ByteBuf headerFrame = msg.getFirst();
-            msg.markReaderIndex();
             headerFrame.markReaderIndex();
             try {
                 // skip bytes up to checksum index
@@ -720,7 +722,6 @@ public class ProducerImpl extends ProducerBase implements TimerTask {
                 }
             } finally {
                 headerFrame.resetReaderIndex();
-                msg.resetReaderIndex();
             }
             return true;
         } else {
@@ -732,14 +733,14 @@ public class ProducerImpl extends ProducerBase implements TimerTask {
     protected static final class OpSendMsg {
         MessageImpl msg;
         List<MessageImpl> msgs;
-        ByteBuf cmd;
+        DoubleByteBuf cmd;
         SendCallback callback;
         long sequenceId;
         long createdAt;
         long batchSizeByte = 0;
         int numMessagesInBatch = 1;
 
-        static OpSendMsg create(MessageImpl msg, ByteBuf cmd, long sequenceId, SendCallback callback) {
+        static OpSendMsg create(MessageImpl msg, DoubleByteBuf cmd, long sequenceId, SendCallback callback) {
             OpSendMsg op = RECYCLER.get();
             op.msg = msg;
             op.cmd = cmd;
@@ -749,7 +750,7 @@ public class ProducerImpl extends ProducerBase implements TimerTask {
             return op;
         }
 
-        static OpSendMsg create(List<MessageImpl> msgs, ByteBuf cmd, long sequenceId, SendCallback callback) {
+        static OpSendMsg create(List<MessageImpl> msgs, DoubleByteBuf cmd, long sequenceId, SendCallback callback) {
             OpSendMsg op = RECYCLER.get();
             op.msgs = msgs;
             op.cmd = cmd;
@@ -812,9 +813,9 @@ public class ProducerImpl extends ProducerBase implements TimerTask {
 
         long requestId = client.newRequestId();
 
-        cnx.sendRequestWithId(Commands.newProducer(topic, producerId, requestId, producerName,
-                conf.isEncryptionEnabled(), metadata), requestId)
-                .thenAccept(pair -> {
+        cnx.sendRequestWithId(
+                Commands.newProducer(topic, producerId, requestId, producerName, conf.isEncryptionEnabled(), metadata),
+                requestId).thenAccept(pair -> {
                     String producerName = pair.getLeft();
                     long lastSequenceId = pair.getRight();
 
@@ -971,12 +972,10 @@ public class ProducerImpl extends ProducerBase implements TimerTask {
      * @param op
      */
     private void stripChecksum(OpSendMsg op) {
-        op.cmd.markReaderIndex();
         int totalMsgBufSize = op.cmd.readableBytes();
-        DoubleByteBuf msg = getDoubleByteBuf(op.cmd);
+        DoubleByteBuf msg = op.cmd;
         if (msg != null) {
             ByteBuf headerFrame = msg.getFirst();
-            msg.markReaderIndex();
             headerFrame.markReaderIndex();
             try {
                 headerFrame.skipBytes(4); // skip [total-size]
@@ -986,7 +985,6 @@ public class ProducerImpl extends ProducerBase implements TimerTask {
                 headerFrame.skipBytes(cmdSize);
 
                 if (!hasChecksum(headerFrame)) {
-                    headerFrame.resetReaderIndex();
                     return;
                 }
 
@@ -1004,10 +1002,8 @@ public class ProducerImpl extends ProducerBase implements TimerTask {
                 headerFrame.writerIndex(headerSize); // set headerFrame write-index to overwrite metadata over checksum
                 metadata.readBytes(headerFrame, metadata.readableBytes());
                 headerFrame.capacity(headerFrameSize - checksumSize); // reduce capacity by removed checksum bytes
-                headerFrame.resetReaderIndex();
-
             } finally {
-                op.cmd.resetReaderIndex();
+                headerFrame.resetReaderIndex();
             }
         } else {
             log.warn("[{}] Failed while casting {} into DoubleByteBuf", producerName, op.cmd.getClass().getName());
@@ -1157,7 +1153,7 @@ public class ProducerImpl extends ProducerBase implements TimerTask {
                 ByteBuf compressedPayload = batchMessageContainer.getCompressedBatchMetadataAndPayload();
                 long sequenceId = batchMessageContainer.sequenceId;
                 ByteBuf encryptedPayload = encryptMessage(batchMessageContainer.messageMetadata, compressedPayload);
-                ByteBuf cmd = sendMessage(producerId, sequenceId, batchMessageContainer.numMessagesInBatch,
+                DoubleByteBuf cmd = sendMessage(producerId, sequenceId, batchMessageContainer.numMessagesInBatch,
                         batchMessageContainer.setBatchAndBuild(), encryptedPayload);
 
                 op = OpSendMsg.create(batchMessageContainer.messages, cmd, sequenceId,
@@ -1202,30 +1198,6 @@ public class ProducerImpl extends ProducerBase implements TimerTask {
                 op.callback.sendComplete(new PulsarClientException(t));
             }
         }
-    }
-
-    /**
-     * Casts input cmd to {@link DoubleByteBuf}
-     *
-     * Incase if leak-detection level is enabled: pulsar instruments {@link DoubleByteBuf} into LeakAwareByteBuf (type
-     * of {@link io.netty.buffer.WrappedByteBuf}) So, this method casts input cmd to {@link DoubleByteBuf} else
-     * retrieves it from LeakAwareByteBuf.
-     *
-     * @param cmd
-     * @return DoubleByteBuf or null in case failed to cast input {@link ByteBuf}
-     */
-    private DoubleByteBuf getDoubleByteBuf(ByteBuf cmd) {
-        DoubleByteBuf msg = null;
-        if (cmd instanceof DoubleByteBuf) {
-            msg = (DoubleByteBuf) cmd;
-        } else {
-            try {
-                msg = (DoubleByteBuf) cmd.unwrap();
-            } catch (Exception e) {
-                log.error("[{}] Failed while casting {} into DoubleByteBuf", producerName, cmd.getClass().getName(), e);
-            }
-        }
-        return msg;
     }
 
     public long getDelayInMillis() {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/Commands.java
@@ -276,7 +276,7 @@ public class Commands {
         }
     }
 
-    public static ByteBuf newMessage(long consumerId, MessageIdData messageId, ByteBuf metadataAndPayload) {
+    public static DoubleByteBuf newMessage(long consumerId, MessageIdData messageId, ByteBuf metadataAndPayload) {
         CommandMessage.Builder msgBuilder = CommandMessage.newBuilder();
         msgBuilder.setConsumerId(consumerId);
         msgBuilder.setMessageId(messageId);
@@ -284,7 +284,7 @@ public class Commands {
         BaseCommand.Builder cmdBuilder = BaseCommand.newBuilder();
         BaseCommand cmd = cmdBuilder.setType(Type.MESSAGE).setMessage(msg).build();
 
-        ByteBuf res = serializeCommandMessageWithSize(cmd, metadataAndPayload);
+        DoubleByteBuf res = serializeCommandMessageWithSize(cmd, metadataAndPayload);
         cmd.recycle();
         cmdBuilder.recycle();
         msg.recycle();
@@ -292,7 +292,7 @@ public class Commands {
         return res;
     }
 
-    public static ByteBuf newSend(long producerId, long sequenceId, int numMessages, ChecksumType checksumType,
+    public static DoubleByteBuf newSend(long producerId, long sequenceId, int numMessages, ChecksumType checksumType,
             MessageMetadata messageData, ByteBuf payload) {
         CommandSend.Builder sendBuilder = CommandSend.newBuilder();
         sendBuilder.setProducerId(producerId);
@@ -302,7 +302,7 @@ public class Commands {
         }
         CommandSend send = sendBuilder.build();
 
-        ByteBuf res = serializeCommandSendWithSize(BaseCommand.newBuilder().setType(Type.SEND).setSend(send),
+        DoubleByteBuf res = serializeCommandSendWithSize(BaseCommand.newBuilder().setType(Type.SEND).setSend(send),
                 checksumType, messageData, payload);
         send.recycle();
         sendBuilder.recycle();
@@ -674,8 +674,8 @@ public class Commands {
         return buf;
     }
 
-    private static ByteBuf serializeCommandSendWithSize(BaseCommand.Builder cmdBuilder, ChecksumType checksumType, MessageMetadata msgMetadata,
-            ByteBuf payload) {
+    private static DoubleByteBuf serializeCommandSendWithSize(BaseCommand.Builder cmdBuilder, ChecksumType checksumType,
+            MessageMetadata msgMetadata, ByteBuf payload) {
         // / Wire format
         // [TOTAL_SIZE] [CMD_SIZE][CMD] [MAGIC_NUMBER][CHECKSUM] [METADATA_SIZE][METADATA] [PAYLOAD]
 
@@ -720,7 +720,7 @@ public class Commands {
             throw new RuntimeException(e);
         }
 
-        ByteBuf command = DoubleByteBuf.get(headers, payload);
+        DoubleByteBuf command = DoubleByteBuf.get(headers, payload);
 
         // write checksum at created checksum-placeholder
         if (includeChecksum) {
@@ -853,7 +853,7 @@ public class Commands {
         return singleMessagePayload;
     }
 
-    private static ByteBuf serializeCommandMessageWithSize(BaseCommand cmd, ByteBuf metadataAndPayload) {
+    private static DoubleByteBuf serializeCommandMessageWithSize(BaseCommand cmd, ByteBuf metadataAndPayload) {
         // / Wire format
         // [TOTAL_SIZE] [CMD_SIZE][CMD] [MAGIC_NUMBER][CHECKSUM] [METADATA_SIZE][METADATA] [PAYLOAD]
         //
@@ -879,7 +879,7 @@ public class Commands {
             throw new RuntimeException(e);
         }
 
-        return DoubleByteBuf.get(headers, metadataAndPayload);
+        return (DoubleByteBuf) DoubleByteBuf.get(headers, metadataAndPayload);
     }
 
     private static int getCurrentProtocolVersion() {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/Commands.java
@@ -276,7 +276,7 @@ public class Commands {
         }
     }
 
-    public static DoubleByteBuf newMessage(long consumerId, MessageIdData messageId, ByteBuf metadataAndPayload) {
+    public static ByteBufPair newMessage(long consumerId, MessageIdData messageId, ByteBuf metadataAndPayload) {
         CommandMessage.Builder msgBuilder = CommandMessage.newBuilder();
         msgBuilder.setConsumerId(consumerId);
         msgBuilder.setMessageId(messageId);
@@ -284,7 +284,7 @@ public class Commands {
         BaseCommand.Builder cmdBuilder = BaseCommand.newBuilder();
         BaseCommand cmd = cmdBuilder.setType(Type.MESSAGE).setMessage(msg).build();
 
-        DoubleByteBuf res = serializeCommandMessageWithSize(cmd, metadataAndPayload);
+        ByteBufPair res = serializeCommandMessageWithSize(cmd, metadataAndPayload);
         cmd.recycle();
         cmdBuilder.recycle();
         msg.recycle();
@@ -292,7 +292,7 @@ public class Commands {
         return res;
     }
 
-    public static DoubleByteBuf newSend(long producerId, long sequenceId, int numMessages, ChecksumType checksumType,
+    public static ByteBufPair newSend(long producerId, long sequenceId, int numMessages, ChecksumType checksumType,
             MessageMetadata messageData, ByteBuf payload) {
         CommandSend.Builder sendBuilder = CommandSend.newBuilder();
         sendBuilder.setProducerId(producerId);
@@ -302,7 +302,7 @@ public class Commands {
         }
         CommandSend send = sendBuilder.build();
 
-        DoubleByteBuf res = serializeCommandSendWithSize(BaseCommand.newBuilder().setType(Type.SEND).setSend(send),
+        ByteBufPair res = serializeCommandSendWithSize(BaseCommand.newBuilder().setType(Type.SEND).setSend(send),
                 checksumType, messageData, payload);
         send.recycle();
         sendBuilder.recycle();
@@ -674,7 +674,7 @@ public class Commands {
         return buf;
     }
 
-    private static DoubleByteBuf serializeCommandSendWithSize(BaseCommand.Builder cmdBuilder, ChecksumType checksumType,
+    private static ByteBufPair serializeCommandSendWithSize(BaseCommand.Builder cmdBuilder, ChecksumType checksumType,
             MessageMetadata msgMetadata, ByteBuf payload) {
         // / Wire format
         // [TOTAL_SIZE] [CMD_SIZE][CMD] [MAGIC_NUMBER][CHECKSUM] [METADATA_SIZE][METADATA] [PAYLOAD]
@@ -720,7 +720,7 @@ public class Commands {
             throw new RuntimeException(e);
         }
 
-        DoubleByteBuf command = DoubleByteBuf.get(headers, payload);
+        ByteBufPair command = ByteBufPair.get(headers, payload);
 
         // write checksum at created checksum-placeholder
         if (includeChecksum) {
@@ -853,7 +853,7 @@ public class Commands {
         return singleMessagePayload;
     }
 
-    private static DoubleByteBuf serializeCommandMessageWithSize(BaseCommand cmd, ByteBuf metadataAndPayload) {
+    private static ByteBufPair serializeCommandMessageWithSize(BaseCommand cmd, ByteBuf metadataAndPayload) {
         // / Wire format
         // [TOTAL_SIZE] [CMD_SIZE][CMD] [MAGIC_NUMBER][CHECKSUM] [METADATA_SIZE][METADATA] [PAYLOAD]
         //
@@ -879,7 +879,7 @@ public class Commands {
             throw new RuntimeException(e);
         }
 
-        return (DoubleByteBuf) DoubleByteBuf.get(headers, metadataAndPayload);
+        return (ByteBufPair) ByteBufPair.get(headers, metadataAndPayload);
     }
 
     private static int getCurrentProtocolVersion() {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/DoubleByteBuf.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/DoubleByteBuf.java
@@ -16,54 +16,23 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-/*
-* Licensed to the Apache Software Foundation (ASF) under one
-* or more contributor license agreements.  See the NOTICE file
-* distributed with this work for additional information
-* regarding copyright ownership.  The ASF licenses this file
-* to you under the Apache License, Version 2.0 (the
-* "License"); you may not use this file except in compliance
-* with the License.  You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
 package org.apache.pulsar.common.api;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.lang.reflect.Constructor;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.nio.channels.FileChannel;
-import java.nio.channels.GatheringByteChannel;
-import java.nio.channels.ScatteringByteChannel;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import io.netty.buffer.AbstractReferenceCountedByteBuf;
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
-import io.netty.util.ResourceLeakDetector;
-import io.netty.util.ResourceLeakDetectorFactory;
-import io.netty.util.ResourceLeakTracker;
+import io.netty.util.ReferenceCounted;
 
 /**
  * ByteBuf that holds 2 buffers. Similar to {@see CompositeByteBuf} but doesn't allocate list to hold them.
  */
-@SuppressWarnings("unchecked")
-public final class DoubleByteBuf extends AbstractReferenceCountedByteBuf {
+public final class DoubleByteBuf extends AbstractReferenceCounted {
 
     private ByteBuf b1;
     private ByteBuf b2;
@@ -77,20 +46,15 @@ public final class DoubleByteBuf extends AbstractReferenceCountedByteBuf {
     };
 
     private DoubleByteBuf(Handle<DoubleByteBuf> recyclerHandle) {
-        super(Integer.MAX_VALUE);
         this.recyclerHandle = recyclerHandle;
     }
 
-    public static ByteBuf get(ByteBuf b1, ByteBuf b2) {
+    public static DoubleByteBuf get(ByteBuf b1, ByteBuf b2) {
         DoubleByteBuf buf = RECYCLER.get();
         buf.setRefCnt(1);
-
-        // Make sure the buffers are not deallocated as long as we hold them. Also, buffers can get retained/releases
-        // outside of DoubleByteBuf scope
-        buf.b1 = b1.retain();
-        buf.b2 = b2.retain();
-        buf.setIndex(0, b1.readableBytes() + b2.readableBytes());
-        return toLeakAwareBuffer(buf);
+        buf.b1 = b1;
+        buf.b2 = b2;
+        return buf;
     }
 
     public ByteBuf getFirst() {
@@ -101,385 +65,50 @@ public final class DoubleByteBuf extends AbstractReferenceCountedByteBuf {
         return b2;
     }
 
-    @Override
-    public boolean isDirect() {
-        return b1.isDirect() && b2.isDirect();
+    public int readableBytes() {
+        return b1.readableBytes() + b2.readableBytes();
     }
 
-    @Override
-    public boolean hasArray() {
-        // There's no single array available
-        return false;
-    }
-
-    @Override
-    public byte[] array() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public int arrayOffset() {
-
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean hasMemoryAddress() {
-        return false;
-    }
-
-    @Override
-    public long memoryAddress() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public int capacity() {
-        return b1.writerIndex() + b2.writerIndex();
-    }
-
-    @Override
-    public int maxCapacity() {
-        return capacity();
-    }
-
-    @Override
-    public int writableBytes() {
-        return 0;
-    }
-
-    @Override
-    public DoubleByteBuf capacity(int newCapacity) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public ByteBufAllocator alloc() {
-        return PooledByteBufAllocator.DEFAULT;
-    }
-
-    @Override
-    public ByteOrder order() {
-        return ByteOrder.BIG_ENDIAN;
-    }
-
-    @Override
-    public byte getByte(int index) {
-        if (index < b1.writerIndex()) {
-            return b1.getByte(index);
-        } else {
-            return b2.getByte(index - b1.writerIndex());
-        }
-    }
-
-    @Override
-    protected byte _getByte(int index) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    protected short _getShort(int index) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    protected int _getUnsignedMedium(int index) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    protected int _getInt(int index) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    protected long _getLong(int index) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public DoubleByteBuf getBytes(int index, byte[] dst, int dstIndex, int length) {
-        return getBytes(index, Unpooled.wrappedBuffer(dst), dstIndex, length);
-    }
-
-    @Override
-    public ByteBuf getBytes(int index, ByteBuffer dst) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public DoubleByteBuf getBytes(int index, ByteBuf dst, int dstIndex, int length) {
-        checkDstIndex(index, length, dstIndex, dst.capacity());
-        if (length == 0) {
-            return this;
-        }
-
-        int b1Length = Math.min(length, b1.readableBytes() - index);
-        if (b1Length > 0) {
-            b1.getBytes(b1.readerIndex() + index, dst, dstIndex, b1Length);
-            dstIndex += b1Length;
-            length -= b1Length;
-            index = 0;
-        } else {
-            index -= b1.readableBytes();
-        }
-
-        if (length > 0) {
-            int b2Length = Math.min(length, b2.readableBytes() - index);
-            b2.getBytes(b2.readerIndex() + index, dst, dstIndex, b2Length);
-        }
-        return this;
-    }
-
-    @Override
-    public int getBytes(int index, GatheringByteChannel out, int length) throws IOException {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public DoubleByteBuf getBytes(int index, OutputStream out, int length) throws IOException {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public DoubleByteBuf setByte(int index, int value) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    protected void _setByte(int index, int value) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public DoubleByteBuf setShort(int index, int value) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    protected void _setShort(int index, int value) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public DoubleByteBuf setMedium(int index, int value) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    protected void _setMedium(int index, int value) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public DoubleByteBuf setInt(int index, int value) {
-        return (DoubleByteBuf) super.setInt(index, value);
-    }
-
-    @Override
-    protected void _setInt(int index, int value) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public DoubleByteBuf setLong(int index, long value) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    protected void _setLong(int index, long value) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public DoubleByteBuf setBytes(int index, byte[] src, int srcIndex, int length) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public DoubleByteBuf setBytes(int index, ByteBuffer src) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public DoubleByteBuf setBytes(int index, ByteBuf src, int srcIndex, int length) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public int setBytes(int index, InputStream in, int length) throws IOException {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public int setBytes(int index, ScatteringByteChannel in, int length) throws IOException {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    protected short _getShortLE(int index) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    protected int _getUnsignedMediumLE(int index) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    protected int _getIntLE(int index) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    protected long _getLongLE(int index) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    protected void _setShortLE(int index, int value) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    protected void _setMediumLE(int index, int value) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    protected void _setIntLE(int index, int value) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    protected void _setLongLE(int index, long value) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public int getBytes(int index, FileChannel out, long position, int length) throws IOException {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public int setBytes(int index, FileChannel in, long position, int length) throws IOException {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public ByteBuf copy(int index, int length) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public int nioBufferCount() {
-        return b1.nioBufferCount() + b2.nioBufferCount();
-    }
-
-    @Override
-    public ByteBuffer internalNioBuffer(int index, int length) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public ByteBuffer nioBuffer(int index, int length) {
-        ByteBuffer dst = ByteBuffer.allocate(length);
-        ByteBuf b = Unpooled.wrappedBuffer(dst);
-        b.writerIndex(0);
-        getBytes(index, b, length);
-        return dst;
-    }
-
-    @Override
-    public ByteBuffer[] nioBuffers(int index, int length) {
-        return new ByteBuffer[] { nioBuffer(index, length) };
-    }
-
-    @Override
-    public DoubleByteBuf discardReadBytes() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public String toString() {
-        String result = super.toString();
-        result = result.substring(0, result.length() - 1);
-        return result + ", components=2)";
-    }
-
-    @Override
-    public ByteBuffer[] nioBuffers() {
-        return nioBuffers(readerIndex(), readableBytes());
+    /**
+     * @return a single buffer with the content of both individual buffers
+     */
+    public ByteBuf coalesce() {
+        ByteBuf b = Unpooled.buffer(readableBytes());
+        b1.getBytes(0, b);
+        b2.getBytes(0, b);
+        return b;
     }
 
     @Override
     protected void deallocate() {
-        // Double release of buffer for the initial ref-count and the internal retain() when the DoubleByteBuf was
-        // created
-        b1.release(2);
-        b2.release(2);
+        b1.release();
+        b2.release();
         b1 = b2 = null;
         recyclerHandle.recycle(this);
     }
 
     @Override
-    public ByteBuf unwrap() {
-        return null;
+    public ReferenceCounted touch(Object hint) {
+        b1.touch(hint);
+        b2.touch(hint);
+        return this;
     }
 
-    private static final Logger log = LoggerFactory.getLogger(DoubleByteBuf.class);
+    public static final Encoder ENCODER = new Encoder();
 
-    private static final ResourceLeakDetector<DoubleByteBuf> leakDetector = ResourceLeakDetectorFactory.instance()
-            .newResourceLeakDetector(DoubleByteBuf.class);
-    private static final Constructor<ByteBuf> simpleLeakAwareByteBufConstructor;
-    private static final Constructor<ByteBuf> advancedLeakAwareByteBufConstructor;
+    @Sharable
+    public static class Encoder extends ChannelOutboundHandlerAdapter {
+        @Override
+        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+            if (msg instanceof DoubleByteBuf) {
+                DoubleByteBuf b = (DoubleByteBuf) msg;
 
-    static {
-        Constructor<ByteBuf> _simpleLeakAwareByteBufConstructor = null;
-        Constructor<ByteBuf> _advancedLeakAwareByteBufConstructor = null;
-        try {
-            Class<?> simpleLeakAwareByteBufClass = Class.forName("io.netty.buffer.SimpleLeakAwareByteBuf");
-            _simpleLeakAwareByteBufConstructor = (Constructor<ByteBuf>) simpleLeakAwareByteBufClass
-                    .getDeclaredConstructor(ByteBuf.class, ResourceLeakTracker.class);
-            _simpleLeakAwareByteBufConstructor.setAccessible(true);
-
-            Class<?> advancedLeakAwareByteBufClass = Class.forName("io.netty.buffer.AdvancedLeakAwareByteBuf");
-            _advancedLeakAwareByteBufConstructor = (Constructor<ByteBuf>) advancedLeakAwareByteBufClass
-                    .getDeclaredConstructor(ByteBuf.class, ResourceLeakTracker.class);
-            _advancedLeakAwareByteBufConstructor.setAccessible(true);
-        } catch (Exception e) {
-            log.error("Failed to use reflection to enable leak detection");
-        } finally {
-            simpleLeakAwareByteBufConstructor = _simpleLeakAwareByteBufConstructor;
-            advancedLeakAwareByteBufConstructor = _advancedLeakAwareByteBufConstructor;
-        }
-    }
-
-    private static ByteBuf toLeakAwareBuffer(DoubleByteBuf buf) {
-        try {
-            ResourceLeakTracker<DoubleByteBuf> leak;
-            switch (ResourceLeakDetector.getLevel()) {
-            case DISABLED:
-                break;
-
-            case SIMPLE:
-                leak = leakDetector.track(buf);
-                if (leak != null) {
-                    return simpleLeakAwareByteBufConstructor.newInstance(buf, leak);
-                }
-                break;
-            case ADVANCED:
-            case PARANOID:
-                leak = leakDetector.track(buf);
-                if (leak != null) {
-                    return advancedLeakAwareByteBufConstructor.newInstance(buf, leak);
-                }
-                break;
+                ctx.write(b.getFirst(), ctx.voidPromise());
+                ctx.write(b.getSecond(), promise);
+            } else {
+                ctx.write(msg, promise);
             }
-            return buf;
-        } catch (Throwable t) {
-            // Catch reflection exception
-            throw new RuntimeException(t);
         }
     }
+
 }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/api/ByteBufPairTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/api/ByteBufPairTest.java
@@ -20,21 +20,20 @@ package org.apache.pulsar.common.api;
 
 import static org.testng.Assert.assertEquals;
 
-import org.apache.pulsar.common.api.DoubleByteBuf;
+import org.apache.pulsar.common.api.ByteBufPair;
 import org.testng.annotations.Test;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 
-public class DoubleByteBufTest {
+public class ByteBufPairTest {
 
     @Test
     public void testDoubleByteBuf() throws Exception {
-
         ByteBuf b1 = PooledByteBufAllocator.DEFAULT.heapBuffer(128, 128);
         b1.writerIndex(b1.capacity());
         ByteBuf b2 = PooledByteBufAllocator.DEFAULT.heapBuffer(128, 128);
         b2.writerIndex(b2.capacity());
-        DoubleByteBuf buf = DoubleByteBuf.get(b1, b2);
+        ByteBufPair buf = ByteBufPair.get(b1, b2);
 
         assertEquals(buf.readableBytes(), 256);
         assertEquals(buf.getFirst(), b1);

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/api/DoubleByteBufTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/api/DoubleByteBufTest.java
@@ -27,48 +27,22 @@ import io.netty.buffer.PooledByteBufAllocator;
 
 public class DoubleByteBufTest {
 
-    /**
-     * Verify that readableBytes() returns writerIndex - readerIndex. In this case writerIndex is the end of the buffer
-     * and readerIndex is increased by 64.
-     *
-     * @throws Exception
-     */
     @Test
-    public void testReadableBytes() throws Exception {
+    public void testDoubleByteBuf() throws Exception {
 
         ByteBuf b1 = PooledByteBufAllocator.DEFAULT.heapBuffer(128, 128);
         b1.writerIndex(b1.capacity());
         ByteBuf b2 = PooledByteBufAllocator.DEFAULT.heapBuffer(128, 128);
         b2.writerIndex(b2.capacity());
-        ByteBuf buf = DoubleByteBuf.get(b1, b2);
+        DoubleByteBuf buf = DoubleByteBuf.get(b1, b2);
 
-        assertEquals(buf.readerIndex(), 0);
-        assertEquals(buf.writerIndex(), 256);
         assertEquals(buf.readableBytes(), 256);
+        assertEquals(buf.getFirst(), b1);
+        assertEquals(buf.getSecond(), b2);
 
-        for (int i = 0; i < 4; ++i) {
-            buf.skipBytes(64);
-            assertEquals(buf.readableBytes(), 256 - 64 * (i + 1));
-        }
-
-        buf.release();
-
-        assertEquals(buf.refCnt(), 0);
-        assertEquals(b1.refCnt(), 0);
-        assertEquals(b2.refCnt(), 0);
-    }
-
-    @Test
-    public void testCapacity() throws Exception {
-
-        ByteBuf b1 = PooledByteBufAllocator.DEFAULT.heapBuffer(128, 128);
-        b1.writerIndex(b1.capacity());
-        ByteBuf b2 = PooledByteBufAllocator.DEFAULT.heapBuffer(128, 128);
-        b2.writerIndex(b2.capacity());
-        ByteBuf buf = DoubleByteBuf.get(b1, b2);
-
-        assertEquals(buf.capacity(), 256);
-        assertEquals(buf.maxCapacity(), 256);
+        assertEquals(buf.refCnt(), 1);
+        assertEquals(b1.refCnt(), 1);
+        assertEquals(b2.refCnt(), 1);
 
         buf.release();
 
@@ -76,4 +50,5 @@ public class DoubleByteBufTest {
         assertEquals(b1.refCnt(), 0);
         assertEquals(b2.refCnt(), 0);
     }
+
 }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/compression/CommandsTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/compression/CommandsTest.java
@@ -22,12 +22,11 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 
 import org.apache.pulsar.checksum.utils.Crc32cChecksum;
 import org.apache.pulsar.common.api.Commands;
-import org.apache.pulsar.common.api.DoubleByteBuf;
 import org.apache.pulsar.common.api.Commands.ChecksumType;
+import org.apache.pulsar.common.api.DoubleByteBuf;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
 import org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream;
 import org.testng.annotations.Test;
@@ -48,20 +47,19 @@ public class CommandsTest {
         MessageMetadata messageMetadata = MessageMetadata.newBuilder().setPublishTime(System.currentTimeMillis())
                 .setProducerName(producerName).setSequenceId(sequenceId).build();
         int expectedChecksum = computeChecksum(messageMetadata, data);
-        ByteBuf clientCommand = Commands.newSend(1, 0, 1, ChecksumType.Crc32c, messageMetadata, data);
+        DoubleByteBuf clientCommand = Commands.newSend(1, 0, 1, ChecksumType.Crc32c, messageMetadata, data);
         clientCommand.retain();
-        ByteBuffer inputBytes = clientCommand.nioBuffer();
-        ByteBuf receivedBuf = Unpooled.wrappedBuffer(inputBytes);
+        ByteBuf receivedBuf = clientCommand.coalesce();
         receivedBuf.skipBytes(4); //skip [total-size]
         int cmdSize = (int) receivedBuf.readUnsignedInt();
         receivedBuf.readerIndex(8 + cmdSize);
         int startMessagePos = receivedBuf.readerIndex();
-        
+
         /*** 1. verify checksum and metadataParsing ***/
         boolean hasChecksum = Commands.hasChecksum(receivedBuf);
         int checksum = Commands.readChecksum(receivedBuf).intValue();
-        
-        
+
+
         // verify checksum is present
         assertTrue(hasChecksum);
         // verify checksum value
@@ -69,13 +67,13 @@ public class CommandsTest {
         MessageMetadata metadata = Commands.parseMessageMetadata(receivedBuf);
         // verify metadata parsing
         assertEquals(metadata.getProducerName(), producerName);
-        
-        /** 2. parseMessageMetadata should skip checksum if present **/  
+
+        /** 2. parseMessageMetadata should skip checksum if present **/
         receivedBuf.readerIndex(startMessagePos);
         metadata = Commands.parseMessageMetadata(receivedBuf);
         // verify metadata parsing
         assertEquals(metadata.getProducerName(), producerName);
-        
+
     }
 
     private int computeChecksum(MessageMetadata msgMetadata, ByteBuf compressedPayload) throws IOException {
@@ -86,12 +84,12 @@ public class CommandsTest {
         metaPayloadFrame.writeInt(metadataSize);
         msgMetadata.writeTo(outStream);
         ByteBuf payload = compressedPayload.copy();
-        ByteBuf metaPayloadBuf = DoubleByteBuf.get(metaPayloadFrame, payload);
-        int computedChecksum = Crc32cChecksum.computeChecksum(metaPayloadBuf); 
+        DoubleByteBuf metaPayloadBuf = DoubleByteBuf.get(metaPayloadFrame, payload);
+        int computedChecksum = Crc32cChecksum.computeChecksum(metaPayloadBuf.coalesce());
         outStream.recycle();
         metaPayloadBuf.release();
         return computedChecksum;
     }
 
-    
+
 }


### PR DESCRIPTION
### Motivation

To avoid the overhead in copying the components of a DoubleByteBuf into a temp buffer, we should treat it as a simple holder of a pair of buffers, without trying to mimic the `ByteBuf` interface. 

That makes it for a much simpler implementation with no overhead.