### PR TITLE
Set loadBalancerEnabled=true in ServiceConfiguration

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -288,7 +288,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     /*** --- Load balancer --- ****/
     // Enable load balancer
-    private boolean loadBalancerEnabled = false;
+    private boolean loadBalancerEnabled = true;
     // load placement strategy[weightedRandomSelection/leastLoadedServer] (only used by SimpleLoadManagerImpl)
     @Deprecated
     private String loadBalancerPlacementStrategy = "leastLoadedServer"; // weighted random selection

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/SLAMonitoringTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/SLAMonitoringTest.java
@@ -92,6 +92,7 @@ public class SLAMonitoringTest {
             config.setZookeeperServers("127.0.0.1" + ":" + ZOOKEEPER_PORT);
             config.setBrokerServicePort(brokerNativeBrokerPorts[i]);
             config.setDefaultNumberOfNamespaceBundles(1);
+            config.setLoadBalancerEnabled(false);
             configurations[i] = config;
 
             pulsarServices[i] = new PulsarService(config);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadBalancerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadBalancerTest.java
@@ -141,7 +141,8 @@ public class LoadBalancerTest {
             config.setZookeeperServers("127.0.0.1" + ":" + ZOOKEEPER_PORT);
             config.setBrokerServicePort(brokerNativeBrokerPorts[i]);
             config.setLoadManagerClassName(SimpleLoadManagerImpl.class.getName());
-            config.setAdvertisedAddress(localhost+i);;
+            config.setAdvertisedAddress(localhost+i);
+            config.setLoadBalancerEnabled(false);
 
             pulsarServices[i] = new PulsarService(config);
             pulsarServices[i].start();


### PR DESCRIPTION
### Motivation

The intended default is to have the load manager enabled and the same setting is set to be the default in `conf/broker.conf`.  

All the config values in the `broker.conf` file must match the `ServiceConfiguration` class defaults.