### PR TITLE
Include BoringSSL native implementation for faster TLS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@ flexible messaging model and an intuitive client API.</description>
 
     <bookkeeper.version>4.3.1.85-yahoo</bookkeeper.version>
     <zookeeper.version>3.4.10</zookeeper.version>
-    <netty.version>4.1.12.Final</netty.version>
+    <netty.version>4.1.20.Final</netty.version>
     <storm.version>1.0.5</storm.version>
     <jetty.version>9.3.11.v20160721</jetty.version>
     <athenz.version>1.7.17</athenz.version>

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -123,6 +123,7 @@ import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.AdaptiveRecvByteBufAllocator;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
+import io.netty.handler.ssl.SslContext;
 import io.netty.util.concurrent.DefaultThreadFactory;
 
 public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies> {
@@ -289,7 +290,8 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
             ServerBootstrap tlsBootstrap = bootstrap.clone();
             tlsBootstrap.childHandler(new PulsarChannelInitializer(this, serviceConfig, true));
             tlsBootstrap.bind(new InetSocketAddress(pulsar.getBindAddress(), tlsPort)).sync();
-            log.info("Started Pulsar Broker TLS service on port {}", tlsPort);
+            log.info("Started Pulsar Broker TLS service on port {} - TLS provider: {}", tlsPort,
+                    SslContext.defaultServerProvider());
         }
 
         // start other housekeeping functions

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -510,7 +510,7 @@ public class BrokerServiceTest extends BrokerTestBase {
             consumer.close();
             fail("should fail");
         } catch (Exception e) {
-            assertTrue(e.getMessage().contains("General SSLEngine problem"));
+            assertTrue(e.getMessage().contains("General OpenSslEngine problem"));
         } finally {
             pulsarClient.close();
         }

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -75,6 +75,8 @@
                   <include>com.fasterxml.jackson.core</include>
                   <include>io.netty:netty</include>
                   <include>io.netty:netty-all</include>
+                  <include>io.netty:netty-tcnative-boringssl-static</include>
+                  
                   <include>org.apache.pulsar:pulsar-common</include>
                   <include>org.apache.pulsar:pulsar-checksum</include>
                   <include>net.jpountz.lz4:lz4</include>

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -70,5 +70,11 @@
       <artifactId>pulsar-checksum</artifactId>
       <version>${project.version}</version>
     </dependency>
+    
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative-boringssl-static</artifactId>
+      <version>2.0.7.Final</version>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
### Motivation

Fixes #1028 

### Modifications

Include Netty-tc-native with statically linked BoringSSL for Linux/Mac/Windows. This will use the native implementation of OpenSSL instead of the JDK version.

### Result

Faster TLS encryption and much less garbage generated.