### PR TITLE
Add timeouts to setup & teardown for ReplicatorTest

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -81,13 +81,13 @@ import org.testng.collections.Lists;
 public class ReplicatorTest extends ReplicatorTestBase {
 
     @Override
-    @BeforeClass
+    @BeforeClass(timeOut = 30000)
     void setup() throws Exception {
         super.setup();
     }
 
     @Override
-    @AfterClass
+    @AfterClass(timeOut = 30000)
     void shutdown() throws Exception {
         super.shutdown();
     }


### PR DESCRIPTION
### Motivation

All the tests in `ReplicatorTest` already do have timeouts, though the build keeps getting stuck on this class. The only possible way left is that the test is getting stuck either in before or after. Adding missing timeouts so that next time we would see the stack trace where the test was stuck on.