### PR TITLE
Comment in config breaks docker scripts

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -165,7 +165,7 @@ enableNonPersistentTopics=true
 # Enable to run bookie along with broker
 enableRunBookieTogether=false
 
-// Enable to run bookie autorecovery along with broker
+# Enable to run bookie autorecovery along with broker
 enableRunBookieAutoRecoveryTogether=false
 
 ### --- Authentication --- ###


### PR DESCRIPTION
docker/scripts/apply-config-from-env.py only accepts # comments, not
double slash.
