### PR TITLE
Explicitly set zookeeper version in broker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,26 @@ flexible messaging model and an intuitive client API.</description>
       <dependency>
         <groupId>org.apache.zookeeper</groupId>
         <artifactId>zookeeper</artifactId>
+        <version>${zookeeper.version}</version>
+        <exclusions>
+          <exclusion>
+            <artifactId>slf4j-log4j12</artifactId>
+            <groupId>org.slf4j</groupId>
+          </exclusion>
+          <exclusion>
+            <artifactId>log4j</artifactId>
+            <groupId>log4j</groupId>
+          </exclusion>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.zookeeper</groupId>
+        <artifactId>zookeeper</artifactId>
         <classifier>tests</classifier>
         <version>${zookeeper.version}</version>
         <exclusions>
@@ -180,7 +200,7 @@ flexible messaging model and an intuitive client API.</description>
             <groupId>log4j</groupId>
           </exclusion>
           <exclusion>
-            <groupId>org.jboss.netty</groupId>
+            <groupId>io.netty</groupId>
             <artifactId>netty</artifactId>
           </exclusion>
         </exclusions>
@@ -741,7 +761,7 @@ flexible messaging model and an intuitive client API.</description>
         </plugin>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>2.3.2</version>
+          <version>3.7.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -761,7 +761,7 @@ flexible messaging model and an intuitive client API.</description>
         </plugin>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.7.0</version>
+          <version>2.3.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -178,10 +178,6 @@ flexible messaging model and an intuitive client API.</description>
             <artifactId>log4j</artifactId>
             <groupId>log4j</groupId>
           </exclusion>
-          <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>netty</artifactId>
-          </exclusion>
         </exclusions>
       </dependency>
 
@@ -198,10 +194,6 @@ flexible messaging model and an intuitive client API.</description>
           <exclusion>
             <artifactId>log4j</artifactId>
             <groupId>log4j</groupId>
