### PR TITLE
Validate expected types in Python code wrapper

### DIFF
--- a/pulsar-client-cpp/python/pulsar.py
+++ b/pulsar-client-cpp/python/pulsar.py
@@ -247,26 +247,16 @@ class Client:
           Configure whether the Pulsar client accepts untrusted TLS certificates
           from the broker.
         """
-        if type(service_url) is not str:
-            raise ValueError("service_url is expected to be a string")
-        if authentication is not None and not isinstance(authentication, Authentication):
-            raise ValueError("authentication is expected to be of type Authentication")
-        if type(operation_timeout_seconds) is not int:
-            raise ValueError("operation_timeout_seconds is expected to be an int")
-        if type(io_threads) is not int:
-            raise ValueError("io_threads is expected to be an int")
-        if type(message_listener_threads) is not int:
-            raise ValueError("message_listener_threads is expected to be an int")
-        if type(concurrent_lookup_requests) is not int:
-            raise ValueError("concurrent_lookup_requests is expected to be an int")
-        if log_conf_file_path is not None and type(log_conf_file_path) is not str:
-            raise ValueError("log_conf_file_path is expected to be a string")
-        if type(use_tls) is not bool:
-            raise ValueError("use_tls is expected to be a boolean")
-        if tls_trust_certs_file_path is not None and type(tls_trust_certs_file_path) is not str:
-            raise ValueError("tls_trust_certs_file_path is expected to be a string")
-        if type(tls_allow_insecure_connection) is not bool:
-            raise ValueError("tls_allow_insecure_connection is expected to be a boolean")
+        _check_type(str, service_url, 'service_url')
+        _check_type_or_none(Authentication, authentication, 'authentication')
+        _check_type(int, operation_timeout_seconds, 'operation_timeout_seconds')
+        _check_type(int, io_threads, 'io_threads')
+        _check_type(int, message_listener_threads, 'message_listener_threads')
+        _check_type(int, concurrent_lookup_requests, 'concurrent_lookup_requests')
+        _check_type_or_none(str, log_conf_file_path, 'log_conf_file_path')
+        _check_type(bool, use_tls, 'use_tls')
+        _check_type_or_none(str, tls_trust_certs_file_path, 'tls_trust_certs_file_path')
+        _check_type(bool, tls_allow_insecure_connection, 'tls_allow_insecure_connection')
 
         conf = _pulsar.ClientConfiguration()
         if authentication:
@@ -331,28 +321,17 @@ class Client:
         * `message_routing_mode`:
           Set the message routing mode for the partitioned producer.
         """
-        if type(topic) is not str:
-            raise ValueError("topic is expected to be a string")
-        if producer_name is not None and type(producer_name) is not str:
-            raise ValueError("producer_name is expected to be a string")
-        if initial_sequence_id is not None and type(initial_sequence_id) is not int:
-            raise ValueError("initial_sequence_id is expected to be an integer")
-        if type(send_timeout_millis) is not int:
-            raise ValueError("send_timeout_millis is expected to be an integer")
-        if not isinstance(compression_type, CompressionType):
-            raise ValueError("compression_type is expected to be a enum")
-        if type(max_pending_messages) is not int:
-            raise ValueError("max_pending_messages is expected to be an integer")
-        if type(block_if_queue_full) is not bool:
-            raise ValueError("block_if_queue_full is expected to be a boolean")
-        if type(batching_enabled) is not bool:
-            raise ValueError("batching_enabled is expected to be a boolean")
-        if type(batching_max_messages) is not int:
-            raise ValueError("batching_max_messages is expected to be an integer")
-        if type(batching_max_allowed_size_in_bytes) is not int:
-            raise ValueError("batching_max_allowed_size_in_bytes is expected to be an integer")
-        if type(batching_max_publish_delay_ms) is not int:
-            raise ValueError("batching_max_publish_delay_ms is expected to be an integer")
+        _check_type(str, topic, 'topic')
+        _check_type(str, producer_name, 'producer_name')
+        _check_type_or_none(int, initial_sequence_id, 'initial_sequence_id')
+        _check_type(int, send_timeout_millis, 'send_timeout_millis')
+        _check_type(CompressionType, compression_type, 'compression_type')
+        _check_type(int, max_pending_messages, 'max_pending_messages')
+        _check_type(bool, block_if_queue_full, 'block_if_queue_full')
+        _check_type(bool, batching_enabled, 'batching_enabled')
+        _check_type(int, batching_max_messages, 'batching_max_messages')
+        _check_type(int, batching_max_allowed_size_in_bytes, 'batching_max_allowed_size_in_bytes')
+        _check_type(int, batching_max_publish_delay_ms, 'batching_max_publish_delay_ms')
 
         conf = _pulsar.ProducerConfiguration()
         conf.send_timeout_millis(send_timeout_millis)
