### PR TITLE
Add api to get list of non-persistent topics

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/NonPersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/NonPersistentTopics.java
@@ -19,7 +19,12 @@
 package org.apache.pulsar.broker.admin;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
 import static org.apache.pulsar.common.util.Codec.decode;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.Encoded;
@@ -32,17 +37,25 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response.Status;
 
+import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.nonpersistent.NonPersistentTopic;
 import org.apache.pulsar.broker.web.RestException;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.util.FutureUtil;
+import org.apache.pulsar.common.naming.DestinationDomain;
 import org.apache.pulsar.common.naming.DestinationName;
+import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.NonPersistentTopicStats;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
+import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Lists;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -147,7 +160,100 @@ public class NonPersistentTopics extends PersistentTopics {
         }
         unloadTopic(dn, authoritative);
     }
+
+    @GET
+    @Path("/{property}/{cluster}/{namespace}")
+    @ApiOperation(value = "Get the list of non-persistent topics under a namespace.", response = String.class, responseContainer = "List")
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Namespace doesn't exist") })
+    public List<String> getList(@PathParam("property") String property, @PathParam("cluster") String cluster,
+            @PathParam("namespace") String namespace) {
+        log.info("[{}] list of topics on namespace {}/{}/{}/{}", clientAppId(), property, cluster, namespace);
+        validateAdminAccessOnProperty(property);
+        Policies policies = getNamespacePolicies(property, cluster, namespace);
+        NamespaceName nsName = NamespaceName.get(property, cluster, namespace);
+
+        if (!cluster.equals(Namespaces.GLOBAL_CLUSTER)) {
+            validateClusterOwnership(cluster);
+            validateClusterForProperty(property, cluster);
+        } else {
+            // check cluster ownership for a given global namespace: redirect if peer-cluster owns it
+            validateGlobalNamespaceOwnership(nsName);
+        }
+        final List<CompletableFuture<List<String>>> futures = Lists.newArrayList();
+        final List<String> boundaries = policies.bundles.getBoundaries();
+        for (int i = 0; i < boundaries.size() - 1; i++) {
+            final String bundle = String.format("%s_%s", boundaries.get(i), boundaries.get(i + 1));
+            try {
+                futures.add(pulsar().getAdminClient().nonPersistentTopics().getListInBundleAsync(nsName.toString(),
+                        bundle));
+            } catch (PulsarServerException e) {
+                log.error(String.format("[%s] Failed to get list of topics under namespace %s/%s/%s/%s", clientAppId(),
+                        property, cluster, namespace, bundle), e);
+                throw new RestException(e);
+            }
+        }
+        final List<String> topics = Lists.newArrayList();
+        try {
+            FutureUtil.waitForAll(futures).get();
+            futures.forEach(topicListFuture -> {
+                try {
+                    if (topicListFuture.isDone() && topicListFuture.get() != null) {
+                        topics.addAll(topicListFuture.get());
+                    }
+                } catch (InterruptedException | ExecutionException e) {
+                    log.error(String.format("[%s] Failed to get list of topics under namespace %s/%s/%s", clientAppId(),
+                            property, cluster, namespace), e);
+                }
+            });
+        } catch (InterruptedException | ExecutionException e) {
+            log.error(String.format("[%s] Failed to get list of topics under namespace %s/%s/%s", clientAppId(),
+                    property, cluster, namespace), e);
+            throw new RestException(e instanceof ExecutionException ? e.getCause() : e);
+        }
+        return topics;
+    }
     
