### PR TITLE
Use Optional instead of null checks when reading isolation policies

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
@@ -90,7 +90,7 @@ public class LoadManagerShared {
         primariesCache.clear();
         secondaryCache.clear();
         NamespaceName namespace = serviceUnit.getNamespaceObject();
-        boolean isIsolationPoliciesPresent = policies.IsIsolationPoliciesPresent(namespace);
+        boolean isIsolationPoliciesPresent = policies.areIsolationPoliciesPresent(namespace);
         boolean isNonPersistentTopic = (serviceUnit instanceof NamespaceBundle)
                 ? ((NamespaceBundle) serviceUnit).hasNonPersistentTopic() : false;
         if (isIsolationPoliciesPresent) {


### PR DESCRIPTION
### Motivation

As it has been done in other place, refactor code that is relying on checking for null to use `Optional` and force explicit dealing for the empty condition and avoid exceptions like: 

```
2018-01-26 03:33:38,823 - WARN  - [pulsar-1-2:SimpleResourceAllocationPolicies@56] - GetIsolationPolicies: Unable to get the namespaceIsolationPolicies [{}]
java.lang.NullPointerException
    at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:770)
    at com.google.common.base.Joiner.toString(Joiner.java:454)
    at com.google.common.base.Joiner.appendTo(Joiner.java:109)
    at com.google.common.base.Joiner.appendTo(Joiner.java:154)
    at com.google.common.base.Joiner.appendTo(Joiner.java:141)
    at com.google.common.base.Joiner.appendTo(Joiner.java:168)
    at org.apache.pulsar.broker.web.PulsarWebResource.path(PulsarWebResource.java:101)
    at org.apache.pulsar.broker.loadbalance.impl.SimpleResourceAllocationPolicies.getIsolationPolicies(SimpleResourceAllocationPolicies.java:54)
    at org.apache.pulsar.broker.loadbalance.impl.SimpleResourceAllocationPolicies.isSharedBroker(SimpleResourceAllocationPolicies.java:97)
    at org.apache.pulsar.broker.loadbalance.impl.LoadManagerShared.applyPolicies(LoadManagerShared.java:129)
    at org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl.selectBrokerForAssignment(ModularLoadManagerImpl.java:659)
    at org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerWrapper.getLeastLoaded(ModularLoadManagerWrapper.java:67)
    at org.apache.pulsar.broker.namespace.NamespaceService.getLeastLoadedFromLoadManager(NamespaceService.java:463)
    at org.apache.pulsar.broker.namespace.NamespaceService.searchForCandidateBroker(NamespaceService.java:338)
    at org.apache.pulsar.broker.namespace.NamespaceService.lambda$15(NamespaceService.java:301)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
    at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at io.netty.util.concurrent.DefaultThreadFactory$DefaultRunnableDecorator.run(DefaultThreadFactory.java:138)
    at java.lang.Thread.run(Thread.java:748)
```