@@ -428,20 +407,13 @@ class Client:
           Sets the time duration for which the broker-side consumer stats will
           be cached in the client.
         """
-        if type(topic) is not str:
-            raise ValueError("topic is expected to be a string")
-        if type(subscription_name) is not str:
-            raise ValueError("subscription_name is expected to be a string")
-        if not isinstance(consumer_type, ConsumerType):
-            raise ValueError("consumer_type is expected to be an enum")
-        if type(receiver_queue_size) is not int:
-            raise ValueError("receiver_queue_size is expected to be an integer")
-        if consumer_name is not None and type(consumer_name) is not str:
-            raise ValueError("consumer_name is expected to be a string")
-        if unacked_messages_timeout_ms is not None and type(unacked_messages_timeout_ms) is not int:
-            raise ValueError("unacked_messages_timeout_ms is expected to be an integer")
-        if type(broker_consumer_stats_cache_time_ms) is not int:
-            raise ValueError("broker_consumer_stats_cache_time_ms is expected to be an integer")
+        _check_type(str, topic, 'topic')
+        _check_type(str, subscription_name, 'subscription_name')
+        _check_type(ConsumerType, consumer_type, 'consumer_type')
+        _check_type(int, receiver_queue_size, 'receiver_queue_size')
+        _check_type_or_none(int, consumer_name, 'consumer_name')
+        _check_type_or_none(int, unacked_messages_timeout_ms, 'unacked_messages_timeout_ms')
+        _check_type(int, broker_consumer_stats_cache_time_ms, 'broker_consumer_stats_cache_time_ms')
 
         conf = _pulsar.ConsumerConfiguration()
         conf.consumer_type(consumer_type)
@@ -507,14 +479,10 @@ class Client:
         * `reader_name`:
           Sets the reader name.
         """
-        if type(topic) is not str:
-            raise ValueError("topic is expected to be a string")
-        if not isinstance(start_message_id, _pulsar.MessageId):
-            raise ValueError("start_message_id is expected to be a MessageId")
-        if type(receiver_queue_size) is not int:
-            raise ValueError("receiver_queue_size is expected to be an integer")
-        if reader_name is not None and type(reader_name) is not str:
-            raise ValueError("reader_name is expected to be a string")
+        _check_type(str, topic, 'topic')
+        _check_type(_pulsar.MessageId, start_message_id, 'start_message_id')
+        _check_type(int, receiver_queue_size, 'receiver_queue_size')
+        _check_type(str, reader_name, 'reader_name')
 
         conf = _pulsar.ReaderConfiguration()
         if reader_listener:
@@ -660,18 +628,12 @@ class Producer:
 
     def _build_msg(self, content, properties, partition_key, sequence_id,
                    replication_clusters, disable_replication):
