### PR TITLE
PIP-13-1/3: Provide `TopicsConsumer` to consume from several topics under same namespace

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentQueueE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentQueueE2ETest.java
@@ -539,11 +539,11 @@ public class PersistentQueueE2ETest extends BrokerTestBase {
             producer.send(("hello-" + i).getBytes());
         }
 
-        Set<MessageIdImpl> c1_receivedMessages = new HashSet<>();
+        Set<MessageId> c1_receivedMessages = new HashSet<>();
 
         // C-1 gets all messages but doesn't ack
         for (int i = 0; i < numMsgs; i++) {
-            c1_receivedMessages.add((MessageIdImpl) consumer1.receive().getMessageId());
+            c1_receivedMessages.add(consumer1.receive().getMessageId());
         }
 
         // C-2 will not get any message initially, since everything went to C-1 already

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
@@ -1,0 +1,333 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import com.google.common.collect.Lists;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.ConsumerConfiguration;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerConfiguration;
+import org.apache.pulsar.client.api.ProducerConfiguration.MessageRoutingMode;
+import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.common.policies.data.PropertyAdmin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class TopicsConsumerImplTest extends ProducerConsumerBase {
+    private static final long testTimeout = 90000; // 1.5 min
+    private static final Logger log = LoggerFactory.getLogger(TopicsConsumerImplTest.class);
+    private final long ackTimeOutMillis = TimeUnit.SECONDS.toMillis(2);
+
+    @Override
+    @BeforeMethod
+    public void setup() throws Exception {
+        super.internalSetup();
+    }
+
+    @Override
+    @AfterMethod
+    public void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test(timeOut = testTimeout)
+    public void testSyncProducerAndConsumer() throws Exception {
+        String key = "TopicsConsumerSyncTest";
+        final String subscriptionName = "my-ex-subscription-" + key;
+        final String messagePredicate = "my-message-" + key + "-";
+        final int totalMessages = 30;
+
+        final String topicName1 = "persistent://prop/use/ns-abc/topic-1-" + key;
+        final String topicName2 = "persistent://prop/use/ns-abc/topic-2-" + key;
+        final String topicName3 = "persistent://prop/use/ns-abc/topic-3-" + key;
+        List<String> topicNames = Lists.newArrayList(topicName1, topicName2, topicName3);
+
+        admin.properties().createProperty("prop", new PropertyAdmin());
+        admin.persistentTopics().createPartitionedTopic(topicName2, 2);
+        admin.persistentTopics().createPartitionedTopic(topicName3, 3);
+
+        ProducerConfiguration producerConfiguration = new ProducerConfiguration();
+        producerConfiguration.setMessageRoutingMode(MessageRoutingMode.RoundRobinPartition);
+
+        // 1. producer connect
+        Producer producer1 = pulsarClient.createProducer(topicName1);
+        Producer producer2 = pulsarClient.createProducer(topicName2, producerConfiguration);
+        Producer producer3 = pulsarClient.createProducer(topicName3, producerConfiguration);
+
+        // 2. Create consumer
+        ConsumerConfiguration conf = new ConsumerConfiguration();
+        conf.setReceiverQueueSize(4);
+        conf.setAckTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS);
+        conf.setSubscriptionType(SubscriptionType.Shared);
+        Consumer consumer = pulsarClient.subscribeAsync(topicNames, subscriptionName, conf).get();
+        assertTrue(consumer instanceof TopicsConsumerImpl);
+
+        // 3. producer publish messages
+        for (int i = 0; i < totalMessages / 3; i++) {
+            producer1.send((messagePredicate + "producer1-" + i).getBytes());
+            producer2.send((messagePredicate + "producer2-" + i).getBytes());
+            producer3.send((messagePredicate + "producer3-" + i).getBytes());
+        }
+
+        HashSet<String> messageSet = new HashSet<>();
+        Message message = consumer.receive();
+        do {
+            assertTrue(message instanceof TopicMessageImpl);
+            messageSet.add(new String(message.getData()));
+            consumer.acknowledge(message);
+            log.info("Consumer acknowledged : " + new String(message.getData()));
+            message = consumer.receive(500, TimeUnit.MILLISECONDS);
+        } while (message != null);
+        assertEquals(messageSet.size(), totalMessages);
+        consumer.close();
+        producer1.close();
+        producer2.close();
+        producer3.close();
+    }
+
+    @Test(timeOut = testTimeout)
+    public void testAsyncConsumer() throws Exception {
+        String key = "TopicsConsumerAsyncTest";
+        final String subscriptionName = "my-ex-subscription-" + key;
+        final String messagePredicate = "my-message-" + key + "-";
+        final int totalMessages = 30;
+
+        final String topicName1 = "persistent://prop/use/ns-abc/topic-1-" + key;
+        final String topicName2 = "persistent://prop/use/ns-abc/topic-2-" + key;
+        final String topicName3 = "persistent://prop/use/ns-abc/topic-3-" + key;
+        List<String> topicNames = Lists.newArrayList(topicName1, topicName2, topicName3);
+
+        admin.properties().createProperty("prop", new PropertyAdmin());
+        admin.persistentTopics().createPartitionedTopic(topicName2, 2);
+        admin.persistentTopics().createPartitionedTopic(topicName3, 3);
+
+        ProducerConfiguration producerConfiguration = new ProducerConfiguration();
+        producerConfiguration.setMessageRoutingMode(MessageRoutingMode.RoundRobinPartition);
+
+        // 1. producer connect
+        Producer producer1 = pulsarClient.createProducer(topicName1);
+        Producer producer2 = pulsarClient.createProducer(topicName2, producerConfiguration);
+        Producer producer3 = pulsarClient.createProducer(topicName3, producerConfiguration);
+
+        // 2. Create consumer
+        ConsumerConfiguration conf = new ConsumerConfiguration();
+        conf.setReceiverQueueSize(4);
+        conf.setAckTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS);
+        conf.setSubscriptionType(SubscriptionType.Shared);
+        Consumer consumer = pulsarClient.subscribeAsync(topicNames, subscriptionName, conf).get();
+        assertTrue(consumer instanceof TopicsConsumerImpl);
+
+        // Asynchronously produce messages
+        List<Future<MessageId>> futures = Lists.newArrayList();
+        for (int i = 0; i < totalMessages / 3; i++) {
+            futures.add(producer1.sendAsync((messagePredicate + "producer1-" + i).getBytes()));
+            futures.add(producer2.sendAsync((messagePredicate + "producer2-" + i).getBytes()));
+            futures.add(producer3.sendAsync((messagePredicate + "producer3-" + i).getBytes()));
+        }
+        log.info("Waiting for async publish to complete : {}", futures.size());
+        for (Future<MessageId> future : futures) {
+            future.get();
+        }
+
+        log.info("start async consume");
+        CountDownLatch latch = new CountDownLatch(totalMessages);
+        ExecutorService executor = Executors.newFixedThreadPool(1);
+        executor.execute(() -> IntStream.range(0, totalMessages).forEach(index ->
+            consumer.receiveAsync()
+                .thenAccept(msg -> {
+                    assertTrue(msg instanceof TopicMessageImpl);
+                    try {
+                        consumer.acknowledge(msg);
+                    } catch (PulsarClientException e1) {
+                        fail("message acknowledge failed", e1);
+                    }
+                    latch.countDown();
+                    log.info("receive index: {}, latch countDown: {}", index, latch.getCount());
+                })
+                .exceptionally(ex -> {
+                    log.warn("receive index: {}, failed receive message {}", index, ex.getMessage());
+                    ex.printStackTrace();
+                    return null;
+                })));
+
+        log.info("start wait");
+        latch.await();
+        log.info("success latch wait");
+        consumer.close();
+        producer1.close();
+        producer2.close();
+        producer3.close();
+    }
+
+    @Test(timeOut = testTimeout)
+    public void testConsumerUnackedRedelivery() throws Exception {
+        String key = "TopicsConsumerRedeliveryTest";
+        final String subscriptionName = "my-ex-subscription-" + key;
+        final String messagePredicate = "my-message-" + key + "-";
+        final int totalMessages = 30;
+
+        final String topicName1 = "persistent://prop/use/ns-abc/topic-1-" + key;
+        final String topicName2 = "persistent://prop/use/ns-abc/topic-2-" + key;
+        final String topicName3 = "persistent://prop/use/ns-abc/topic-3-" + key;
+        List<String> topicNames = Lists.newArrayList(topicName1, topicName2, topicName3);
+
+        admin.properties().createProperty("prop", new PropertyAdmin());
+        admin.persistentTopics().createPartitionedTopic(topicName2, 2);
+        admin.persistentTopics().createPartitionedTopic(topicName3, 3);
+
+        ProducerConfiguration producerConfiguration = new ProducerConfiguration();
+        producerConfiguration.setMessageRoutingMode(MessageRoutingMode.RoundRobinPartition);
+
+        // 1. producer connect
+        Producer producer1 = pulsarClient.createProducer(topicName1);
+        Producer producer2 = pulsarClient.createProducer(topicName2, producerConfiguration);
+        Producer producer3 = pulsarClient.createProducer(topicName3, producerConfiguration);
+
+        // 2. Create consumer
+        ConsumerConfiguration conf = new ConsumerConfiguration();
+        conf.setReceiverQueueSize(4);
+        conf.setAckTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS);
+        conf.setSubscriptionType(SubscriptionType.Shared);
+        Consumer consumer = pulsarClient.subscribeAsync(topicNames, subscriptionName, conf).get();
+        assertTrue(consumer instanceof TopicsConsumerImpl);
+
+        // 3. producer publish messages
+        for (int i = 0; i < totalMessages / 3; i++) {
+            producer1.send((messagePredicate + "producer1-" + i).getBytes());
+            producer2.send((messagePredicate + "producer2-" + i).getBytes());
+            producer3.send((messagePredicate + "producer3-" + i).getBytes());
+        }
+
+        // 4. Receiver receives the message, not ack, Unacked Message Tracker size should be totalMessages.
+        Message message = consumer.receive();
+        while (message != null) {
+            assertTrue(message instanceof TopicMessageImpl);
+            log.info("Consumer received : " + new String(message.getData()));
+            message = consumer.receive(500, TimeUnit.MILLISECONDS);
+        }
+        long size = ((TopicsConsumerImpl) consumer).getUnAckedMessageTracker().size();
+        log.info(key + " Unacked Message Tracker size is " + size);
+        assertEquals(size, totalMessages);
+
+        // 5. Blocking call, redeliver should kick in, after receive and ack, Unacked Message Tracker size should be 0.
+        message = consumer.receive();
+        log.info("Consumer received : " + new String(message.getData()));
+
+        HashSet<String> hSet = new HashSet<>();
+        do {
+            assertTrue(message instanceof TopicMessageImpl);
+            hSet.add(new String(message.getData()));
+            consumer.acknowledge(message);
+            log.info("Consumer acknowledged : " + new String(message.getData()));
+            message = consumer.receive(500, TimeUnit.MILLISECONDS);
+        } while (message != null);
+
+        size = ((TopicsConsumerImpl) consumer).getUnAckedMessageTracker().size();
+        log.info(key + " Unacked Message Tracker size is " + size);
+        assertEquals(size, 0);
+        assertEquals(hSet.size(), totalMessages);
+
+        // 6. producer publish more messages
+        for (int i = 0; i < totalMessages / 3; i++) {
+            producer1.send((messagePredicate + "producer1-round2" + i).getBytes());
+            producer2.send((messagePredicate + "producer2-round2" + i).getBytes());
+            producer3.send((messagePredicate + "producer3-round2" + i).getBytes());
+        }
+
+        // 7. Receiver receives the message, ack them
+        message = consumer.receive();
+        int received = 0;
+        while (message != null) {
+            assertTrue(message instanceof TopicMessageImpl);
+            received++;
+            String data = new String(message.getData());
+            log.info("Consumer received : " + data);
+            consumer.acknowledge(message);
+            message = consumer.receive(100, TimeUnit.MILLISECONDS);
+        }
+        size = ((TopicsConsumerImpl) consumer).getUnAckedMessageTracker().size();
+        log.info(key + " Unacked Message Tracker size is " + size);
+        assertEquals(size, 0);
+        assertEquals(received, totalMessages);
+
+        // 8. Simulate ackTimeout
+        ((TopicsConsumerImpl) consumer).getUnAckedMessageTracker().toggle();
+        ((TopicsConsumerImpl) consumer).getConsumers().forEach(c -> c.getUnAckedMessageTracker().toggle());
+
+        // 9. producer publish more messages
+        for (int i = 0; i < totalMessages / 3; i++) {
+            producer1.send((messagePredicate + "producer1-round3" + i).getBytes());
+            producer2.send((messagePredicate + "producer2-round3" + i).getBytes());
+            producer3.send((messagePredicate + "producer3-round3" + i).getBytes());
+        }
+
+        // 10. Receiver receives the message, doesn't ack
+        message = consumer.receive();
+        while (message != null) {
+            String data = new String(message.getData());
+            log.info("Consumer received : " + data);
+            message = consumer.receive(100, TimeUnit.MILLISECONDS);
+        }
+        size = ((TopicsConsumerImpl) consumer).getUnAckedMessageTracker().size();
+        log.info(key + " Unacked Message Tracker size is " + size);
+        assertEquals(size, 30);
+
+        Thread.sleep(ackTimeOutMillis);
+
+        // 11. Receiver receives redelivered messages
+        message = consumer.receive();
+        int redelivered = 0;
+        while (message != null) {
+            assertTrue(message instanceof TopicMessageImpl);
+            redelivered++;
+            String data = new String(message.getData());
+            log.info("Consumer received : " + data);
+            consumer.acknowledge(message);
+            message = consumer.receive(100, TimeUnit.MILLISECONDS);
+        }
+        assertEquals(redelivered, 30);
+        size =  ((TopicsConsumerImpl) consumer).getUnAckedMessageTracker().size();
+        log.info(key + " Unacked Message Tracker size is " + size);
+        assertEquals(size, 0);
+
+        consumer.close();
+        producer1.close();
+        producer2.close();
+        producer3.close();
+    }
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
@@ -22,6 +22,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+import com.google.common.collect.Lists;
 import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -31,7 +32,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
