### PR TITLE
Fix: ignore auth flag for websocket-proxy to broker authentication

### DIFF
--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketService.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketService.java
@@ -184,7 +184,8 @@ public class WebSocketService implements Closeable {
         clientConf.setIoThreads(config.getWebSocketNumIoThreads());
         clientConf.setConnectionsPerBroker(config.getWebSocketConnectionsPerBroker());
 
-        if (config.isAuthenticationEnabled()) {
+        if (isNotBlank(config.getBrokerClientAuthenticationPlugin())
+                && isNotBlank(config.getBrokerClientAuthenticationParameters())) {
             clientConf.setAuthentication(config.getBrokerClientAuthenticationPlugin(),
                     config.getBrokerClientAuthenticationParameters());
         }


### PR DESCRIPTION
### Motivation

Right now, when user wants to deploy websocket proxy which communicates to broker it requires
- Disable client to websocket authentication by disabling `authenticationEnabled` flag.
- Enable websocket proxy to broker authentication if auth-param present.
So, websocket to broker authentication should not depend on `authenticationEnabled` flag.

### Modifications

Remove websocket to broker auth dependency form `authenticationEnabled` flag.

### Result

User can disable webscoket authentication and same user can enable websocket to broker authentication also.