-        if type(content) is not bytes:
-            raise ValueError("content is expected to be of type bytes")
-        if properties is not None and type(properties) is not dict:
-            raise ValueError("properties is expected to be a dict")
-        if partition_key is not None and type(partition_key) is not str:
-            raise ValueError("partition_key is expected to be a string")
-        if sequence_id is not None and type(sequence_id) is not int:
-            raise ValueError("sequence_id is expected to be an integer")
-        if replication_clusters is not None and type(replication_clusters) is not list:
-            raise ValueError("replication_clusters is expected to be a list")
-        if type(disable_replication) is not bool:
-            raise ValueError("disable_replication is expected to be a boolean")
+        _check_type(bytes, content, 'content')
+        _check_type_or_none(dict, properties, 'properties')
+        _check_type_or_none(str, partition_key, 'partition_key')
+        _check_type_or_none(int, sequence_id, 'sequence_id')
+        _check_type_or_none(list, replication_clusters, 'replication_clusters')
+        _check_type(bool, disable_replication, 'disable_replication')
 
         mb = _pulsar.MessageBuilder()
         mb.content(content)
@@ -733,9 +695,8 @@ class Consumer:
         """
         if timeout_millis is None:
             return self._consumer.receive()
-        elif type(timeout_millis) is not int:
-            raise ValueError("timeout_millis is expected to be an integer")
         else:
+            _check_type(int, timeout_millis, 'timeout_millis')
             return self._consumer.receive(timeout_millis)
 
     def acknowledge(self, message):
@@ -827,9 +788,8 @@ class Reader:
         """
         if timeout_millis is None:
             return self._reader.read_next()
-        elif type(timeout_millis) is not int:
-            raise ValueError("timeout_millis is expected to be an integer")
         else:
+            _check_type(int, timeout_millis, 'timeout_millis')
             return self._reader.read_next(timeout_millis)
 
     def close(self):
@@ -838,3 +798,14 @@ class Reader:
         """
         self._reader.close()
         self._client._consumers.remove(self)
+
+
+def _check_type(var_type, var, name):
+    if not isinstance(var, var_type):
+        raise ValueError("Argument %s is expected to be of type '%s'" % (name, var_type.__name__))
+
+
+def _check_type_or_none(var_type, var, name):
+    if var is not None and not isinstance(var, var_type):
+        raise ValueError("Argument %s is expected to be either None or of type '%s'"
+                         % (name, var_type.__name__))

--- a/pulsar-client-cpp/python/pulsar.py
+++ b/pulsar-client-cpp/python/pulsar.py
@@ -320,7 +320,7 @@ class Client:
           Set the message routing mode for the partitioned producer.
         """
         _check_type(str, topic, 'topic')
-        _check_type(str, producer_name, 'producer_name')
+        _check_type_or_none(str, producer_name, 'producer_name')
         _check_type_or_none(int, initial_sequence_id, 'initial_sequence_id')
         _check_type(int, send_timeout_millis, 'send_timeout_millis')
         _check_type(CompressionType, compression_type, 'compression_type')
@@ -409,7 +409,7 @@ class Client:
         _check_type(str, subscription_name, 'subscription_name')
         _check_type(ConsumerType, consumer_type, 'consumer_type')
         _check_type(int, receiver_queue_size, 'receiver_queue_size')
-        _check_type_or_none(int, consumer_name, 'consumer_name')
+        _check_type_or_none(str, consumer_name, 'consumer_name')
         _check_type_or_none(int, unacked_messages_timeout_ms, 'unacked_messages_timeout_ms')
         _check_type(int, broker_consumer_stats_cache_time_ms, 'broker_consumer_stats_cache_time_ms')
 
@@ -480,7 +480,7 @@ class Client:
         _check_type(str, topic, 'topic')
         _check_type(_pulsar.MessageId, start_message_id, 'start_message_id')
         _check_type(int, receiver_queue_size, 'receiver_queue_size')
-        _check_type(str, reader_name, 'reader_name')
+        _check_type_or_none(str, reader_name, 'reader_name')
 
         conf = _pulsar.ReaderConfiguration()
         if reader_listener:

