### PR TITLE
Force to use Django 1.11 in Pulsar Dashboard

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update
 RUN apt-get -y install postgresql python sudo nginx supervisor
 
 # Python dependencies
-RUN pip install uwsgi Django psycopg2 pytz requests
+RUN pip install uwsgi 'Django<2.0' psycopg2 pytz requests
 
 # Postgres configuration
 COPY conf/postgresql.conf /etc/postgresql/9.4/main/


### PR DESCRIPTION
### Motivation

Build master build in Jenkins is currently failing when creating the `pulsar-dashboard` Docker image at the end of the build job. 

The reason it's failing is that it's pulling in the latest Django version (2.0) that only supports Python-3.0. Eg: 

```
Collecting Django
  Downloading Django-2.0.tar.gz (8.0MB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-vsYydS/Django/setup.py", line 32, in <module>
        version = __import__('django').get_version()
      File "django/__init__.py", line 1, in <module>
        from django.utils.version import get_version
      File "django/utils/version.py", line 61, in <module>
        @functools.lru_cache()
    AttributeError: 'module' object has no attribute 'lru_cache'
```

### Modifications

Since we use Python 2.7, we need to stick with Django version < 2.0.