-
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerConfiguration;
 import org.apache.pulsar.client.api.Message;
@@ -48,8 +48,6 @@ import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.Lists;
 
 public class TopicsConsumerImplTest extends ProducerConsumerBase {
     private static final long testTimeout = 90000; // 1.5 min
@@ -520,4 +518,5 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         producer2.close();
         producer3.close();
     }
+
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/Message.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/Message.java
@@ -124,4 +124,14 @@ public interface Message {
      * @return the key of the message
      */
     String getKey();
+
+    /**
+     * Get the topic name of this message.
+     * This is mainly for TopicsConsumerImpl to identify a message belongs to which topic.
+     *
+     * @return the topic name
+     */
+    default String getTopicName() {
+        return null;
+    }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/Message.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/Message.java
@@ -124,14 +124,4 @@ public interface Message {
      * @return the key of the message
      */
     String getKey();
-
-    /**
-     * Get the topic name of this message.
-     * This is mainly for TopicsConsumerImpl to identify a message belongs to which topic.
-     *
-     * @return the topic name
-     */
-    default String getTopicName() {
-        return null;
-    }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/MessageId.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/MessageId.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.client.api;
 
 import java.io.IOException;
-
 import org.apache.pulsar.client.impl.MessageIdImpl;
 
 /**
@@ -36,6 +35,16 @@ public interface MessageId extends Comparable<MessageId>{
      * Serialize the message ID into a byte array
      */
     byte[] toByteArray();
+
+    /**
+     * Get the topic name of this MessageId.
+     * This is mainly for TopicsConsumerImpl to identify a message belongs to which topic.
+     *
+     * @return the topic name
+     */
+    default String getTopicName() {
+        return null;
+    }
 
     /**
      * De-serialize a message id from a byte array

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/MessageId.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/MessageId.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.client.api;
 
 import java.io.IOException;
+
 import org.apache.pulsar.client.impl.MessageIdImpl;
 
 /**
@@ -35,16 +36,6 @@ public interface MessageId extends Comparable<MessageId>{
      * Serialize the message ID into a byte array
      */
     byte[] toByteArray();
-
-    /**
-     * Get the topic name of this MessageId.
-     * This is mainly for TopicsConsumerImpl to identify a message belongs to which topic.
-     *
-     * @return the topic name
-     */
-    default String getTopicName() {
-        return null;
-    }
 
     /**
      * De-serialize a message id from a byte array

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/PulsarClient.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/PulsarClient.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.client.api;
 
 import java.io.Closeable;
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.pulsar.client.impl.PulsarClientImpl;
@@ -245,4 +246,60 @@ public interface PulsarClient extends Closeable {
      *             if the forceful shutdown fails
      */
     void shutdown() throws PulsarClientException;
+
+
+    /**
+     * Subscribe to the given topic and subscription combination with default {@code ConsumerConfiguration}
+     *
+     * @param topics
+     *            The collection of topic names, they should be under same namespace
+     * @param subscription
+     *            The name of the subscription
+     * @return The {@code Consumer} object
+     * @throws PulsarClientException
+     */
+    Consumer subscribe(Collection<String> topics, String subscription) throws PulsarClientException;
+
+    /**
+     * Asynchronously subscribe to the given topics and subscription combination with
+     * default {@code ConsumerConfiguration}
+     *
+     * @param topics
+     *            The collection of topic names, they should be under same namespace
+     * @param subscription
+     *            The name of the subscription
+     * @return Future of the {@code Consumer} object
+     */
+    CompletableFuture<Consumer> subscribeAsync(Collection<String> topics, String subscription);
+
+    /**
+     * Subscribe to the given topics and subscription combination using given {@code ConsumerConfiguration}
+     *
+     * @param topics
+     *            The collection of topic names, they should be under same namespace
+     * @param subscription
+     *            The name of the subscription
+     * @param conf
+     *            The {@code ConsumerConfiguration} object
+     * @return Future of the {@code Consumer} object
+     */
+    Consumer subscribe(Collection<String> topics, String subscription, ConsumerConfiguration conf)
+        throws PulsarClientException;
+
+    /**
+     * Asynchronously subscribe to the given topics and subscription combination using given
+     * {@code ConsumerConfiguration}
+     *
+     * @param topics
+     *            The collection of topic names, they should be under same namespace
+     * @param subscription
+     *            The name of the subscription
+     * @param conf
+     *            The {@code ConsumerConfiguration} object
+     * @return Future of the {@code Consumer} object
+     */
+    CompletableFuture<Consumer> subscribeAsync(Collection<String> topics,
+                                               String subscription,
+                                               ConsumerConfiguration conf);
+
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.impl;
 
+import com.google.common.collect.Queues;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -27,7 +28,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerConfiguration;
 import org.apache.pulsar.client.api.Message;
@@ -40,8 +40,6 @@ import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.collections.GrowableArrayBlockingQueue;
-
-import com.google.common.collect.Queues;
 
 public abstract class ConsumerBase extends HandlerBase implements Consumer {
 
@@ -57,7 +55,7 @@ public abstract class ConsumerBase extends HandlerBase implements Consumer {
     protected final ExecutorService listenerExecutor;
     final BlockingQueue<Message> incomingMessages;
     protected final ConcurrentLinkedQueue<CompletableFuture<Message>> pendingReceives;
-    protected final int maxReceiverQueueSize;
+    protected int maxReceiverQueueSize;
 
     protected ConsumerBase(PulsarClientImpl client, String topic, String subscription, ConsumerConfiguration conf,
             int receiverQueueSize, ExecutorService listenerExecutor, CompletableFuture<Consumer> subscribeFuture) {
@@ -330,7 +328,7 @@ public abstract class ConsumerBase extends HandlerBase implements Consumer {
      * the connected consumers. This is a non blocking call and doesn't throw an exception. In case the connection
      * breaks, the messages are redelivered after reconnect.
      */
-    protected abstract void redeliverUnacknowledgedMessages(Set<MessageIdImpl> messageIds);
+    protected abstract void redeliverUnacknowledgedMessages(Set<MessageId> messageIds);
 
     @Override
     public String toString() {
@@ -340,4 +338,9 @@ public abstract class ConsumerBase extends HandlerBase implements Consumer {
                 ", topic='" + topic + '\'' +
                 '}';
     }
+
+    protected void setMaxReceiverQueueSize(int newSize) {
+        this.maxReceiverQueueSize = newSize;
+    }
+
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -18,10 +18,19 @@
  */
 package org.apache.pulsar.client.impl;
 
+import static com.google.common.base.Preconditions.checkState;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import io.netty.channel.EventLoopGroup;
+import io.netty.util.HashedWheelTimer;
+import io.netty.util.Timer;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import java.util.Collection;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -29,7 +38,6 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-
 import org.apache.pulsar.client.api.ClientConfiguration;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerConfiguration;
@@ -49,14 +57,6 @@ import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.netty.EventLoopUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-
-import io.netty.channel.EventLoopGroup;
-import io.netty.util.HashedWheelTimer;
-import io.netty.util.Timer;
-import io.netty.util.concurrent.DefaultThreadFactory;
 
 public class PulsarClientImpl implements PulsarClient {
 
@@ -279,6 +279,104 @@ public class PulsarClientImpl implements PulsarClient {
         });
 
         return consumerSubscribedFuture;
+    }
+
+
+    @Override
+    public Consumer subscribe(Collection<String> topics, final String subscription) throws PulsarClientException {
+        return subscribe(topics, subscription, new ConsumerConfiguration());
+    }
+
+    @Override
+    public Consumer subscribe(Collection<String> topics,
+                              String subscription,
+                              ConsumerConfiguration conf)
+        throws PulsarClientException {
+        try {
+            return subscribeAsync(topics, subscription, conf).get();
+        } catch (ExecutionException e) {
+            Throwable t = e.getCause();
+            if (t instanceof PulsarClientException) {
+                throw (PulsarClientException) t;
+            } else {
+                throw new PulsarClientException(t);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new PulsarClientException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Consumer> subscribeAsync(Collection<String> topics, String subscription) {
+        return subscribeAsync(topics, subscription, new ConsumerConfiguration());
+    }
+
+    @Override
+    public CompletableFuture<Consumer> subscribeAsync(Collection<String> topics,
+                                                      String subscription,
+                                                      ConsumerConfiguration conf) {
+        if (topics == null || topics.isEmpty()) {
+            return FutureUtil.failedFuture(new PulsarClientException.InvalidTopicNameException("Empty topics name"));
+        }
+        if (topics.size() == 1) {
+            return subscribeAsync(topics.stream().findFirst().get(), subscription, conf);
+        }
+
+        if (state.get() != State.Open) {
+            return FutureUtil.failedFuture(new PulsarClientException.AlreadyClosedException("Client already closed"));
+        }
+        if (topicsNameInvalid(topics)) {
+            return FutureUtil.failedFuture(new PulsarClientException.InvalidTopicNameException("Invalid topic name"));
+        }
+        if (isBlank(subscription)) {
+            return FutureUtil
+                .failedFuture(new PulsarClientException.InvalidConfigurationException("Empty subscription name"));
+        }
+        if (conf == null) {
+            return FutureUtil.failedFuture(
+                new PulsarClientException.InvalidConfigurationException("Consumer configuration undefined"));
+        }
+
+        CompletableFuture<Consumer> consumerSubscribedFuture = new CompletableFuture<>();
+
+        ConsumerBase consumer = new TopicsConsumerImpl(PulsarClientImpl.this, topics, subscription,
+            conf, externalExecutorProvider.getExecutor(),
+            consumerSubscribedFuture);
+        synchronized (consumers) {
+            consumers.put(consumer, Boolean.TRUE);
+        }
+
+        return consumerSubscribedFuture;
+    }
+
+    // Check topics are valid.
+    // - each topic is valid,
+    // - every topic has same namespace.
+    private boolean topicsNameInvalid(Collection<String> topics) {
+        checkState(topics != null && topics.size() > 1,
+            "topics should should contain more than 1 topics");
+
+        final String namespace = DestinationName.get(topics.stream().findFirst().get()).getNamespace();
+
+        Optional<String> result = topics.stream()
+            .filter(topic -> {
+                boolean topicInvalid = !DestinationName.isValid(topic);
+                if (topicInvalid) {
+                    return true;
+                }
+
+                String newNamespace =  DestinationName.get(topic).getNamespace();
+                if (!namespace.equals(newNamespace)) {
+                    return true;
+                } else {
+                    return false;
+                }
+            }).findFirst();
+        if (result.isPresent()) {
+            log.warn("[{}] Received invalid topic name.  {}/{}", result.get());
+        }
+        return result.isPresent();
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -18,19 +18,11 @@
  */
 package org.apache.pulsar.client.impl;
 
-import static com.google.common.base.Preconditions.checkState;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import io.netty.channel.EventLoopGroup;
-import io.netty.util.HashedWheelTimer;
-import io.netty.util.Timer;
-import io.netty.util.concurrent.DefaultThreadFactory;
 import java.util.Collection;
 import java.util.IdentityHashMap;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -38,6 +30,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+
 import org.apache.pulsar.client.api.ClientConfiguration;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerConfiguration;
@@ -57,6 +50,14 @@ import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.netty.EventLoopUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.util.HashedWheelTimer;
+import io.netty.util.Timer;
+import io.netty.util.concurrent.DefaultThreadFactory;
 
 public class PulsarClientImpl implements PulsarClient {
 
@@ -319,16 +320,11 @@ public class PulsarClientImpl implements PulsarClient {
         if (topics == null || topics.isEmpty()) {
             return FutureUtil.failedFuture(new PulsarClientException.InvalidTopicNameException("Empty topics name"));
         }
-        if (topics.size() == 1) {
-            return subscribeAsync(topics.stream().findFirst().get(), subscription, conf);
-        }
 
         if (state.get() != State.Open) {
             return FutureUtil.failedFuture(new PulsarClientException.AlreadyClosedException("Client already closed"));
         }
-        if (topicsNameInvalid(topics)) {
-            return FutureUtil.failedFuture(new PulsarClientException.InvalidTopicNameException("Invalid topic name"));
-        }
+
         if (isBlank(subscription)) {
             return FutureUtil
                 .failedFuture(new PulsarClientException.InvalidConfigurationException("Empty subscription name"));
@@ -348,35 +344,6 @@ public class PulsarClientImpl implements PulsarClient {
         }
 
         return consumerSubscribedFuture;
-    }
-
-    // Check topics are valid.
-    // - each topic is valid,
-    // - every topic has same namespace.
-    private boolean topicsNameInvalid(Collection<String> topics) {
-        checkState(topics != null && topics.size() > 1,
-            "topics should should contain more than 1 topics");
-
-        final String namespace = DestinationName.get(topics.stream().findFirst().get()).getNamespace();
-
-        Optional<String> result = topics.stream()
-            .filter(topic -> {
-                boolean topicInvalid = !DestinationName.isValid(topic);
-                if (topicInvalid) {
-                    return true;
-                }
-
-                String newNamespace =  DestinationName.get(topic).getNamespace();
-                if (!namespace.equals(newNamespace)) {
-                    return true;
-                } else {
-                    return false;
-                }
-            }).findFirst();
-        if (result.isPresent()) {
-            log.warn("[{}] Received invalid topic name.  {}/{}", result.get());
-        }
-        return result.isPresent();
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageIdImpl.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import org.apache.pulsar.client.api.MessageId;
+
+public class TopicMessageIdImpl implements MessageId {
+    private final String topicName;
+    private final MessageId messageId;
+
+    TopicMessageIdImpl(String topicName, MessageId messageId) {
+        this.topicName = topicName;
+        this.messageId = messageId;
+    }
+
+    @Override
+    public String getTopicName() {
+        return topicName;
+    }
+
+    public MessageId getInnerMessageId() {
+        return messageId;
+    }
+
+    @Override
+    public byte[] toByteArray() {
+        return messageId.toByteArray();
+    }
+
+    @Override
+    public int compareTo(MessageId o) {
+        return messageId.compareTo(o);
+    }
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageIdImpl.java
@@ -29,7 +29,6 @@ public class TopicMessageIdImpl implements MessageId {
         this.messageId = messageId;
     }
 
-    @Override
     public String getTopicName() {
         return topicName;
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageImpl.java
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.pulsar.client.impl;
 
 import java.util.Map;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageImpl.java
@@ -1,0 +1,79 @@
+package org.apache.pulsar.client.impl;
+
+import java.util.Map;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+
+public class TopicMessageImpl implements Message {
+
+    private final String topicName;
+    private final Message msg;
+    private final MessageId msgId;
+
+    TopicMessageImpl(String topicName,
+                     Message msg) {
+        this.topicName = topicName;
+        this.msg = msg;
+        this.msgId = new TopicMessageIdImpl(topicName, msg.getMessageId());
+    }
+
+    @Override
+    public String getTopicName() {
+        return topicName;
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        return msg.getProperties();
+    }
+
+    @Override
+    public boolean hasProperty(String name) {
+        return msg.hasProperty(name);
+    }
+
+    @Override
+    public String getProperty(String name) {
+        return msg.getProperty(name);
+    }
+
+    @Override
+    public byte[] getData() {
+        return msg.getData();
+    }
+
+    @Override
+    public MessageId getMessageId() {
+        return msgId;
+    }
+
+    @Override
+    public long getPublishTime() {
+        return msg.getPublishTime();
+    }
+
+    @Override
+    public long getEventTime() {
+        return msg.getEventTime();
+    }
+
+    @Override
+    public long getSequenceId() {
+        return msg.getSequenceId();
+    }
+
+    @Override
+    public String getProducerName() {
+        return msg.getProducerName();
+    }
+
+    @Override
+    public boolean hasKey() {
+        return msg.hasKey();
+    }
+
+    @Override
+    public String getKey() {
+        return msg.getKey();
+    }
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageImpl.java
@@ -36,9 +36,17 @@ public class TopicMessageImpl implements Message {
         this.msgId = new TopicMessageIdImpl(topicName, msg.getMessageId());
     }
 
-    @Override
+    /**
+     * Get the topic name of this message.
+     * @return the name of the topic on which this message was published
+     */
     public String getTopicName() {
         return topicName;
+    }
+
+    @Override
+    public MessageId getMessageId() {
+        return msgId;
     }
 
     @Override
@@ -59,11 +67,6 @@ public class TopicMessageImpl implements Message {
     @Override
     public byte[] getData() {
         return msg.getData();
-    }
-
-    @Override
-    public MessageId getMessageId() {
-        return msgId;
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicsConsumerImpl.java
@@ -19,11 +19,14 @@
 package org.apache.pulsar.client.impl;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -33,24 +36,23 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
-
+import java.util.stream.IntStream;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerConfiguration;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.util.FutureUtil;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType;
 import org.apache.pulsar.common.naming.DestinationName;
-import org.apache.pulsar.common.util.FutureUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.Lists;
+public class TopicsConsumerImpl extends ConsumerBase {
 
-public class PartitionedConsumerImpl extends ConsumerBase {
-
-    private final List<ConsumerImpl> consumers;
+    // Map <topic+partition, consumer>, when get do ACK, consumer will by find by topic name
+    private final ConcurrentHashMap<String, ConsumerImpl> consumers;
 
     // Queue of partition consumers on which we have stopped calling receiveAsync() because the
     // shared incoming queue was full
@@ -60,19 +62,28 @@ public class PartitionedConsumerImpl extends ConsumerBase {
     // resume receiving from the paused consumer partitions
     private final int sharedQueueResumeThreshold;
 
-    private final int numPartitions;
+    // sum of topicPartitions, simple topic has 1, partitioned topic equals to partition number.
+    int numberTopicPartitions;
+
+    //private final int numPartitions;
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
     private final ConsumerStats stats;
     private final UnAckedMessageTracker unAckedMessageTracker;
 
-    PartitionedConsumerImpl(PulsarClientImpl client, String topic, String subscription, ConsumerConfiguration conf,
-            int numPartitions, ExecutorService listenerExecutor, CompletableFuture<Consumer> subscribeFuture) {
-        super(client, topic, subscription, conf, Math.max(Math.max(2, numPartitions), conf.getReceiverQueueSize()), listenerExecutor,
-                subscribeFuture);
-        this.consumers = Lists.newArrayListWithCapacity(numPartitions);
+    // use in addConsumer
+    private AtomicReference<Throwable> subscribeFail = new AtomicReference<Throwable>();
+    private AtomicInteger completed = new AtomicInteger(0);
+
+    TopicsConsumerImpl(PulsarClientImpl client, Collection<String> topics, String subscription,
+                       ConsumerConfiguration conf, ExecutorService listenerExecutor,
+                       CompletableFuture<Consumer> subscribeFuture) {
+        super(client, "TopicsConsumerFakeTopicName", subscription,
+            conf, Math.max(2, conf.getReceiverQueueSize()), listenerExecutor,
+            subscribeFuture);
+        this.consumers = new ConcurrentHashMap<>();
         this.pausedConsumers = new ConcurrentLinkedQueue<>();
         this.sharedQueueResumeThreshold = maxReceiverQueueSize / 2;
-        this.numPartitions = numPartitions;
+        this.numberTopicPartitions = 0;
 
         if (conf.getAckTimeoutMillis() != 0) {
             this.unAckedMessageTracker = new UnAckedMessageTracker(client, this, conf.getAckTimeoutMillis());
@@ -82,62 +93,94 @@ public class PartitionedConsumerImpl extends ConsumerBase {
 
         stats = client.getConfiguration().getStatsIntervalSeconds() > 0 ? new ConsumerStats() : null;
         checkArgument(conf.getReceiverQueueSize() > 0,
-                "Receiver queue size needs to be greater than 0 for Partitioned Topics");
-        start();
-    }
+            "Receiver queue size needs to be greater than 0 for Partitioned Topics");
 
-    private void start() {
-        AtomicReference<Throwable> subscribeFail = new AtomicReference<Throwable>();
-        AtomicInteger completed = new AtomicInteger();
         ConsumerConfiguration internalConfig = getInternalConsumerConfig();
-        for (int partitionIndex = 0; partitionIndex < numPartitions; partitionIndex++) {
-            String partitionName = DestinationName.get(topic).getPartition(partitionIndex).toString();
-            ConsumerImpl consumer = new ConsumerImpl(client, partitionName, subscription, internalConfig,
-                    client.externalExecutorProvider().getExecutor(), partitionIndex, new CompletableFuture<Consumer>());
-            consumers.add(consumer);
-            consumer.subscribeFuture().handle((cons, subscribeException) -> {
-                if (subscribeException != null) {
-                    setState(State.Failed);
-                    subscribeFail.compareAndSet(null, subscribeException);
-                    client.cleanupConsumer(this);
+        topics.forEach(topic ->
+            client.getPartitionedTopicMetadata(topic).thenAccept(metadata -> {
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}] Received topic metadata. partitions: {}", topic, metadata.partitions);
                 }
-                if (completed.incrementAndGet() == numPartitions) {
-                    if (subscribeFail.get() == null) {
-                        try {
-                            // We have successfully created N consumers, so we can start receiving messages now
-                            starReceivingMessages();
-                            setState(State.Ready);
-                            subscribeFuture().complete(PartitionedConsumerImpl.this);
-                            log.info("[{}] [{}] Created partitioned consumer", topic, subscription);
-                            return null;
-                        } catch (PulsarClientException e) {
-                            subscribeFail.set(e);
-                        }
-                    }
-                    closeAsync().handle((ok, closeException) -> {
-                        subscribeFuture().completeExceptionally(subscribeFail.get());
-                        client.cleanupConsumer(this);
-                        return null;
+
+                if (metadata.partitions > 1) {
+                    numberTopicPartitions += metadata.partitions;
+                    IntStream.range(0, metadata.partitions).forEach(partitionIndex -> {
+                        String partitionName = DestinationName.get(topic).getPartition(partitionIndex).toString();
+                        addConsumer(
+                            new ConsumerImpl(client, partitionName, subscription, internalConfig,
+                                client.externalExecutorProvider().getExecutor(), partitionIndex,
+                                new CompletableFuture<Consumer>()));
                     });
-                    log.error("[{}] [{}] Could not create partitioned consumer.", topic, subscription,
-                            subscribeFail.get().getCause());
+                } else {
+                    ++ numberTopicPartitions;
+                    addConsumer(
+                        new ConsumerImpl(client, topic, subscription, internalConfig,
+                            client.externalExecutorProvider().getExecutor(), 0,
+                            new CompletableFuture<Consumer>()));
                 }
+            }).exceptionally(ex -> {
+                log.warn("[{}] Failed to get partitioned topic metadata: {}", topic, ex.getMessage());
+                subscribeFuture.completeExceptionally(ex);
                 return null;
-            });
-        }
+            })
+        );
     }
 
-    private void starReceivingMessages() throws PulsarClientException {
-        for (ConsumerImpl consumer : consumers) {
+    private void addConsumer(ConsumerImpl consumer) {
+        consumers.putIfAbsent(consumer.getTopic(), consumer);
+        if (log.isDebugEnabled()) {
+            log.debug("[{}] Put topic consumer-{} into topics consumer", topic, consumer.getTopic());
+        }
+        consumer.subscribeFuture().handle((cons, subscribeException) -> {
+            if (subscribeException != null) {
+                setState(State.Failed);
+                subscribeFail.compareAndSet(null, subscribeException);
+                client.cleanupConsumer(this);
+            }
+            if (completed.incrementAndGet() == numberTopicPartitions) {
+                if (subscribeFail.get() == null) {
+                    try {
+                        if (numberTopicPartitions > maxReceiverQueueSize) {
+                            setMaxReceiverQueueSize(numberTopicPartitions);
+                        }
+                        // We have successfully created N consumers, so we can start receiving messages now
+                        startReceivingMessages();
+                        setState(State.Ready);
+                        subscribeFuture().complete(TopicsConsumerImpl.this);
+                        log.info("[{}] [{}] Created topics consumer with {} sub-consumers",
+                            topic, subscription, numberTopicPartitions);
+                        return null;
+                    } catch (PulsarClientException e) {
+                        subscribeFail.set(e);
+                    }
+                }
+                closeAsync().handle((ok, closeException) -> {
+                    subscribeFuture().completeExceptionally(subscribeFail.get());
+                    client.cleanupConsumer(this);
+                    return null;
+                });
+                log.error("[{}] [{}] Could not create topics consumer.", topic, subscription,
+                    subscribeFail.get().getCause());
+            }
+            return null;
+        });
+    }
+
+    private void startReceivingMessages() throws PulsarClientException {
+        consumers.values().stream().forEach(consumer -> {
             consumer.sendFlowPermitsToBroker(consumer.cnx(), conf.getReceiverQueueSize());
             receiveMessageFromConsumer(consumer);
-        }
+        });
     }
 
     private void receiveMessageFromConsumer(ConsumerImpl consumer) {
         consumer.receiveAsync().thenAccept(message -> {
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] [{}] Receive message from sub consumer:{}",
+                    topic, subscription, consumer.getTopic());
+            }
             // Process the message, add to the queue and trigger listener or async callback
-            messageReceived(message);
+            messageReceived(consumer, message);
 
             // we're modifying pausedConsumers
             lock.writeLock().lock();
@@ -159,6 +202,60 @@ public class PartitionedConsumerImpl extends ConsumerBase {
                 lock.writeLock().unlock();
             }
         });
+    }
+
+    private void messageReceived(ConsumerImpl consumer, Message message) {
+        checkArgument(message instanceof MessageImpl);
+        lock.writeLock().lock();
+        try {
+            TopicMessageImpl topicMessage = new TopicMessageImpl(consumer.getTopic(), message);
+            unAckedMessageTracker.add(topicMessage.getMessageId());
+
+            if (log.isDebugEnabled()) {
+                log.debug("[{}][{}] Received message from topics-consumer {}",
+                    topic, subscription, message.getMessageId());
+            }
+
+            // if asyncReceive is waiting : return message to callback without adding to incomingMessages queue
+            if (!pendingReceives.isEmpty()) {
+                CompletableFuture<Message> receivedFuture = pendingReceives.poll();
+                listenerExecutor.execute(() -> receivedFuture.complete(topicMessage));
+            } else {
+                // Enqueue the message so that it can be retrieved when application calls receive()
+                // Waits for the queue to have space for the message
+                // This should never block cause PartitonedConsumerImpl should always use GrowableArrayBlockingQueue
+                incomingMessages.put(topicMessage);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } finally {
+            lock.writeLock().unlock();
+        }
+
+        if (listener != null) {
+            // Trigger the notification on the message listener in a separate thread to avoid blocking the networking
+            // thread while the message processing happens
+            listenerExecutor.execute(() -> {
+                Message msg;
+                try {
+                    msg = internalReceive();
+                } catch (PulsarClientException e) {
+                    log.warn("[{}] [{}] Failed to dequeue the message for listener", topic, subscription, e);
+                    return;
+                }
+
+                try {
+                    if (log.isDebugEnabled()) {
+                        log.debug("[{}][{}] Calling message listener for message {}",
+                            topic, subscription, message.getMessageId());
+                    }
+                    listener.received(TopicsConsumerImpl.this, msg);
+                } catch (Throwable t) {
+                    log.error("[{}][{}] Message listener error in processing message: {}",
+                        topic, subscription, message, t);
+                }
+            });
+        }
     }
 
     private void resumeReceivingFromPausedConsumersIfNeeded() {
@@ -187,7 +284,8 @@ public class PartitionedConsumerImpl extends ConsumerBase {
         Message message;
         try {
             message = incomingMessages.take();
-            unAckedMessageTracker.add((MessageIdImpl) message.getMessageId());
+            checkState(message instanceof TopicMessageImpl);
+            unAckedMessageTracker.add(message.getMessageId());
             resumeReceivingFromPausedConsumersIfNeeded();
             return message;
         } catch (InterruptedException e) {
@@ -202,7 +300,8 @@ public class PartitionedConsumerImpl extends ConsumerBase {
         try {
             message = incomingMessages.poll(timeout, unit);
             if (message != null) {
-                unAckedMessageTracker.add((MessageIdImpl) message.getMessageId());
+                checkArgument(message instanceof TopicMessageImpl);
+                unAckedMessageTracker.add(message.getMessageId());
             }
             resumeReceivingFromPausedConsumersIfNeeded();
             return message;
@@ -222,7 +321,8 @@ public class PartitionedConsumerImpl extends ConsumerBase {
             if (message == null) {
                 pendingReceives.add(result);
             } else {
-                unAckedMessageTracker.add((MessageIdImpl) message.getMessageId());
+                checkState(message instanceof TopicMessageImpl);
+                unAckedMessageTracker.add(message.getMessageId());
                 resumeReceivingFromPausedConsumersIfNeeded();
                 result.complete(message);
             }
@@ -239,7 +339,7 @@ public class PartitionedConsumerImpl extends ConsumerBase {
     @Override
     protected CompletableFuture<Void> doAcknowledge(MessageId messageId, AckType ackType,
                                                     Map<String,Long> properties) {
-        checkArgument(messageId instanceof MessageIdImpl);
+        checkArgument(messageId instanceof TopicMessageIdImpl);
 
         if (getState() != State.Ready) {
             return FutureUtil.failedFuture(new PulsarClientException("Consumer already closed"));
@@ -247,14 +347,15 @@ public class PartitionedConsumerImpl extends ConsumerBase {
 
         if (ackType == AckType.Cumulative) {
             return FutureUtil.failedFuture(new PulsarClientException.NotSupportedException(
-                    "Cumulative acknowledge not supported for partitioned topics"));
+                    "Cumulative acknowledge not supported for topics consumer"));
         } else {
+            ConsumerImpl consumer = consumers.get(messageId.getTopicName());
 
-            ConsumerImpl consumer = consumers.get(((MessageIdImpl) messageId).getPartitionIndex());
-            return consumer.doAcknowledge(messageId, ackType, properties).thenRun(() ->
-                    unAckedMessageTracker.remove((MessageIdImpl) messageId));
+            MessageId innerId = ((TopicMessageIdImpl)messageId).getInnerMessageId();
+            return consumer.doAcknowledge(innerId, ackType, properties)
+                .thenRun(() ->
+                    unAckedMessageTracker.remove(messageId));
         }
-
     }
 
     @Override
@@ -266,9 +367,10 @@ public class PartitionedConsumerImpl extends ConsumerBase {
         setState(State.Closing);
 
         AtomicReference<Throwable> unsubscribeFail = new AtomicReference<Throwable>();
-        AtomicInteger completed = new AtomicInteger(numPartitions);
+        AtomicInteger completed = new AtomicInteger(numberTopicPartitions);
         CompletableFuture<Void> unsubscribeFuture = new CompletableFuture<>();
-        for (Consumer consumer : consumers) {
+
+        consumers.values().stream().forEach(consumer -> {
             if (consumer != null) {
                 consumer.unsubscribeAsync().handle((unsubscribed, ex) -> {
                     if (ex != null) {
@@ -279,20 +381,20 @@ public class PartitionedConsumerImpl extends ConsumerBase {
                             setState(State.Closed);
                             unAckedMessageTracker.close();
                             unsubscribeFuture.complete(null);
-                            log.info("[{}] [{}] Unsubscribed Partitioned Consumer", topic, subscription);
+                            log.info("[{}] [{}] [{}] Unsubscribed Partitioned Consumer",
+                                topic, subscription, consumerName);
                         } else {
                             setState(State.Failed);
                             unsubscribeFuture.completeExceptionally(unsubscribeFail.get());
-                            log.error("[{}] [{}] Could not unsubscribe Partitioned Consumer", topic, subscription,
-                                    unsubscribeFail.get().getCause());
+                            log.error("[{}] [{}] [{}] Could not unsubscribe Partitioned Consumer",
+                                topic, subscription, consumerName, unsubscribeFail.get().getCause());
                         }
                     }
 
                     return null;
                 });
             }
-
-        }
+        });
 
         return unsubscribeFuture;
     }
@@ -306,9 +408,10 @@ public class PartitionedConsumerImpl extends ConsumerBase {
         setState(State.Closing);
 
         AtomicReference<Throwable> closeFail = new AtomicReference<Throwable>();
-        AtomicInteger completed = new AtomicInteger(numPartitions);
+        AtomicInteger completed = new AtomicInteger(numberTopicPartitions);
         CompletableFuture<Void> closeFuture = new CompletableFuture<>();
-        for (Consumer consumer : consumers) {
+
+        consumers.values().stream().forEach(consumer -> {
             if (consumer != null) {
                 consumer.closeAsync().handle((closed, ex) -> {
                     if (ex != null) {
@@ -327,15 +430,14 @@ public class PartitionedConsumerImpl extends ConsumerBase {
                             setState(State.Failed);
                             closeFuture.completeExceptionally(closeFail.get());
                             log.error("[{}] [{}] Could not close Partitioned Consumer", topic, subscription,
-                                    closeFail.get().getCause());
+                                closeFail.get().getCause());
                         }
                     }
 
                     return null;
                 });
             }
-
-        }
+        });
 
         return closeFuture;
     }
@@ -361,12 +463,7 @@ public class PartitionedConsumerImpl extends ConsumerBase {
 
     @Override
     public boolean isConnected() {
-        for (ConsumerImpl consumer : consumers) {
-            if (!consumer.isConnected()) {
-                return false;
-            }
-        }
-        return true;
+        return consumers.values().stream().allMatch(consumer -> consumer.isConnected());
     }
 
     @Override
@@ -381,54 +478,6 @@ public class PartitionedConsumerImpl extends ConsumerBase {
 
     }
 
-    void messageReceived(Message message) {
-        lock.writeLock().lock();
-        try {
-            unAckedMessageTracker.add((MessageIdImpl) message.getMessageId());
-            if (log.isDebugEnabled()) {
-                log.debug("[{}][{}] Received message from partitioned-consumer {}", topic, subscription, message.getMessageId());
-            }
-            // if asyncReceive is waiting : return message to callback without adding to incomingMessages queue
-            if (!pendingReceives.isEmpty()) {
-                CompletableFuture<Message> receivedFuture = pendingReceives.poll();
-                listenerExecutor.execute(() -> receivedFuture.complete(message));
-            } else {
-                // Enqueue the message so that it can be retrieved when application calls receive()
-                // Waits for the queue to have space for the message
-                // This should never block cause PartitonedConsumerImpl should always use GrowableArrayBlockingQueue
-                incomingMessages.put(message);
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        } finally {
-            lock.writeLock().unlock();
-        }
-
-        if (listener != null) {
-            // Trigger the notification on the message listener in a separate thread to avoid blocking the networking
-            // thread while the message processing happens
-            listenerExecutor.execute(() -> {
-                Message msg;
-                try {
-                    msg = internalReceive();
-                } catch (PulsarClientException e) {
-                    log.warn("[{}] [{}] Failed to dequeue the message for listener", topic, subscription, e);
-                    return;
-                }
-
-                try {
-                    if (log.isDebugEnabled()) {
-                        log.debug("[{}][{}] Calling message listener for message {}", topic, subscription, message.getMessageId());
-                    }
-                    listener.received(PartitionedConsumerImpl.this, msg);
-                } catch (Throwable t) {
-                    log.error("[{}][{}] Message listener error in processing message: {}", topic, subscription, message,
-                            t);
-                }
-            });
-        }
-    }
-
     @Override
     String getHandlerName() {
         return subscription;
@@ -439,11 +488,6 @@ public class PartitionedConsumerImpl extends ConsumerBase {
         internalConsumerConfig.setReceiverQueueSize(conf.getReceiverQueueSize());
         internalConsumerConfig.setSubscriptionType(conf.getSubscriptionType());
         internalConsumerConfig.setConsumerName(consumerName);
-
-        int receiverQueueSize = Math.min(conf.getReceiverQueueSize(),
-                conf.getMaxTotalReceiverQueueSizeAcrossPartitions() / numPartitions);
-        internalConsumerConfig.setReceiverQueueSize(receiverQueueSize);
-
         if (conf.getCryptoKeyReader() != null) {
             internalConsumerConfig.setCryptoKeyReader(conf.getCryptoKeyReader());
             internalConsumerConfig.setCryptoFailureAction(conf.getCryptoFailureAction());
@@ -458,9 +502,7 @@ public class PartitionedConsumerImpl extends ConsumerBase {
     @Override
     public void redeliverUnacknowledgedMessages() {
         synchronized (this) {
-            for (ConsumerImpl c : consumers) {
-                c.redeliverUnacknowledgedMessages();
-            }
+            consumers.values().stream().forEach(consumer -> consumer.redeliverUnacknowledgedMessages());
             incomingMessages.clear();
             unAckedMessageTracker.clear();
             resumeReceivingFromPausedConsumersIfNeeded();
@@ -469,19 +511,20 @@ public class PartitionedConsumerImpl extends ConsumerBase {
 
     @Override
     public void redeliverUnacknowledgedMessages(Set<MessageId> messageIds) {
-        checkArgument(messageIds.stream().findFirst().get() instanceof MessageIdImpl);
+        checkArgument(messageIds.stream().findFirst().get() instanceof TopicMessageIdImpl);
+
         if (conf.getSubscriptionType() != SubscriptionType.Shared) {
             // We cannot redeliver single messages if subscription type is not Shared
             redeliverUnacknowledgedMessages();
             return;
         }
         removeExpiredMessagesFromQueue(messageIds);
-        messageIds.stream()
-            .map(messageId -> (MessageIdImpl)messageId)
-            .collect(Collectors.groupingBy(MessageIdImpl::getPartitionIndex, Collectors.toSet()))
-            .forEach((partitionIndex, messageIds1) ->
-                consumers.get(partitionIndex).redeliverUnacknowledgedMessages(
-                    messageIds1.stream().map(mid -> (MessageId)mid).collect(Collectors.toSet())));
+        messageIds.stream().map(messageId -> (TopicMessageIdImpl)messageId)
+            .collect(Collectors.groupingBy(TopicMessageIdImpl::getTopicName, Collectors.toSet()))
+            .forEach((topicName, messageIds1) ->
+                consumers.get(topicName)
+                    .redeliverUnacknowledgedMessages(messageIds1.stream()
+                        .map(mid -> mid.getInnerMessageId()).collect(Collectors.toSet())));
         resumeReceivingFromPausedConsumersIfNeeded();
     }
 
@@ -498,7 +541,7 @@ public class PartitionedConsumerImpl extends ConsumerBase {
 
     @Override
     public CompletableFuture<Void> seekAsync(MessageId messageId) {
-        return FutureUtil.failedFuture(new PulsarClientException("Seek operation not supported on partitioned topics"));
+        return FutureUtil.failedFuture(new PulsarClientException("Seek operation not supported on topics consumer"));
     }
 
     /**
@@ -507,30 +550,26 @@ public class PartitionedConsumerImpl extends ConsumerBase {
      * @return true if all batch messages have been acknowledged
      */
     public boolean isBatchingAckTrackerEmpty() {
-        boolean state = true;
-        for (Consumer consumer : consumers) {
-            state &= ((ConsumerImpl) consumer).isBatchingAckTrackerEmpty();
-        }
-        return state;
+        return consumers.values().stream().allMatch(consumer -> consumer.isBatchingAckTrackerEmpty());
     }
 
     List<ConsumerImpl> getConsumers() {
-        return consumers;
+        return consumers.values().stream().collect(Collectors.toList());
     }
 
     @Override
     public int getAvailablePermits() {
-        return consumers.stream().mapToInt(ConsumerImpl::getAvailablePermits).sum();
+        return consumers.values().stream().mapToInt(ConsumerImpl::getAvailablePermits).sum();
     }
 
     @Override
     public boolean hasReachedEndOfTopic() {
-        return consumers.stream().allMatch(Consumer::hasReachedEndOfTopic);
+        return consumers.values().stream().allMatch(Consumer::hasReachedEndOfTopic);
     }
 
     @Override
     public int numMessagesInQueue() {
-        return incomingMessages.size() + consumers.stream().mapToInt(ConsumerImpl::numMessagesInQueue).sum();
+        return incomingMessages.size() + consumers.values().stream().mapToInt(ConsumerImpl::numMessagesInQueue).sum();
     }
 
     @Override
@@ -539,9 +578,8 @@ public class PartitionedConsumerImpl extends ConsumerBase {
             return null;
         }
         stats.reset();
-        for (int i = 0; i < numPartitions; i++) {
-            stats.updateCumulativeStats(consumers.get(i).getStats());
-        }
+
+        consumers.values().stream().forEach(consumer -> stats.updateCumulativeStats(consumer.getStats()));
         return stats;
     }
 
@@ -559,8 +597,9 @@ public class PartitionedConsumerImpl extends ConsumerBase {
 
             // try not to remove elements that are added while we remove
             Message message = incomingMessages.poll();
+            checkState(message instanceof TopicMessageImpl);
             while (message != null) {
-                MessageIdImpl messageId = (MessageIdImpl) message.getMessageId();
+                MessageId messageId = message.getMessageId();
                 if (!messageIds.contains(messageId)) {
                     messageIds.add(messageId);
                     break;
@@ -570,5 +609,5 @@ public class PartitionedConsumerImpl extends ConsumerBase {
         }
     }
 
-    private static final Logger log = LoggerFactory.getLogger(PartitionedConsumerImpl.class);
+    private static final Logger log = LoggerFactory.getLogger(TopicsConsumerImpl.class);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicsConsumerImpl.java
@@ -21,10 +21,10 @@ package org.apache.pulsar.client.impl;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
-import com.google.common.collect.Lists;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -38,19 +38,25 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerConfiguration;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.util.ConsumerName;
 import org.apache.pulsar.client.util.FutureUtil;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType;
 import org.apache.pulsar.common.naming.DestinationName;
+import org.apache.pulsar.common.naming.NamespaceName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class TopicsConsumerImpl extends ConsumerBase {
+
+    // All topics should be in same namespace
+    protected final NamespaceName namespaceName;
 
     // Map <topic+partition, consumer>, when get do ACK, consumer will by find by topic name
     private final ConcurrentHashMap<String, ConsumerImpl> consumers;
@@ -69,10 +75,10 @@ public class TopicsConsumerImpl extends ConsumerBase {
     // sum of topicPartitions, simple topic has 1, partitioned topic equals to partition number.
     AtomicInteger numberTopicPartitions;
 
-    //private final int numPartitions;
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
     private final ConsumerStats stats;
     private final UnAckedMessageTracker unAckedMessageTracker;
+    private final ConsumerConfiguration internalConfig;
 
     // use in addConsumer
     private AtomicReference<Throwable> subscribeFail = new AtomicReference<Throwable>();
@@ -81,11 +87,13 @@ public class TopicsConsumerImpl extends ConsumerBase {
     TopicsConsumerImpl(PulsarClientImpl client, Collection<String> topics, String subscription,
                        ConsumerConfiguration conf, ExecutorService listenerExecutor,
                        CompletableFuture<Consumer> subscribeFuture) {
-        super(client, "TopicsConsumerFakeTopicName", subscription,
+        super(client, "TopicsConsumerFakeTopicName" + ConsumerName.generateRandomName(), subscription,
             conf, Math.max(2, conf.getReceiverQueueSize()), listenerExecutor,
             subscribeFuture);
 
-        topics.forEach(topic -> checkArgument(DestinationName.isValid(topic), "Invalid topic name:" + topic));
+        this.namespaceName = DestinationName.get(topics.stream().findFirst().get()).getNamespaceObject();
+
+        checkArgument(!topicsNameInvalid(topics), "Topics should have same namespace " + this.namespaceName.toString());
 
         this.topics = new ConcurrentHashMap<>();
         this.consumers = new ConcurrentHashMap<>();
@@ -103,7 +111,7 @@ public class TopicsConsumerImpl extends ConsumerBase {
         checkArgument(conf.getReceiverQueueSize() > 0,
             "Receiver queue size needs to be greater than 0 for Topics Consumer");
 
-        ConsumerConfiguration internalConfig = getInternalConsumerConfig();
+        internalConfig = getInternalConsumerConfig();
         topics.forEach(topic ->
             client.getPartitionedTopicMetadata(topic).thenAccept(metadata -> {
                 if (log.isDebugEnabled()) {
@@ -138,6 +146,36 @@ public class TopicsConsumerImpl extends ConsumerBase {
         );
     }
 
+    // Check topics are valid.
+    // - each topic is valid,
+    // - every topic has same namespace.
+    private static boolean topicsNameInvalid(Collection<String> topics) {
+        checkState(topics != null && topics.size() > 1,
+            "topics should should contain more than 1 topics");
+
+        final String namespace = DestinationName.get(topics.stream().findFirst().get()).getNamespace();
+
+        Optional<String> result = topics.stream()
+            .filter(topic -> {
+                boolean topicInvalid = !DestinationName.isValid(topic);
+                if (topicInvalid) {
+                    return true;
+                }
+
+                String newNamespace =  DestinationName.get(topic).getNamespace();
+                if (!namespace.equals(newNamespace)) {
+                    return true;
+                } else {
+                    return false;
+                }
+            }).findFirst();
+        if (result.isPresent()) {
+            log.warn("[{}] Received invalid topic name.  {}/{}", result.get());
+        }
+        return result.isPresent();
+    }
+
+    // add Consumer for all given topics when initiate.
     private void addConsumer(ConsumerImpl consumer) {
         consumers.putIfAbsent(consumer.getTopic(), consumer);
         if (log.isDebugEnabled()) {
@@ -156,7 +194,7 @@ public class TopicsConsumerImpl extends ConsumerBase {
                             setMaxReceiverQueueSize(numberTopicPartitions.get());
                         }
                         // We have successfully created N consumers, so we can start receiving messages now
-                        startReceivingMessages();
+                        startReceivingMessages(consumers.values().stream().collect(Collectors.toList()));
                         setState(State.Ready);
                         subscribeFuture().complete(TopicsConsumerImpl.this);
                         log.info("[{}] [{}] Created topics consumer with {} sub-consumers",
@@ -178,8 +216,12 @@ public class TopicsConsumerImpl extends ConsumerBase {
         });
     }
 
-    private void startReceivingMessages() throws PulsarClientException {
-        consumers.values().stream().forEach(consumer -> {
+    private void startReceivingMessages(List<ConsumerImpl> newConsumers) throws PulsarClientException {
+        if (log.isDebugEnabled()) {
+            log.debug("[{}] startReceivingMessages for {} new consumers in topics consumer",
+                topic, newConsumers.size());
+        }
+        newConsumers.forEach(consumer -> {
             consumer.sendFlowPermitsToBroker(consumer.cnx(), conf.getReceiverQueueSize());
             receiveMessageFromConsumer(consumer);
         });
@@ -429,6 +471,12 @@ public class TopicsConsumerImpl extends ConsumerBase {
                     if (ex != null) {
                         closeFail.compareAndSet(null, ex);
                     }
+
+                    if (log.isDebugEnabled()) {
+                        log.debug("[[{}] [{}] Closed Topics Consumer {}, want close {}, completed {}",
+                            topic, subscription, consumer, consumers.size(), completed.get());
+                    }
+
                     if (completed.decrementAndGet() == 0) {
                         if (closeFail.get() == null) {
                             setState(State.Closed);
@@ -616,6 +664,231 @@ public class TopicsConsumerImpl extends ConsumerBase {
                 message = incomingMessages.poll();
             }
         }
+    }
+
+    // subscribe one more given topic
+    public CompletableFuture<Void> subscribeAsync(String topicName) {
+        checkArgument(DestinationName.isValid(topicName), "Invalid topic name:" + topicName);
+        checkArgument(DestinationName.get(topicName).getNamespace().equals(
+            DestinationName.get(topics.keys().nextElement()).getNamespace()),
+            "Topic " + topicName + " not in same namespace with Topics" );
+        checkArgument(!topics.containsKey(topicName), "Topics already contains topic:" + topicName);
+
+        if (getState() == State.Closing || getState() == State.Closed) {
+            return FutureUtil.failedFuture(
+                new PulsarClientException.AlreadyClosedException("Topics Consumer was already closed"));
+        }
+
+        CompletableFuture<Void> subscribeResult = new CompletableFuture<>();
+
+        AtomicReference<Throwable> subscribeFailure = new AtomicReference<Throwable>();
+        final AtomicInteger partitionNumber = new AtomicInteger(0);
+
+        client.getPartitionedTopicMetadata(topicName).thenAccept(metadata -> {
+            if (log.isDebugEnabled()) {
+                log.debug("Received topic {} metadata.partitions: {}", topicName, metadata.partitions);
+            }
+
+            if (metadata.partitions > 1) {
+                this.topics.putIfAbsent(topicName, metadata.partitions);
+                numberTopicPartitions.addAndGet(metadata.partitions);
+                partitionNumber.addAndGet(metadata.partitions);
+
+                IntStream.range(0, metadata.partitions).forEach(partitionIndex -> {
+                    String partitionName = DestinationName.get(topicName).getPartition(partitionIndex).toString();
+                    addConsumerForOneTopic(
+                        new ConsumerImpl(client, partitionName, subscription, internalConfig,
+                            client.externalExecutorProvider().getExecutor(), partitionIndex,
+                            new CompletableFuture<Consumer>()),
+                        topicName,
+                        partitionNumber,
+                        subscribeFailure,
+                        subscribeResult);
+                });
+            } else {
+                this.topics.putIfAbsent(topicName, 1);
+                numberTopicPartitions.incrementAndGet();
+                partitionNumber.incrementAndGet();
+
+                addConsumerForOneTopic(
+                    new ConsumerImpl(client, topicName, subscription, internalConfig,
+                        client.externalExecutorProvider().getExecutor(), 0,
+                        new CompletableFuture<Consumer>()),
+                    topicName,
+                    partitionNumber,
+                    subscribeFailure,
+                    subscribeResult);
+            }
+        }).exceptionally(ex -> {
+            log.warn("[{}] Failed to get partitioned topic metadata: {}", topicName, ex.getMessage());
+            subscribeResult.completeExceptionally(ex);
+            return null;
+        });
+
+        return subscribeResult;
+    }
+
+    // handling failure during subscribe new topic
+    private void handleSubscribeOneTopicError(String topicName, Throwable error) {
+        log.warn("[{}] Failed to subscribe for topic [{}] in topics consumer ", topic, topicName, error.getMessage());
+
+        consumers.values().stream().filter(consumer1 -> {
+            String consumerTopicName = consumer1.getTopic();
+            if (DestinationName.get(consumerTopicName).getPartitionedTopicName().equals(topicName)) {
+                return true;
+            } else {
+                return false;
+            }
+        }).forEach(consumer2 ->  {
+            consumer2.closeAsync().handle((ok, closeException) -> {
+                consumer2.subscribeFuture().completeExceptionally(error);
+                return null;
+            });
+            consumers.remove(consumer2.getTopic());
+        });
+
+        topics.remove(topicName);
+        checkState(numberTopicPartitions.get() == consumers.values().size());
+    }
+
+    /**
+     * Add consumer for the given topic.
+     * @param numPartitionsToCreate the partition number for this topicName. once success add a consumer, it get a
+     *                              decrement. when this reach 0, it has success add all consumers.
+     * @param subscribeFailure this use to record the Throwable that meet during consumers subscribe.
+     * @param resultFuture the final result future for the subscribe of new topic.
+     */
+    private void addConsumerForOneTopic(ConsumerImpl consumer,
+                                        String topicName,
+                                        AtomicInteger numPartitionsToCreate,
+                                        AtomicReference<Throwable> subscribeFailure,
+                                        CompletableFuture<Void> resultFuture) {
+        if (log.isDebugEnabled()) {
+            log.debug("[{}] Put topic consumer-{} into topics consumer for {}", topic, consumer.getTopic(), topicName);
+        }
+        consumer.subscribeFuture().handle((cons, subscribeException) -> {
+            if (subscribeException != null) {
+                subscribeFailure.compareAndSet(null, subscribeException);
+                handleSubscribeOneTopicError(topicName, subscribeException);
+                resultFuture.completeExceptionally(subscribeException);
+            } else {
+                // success subscribe this consumer, add it in.
+                consumers.putIfAbsent(consumer.getTopic(), consumer);
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}] topic consumer-{} subscribed success. numPartitionsToCreate: {}",
+                        topic, consumer.getTopic(), numPartitionsToCreate.get());
+                }
+            }
+
+            // completed all consumer subscribe
+            if (numPartitionsToCreate.decrementAndGet() == 0) {
+                if (subscribeFailure.get() == null) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("[{}] Success subscribed for topic {} in topics consumer",
+                            topic, topicName);
+                    }
+
+                    try {
+                        if (numberTopicPartitions.get() > maxReceiverQueueSize) {
+                            setMaxReceiverQueueSize(numberTopicPartitions.get());
+                        }
+
+                        int numTopics = this.topics.values().stream().mapToInt(Integer::intValue).sum();
+                        checkState(numberTopicPartitions.get() == numTopics,
+                            "numberTopicPartitions "+ numberTopicPartitions.get()
+                                + " not equals expected: " + numTopics);
+
+                        // We have successfully created new consumers, so we can start receiving messages for them
+                        startReceivingMessages(
+                            consumers.values().stream()
+                                .filter(consumer1 -> {
+                                    String consumerTopicName = consumer1.getTopic();
+                                    if (DestinationName.get(consumerTopicName)
+                                        .getPartitionedTopicName().equals(topicName)) {
+                                        return true;
+                                    } else {
+                                        return false;
+                                    }
+                                })
+                                .collect(Collectors.toList()));
+
+                        resultFuture.complete(null);
+                        log.info("[{}] [{}] Success subscribe new topic {} in topics consumer, numberTopicPartitions {}",
+                            topic, subscription, topicName, numberTopicPartitions.get());
+                        return null;
+                    } catch (PulsarClientException e) {
+                        handleSubscribeOneTopicError(topicName, e);
+                        resultFuture.completeExceptionally(e);
+                    }
+                }
+
+                log.error("[{}] [{}] Could not subscribe more topic {} in topics consumer.",
+                    topic, subscription, topicName, subscribeFailure.get().getCause());
+            }
+            return null;
+        });
+    }
+
+    // un-subscribe a given topic
+    public CompletableFuture<Void> unsubscribeAsync(String topicName) {
+        checkArgument(DestinationName.isValid(topicName), "Invalid topic name:" + topicName);
+
+        if (getState() == State.Closing || getState() == State.Closed) {
+            return FutureUtil.failedFuture(
+                new PulsarClientException.AlreadyClosedException("Topics Consumer was already closed"));
+        }
+
+        AtomicReference<Throwable> unsubscribeFail = new AtomicReference<Throwable>();
+        AtomicInteger completed = new AtomicInteger(topics.get(topicName));
+        CompletableFuture<Void> unsubscribeFuture = new CompletableFuture<>();
+        ConcurrentLinkedQueue<ConsumerImpl> successConsumers = new ConcurrentLinkedQueue<>();
+
+        String topicPartName = DestinationName.get(topicName).getPartitionedTopicName();
+
+        consumers.values().stream().filter(consumer -> {
+            String consumerTopicName = consumer.getTopic();
+            if (DestinationName.get(consumerTopicName).getPartitionedTopicName().equals(topicPartName)) {
+                return true;
+            } else {
+                return false;
+            }
+        }).forEach(consumer -> {
+            if (consumer != null) {
+                consumer.unsubscribeAsync().handle((unsubscribed, ex) -> {
+                    if (ex != null) {
+                        unsubscribeFail.compareAndSet(null, ex);
+                    } else {
+                        successConsumers.add(consumer);
+                    }
+
+                    if (completed.decrementAndGet() == 0) {
+                        if (unsubscribeFail.get() == null) {
+                            successConsumers.forEach(consumer1 -> {
+                                consumers.remove(consumer1.getTopic());
+                                pausedConsumers.remove(consumer1);
+                                numberTopicPartitions.decrementAndGet();
+                            });
+
+                            topics.remove(topicName);
+                            unAckedMessageTracker.removeTopicMessages(topicName);
+
+                            unsubscribeFuture.complete(null);
+                            log.info("[{}] [{}] [{}] Unsubscribed Topics Consumer, numberTopicPartitions: {}",
+                                topicName, subscription, consumerName, numberTopicPartitions);
+                        } else {
+                            unsubscribeFuture.completeExceptionally(unsubscribeFail.get());
+                            setState(State.Failed);
+                            log.error("[{}] [{}] [{}] Could not unsubscribe Topics Consumer",
+                                topicName, subscription, consumerName, unsubscribeFail.get().getCause());
+                        }
+                    }
+
+                    return null;
+                });
+            }
+        });
+
+        return unsubscribeFuture;
     }
 
     // get topics name

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicsConsumerImpl.java
@@ -47,10 +47,10 @@ import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.util.ConsumerName;
-import org.apache.pulsar.client.util.FutureUtil;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType;
 import org.apache.pulsar.common.naming.DestinationName;
 import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.util.FutureUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedMessageTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedMessageTracker.java
@@ -171,8 +171,8 @@ public class UnAckedMessageTracker implements Closeable {
     public int removeMessagesTill(MessageId msgId) {
         readLock.lock();
         try {
-            int currentSetRemovedMsgCount = currentSet.removeIf(m -> (m.compareTo(msgId) < 0));
-            int oldSetRemovedMsgCount = oldOpenSet.removeIf(m -> (m.compareTo(msgId) < 0));
+            int currentSetRemovedMsgCount = currentSet.removeIf(m -> (m.compareTo(msgId) <= 0));
+            int oldSetRemovedMsgCount = oldOpenSet.removeIf(m -> (m.compareTo(msgId) <= 0));
 
             return currentSetRemovedMsgCount + oldSetRemovedMsgCount;
         } finally {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedMessageTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedMessageTracker.java
@@ -18,26 +18,23 @@
  */
 package org.apache.pulsar.client.impl;
 
+import io.netty.util.Timeout;
+import io.netty.util.TimerTask;
 import java.io.Closeable;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-
+import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.netty.util.Timeout;
-import io.netty.util.TimerTask;
-
 public class UnAckedMessageTracker implements Closeable {
     private static final Logger log = LoggerFactory.getLogger(UnAckedMessageTracker.class);
-    private ConcurrentOpenHashSet<MessageIdImpl> currentSet;
-    private ConcurrentOpenHashSet<MessageIdImpl> oldOpenSet;
+    private ConcurrentOpenHashSet<MessageId> currentSet;
+    private ConcurrentOpenHashSet<MessageId> oldOpenSet;
     private final ReentrantReadWriteLock readWriteLock;
     private final Lock readLock;
     private final Lock writeLock;
@@ -51,17 +48,17 @@ public class UnAckedMessageTracker implements Closeable {
         }
 
         @Override
-        public boolean add(MessageIdImpl m) {
+        public boolean add(MessageId m) {
             return true;
         }
 
         @Override
-        public boolean remove(MessageIdImpl m) {
+        public boolean remove(MessageId m) {
             return true;
         }
 
         @Override
-        public int removeMessagesTill(MessageIdImpl msgId) {
+        public int removeMessagesTill(MessageId msgId) {
             return 0;
         }
 
@@ -77,8 +74,8 @@ public class UnAckedMessageTracker implements Closeable {
     }
 
     public UnAckedMessageTracker(PulsarClientImpl client, ConsumerBase consumerBase, long ackTimeoutMillis) {
-        currentSet = new ConcurrentOpenHashSet<MessageIdImpl>();
-        oldOpenSet = new ConcurrentOpenHashSet<MessageIdImpl>();
+        currentSet = new ConcurrentOpenHashSet<MessageId>();
+        oldOpenSet = new ConcurrentOpenHashSet<MessageId>();
         readWriteLock = new ReentrantReadWriteLock();
         readLock = readWriteLock.readLock();
         writeLock = readWriteLock.writeLock();
@@ -92,7 +89,7 @@ public class UnAckedMessageTracker implements Closeable {
             public void run(Timeout t) throws Exception {
                 if (isAckTimeout()) {
                     log.warn("[{}] {} messages have timed-out", consumerBase, oldOpenSet.size());
-                    Set<MessageIdImpl> messageIds = new HashSet<>();
+                    Set<MessageId> messageIds = new HashSet<>();
                     oldOpenSet.forEach(messageIds::add);
                     oldOpenSet.clear();
                     consumerBase.redeliverUnacknowledgedMessages(messageIds);
@@ -106,7 +103,7 @@ public class UnAckedMessageTracker implements Closeable {
     void toggle() {
         writeLock.lock();
         try {
-            ConcurrentOpenHashSet<MessageIdImpl> temp = currentSet;
+            ConcurrentOpenHashSet<MessageId> temp = currentSet;
             currentSet = oldOpenSet;
             oldOpenSet = temp;
         } finally {
@@ -124,7 +121,7 @@ public class UnAckedMessageTracker implements Closeable {
         }
     }
 
-    public boolean add(MessageIdImpl m) {
+    public boolean add(MessageId m) {
         readLock.lock();
         try {
             oldOpenSet.remove(m);
@@ -144,7 +141,7 @@ public class UnAckedMessageTracker implements Closeable {
         }
     }
 
-    public boolean remove(MessageIdImpl m) {
+    public boolean remove(MessageId m) {
         readLock.lock();
         try {
             return currentSet.remove(m) || oldOpenSet.remove(m);
@@ -171,15 +168,12 @@ public class UnAckedMessageTracker implements Closeable {
         }
     }
 
-    public int removeMessagesTill(MessageIdImpl msgId) {
+    public int removeMessagesTill(MessageId msgId) {
         readLock.lock();
         try {
-            int currentSetRemovedMsgCount = currentSet.removeIf(m -> ((m.getLedgerId() < msgId.getLedgerId()
-                    || (m.getLedgerId() == msgId.getLedgerId() && m.getEntryId() <= msgId.getEntryId()))
-                    && m.getPartitionIndex() == msgId.getPartitionIndex()));
-            int oldSetRemovedMsgCount = oldOpenSet.removeIf(m -> ((m.getLedgerId() < msgId.getLedgerId()
-                    || (m.getLedgerId() == msgId.getLedgerId() && m.getEntryId() <= msgId.getEntryId()))
-                    && m.getPartitionIndex() == msgId.getPartitionIndex()));
+            int currentSetRemovedMsgCount = currentSet.removeIf(m -> (m.compareTo(msgId) < 0));
+            int oldSetRemovedMsgCount = oldOpenSet.removeIf(m -> (m.compareTo(msgId) < 0));
+
             return currentSetRemovedMsgCount + oldSetRemovedMsgCount;
         } finally {
             readLock.unlock();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedMessageTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedMessageTracker.java
@@ -26,7 +26,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.function.Predicate;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashSet;
 import org.slf4j.Logger;
@@ -34,10 +33,10 @@ import org.slf4j.LoggerFactory;
 
 public class UnAckedMessageTracker implements Closeable {
     private static final Logger log = LoggerFactory.getLogger(UnAckedMessageTracker.class);
-    private ConcurrentOpenHashSet<MessageId> currentSet;
-    private ConcurrentOpenHashSet<MessageId> oldOpenSet;
+    protected ConcurrentOpenHashSet<MessageId> currentSet;
+    protected ConcurrentOpenHashSet<MessageId> oldOpenSet;
     private final ReentrantReadWriteLock readWriteLock;
-    private final Lock readLock;
+    protected final Lock readLock;
     private final Lock writeLock;
     private Timeout timeout;
 
@@ -174,30 +173,6 @@ public class UnAckedMessageTracker implements Closeable {
         try {
             int currentSetRemovedMsgCount = currentSet.removeIf(m -> (m.compareTo(msgId) <= 0));
             int oldSetRemovedMsgCount = oldOpenSet.removeIf(m -> (m.compareTo(msgId) <= 0));
-
-            return currentSetRemovedMsgCount + oldSetRemovedMsgCount;
-        } finally {
-            readLock.unlock();
-        }
-    }
-
-    public int removeTopicMessages(String topicName) {
-        readLock.lock();
-        try {
-            int currentSetRemovedMsgCount = currentSet.removeIf(m -> {
-                if (m instanceof TopicMessageIdImpl) {
-                    return m.getTopicName().contains(topicName);
-                } else {
-                    return false;
-                }
-            });
-            int oldSetRemovedMsgCount = oldOpenSet.removeIf(m -> {
-                if (m instanceof TopicMessageIdImpl) {
-                    return m.getTopicName().contains(topicName);
-                } else {
-                    return false;
-                }
-            });
 
             return currentSetRemovedMsgCount + oldSetRemovedMsgCount;
         } finally {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedTopicMessageTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedTopicMessageTracker.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import static com.google.common.base.Preconditions.checkState;
+
+public class UnAckedTopicMessageTracker extends UnAckedMessageTracker {
+
+    public UnAckedTopicMessageTracker(PulsarClientImpl client, ConsumerBase consumerBase, long ackTimeoutMillis) {
+        super(client, consumerBase, ackTimeoutMillis);
+    }
+
+    public int removeTopicMessages(String topicName) {
+        readLock.lock();
+        try {
+            int currentSetRemovedMsgCount = currentSet.removeIf(m -> {
+                checkState(m instanceof TopicMessageIdImpl,
+                    "message should be of type TopicMessageIdImpl");
+                return ((TopicMessageIdImpl)m).getTopicName().contains(topicName);
+            });
+            int oldSetRemovedMsgCount = oldOpenSet.removeIf(m -> {
+                checkState(m instanceof TopicMessageIdImpl,
+                    "message should be of type TopicMessageIdImpl");
+                return ((TopicMessageIdImpl)m).getTopicName().contains(topicName);
+            });
+
+            return currentSetRemovedMsgCount + oldSetRemovedMsgCount;
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+}


### PR DESCRIPTION
### Motivation
This is a first sub-task for pip-13, which would like handle subscription to topics under same namespace.

### Modifications
- add subscribe methods in `PulsarClient` and `PulsarClientImpl`.
- add `TopicsConsumerImpl`, `TopicMessageImpl`, `TopicMessageIdImpl`, add some test.
- change parameter in `UnAckedMessageTracker` from `MessageIdImpl` to `MessageId`.

### Result
old methods behaviour not changed, 
user could use new method to subscribe to topics