### PR TITLE
Issue #1119: move dockerfile for pulsar dcos prometheus into pulsar repo

### DIFF
--- a/docker/prometheus-dcos/Dockerfile
+++ b/docker/prometheus-dcos/Dockerfile
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+FROM prom/prometheus:v1.8.2
+
+COPY  prometheus.yml /etc/prometheus/prometheus.yml

--- a/docker/prometheus-dcos/prometheus.yml
+++ b/docker/prometheus-dcos/prometheus.yml
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'marathon'
+    scrape_interval: '15s'
+    marathon_sd_configs:
+    # set to marathon sever
+      - servers: ['http://marathon.mesos:8080']
+    relabel_configs:
+      # disable all targets which do not have a METRICS_PATH on them
+      - source_labels: [__meta_marathon_port_definition_label_METRICS_PATH]
+        action: keep
+        regex: (.+)
+
+      # assign the value of METRICS_PATH to the prometheus target's metrics path
+      - source_labels: [__meta_marathon_port_definition_label_METRICS_PATH]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)


### PR DESCRIPTION
### Motivation

We have added [pulsar-prometheus](https://github.com/apache/incubator-pulsar/blob/master/deployment/dcos/PulsarGroups.json#L251) docker image in #950 for docs deployment. it is not present into pulsar repo. It would be great if we can add it to pulsar repo for any future changes or enhancement.
The original code is [here](https://github.com/zhaijack/prometheus_pulsar_dcos).

### Modifications

Add Dockerfile and prometheus config file for dcos-mesos-marathon service discovery.

### Result

Bring alternative for `PulsarGroups.json` to use new prometheus image, after `apachepulsar` have it.