+    @GET
+    @Path("/{property}/{cluster}/{namespace}/{bundle}")
+    @ApiOperation(value = "Get the list of non-persistent topics under a namespace bundle.", response = String.class, responseContainer = "List")
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Namespace doesn't exist") })
+    public List<String> getListFromBundle(@PathParam("property") String property, @PathParam("cluster") String cluster,
+            @PathParam("namespace") String namespace, @PathParam("bundle") String bundleRange) {
+        log.info("[{}] list of topics on namespace bundle {}/{}/{}/{}", clientAppId(), property, cluster, namespace,
+                bundleRange);
+        validateAdminAccessOnProperty(property);
+        Policies policies = getNamespacePolicies(property, cluster, namespace);
+        if (!cluster.equals(Namespaces.GLOBAL_CLUSTER)) {
+            validateClusterOwnership(cluster);
+            validateClusterForProperty(property, cluster);
+        } else {
+            // check cluster ownership for a given global namespace: redirect if peer-cluster owns it
+            validateGlobalNamespaceOwnership(NamespaceName.get(property, cluster, namespace));
+        }
+        NamespaceName fqnn = NamespaceName.get(property, cluster, namespace);
+        if (!isBundleOwnedByAnyBroker(fqnn, policies.bundles, bundleRange)) {
+            log.info("[{}] Namespace bundle is not owned by any broker {}/{}/{}/{}", clientAppId(), property, cluster,
+                    namespace, bundleRange);
+            return null;
+        }
+        NamespaceBundle nsBundle = validateNamespaceBundleOwnership(fqnn, policies.bundles, bundleRange, true, true);
+        try {
+            final List<String> topicList = Lists.newArrayList();
+            pulsar().getBrokerService().getTopics().forEach((name, topicFuture) -> {
+                DestinationName topicName = DestinationName.get(name);
+                if (nsBundle.includes(topicName)) {
+                    topicList.add(name);
+                }
+            });
+            return topicList;
+        } catch (Exception e) {
+            log.error("[{}] Failed to unload namespace bundle {}/{}", clientAppId(), fqnn.toString(), bundleRange, e);
+            throw new RestException(e);
+        }
+    }
+
     protected void validateAdminOperationOnDestination(DestinationName fqdn, boolean authoritative) {
         validateAdminAccessOnProperty(fqdn.getProperty());
         validateDestinationOwnership(fqdn, authoritative);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -456,7 +456,7 @@ public class NonPersistentTopic implements Topic {
 
         FutureUtil.waitForAll(futures).thenRun(() -> {
             log.info("[{}] Topic closed", topic);
-            brokerService.removeTopicFromCache(topic);
+            brokerService.pulsar().getExecutor().submit(() -> brokerService.removeTopicFromCache(topic));
             closeFuture.complete(null);
         }).exceptionally(exception -> {
             log.error("[{}] Error closing topic", topic, exception);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
@@ -709,4 +709,29 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         List<String> namespaces2 = admin.namespaces().getAntiAffinityNamespaces("dummy", "use", "invalid-group");
         assertEquals(namespaces2.size(), 0);
     }
+    
+    @Test
+    public void testNonPersistentTopics() throws Exception {
+        final String namespace = "prop-xyz/use/ns2";
+        final String topicName = "non-persistent://" + namespace + "/topic";
+        admin.namespaces().createNamespace(namespace, 20);
+        int totalTopics = 100;
+        
+        Set<String> topicNames = Sets.newHashSet();
+        for (int i = 0; i < totalTopics; i++) {
+            topicNames.add(topicName + i);
+            Producer producer = pulsarClient.createProducer(topicName + i);
+            producer.close();
+        }
+
+        for (int i = 0; i < totalTopics; i++) {
+            Topic topic = pulsar.getBrokerService().getTopicReference(topicName + i);
+            assertNotNull(topic);
+        }
+
+        Set<String> topicsInNs = Sets.newHashSet(admin.nonPersistentTopics().getList(namespace));
+        assertEquals(topicsInNs.size(), totalTopics);
+        topicsInNs.removeAll(topicNames);
+        assertEquals(topicsInNs.size(), 0);
+    }
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/NonPersistentTopics.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/NonPersistentTopics.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.admin;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.pulsar.client.admin.PulsarAdminException.NotAuthorizedException;
@@ -224,5 +225,43 @@ public interface NonPersistentTopics {
      * @return a future that can be used to track when the topic is unloaded
      */
     CompletableFuture<Void> unloadAsync(String destination);
+
+    /**
+     * Get list of topics exist into given bundle
+     * 
+     * @param namespace
+     * @param bundleRange
+     * @return
+     * @throws PulsarAdminException
+     */
+    List<String> getListInBundle(String namespace, String bundleRange)
+            throws PulsarAdminException;
+
+    /**
+     * Get list of topics exist into given bundle asynchronously.
+     * 
+     * @param namespace
+     * @param bundleRange
+     * @return
+     */
+    CompletableFuture<List<String>> getListInBundleAsync(String namespace, String bundleRange);
+
+    /**
+     * Get list of topics exist into given namespace
+     * 
+     * @param namespace
+     * @return
+     * @throws PulsarAdminException
+     */
+    List<String> getList(String namespace) throws PulsarAdminException;
+
+    /**
+     * Get list of topics exist into given namespace asynchronously.
+     * 
+     * @param namespace
+     * @param bundleRange
+     * @return
+     */
+    CompletableFuture<List<String>> getListAsync(String namespace);
 
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNonPersistentTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNonPersistentTopics.java
@@ -38,6 +38,8 @@ public class CmdNonPersistentTopics extends CmdBase {
         jcommander.addCommand("stats", new GetStats());
         jcommander.addCommand("stats-internal", new GetInternalStats());
         jcommander.addCommand("get-partitioned-topic-metadata", new GetPartitionedTopicMetadataCmd());
+        jcommander.addCommand("list", new GetList());
+        jcommander.addCommand("list-in-bundle", new GetListInBundle());
     }
 
     @Parameters(commandDescription = "Lookup a destination from the current serving broker")
@@ -106,6 +108,34 @@ public class CmdNonPersistentTopics extends CmdBase {
         void run() throws Exception {
             String persistentTopic = validateNonPersistentTopic(params);
             print(nonPersistentTopics.getPartitionedTopicMetadata(persistentTopic));
+        }
+    }
+    
+    @Parameters(commandDescription = "Get list of non-persistent topics present under a namespace")
+    private class GetList extends CliCommand {
+        @Parameter(description = "property/cluster/namespace\n", required = true)
+        private java.util.List<String> params;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String namespace = validateNamespace(params);
+            print(nonPersistentTopics.getList(namespace));
+        }
+    }
+    
+    @Parameters(commandDescription = "Get list of non-persistent topics present under a namespace bundle")
+    private class GetListInBundle extends CliCommand {
+        @Parameter(description = "property/cluster/namespace\n", required = true)
+        private java.util.List<String> params;
+        
+        @Parameter(names = { "-b",
+                "--bundle" }, description = "bundle range", required = true)
+        private String bundleRange;
+
+        @Override
+        void run() throws PulsarAdminException {
+            String namespace = validateNamespace(params);
+            print(nonPersistentTopics.getListInBundle(namespace, bundleRange));
         }
     }
 }

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -494,6 +494,12 @@ public class PulsarAdminToolTest {
 
         topics.run(split("create-partitioned-topic non-persistent://myprop/clust/ns1/ds1 --partitions 32"));
         verify(mockTopics).createPartitionedTopic("non-persistent://myprop/clust/ns1/ds1", 32);
+        
+        topics.run(split("list myprop/clust/ns1"));
+        verify(mockTopics).getList("myprop/clust/ns1");
+        
+        topics.run(split("list-in-bundle myprop/clust/ns1 --bundle 0x23d70a30_0x26666658"));
+        verify(mockTopics).getListInBundle("myprop/clust/ns1", "0x23d70a30_0x26666658");
 
     }
 


### PR DESCRIPTION
### Motivation

After enabling non-persistent topics, operationally we want to know number of non-persistent topics under a given namespace. Right now, we don't have api which provides list of non-persistent topics for a namespace.

### Modifications

Added a CLI tool and admin-api to get list of non-persistent topics.

### Result

we can find of list of non-persistent topics using admin-api and cli tool.
