### PR TITLE
Fix url option on client tool

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
@@ -100,12 +100,13 @@ public class PulsarClientTool {
 
     public int run(String[] args) {
         try {
+            commandParser.parse(args);
+
             if (isBlank(this.serviceURL)) {
                 commandParser.usage();
                 return -1;
             }
 
-            commandParser.parse(args);
             if (help) {
                 commandParser.usage();
                 return 0;


### PR DESCRIPTION
### Motivation
We can't use `pulsar-client` command without specifing `serviceUrl`,`brokerServiceUrl`, or `webServiceUrl`.

```
$ cat /path/to/client.conf
serviceUrl=
brokerServiceUrl=
webServiceUrl=
authPlugin=
authParams=
useTls=

$ pulsar-client --url <broker url> consume -s <subscription name> <topic>
<usage>
```

I want to use client tool with only `--url` option.

### Modifications
Enable `pulsar-client` command to be used with only `--url` option.