-          </exclusion>
-          <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>netty</artifactId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -120,34 +120,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.zookeeper</groupId>
-      <artifactId>zookeeper</artifactId>
-      <version>${zookeeper.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>net.java.dev.javacc</groupId>
-          <artifactId>javacc</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-	</exclusion>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty</artifactId>
-        </exclusion>
-      </exclusions>
-     </dependency>
-
-    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
     </dependency>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -120,6 +120,34 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.zookeeper</groupId>
+      <artifactId>zookeeper</artifactId>
+      <version>${zookeeper.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>net.java.dev.javacc</groupId>
+          <artifactId>javacc</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+	</exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
+      </exclusions>
+     </dependency>
+
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
     </dependency>

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/AntiAffinityNamespaceGroupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/AntiAffinityNamespaceGroupTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.loadbalance;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
@@ -68,8 +69,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.google.common.hash.Hashing;
-
-import junit.framework.Assert;
 
 public class AntiAffinityNamespaceGroupTest {
     private LocalBookkeeperEnsemble bkEnsemble;
@@ -240,7 +239,7 @@ public class AntiAffinityNamespaceGroupTest {
         Set<String> candidate = Sets.newHashSet();
         Map<String, Map<String, Set<String>>> brokerToNamespaceToBundleRange = Maps.newHashMap();
 
-        Assert.assertEquals(brokers.size(), totalBrokers);
+        assertEquals(brokers.size(), totalBrokers);
 
         String assignedNamespace = namespace + "0" + bundle;
         candidate.addAll(brokers);
@@ -248,7 +247,7 @@ public class AntiAffinityNamespaceGroupTest {
         // for namespace-0 all brokers available
         LoadManagerShared.filterAntiAffinityGroupOwnedBrokers(pulsar1, assignedNamespace, brokers,
                 brokerToNamespaceToBundleRange, brokerToDomainMap);
-        Assert.assertEquals(brokers.size(), totalBrokers);
+        assertEquals(brokers.size(), totalBrokers);
 
         // add namespace-0 to broker-0 of domain-0 => state: n0->b0
         selectBrokerForNamespace(brokerToNamespaceToBundleRange, "brokerName-0", namespace + "0", assignedNamespace);
@@ -257,8 +256,8 @@ public class AntiAffinityNamespaceGroupTest {
         assignedNamespace = namespace + "1" + bundle;
         LoadManagerShared.filterAntiAffinityGroupOwnedBrokers(pulsar1, assignedNamespace, candidate,
                 brokerToNamespaceToBundleRange, brokerToDomainMap);
-        Assert.assertEquals(candidate.size(), 2);
-        candidate.forEach(broker -> Assert.assertEquals(brokerToDomainMap.get(broker), "domain-1"));
+        assertEquals(candidate.size(), 2);
+        candidate.forEach(broker -> assertEquals(brokerToDomainMap.get(broker), "domain-1"));
 
         // add namespace-1 to broker-2 of domain-1 => state: n0->b0, n1->b2
         selectBrokerForNamespace(brokerToNamespaceToBundleRange, "brokerName-2", namespace + "1", assignedNamespace);
@@ -267,9 +266,9 @@ public class AntiAffinityNamespaceGroupTest {
         assignedNamespace = namespace + "2" + bundle;
         LoadManagerShared.filterAntiAffinityGroupOwnedBrokers(pulsar1, assignedNamespace, candidate,
                 brokerToNamespaceToBundleRange, brokerToDomainMap);
-        Assert.assertEquals(candidate.size(), 2);
-        Assert.assertTrue(candidate.contains("brokerName-1"));
-        Assert.assertTrue(candidate.contains("brokerName-3"));
+        assertEquals(candidate.size(), 2);
+        assertTrue(candidate.contains("brokerName-1"));
+        assertTrue(candidate.contains("brokerName-3"));
 
         // add namespace-2 to broker-1 of domain-0 => state: n0->b0, n1->b2, n2->b1
         selectBrokerForNamespace(brokerToNamespaceToBundleRange, "brokerName-1", namespace + "2", assignedNamespace);
@@ -278,8 +277,8 @@ public class AntiAffinityNamespaceGroupTest {
         assignedNamespace = namespace + "3" + bundle;
         LoadManagerShared.filterAntiAffinityGroupOwnedBrokers(pulsar1, assignedNamespace, candidate,
                 brokerToNamespaceToBundleRange, brokerToDomainMap);
-        Assert.assertEquals(candidate.size(), 1);
-        Assert.assertTrue(candidate.contains("brokerName-3"));
+        assertEquals(candidate.size(), 1);
+        assertTrue(candidate.contains("brokerName-3"));
         // add namespace-3 to broker-3 of domain-1 => state: n0->b0, n1->b2, n2->b1, n3->b3
         selectBrokerForNamespace(brokerToNamespaceToBundleRange, "brokerName-3", namespace + "3", assignedNamespace);
         candidate.addAll(brokers);
@@ -287,7 +286,7 @@ public class AntiAffinityNamespaceGroupTest {
         assignedNamespace = namespace + "4" + bundle;
         LoadManagerShared.filterAntiAffinityGroupOwnedBrokers(pulsar1, assignedNamespace, candidate,
                 brokerToNamespaceToBundleRange, brokerToDomainMap);
-        Assert.assertEquals(candidate.size(), 4);
+        assertEquals(candidate.size(), 4);
     }
 
     /**
@@ -335,7 +334,7 @@ public class AntiAffinityNamespaceGroupTest {
         candidate.addAll(brokers);
         LoadManagerShared.filterAntiAffinityGroupOwnedBrokers(pulsar1, assignedNamespace, brokers,
                 brokerToNamespaceToBundleRange, null);
-        Assert.assertEquals(brokers.size(), 3);
+        assertEquals(brokers.size(), 3);
 
         // add ns-0 to broker-0
         selectBrokerForNamespace(brokerToNamespaceToBundleRange, "broker-0", namespace + "0", assignedNamespace);
@@ -344,9 +343,9 @@ public class AntiAffinityNamespaceGroupTest {
         // available brokers for ns-1 => broker-1, broker-2
         LoadManagerShared.filterAntiAffinityGroupOwnedBrokers(pulsar1, assignedNamespace, candidate,
                 brokerToNamespaceToBundleRange, null);
-        Assert.assertEquals(candidate.size(), 2);
-        Assert.assertTrue(candidate.contains("broker-1"));
-        Assert.assertTrue(candidate.contains("broker-2"));
+        assertEquals(candidate.size(), 2);
+        assertTrue(candidate.contains("broker-1"));
+        assertTrue(candidate.contains("broker-2"));
 
         // add ns-1 to broker-1
         selectBrokerForNamespace(brokerToNamespaceToBundleRange, "broker-1", namespace + "1", assignedNamespace);
@@ -355,8 +354,8 @@ public class AntiAffinityNamespaceGroupTest {
         assignedNamespace = namespace + "2" + bundle;
         LoadManagerShared.filterAntiAffinityGroupOwnedBrokers(pulsar1, assignedNamespace, candidate,
                 brokerToNamespaceToBundleRange, null);
-        Assert.assertEquals(candidate.size(), 1);
-        Assert.assertTrue(candidate.contains("broker-2"));
+        assertEquals(candidate.size(), 1);
+        assertTrue(candidate.contains("broker-2"));
 
         // add ns-2 to broker-2
         selectBrokerForNamespace(brokerToNamespaceToBundleRange, "broker-2", namespace + "2", assignedNamespace);
@@ -365,7 +364,7 @@ public class AntiAffinityNamespaceGroupTest {
         assignedNamespace = namespace + "3" + bundle;
         LoadManagerShared.filterAntiAffinityGroupOwnedBrokers(pulsar1, assignedNamespace, candidate,
                 brokerToNamespaceToBundleRange, null);
-        Assert.assertEquals(candidate.size(), 3);
+        assertEquals(candidate.size(), 3);
     }
 
     private void selectBrokerForNamespace(Map<String, Map<String, Set<String>>> brokerToNamespaceToBundleRange,


### PR DESCRIPTION
The broker "shades" zookeeper via the aspectj stuff, but the version
it shades is the one pulled in with bookkeeper-server, not the version
specified in the top level pom. This is fairly harmless, but it breaks
the pulsar zookeeper-shell command if you want to specify a zookeeper
command from the commandline.

This change explicitly pulls in the correct zookeeper version,
excluding all the stuff that we usually exclude when pulling zookeeper.