--- a/pulsar-client-cpp/python/pulsar.py
+++ b/pulsar-client-cpp/python/pulsar.py
@@ -185,10 +185,8 @@ class Authentication:
         * `authParamsString`: Comma-separated list of provider-specific
           configuration params
         """
-        if type(dynamicLibPath) is not str:
-            raise ValueError("dynamicLibPath is expected to be a string")
-        if type(authParamsString) is not str:
-            raise ValueError("authParamsString is expected to be a string")
+        _check_type(str, dynamicLibPath, 'dynamicLibPath')
+        _check_type(str, authParamsString, 'authParamsString')
         self.auth = _pulsar.Authentication(dynamicLibPath, authParamsString)
 
 

--- a/pulsar-client-cpp/python/pulsar.py
+++ b/pulsar-client-cpp/python/pulsar.py
@@ -185,6 +185,10 @@ class Authentication:
         * `authParamsString`: Comma-separated list of provider-specific
           configuration params
         """
+        if type(dynamicLibPath) is not str:
+            raise ValueError("dynamicLibPath is expected to be a string")
+        if type(authParamsString) is not str:
+            raise ValueError("authParamsString is expected to be a string")
         self.auth = _pulsar.Authentication(dynamicLibPath, authParamsString)
 
 
@@ -243,6 +247,27 @@ class Client:
           Configure whether the Pulsar client accepts untrusted TLS certificates
           from the broker.
         """
+        if type(service_url) is not str:
+            raise ValueError("service_url is expected to be a string")
+        if authentication is not None and not isinstance(authentication, Authentication):
+            raise ValueError("authentication is expected to be of type Authentication")
+        if type(operation_timeout_seconds) is not int:
+            raise ValueError("operation_timeout_seconds is expected to be an int")
+        if type(io_threads) is not int:
+            raise ValueError("io_threads is expected to be an int")
+        if type(message_listener_threads) is not int:
+            raise ValueError("message_listener_threads is expected to be an int")
+        if type(concurrent_lookup_requests) is not int:
+            raise ValueError("concurrent_lookup_requests is expected to be an int")
+        if log_conf_file_path is not None and type(log_conf_file_path) is not str:
+            raise ValueError("log_conf_file_path is expected to be a string")
+        if type(use_tls) is not bool:
+            raise ValueError("use_tls is expected to be a boolean")
+        if tls_trust_certs_file_path is not None and type(tls_trust_certs_file_path) is not str:
+            raise ValueError("tls_trust_certs_file_path is expected to be a string")
+        if type(tls_allow_insecure_connection) is not bool:
+            raise ValueError("tls_allow_insecure_connection is expected to be a boolean")
+
         conf = _pulsar.ClientConfiguration()
         if authentication:
             conf.authentication(authentication.auth)
@@ -306,6 +331,29 @@ class Client:
         * `message_routing_mode`:
           Set the message routing mode for the partitioned producer.
         """
+        if type(topic) is not str:
+            raise ValueError("topic is expected to be a string")
+        if producer_name is not None and type(producer_name) is not str:
+            raise ValueError("producer_name is expected to be a string")
+        if initial_sequence_id is not None and type(initial_sequence_id) is not int:
+            raise ValueError("initial_sequence_id is expected to be an integer")
+        if type(send_timeout_millis) is not int:
+            raise ValueError("send_timeout_millis is expected to be an integer")
+        if not isinstance(compression_type, CompressionType):
+            raise ValueError("compression_type is expected to be a enum")
+        if type(max_pending_messages) is not int:
+            raise ValueError("max_pending_messages is expected to be an integer")
+        if type(block_if_queue_full) is not bool:
+            raise ValueError("block_if_queue_full is expected to be a boolean")
+        if type(batching_enabled) is not bool:
+            raise ValueError("batching_enabled is expected to be a boolean")
+        if type(batching_max_messages) is not int:
+            raise ValueError("batching_max_messages is expected to be an integer")
+        if type(batching_max_allowed_size_in_bytes) is not int:
+            raise ValueError("batching_max_allowed_size_in_bytes is expected to be an integer")
+        if type(batching_max_publish_delay_ms) is not int:
+            raise ValueError("batching_max_publish_delay_ms is expected to be an integer")
+
         conf = _pulsar.ProducerConfiguration()
         conf.send_timeout_millis(send_timeout_millis)
         conf.compression_type(compression_type)
