### PR TITLE
Support ztsUrl parameter in athenz client plugin

### DIFF
--- a/pulsar-client-auth-athenz/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationAthenz.java
+++ b/pulsar-client-auth-athenz/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationAthenz.java
@@ -56,6 +56,7 @@ public class AuthenticationAthenz implements Authentication, EncodedAuthenticati
     private static final String APPLICATION_X_PEM_FILE_BASE64 = "application/x-pem-file;base64";
 
     private transient ZTSClient ztsClient = null;
+    private String ztsUrl;
     private String tenantDomain;
     private String tenantService;
     private String providerDomain;
@@ -150,6 +151,9 @@ public class AuthenticationAthenz implements Authentication, EncodedAuthenticati
         if (authParams.containsKey("roleHeader")) {
             System.setProperty("athenz.auth.role.header", authParams.get("roleHeader"));
         }
+        if (authParams.containsKey("ztsUrl")) {
+            this.ztsUrl = authParams.get("ztsUrl");
+        }
     }
 
     @Override
@@ -164,7 +168,7 @@ public class AuthenticationAthenz implements Authentication, EncodedAuthenticati
         if (ztsClient == null) {
             ServiceIdentityProvider siaProvider = new SimpleServiceIdentityProvider(tenantDomain, tenantService,
                     privateKey, keyId);
-            ztsClient = new ZTSClient(null, tenantDomain, tenantService, siaProvider);
+            ztsClient = new ZTSClient(ztsUrl, tenantDomain, tenantService, siaProvider);
         }
         return ztsClient;
     }

--- a/pulsar-client-auth-athenz/src/test/java/org/apache/pulsar/client/impl/auth/AuthenticationAthenzTest.java
+++ b/pulsar-client-auth-athenz/src/test/java/org/apache/pulsar/client/impl/auth/AuthenticationAthenzTest.java
@@ -111,6 +111,14 @@ public class AuthenticationAthenzTest {
     }
 
     @Test
+    public void testZtsUrl() throws Exception {
+        Field field = auth.getClass().getDeclaredField("ztsUrl");
+        field.setAccessible(true);
+        String ztsUrl = (String) field.get(auth);
+        assertEquals(ztsUrl, "https://localhost:4443/");
+    }
+
+    @Test
     public void testLoadPrivateKeyBase64() throws Exception {
         try {
             String paramsStr = new String(Files.readAllBytes(Paths.get("./src/test/resources/authParams.json")));

--- a/pulsar-client-auth-athenz/src/test/resources/authParams.json
+++ b/pulsar-client-auth-athenz/src/test/resources/authParams.json
@@ -2,5 +2,6 @@
 	"tenantService": "test_service",
 	"privateKey": "./src/test/resources/tenant_private.pem",
 	"providerDomain": "test_provider",
-	"tenantDomain": "test_tenant"
+	"tenantDomain": "test_tenant",
+	"ztsUrl": "https://localhost:4443/"
 }


### PR DESCRIPTION
### Motivation
Currently, we have to place athenz configuration file for zts url.

### Modifications
Enable zts url to be specified by authParams.

### Result
clients don't need conf file to specify zts url.