### PR TITLE
Fix: deadlock while closing non-persistent topic

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -456,7 +456,7 @@ public class NonPersistentTopic implements Topic {
 
         FutureUtil.waitForAll(futures).thenRun(() -> {
             log.info("[{}] Topic closed", topic);
-            brokerService.removeTopicFromCache(topic);
+            brokerService.pulsar().getExecutor().submit(() -> brokerService.removeTopicFromCache(topic));
             closeFuture.complete(null);
         }).exceptionally(exception -> {
             log.error("[{}] Error closing topic", topic, exception);


### PR DESCRIPTION
### Motivation

When Broker tries to close the non-persistent topic which doesn't have any producers/consumer connected then the thread which iterates to `topic-map` that tries to remove element from `topic-map`, and it creates deadlock while closing non-persistent topic.

```
 - org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section.remove(java.lang.Object, java.lang.Object, int) @bci=1, line=305 (Interpreted frame)
 - org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section.access$2(org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section, java.lang.Object, java.lang.Object, int) @bci=4, line=304 (Interpreted frame)
 - org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap.remove(java.lang.Object) @bci=19, line=136 (Interpreted frame)
 - org.apache.pulsar.broker.service.BrokerService.removeTopicFromCache(java.lang.String) @bci=167, line=934 (Interpreted frame)
 - org.apache.pulsar.broker.service.nonpersistent.NonPersistentTopic.lambda$13(java.util.concurrent.CompletableFuture) @bci=23, line=459 (Interpreted frame)
 - org.apache.pulsar.broker.service.nonpersistent.NonPersistentTopic$$Lambda$218.run() @bci=8 (Interpreted frame)
 - java.util.concurrent.CompletableFuture.uniRun(java.util.concurrent.CompletableFuture, java.lang.Runnable, java.util.concurrent.CompletableFuture$UniRun) @bci=75, line=705 (Interpreted frame)
 - java.util.concurrent.CompletableFuture.uniRunStage(java.util.concurrent.Executor, java.lang.Runnable) @bci=28, line=717 (Interpreted frame)
 - java.util.concurrent.CompletableFuture.thenRun(java.lang.Runnable) @bci=3, line=2010 (Interpreted frame)
 - org.apache.pulsar.broker.service.nonpersistent.NonPersistentTopic.close() @bci=154, line=457 (Interpreted frame)
 - org.apache.pulsar.broker.service.BrokerService$$Lambda$214.apply(java.lang.Object) @bci=4 (Interpreted frame)
 - java.util.concurrent.CompletableFuture.uniComposeStage(java.util.concurrent.Executor, java.util.function.Function) @bci=67, line=981 (Interpreted frame)
 - java.util.concurrent.CompletableFuture.thenCompose(java.util.function.Function) @bci=3, line=2124 (Interpreted frame)
 - org.apache.pulsar.broker.service.BrokerService.lambda$33(org.apache.pulsar.common.naming.NamespaceBundle, java.util.List, java.lang.String, java.util.concurrent.CompletableFuture) @bci=35, line=888 (Interpreted frame)
 - org.apache.pulsar.broker.service.BrokerService$$Lambda$213.accept(java.lang.Object, java.lang.Object) @bci=16 (Interpreted frame)
 - org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section.forEach(java.util.function.BiConsumer) @bci=116, line=386 (Interpreted frame)
 - org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap.forEach(java.util.function.BiConsumer) @bci=22, line=160 (Compiled frame)
 - org.apache.pulsar.broker.service.BrokerService.unloadServiceUnit(org.apache.pulsar.common.naming.NamespaceBundle) @bci=23, line=883 (Interpreted frame)
 - org.apache.pulsar.broker.namespace.OwnedBundle.handleUnloadRequest(org.apache.pulsar.broker.PulsarService, long, java.util.concurrent.TimeUnit) @bci=154, line=125 (Interpreted frame)
 - org.apache.pulsar.broker.namespace.NamespaceService.unloadNamespaceBundle(org.apache.pulsar.common.naming.NamespaceBundle, long, java.util.concurrent.TimeUnit) @bci=21, line=482 (Interpreted frame)
```

### Modifications

remove non-persistent topic from separate thread to avoid deadlock.

### Result

It prevents deadlock while closing non-persistent topic.
