### PR TITLE
Add support for new configration interface to AuthenticaionTls

### DIFF
--- a/pulsar-client-auth-athenz/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationAthenz.java
+++ b/pulsar-client-auth-athenz/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationAthenz.java
@@ -27,20 +27,17 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.PrivateKey;
 import java.util.Base64;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
+import org.apache.pulsar.client.api.AuthenticationUtil;
 import org.apache.pulsar.client.api.EncodedAuthenticationParameterSupport;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.PulsarClientException.GettingAuthenticationDataException;
-import org.apache.pulsar.common.util.ObjectMapperFactory;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Splitter;
 import com.yahoo.athenz.auth.ServiceIdentityProvider;
 import com.yahoo.athenz.auth.impl.SimpleServiceIdentityProvider;
@@ -108,15 +105,10 @@ public class AuthenticationAthenz implements Authentication, EncodedAuthenticati
             throw new IllegalArgumentException("authParams must not be empty");
         }
 
-        // Convert JSON to Map
         try {
-            ObjectMapper jsonMapper = ObjectMapperFactory.create();
-            Map<String, String> authParamsMap = jsonMapper.readValue(encodedAuthParamString,
-                    new TypeReference<HashMap<String, String>>() {
-                    });
-            setAuthParams(authParamsMap);
+            setAuthParams(AuthenticationUtil.configureFromJsonString(encodedAuthParamString));
         } catch (IOException e) {
-            throw new IllegalArgumentException("Failed to parse authParams");
+            throw new IllegalArgumentException("Failed to parse authParams", e);
         }
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/Authentication.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/Authentication.java
@@ -43,7 +43,11 @@ public interface Authentication extends Closeable, Serializable {
      * Configure the authentication plugins with the supplied parameters
      *
      * @param authParams
+     * @deprecated This method will be deleted on version 2.0, instead please use configure(String
+     *             encodedAuthParamString) which is in EncodedAuthenticationParameterSupport for now and will be
+     *             integrated into this interface.
      */
+    @Deprecated
     void configure(Map<String, String> authParams);
 
     /**

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/AuthenticationFactory.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/AuthenticationFactory.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.client.api;
 
 import java.util.Map;
-import java.util.HashMap;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import org.apache.pulsar.client.api.PulsarClientException.UnsupportedAuthenticationException;
@@ -27,21 +26,6 @@ import org.apache.pulsar.client.impl.auth.AuthenticationDisabled;
 import org.apache.pulsar.client.api.EncodedAuthenticationParameterSupport;
 
 public final class AuthenticationFactory {
-
-    private static Map<String, String> parseAuthParamsString(String authParamsString) {
-        Map<String, String> authParams = new HashMap<>();
-
-        if (isNotBlank(authParamsString)) {
-            String[] params = authParamsString.split(",");
-            for (String p : params) {
-                String[] kv = p.split(":");
-                if (kv.length == 2) {
-                    authParams.put(kv[0], kv[1]);
-                }
-            }
-        }
-        return authParams;
-    }
 
     /**
      * Create an instance of the Authentication-Plugin
@@ -63,7 +47,7 @@ public final class AuthenticationFactory {
                     ((EncodedAuthenticationParameterSupport) auth).configure(authParamsString);
                 } else {
                     // Parse parameters by default parse logic.
-                    auth.configure(parseAuthParamsString(authParamsString));
+                    auth.configure(AuthenticationUtil.configureFromPulsar1AuthParamString(authParamsString));
                 }
                 return auth;
             } else {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/AuthenticationUtil.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/AuthenticationUtil.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.pulsar.common.util.ObjectMapperFactory;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class AuthenticationUtil {
+	public static Map<String, String> configureFromJsonString(String authParamsString) throws IOException {
+		ObjectMapper jsonMapper = ObjectMapperFactory.create();
+		return jsonMapper.readValue(authParamsString, new TypeReference<HashMap<String, String>>() {
+		});
+	}
+
+	public static Map<String, String> configureFromPulsar1AuthParamString(String authParamsString) {
+		Map<String, String> authParams = new HashMap<>();
+
+		if (isNotBlank(authParamsString)) {
+			String[] params = authParamsString.split(",");
+			for (String p : params) {
+				String[] kv = p.split(":");
+				if (kv.length == 2) {
+					authParams.put(kv[0], kv[1]);
+				}
+			}
+		}
+		return authParams;
+	}
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationDisabled.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationDisabled.java
@@ -23,9 +23,10 @@ import java.util.Map;
 
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
+import org.apache.pulsar.client.api.EncodedAuthenticationParameterSupport;
 import org.apache.pulsar.client.api.PulsarClientException;
 
-public class AuthenticationDisabled implements Authentication {
+public class AuthenticationDisabled implements Authentication, EncodedAuthenticationParameterSupport {
 
     protected final AuthenticationDataProvider nullData = new AuthenticationDataNull();
     /**
@@ -47,6 +48,11 @@ public class AuthenticationDisabled implements Authentication {
     }
 
     @Override
+    public void configure(String encodedAuthParamString) {
+    }
+
+    @Override
+    @Deprecated
     public void configure(Map<String, String> authParams) {
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationTls.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/AuthenticationTls.java
@@ -23,6 +23,8 @@ import java.util.Map;
 
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationDataProvider;
+import org.apache.pulsar.client.api.AuthenticationUtil;
+import org.apache.pulsar.client.api.EncodedAuthenticationParameterSupport;
 import org.apache.pulsar.client.api.PulsarClientException;
 
 /**
@@ -32,7 +34,7 @@ import org.apache.pulsar.client.api.PulsarClientException;
  * tlsCertFile: A file path for a client certificate. tlsKeyFile: A file path for a client private key.
  *
  */
-public class AuthenticationTls implements Authentication {
+public class AuthenticationTls implements Authentication, EncodedAuthenticationParameterSupport {
 
     private static final long serialVersionUID = 1L;
 
@@ -59,14 +61,24 @@ public class AuthenticationTls implements Authentication {
     }
 
     @Override
+    public void configure(String encodedAuthParamString) {
+        setAuthParams(AuthenticationUtil.configureFromPulsar1AuthParamString(encodedAuthParamString));
+    }
+
+    @Override
+    @Deprecated
     public void configure(Map<String, String> authParams) {
-        certFilePath = authParams.get("tlsCertFile");
-        keyFilePath = authParams.get("tlsKeyFile");
+        setAuthParams(authParams);
     }
 
     @Override
     public void start() throws PulsarClientException {
         // noop
+    }
+
+    private void setAuthParams(Map<String, String> authParams) {
+        certFilePath = authParams.get("tlsCertFile");
+        keyFilePath = authParams.get("tlsKeyFile");
     }
 
 }


### PR DESCRIPTION


### Motivation

AuthenticationTls only supports the old configure interface but we should the new one as preparation for 2.0

### Modifications

- Adds EncodedAuthenticationParameterSupport interface to
AuthenticationTls and AuthenticationDisabled.
- Mark some methods deprecated as preparation for 2.0

### Result

Authentication plugins are ready for 2.0.
