### PR TITLE
Use Apache dist server with HTTPS to link the release signatures

### DIFF
--- a/site/download.md
+++ b/site/download.md
@@ -24,7 +24,9 @@ layout: content
 
 -->
 
-{% capture root_url %}http://www.apache.org/dyn/closer.cgi/incubator/pulsar/pulsar-{{ site.current_version }}/apache-pulsar-{{ site.current_version }}{% endcapture %}
+{% capture mirror_url %}https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=incubator/pulsar/pulsar-{{ site.current_version }}/apache-pulsar-{{ site.current_version }}{% endcapture %}
+
+{% capture dist_url %}https://www.apache.org/dist/incubator/pulsar/pulsar-{{ site.current_version }}/apache-pulsar-{{ site.current_version }}{% endcapture %}
 
 You can download Pulsar from the [releases page](https://github.com/apache/incubator-pulsar/releases) on GitHub or here:
 
@@ -32,10 +34,10 @@ You can download Pulsar from the [releases page](https://github.com/apache/incub
 
 Release | Link | Crypto files
 :-------|:-----|:------------
-Binary | [pulsar-{{ site.current_version }}-bin.tar.gz]({{ root_url }}-bin.tar.gz) | [asc]({{ root_url }}-bin.tar.gz.asc), [md5]({{ root_url }}-bin.tar.gz.md5), [sha512]({{ root_url }}-bin.tar.gz.sha512)
-Source | [pulsar-{{ site.current_version }}-src.tar.gz]({{ root_url }}-src.tar.gz) | [asc]({{ root_url }}-src.tar.gz.asc), [md5]({{ root_url }}-src.tar.gz.md5), [sha512]({{ root_url }}-src.tar.gz.sha512)
+Binary | [pulsar-{{ site.current_version }}-bin.tar.gz]({{ mirror_url }}-bin.tar.gz) | [asc]({{ dist_url }}-bin.tar.gz.asc), [md5]({{ dist_url }}-bin.tar.gz.md5), [sha512]({{ dist_url }}-bin.tar.gz.sha512)
+Source | [pulsar-{{ site.current_version }}-src.tar.gz]({{ mirror_url }}-src.tar.gz) | [asc]({{ dist_url }}-src.tar.gz.asc), [md5]({{ dist_url }}-src.tar.gz.md5), [sha512]({{ dist_url }}-src.tar.gz.sha512)
 
-{% include admonition.html type="info" content='You can download the [KEYS](http://www.apache.org/dev/release-signing#keys-policy) file for Pulsar <a href="http://www.apache.org/dist/incubator/pulsar/KEYS" download>here</a>.' %}
+{% include admonition.html type="info" content='You can download the [KEYS](http://www.apache.org/dev/release-signing#keys-policy) file for Pulsar <a href="https://www.apache.org/dist/incubator/pulsar/KEYS" download>here</a>.' %}
 
 ### Release notes for the {{ site.current_version }} release
 


### PR DESCRIPTION
### Motivation

As pointed in #986, we're currently linking the release crypto signatures to the ASF mirrors, while they should be pointing to the "dist" server which is the source of truth. 

### Modifications

 * Fixed links to point to dist