### PR TITLE
In Kafka consumer wrapper, group multiple messages when the app polls

### DIFF
--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
@@ -61,8 +61,6 @@ import org.apache.pulsar.client.util.ConsumerName;
 import org.apache.pulsar.client.util.FutureUtil;
 import org.apache.pulsar.common.naming.DestinationName;
 
-import com.google.common.collect.Lists;
-
 public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListener {
 
     private static final long serialVersionUID = 1L;
@@ -146,6 +144,9 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
         Properties properties = new Properties();
         config.originals().forEach((k, v) -> properties.put(k, v));
         ClientConfiguration clientConf = PulsarKafkaConfig.getClientConfiguration(properties);
+        // Since this client instance is going to be used just for the consumers, we can enable Nagle to group
+        // all the acknowledgments sent to broker within a short time frame
+        clientConf.setUseTcpNoDelay(false);
         try {
             client = PulsarClient.create(serviceUrl, clientConf);
         } catch (PulsarClientException e) {
@@ -270,6 +271,8 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
         });
     }
 
+    private static final int MAX_RECORDS_IN_SINGLE_POLL = 1000;
+
     @SuppressWarnings("unchecked")
     @Override
     public ConsumerRecords<K, V> poll(long timeoutMillis) {
@@ -279,40 +282,49 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
                 return (ConsumerRecords<K, V>) ConsumerRecords.EMPTY;
             }
 
+            Map<TopicPartition, List<ConsumerRecord<K, V>>> records = new HashMap<>();
+
+            int numberOfRecords = 0;
+
+            while (item != null && ++numberOfRecords < MAX_RECORDS_IN_SINGLE_POLL) {
+                DestinationName dn = DestinationName.get(item.consumer.getTopic());
+                String topic = dn.getPartitionedTopicName();
+                int partition = dn.isPartitioned() ? dn.getPartitionIndex() : 0;
+                Message msg = item.message;
+                MessageIdImpl msgId = (MessageIdImpl) msg.getMessageId();
+                long offset = MessageIdUtils.getOffset(msgId);
+
+                TopicPartition tp = new TopicPartition(topic, partition);
+
+                K key = getKey(topic, msg);
+                V value = valueDeserializer.deserialize(topic, msg.getData());
+
+                TimestampType timestampType = TimestampType.LOG_APPEND_TIME;
+                long timestamp = msg.getPublishTime();
+
+                if (msg.getEventTime() > 0) {
+                    // If we have Event time, use that in preference
+                    timestamp = msg.getEventTime();
+                    timestampType = TimestampType.CREATE_TIME;
+                }
+
+                ConsumerRecord<K, V> consumerRecord = new ConsumerRecord<>(topic, partition, offset, timestamp,
+                        timestampType, -1, msg.hasKey() ? msg.getKey().length() : 0, msg.getData().length, key, value);
+
+                records.computeIfAbsent(tp, k -> new ArrayList<>()).add(consumerRecord);
+
+                // Update last offset seen by application
+                lastReceivedOffset.put(tp, offset);
+
+                // Check if we have an item already available
+                item = receivedMessages.poll(0, TimeUnit.MILLISECONDS);
+            }
+
             if (isAutoCommit) {
                 // Commit the offset of previously dequeued messages
                 commitAsync();
             }
 