@@ -380,6 +428,21 @@ class Client:
           Sets the time duration for which the broker-side consumer stats will
           be cached in the client.
         """
+        if type(topic) is not str:
+            raise ValueError("topic is expected to be a string")
+        if type(subscription_name) is not str:
+            raise ValueError("subscription_name is expected to be a string")
+        if not isinstance(consumer_type, ConsumerType):
+            raise ValueError("consumer_type is expected to be an enum")
+        if type(receiver_queue_size) is not int:
+            raise ValueError("receiver_queue_size is expected to be an integer")
+        if consumer_name is not None and type(consumer_name) is not str:
+            raise ValueError("consumer_name is expected to be a string")
+        if unacked_messages_timeout_ms is not None and type(unacked_messages_timeout_ms) is not int:
+            raise ValueError("unacked_messages_timeout_ms is expected to be an integer")
+        if type(broker_consumer_stats_cache_time_ms) is not int:
+            raise ValueError("broker_consumer_stats_cache_time_ms is expected to be an integer")
+
         conf = _pulsar.ConsumerConfiguration()
         conf.consumer_type(consumer_type)
         if message_listener:
@@ -444,6 +507,15 @@ class Client:
         * `reader_name`:
           Sets the reader name.
         """
+        if type(topic) is not str:
+            raise ValueError("topic is expected to be a string")
+        if not isinstance(start_message_id, _pulsar.MessageId):
+            raise ValueError("start_message_id is expected to be a MessageId")
+        if type(receiver_queue_size) is not int:
+            raise ValueError("receiver_queue_size is expected to be an integer")
+        if reader_name is not None and type(reader_name) is not str:
+            raise ValueError("reader_name is expected to be a string")
+
         conf = _pulsar.ReaderConfiguration()
         if reader_listener:
             conf.reader_listener(reader_listener)
@@ -588,6 +660,19 @@ class Producer:
 
     def _build_msg(self, content, properties, partition_key, sequence_id,
                    replication_clusters, disable_replication):
+        if type(content) is not bytes:
+            raise ValueError("content is expected to be of type bytes")
+        if properties is not None and type(properties) is not dict:
+            raise ValueError("properties is expected to be a dict")
+        if partition_key is not None and type(partition_key) is not str:
+            raise ValueError("partition_key is expected to be a string")
+        if sequence_id is not None and type(sequence_id) is not int:
+            raise ValueError("sequence_id is expected to be an integer")
+        if replication_clusters is not None and type(replication_clusters) is not list:
+            raise ValueError("replication_clusters is expected to be a list")
+        if type(disable_replication) is not bool:
+            raise ValueError("disable_replication is expected to be a boolean")
+
         mb = _pulsar.MessageBuilder()
         mb.content(content)
         if properties:
@@ -648,6 +733,8 @@ class Consumer:
         """
         if timeout_millis is None:
             return self._consumer.receive()
+        elif type(timeout_millis) is not int:
+            raise ValueError("timeout_millis is expected to be an integer")
         else:
             return self._consumer.receive(timeout_millis)
 
@@ -740,6 +827,8 @@ class Reader:
         """
         if timeout_millis is None:
             return self._reader.read_next()
+        elif type(timeout_millis) is not int:
+            raise ValueError("timeout_millis is expected to be an integer")
         else:
             return self._reader.read_next(timeout_millis)
 