-            DestinationName dn = DestinationName.get(item.consumer.getTopic());
-            String topic = dn.getPartitionedTopicName();
-            int partition = dn.isPartitioned() ? dn.getPartitionIndex() : 0;
-            Message msg = item.message;
-            MessageIdImpl msgId = (MessageIdImpl) msg.getMessageId();
-            long offset = MessageIdUtils.getOffset(msgId);
-
-            TopicPartition tp = new TopicPartition(topic, partition);
-
-            K key = getKey(topic, msg);
-            V value = valueDeserializer.deserialize(topic, msg.getData());
-
-            TimestampType timestampType = TimestampType.LOG_APPEND_TIME;
-            long timestamp = msg.getPublishTime();
-
-            if (msg.getEventTime() > 0) {
-                // If we have Event time, use that in preference
-                timestamp = msg.getEventTime();
-                timestampType = TimestampType.CREATE_TIME;
-            }
-
-            ConsumerRecord<K, V> consumerRecord = new ConsumerRecord<>(topic, partition, offset, timestamp,
-                    timestampType, -1, msg.hasKey() ? msg.getKey().length() : 0, msg.getData().length, key, value);
-
-            Map<TopicPartition, List<ConsumerRecord<K, V>>> records = new HashMap<>();
-            records.put(tp, Lists.newArrayList(consumerRecord));
-
-            // Update last offset seen by application
-            lastReceivedOffset.put(tp, offset);
             return new ConsumerRecords<>(records);
         } catch (InterruptedException e) {
             throw new RuntimeException(e);

--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/test/java/org/apache/pulsar/client/kafka/compat/tests/KafkaConsumerTest.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/test/java/org/apache/pulsar/client/kafka/compat/tests/KafkaConsumerTest.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -82,13 +83,14 @@ public class KafkaConsumerTest extends BrokerTestBase {
             pulsarProducer.send(msg);
         }
 
-        for (int i = 0; i < 10; i++) {
+        AtomicInteger received = new AtomicInteger();
+        while (received.get() < 10) {
             ConsumerRecords<String, String> records = consumer.poll(100);
-            assertEquals(records.count(), 1);
-            int idx = i;
             records.forEach(record -> {
-                assertEquals(record.key(), Integer.toString(idx));
-                assertEquals(record.value(), "hello-" + idx);
+                assertEquals(record.key(), Integer.toString(received.get()));
+                assertEquals(record.value(), "hello-" + received.get());
+
+                received.incrementAndGet();
             });
 
             consumer.commitSync();
@@ -119,13 +121,14 @@ public class KafkaConsumerTest extends BrokerTestBase {
             pulsarProducer.send(msg);
         }
 
-        for (int i = 0; i < 10; i++) {
+
+        AtomicInteger received = new AtomicInteger();
+        while (received.get() < 10) {
             ConsumerRecords<String, String> records = consumer.poll(100);
-            assertEquals(records.count(), 1);
-            int idx = i;
             records.forEach(record -> {
-                assertEquals(record.key(), Integer.toString(idx));
-                assertEquals(record.value(), "hello-" + idx);
+                assertEquals(record.key(), Integer.toString(received.get()));
+                assertEquals(record.value(), "hello-" + received.get());
+                received.incrementAndGet();
             });
         }
 
@@ -162,18 +165,19 @@ public class KafkaConsumerTest extends BrokerTestBase {
             pulsarProducer.send(msg);
         }
 
-        for (int i = 0; i < 10; i++) {
+        AtomicInteger received = new AtomicInteger();
+        while (received.get() < 10) {
             ConsumerRecords<String, String> records = consumer.poll(100);
-            assertEquals(records.count(), 1);
-            int idx = i;
             records.forEach(record -> {
-                assertEquals(record.key(), Integer.toString(idx));
-                assertEquals(record.value(), "hello-" + idx);
+                assertEquals(record.key(), Integer.toString(received.get()));
+                assertEquals(record.value(), "hello-" + received.get());
 
                 Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
                 offsets.put(new TopicPartition(record.topic(), record.partition()),
                         new OffsetAndMetadata(record.offset()));
                 consumer.commitSync(offsets);
+
+                received.incrementAndGet();
             });
         }
 
@@ -225,9 +229,10 @@ public class KafkaConsumerTest extends BrokerTestBase {
 
         consumers.forEach(consumer -> {
             int expectedMessaged = N / consumers.size();
-            for (int i = 0; i < expectedMessaged; i++) {
+
+            for (int i = 0; i < expectedMessaged;) {
                 ConsumerRecords<String, String> records = consumer.poll(100);
-                assertEquals(records.count(), 1);
+                i += records.count();
             }
 
             // No more messages for this consumer
@@ -260,13 +265,14 @@ public class KafkaConsumerTest extends BrokerTestBase {
             pulsarProducer.send(msg);
         }
 
-        for (int i = 0; i < 10; i++) {
+        AtomicInteger received = new AtomicInteger();
+        while (received.get() < 10) {
             ConsumerRecords<String, String> records = consumer.poll(100);
-            assertEquals(records.count(), 1);
-            int idx = i;
             records.forEach(record -> {
-                assertEquals(record.key(), Integer.toString(idx));
-                assertEquals(record.value(), "hello-" + idx);
+                assertEquals(record.key(), Integer.toString(received.get()));
+                assertEquals(record.value(), "hello-" + received.get());
+
+                received.incrementAndGet();
             });
 
             consumer.commitSync();
@@ -277,13 +283,14 @@ public class KafkaConsumerTest extends BrokerTestBase {
         Thread.sleep(500);
 
         // Messages should be available again
-        for (int i = 0; i < 10; i++) {
+        received.set(0);
+        while (received.get() < 10) {
             ConsumerRecords<String, String> records = consumer.poll(100);
-            assertEquals(records.count(), 1);
-            int idx = i;
             records.forEach(record -> {
-                assertEquals(record.key(), Integer.toString(idx));
-                assertEquals(record.value(), "hello-" + idx);
+                assertEquals(record.key(), Integer.toString(received.get()));
+                assertEquals(record.value(), "hello-" + received.get());
+
+                received.incrementAndGet();
             });
 
             consumer.commitSync();
@@ -314,13 +321,14 @@ public class KafkaConsumerTest extends BrokerTestBase {
             pulsarProducer.send(msg);
         }
 
-        for (int i = 0; i < 10; i++) {
+        AtomicInteger received = new AtomicInteger();
+        while (received.get() < 10) {
             ConsumerRecords<String, String> records = consumer.poll(100);
-            assertEquals(records.count(), 1);
-            int idx = i;
             records.forEach(record -> {
-                assertEquals(record.key(), Integer.toString(idx));
-                assertEquals(record.value(), "hello-" + idx);
+                assertEquals(record.key(), Integer.toString(received.get()));
+                assertEquals(record.value(), "hello-" + received.get());
+
+                received.incrementAndGet();
             });
 
             consumer.commitSync();


### PR DESCRIPTION
### Motivation

Kafka application expects to have multiple records returned in a single `poll()` call. If we pass them in bulk, the cumulative ack will become more efficient because a single ack will take care of whole group.