--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -320,6 +320,268 @@ class PulsarTest(TestCase):
             # Exception is expected
             pass
 
+    def test_message_argument_errors(self):
+        client = Client(self.serviceUrl)
+        topic = 'persistent://sample/standalone/ns1/my-python-test-producer'
+        producer = client.create_producer(topic)
+
+        content = 'test'.encode('utf-8')
+
+        try:
+            producer.send(5)
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            producer.send(content, properties='test')
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            producer.send(content, partition_key=5)
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            producer.send(content, sequence_id='test')
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            producer.send(content, replication_clusters=5)
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            producer.send(content, disable_replication='test')
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        client.close()
+
+    def test_client_argument_errors(self):
+        try:
+            Client(None)
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            Client(self.serviceUrl, authentication="test")
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            Client(self.serviceUrl, operation_timeout_seconds="test")
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            Client(self.serviceUrl, io_threads="test")
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            Client(self.serviceUrl, message_listener_threads="test")
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            Client(self.serviceUrl, concurrent_lookup_requests="test")
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            Client(self.serviceUrl, log_conf_file_path=5)
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            Client(self.serviceUrl, use_tls="test")
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            Client(self.serviceUrl, tls_trust_certs_file_path=5)
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            Client(self.serviceUrl, tls_allow_insecure_connection="test")
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+    def test_producer_argument_errors(self):
+        client = Client(self.serviceUrl)
+
+        try:
+            client.create_producer(None)
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        topic = 'persistent://sample/standalone/ns1/my-python-test-producer'
+
+        try:
+            client.create_producer(topic, producer_name=5)
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            client.create_producer(topic, initial_sequence_id='test')
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            client.create_producer(topic, send_timeout_millis='test')
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            client.create_producer(topic, compression_type=None)
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            client.create_producer(topic, max_pending_messages='test')
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            client.create_producer(topic, block_if_queue_full='test')
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            client.create_producer(topic, batching_enabled='test')
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            client.create_producer(topic, batching_enabled='test')
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            client.create_producer(topic, batching_max_allowed_size_in_bytes='test')
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            client.create_producer(topic, batching_max_publish_delay_ms='test')
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        client.close()
+
+    def test_consumer_argument_errors(self):
+        client = Client(self.serviceUrl)
+
+        topic = 'persistent://sample/standalone/ns1/my-python-test-producer'
+        sub_name = 'my-sub-name'
+
+        try:
+            client.subscribe(None, sub_name)
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            client.subscribe(topic, None)
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            client.subscribe(topic, sub_name, consumer_type=None)
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            client.subscribe(topic, sub_name, receiver_queue_size='test')
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            client.subscribe(topic, sub_name, consumer_name=5)
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            client.subscribe(topic, sub_name, unacked_messages_timeout_ms='test')
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            client.subscribe(topic, sub_name, broker_consumer_stats_cache_time_ms='test')
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        client.close()
+
+    def test_reader_argument_errors(self):
+        client = Client(self.serviceUrl)
+        topic = 'persistent://sample/standalone/ns1/my-python-test-producer'
+
+        # This should not raise exception
+        client.create_reader(topic, MessageId.earliest)
+
+        try:
+            client.create_reader(None, MessageId.earliest)
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            client.create_reader(topic, None)
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            client.create_reader(topic, MessageId.earliest, receiver_queue_size='test')
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        try:
+            client.create_reader(topic, MessageId.earliest, reader_name=5)
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
+
+        client.close()
+
 
 if __name__ == '__main__':
     main()

--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -248,7 +248,8 @@ class PulsarTest(TestCase):
                    'true')
         client = Client(self.serviceUrl)
 
-        topic = 'persistent://sample/standalone/ns1/my-python-test-producer-sequence-after-reconnection-' + str(time.time())
+        topic = 'persistent://sample/standalone/ns1/my-python-test-producer-sequence-after-reconnection-' \
+            + str(time.time())
 
         producer = client.create_producer(topic, producer_name='my-producer-name')
         self.assertEqual(producer.last_sequence_id(), -1)
@@ -327,176 +328,43 @@ class PulsarTest(TestCase):
 
         content = 'test'.encode('utf-8')
 
-        try:
-            producer.send(5)
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            producer.send(content, properties='test')
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            producer.send(content, partition_key=5)
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            producer.send(content, sequence_id='test')
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            producer.send(content, replication_clusters=5)
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            producer.send(content, disable_replication='test')
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
+        self._check_value_error(lambda: producer.send(5))
+        self._check_value_error(lambda: producer.send(content, properties='test'))
+        self._check_value_error(lambda: producer.send(content, partition_key=5))
+        self._check_value_error(lambda: producer.send(content, sequence_id='test'))
+        self._check_value_error(lambda: producer.send(content, replication_clusters=5))
+        self._check_value_error(lambda: producer.send(content, disable_replication='test'))
         client.close()
 
     def test_client_argument_errors(self):
-        try:
-            Client(None)
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            Client(self.serviceUrl, authentication="test")
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            Client(self.serviceUrl, operation_timeout_seconds="test")
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            Client(self.serviceUrl, io_threads="test")
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            Client(self.serviceUrl, message_listener_threads="test")
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            Client(self.serviceUrl, concurrent_lookup_requests="test")
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            Client(self.serviceUrl, log_conf_file_path=5)
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            Client(self.serviceUrl, use_tls="test")
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            Client(self.serviceUrl, tls_trust_certs_file_path=5)
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            Client(self.serviceUrl, tls_allow_insecure_connection="test")
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
+        self._check_value_error(lambda: Client(None))
+        self._check_value_error(lambda: Client(self.serviceUrl, authentication="test"))
+        self._check_value_error(lambda: Client(self.serviceUrl, operation_timeout_seconds="test"))
+        self._check_value_error(lambda: Client(self.serviceUrl, io_threads="test"))
+        self._check_value_error(lambda: Client(self.serviceUrl, message_listener_threads="test"))
+        self._check_value_error(lambda: Client(self.serviceUrl, concurrent_lookup_requests="test"))
+        self._check_value_error(lambda: Client(self.serviceUrl, log_conf_file_path=5))
+        self._check_value_error(lambda: Client(self.serviceUrl, use_tls="test"))
+        self._check_value_error(lambda: Client(self.serviceUrl, tls_trust_certs_file_path=5))
+        self._check_value_error(lambda: Client(self.serviceUrl, tls_allow_insecure_connection="test"))
 
     def test_producer_argument_errors(self):
         client = Client(self.serviceUrl)
 
-        try:
-            client.create_producer(None)
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
+        self._check_value_error(lambda: client.create_producer(None))
 
         topic = 'persistent://sample/standalone/ns1/my-python-test-producer'
 
-        try:
-            client.create_producer(topic, producer_name=5)
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            client.create_producer(topic, initial_sequence_id='test')
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            client.create_producer(topic, send_timeout_millis='test')
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            client.create_producer(topic, compression_type=None)
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            client.create_producer(topic, max_pending_messages='test')
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            client.create_producer(topic, block_if_queue_full='test')
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            client.create_producer(topic, batching_enabled='test')
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            client.create_producer(topic, batching_enabled='test')
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            client.create_producer(topic, batching_max_allowed_size_in_bytes='test')
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            client.create_producer(topic, batching_max_publish_delay_ms='test')
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
+        self._check_value_error(lambda: client.create_producer(topic, producer_name=5))
+        self._check_value_error(lambda: client.create_producer(topic, initial_sequence_id='test'))
+        self._check_value_error(lambda: client.create_producer(topic, send_timeout_millis='test'))
+        self._check_value_error(lambda: client.create_producer(topic, compression_type=None))
+        self._check_value_error(lambda: client.create_producer(topic, max_pending_messages='test'))
+        self._check_value_error(lambda: client.create_producer(topic, block_if_queue_full='test'))
+        self._check_value_error(lambda: client.create_producer(topic, batching_enabled='test'))
+        self._check_value_error(lambda: client.create_producer(topic, batching_enabled='test'))
+        self._check_value_error(lambda: client.create_producer(topic, batching_max_allowed_size_in_bytes='test'))
+        self._check_value_error(lambda: client.create_producer(topic, batching_max_publish_delay_ms='test'))
         client.close()
 
     def test_consumer_argument_errors(self):
@@ -505,48 +373,13 @@ class PulsarTest(TestCase):
         topic = 'persistent://sample/standalone/ns1/my-python-test-producer'
         sub_name = 'my-sub-name'
 
-        try:
-            client.subscribe(None, sub_name)
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            client.subscribe(topic, None)
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            client.subscribe(topic, sub_name, consumer_type=None)
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            client.subscribe(topic, sub_name, receiver_queue_size='test')
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            client.subscribe(topic, sub_name, consumer_name=5)
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            client.subscribe(topic, sub_name, unacked_messages_timeout_ms='test')
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            client.subscribe(topic, sub_name, broker_consumer_stats_cache_time_ms='test')
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
+        self._check_value_error(lambda: client.subscribe(None, sub_name))
+        self._check_value_error(lambda: client.subscribe(topic, None))
+        self._check_value_error(lambda: client.subscribe(topic, sub_name, consumer_type=None))
+        self._check_value_error(lambda: client.subscribe(topic, sub_name, receiver_queue_size='test'))
+        self._check_value_error(lambda: client.subscribe(topic, sub_name, consumer_name=5))
+        self._check_value_error(lambda: client.subscribe(topic, sub_name, unacked_messages_timeout_ms='test'))
+        self._check_value_error(lambda: client.subscribe(topic, sub_name, broker_consumer_stats_cache_time_ms='test'))
         client.close()
 
     def test_reader_argument_errors(self):
@@ -556,31 +389,19 @@ class PulsarTest(TestCase):
         # This should not raise exception
         client.create_reader(topic, MessageId.earliest)
 
-        try:
-            client.create_reader(None, MessageId.earliest)
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            client.create_reader(topic, None)
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            client.create_reader(topic, MessageId.earliest, receiver_queue_size='test')
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
-        try:
-            client.create_reader(topic, MessageId.earliest, reader_name=5)
-            self.assertTrue(False)
-        except ValueError:
-            pass  # Expected
-
+        self._check_value_error(lambda: client.create_reader(None, MessageId.earliest))
+        self._check_value_error(lambda: client.create_reader(topic, None))
+        self._check_value_error(lambda: client.create_reader(topic, MessageId.earliest, receiver_queue_size='test'))
+        self._check_value_error(lambda: client.create_reader(topic, MessageId.earliest, reader_name=5))
         client.close()
+
+    def _check_value_error(self, fun):
+        try:
+            fun()
+            # Should throw exception
+            self.assertTrue(False)
+        except ValueError:
+            pass  # Expected
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Motivation

Fixes #1092 

Always validate the expected argument types and raise `ValueError` instead of letting the boost-python wrapper to raise exception with C++ template errors: 

Example of error: 

```
Traceback (most recent call last):
  File "pulsar_test.py", line 325, in test_argument_errors
    Client(None)
  File "/Users/mmerli/prg/pulsar/pulsar-client-cpp/python/pulsar.py", line 259, in __init__
    self._client = _pulsar.Client(service_url, conf)
Boost.Python.ArgumentError: Python argument types in
    Client.__init__(Client, NoneType, ClientConfiguration)
did not match C++ signature:
    __init__(_object*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, pulsar::ClientConfiguration)
```
