### PR TITLE
Added REST handler to create a subscription on a topic

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/CreateSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/CreateSubscriptionTest.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.admin;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+import javax.ws.rs.ClientErrorException;
+import javax.ws.rs.core.Response.Status;
+
+import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.client.admin.PulsarAdminException.ConflictException;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.common.naming.DestinationName;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.Lists;
+
+public class CreateSubscriptionTest extends MockedPulsarServiceBaseTest {
+
+    @BeforeMethod
+    @Override
+    public void setup() throws Exception {
+        super.internalSetup();
+    }
+
+    @AfterMethod
+    @Override
+    public void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test
+    public void createSubscriptionSingleTopic() throws Exception {
+        String topic = "persistent://prop-xyz/use/ns1/my-topic";
+        admin.persistentTopics().createSubscription(topic, "sub-1", MessageId.latest);
+
+        // Create should fail if the subscription already exists
+        try {
+            admin.persistentTopics().createSubscription(topic, "sub-1", MessageId.latest);
+            fail("Should have failed");
+        } catch (ConflictException e) {
+            assertEquals(((ClientErrorException) e.getCause()).getResponse().getStatus(),
+                    Status.CONFLICT.getStatusCode());
+        }
+
+        assertEquals(admin.persistentTopics().getSubscriptions(topic), Lists.newArrayList("sub-1"));
+
+        Producer p1 = pulsarClient.createProducer(topic);
+        p1.send("test-1".getBytes());
+        p1.send("test-2".getBytes());
+        MessageId m3 = p1.send("test-3".getBytes());
+
+        assertEquals(admin.persistentTopics().getStats(topic).subscriptions.get("sub-1").msgBacklog, 3);
+
+        admin.persistentTopics().createSubscription(topic, "sub-2", MessageId.latest);
+        assertEquals(admin.persistentTopics().getStats(topic).subscriptions.get("sub-2").msgBacklog, 0);
+
+        admin.persistentTopics().createSubscription(topic, "sub-3", MessageId.earliest);
+        assertEquals(admin.persistentTopics().getStats(topic).subscriptions.get("sub-3").msgBacklog, 3);
+
+        admin.persistentTopics().createSubscription(topic, "sub-5", m3);
+        assertEquals(admin.persistentTopics().getStats(topic).subscriptions.get("sub-5").msgBacklog, 1);
+    }
+
+    @Test
+    public void createSubscriptionOnPartitionedTopic() throws Exception {
+        String topic = "persistent://prop-xyz/use/ns1/my-partitioned-topic";
+        admin.persistentTopics().createPartitionedTopic(topic, 10);
+
+        admin.persistentTopics().createSubscription(topic, "sub-1", MessageId.latest);
+
+        // Create should fail if the subscription already exists
+        try {
+            admin.persistentTopics().createSubscription(topic, "sub-1", MessageId.latest);
+            fail("Should have failed");
+        } catch (Exception e) {
+            // Expected
+        }
+
+        for (int i = 0; i < 10; i++) {
+            assertEquals(
+                    admin.persistentTopics().getSubscriptions(DestinationName.get(topic).getPartition(i).toString()),
+                    Lists.newArrayList("sub-1"));
+        }
+    }
+}

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PersistentTopics.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PersistentTopics.java
@@ -196,7 +196,7 @@ public interface PersistentTopics {
      * @return a future that can be used to track when the partitioned topic is created
      */
     CompletableFuture<Void> createPartitionedTopicAsync(String destination, int numPartitions);
-    
+
     /**
      * Update number of partitions of a non-global partitioned topic.
      * <p>
@@ -208,7 +208,7 @@ public interface PersistentTopics {
      *            Destination name
      * @param numPartitions
      *            Number of new partitions of already exist partitioned-topic
-     * 
+     *
      * @return a future that can be used to track when the partitioned topic is updated
      */
     void updatePartitionedTopic(String destination, int numPartitions) throws PulsarAdminException;
@@ -224,7 +224,7 @@ public interface PersistentTopics {
      *            Destination name
      * @param numPartitions
      *            Number of new partitions of already exist partitioned-topic
-     * 
+     *
      * @return a future that can be used to track when the partitioned topic is updated
      */
     CompletableFuture<Void> updatePartitionedTopicAsync(String destination, int numPartitions);
@@ -311,7 +311,7 @@ public interface PersistentTopics {
      * @return a future that can be used to track when the topic is deleted
      */
     CompletableFuture<Void> deleteAsync(String destination);
-    
+
     /**
      * Unload a topic.
      * <p>
@@ -798,6 +798,42 @@ public interface PersistentTopics {
     CompletableFuture<List<Message>> peekMessagesAsync(String destination, String subName, int numMessages);
 
     /**
+     * Create a new subscription on a topic
+     *
+     * @param destination
+     *            Destination name
+     * @param subscriptionName
+     *            Subscription name
+     * @param messageId
+     *            The {@link MessageId} on where to initialize the subscription. It could be {@link MessageId#latest},
+     *            {@link MessageId#earliest} or a specific message id.
+     *
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws ConflictException
+     *             Subscription already exists
+     * @throws NotAllowedException
+     *             Command disallowed for requested resource
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    void createSubscription(String destination, String subscriptionName, MessageId messageId)
+            throws PulsarAdminException;
+
+    /**
+     * Create a new subscription on a topic
+     *
+     * @param destination
+     *            Destination name
+     * @param subscriptionName
+     *            Subscription name
+     * @param messageId
+     *            The {@link MessageId} on where to initialize the subscription. It could be {@link MessageId#latest},
+     *            {@link MessageId#earliest} or a specific message id.
+     */
+    CompletableFuture<Void> createSubscriptionAsync(String destination, String subscriptionName, MessageId messageId);
+
+    /**
      * Reset cursor position on a topic subscription
      *
      * @param destination
@@ -829,7 +865,7 @@ public interface PersistentTopics {
      *            reset subscription to position closest to time in ms since epoch
      */
     CompletableFuture<Void> resetCursorAsync(String destination, String subName, long timestamp);
-    
+
     /**
      * Reset cursor position on a topic subscription
      *

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -36,6 +36,8 @@ import org.apache.pulsar.client.admin.PersistentTopics;
 import org.apache.pulsar.client.admin.Properties;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.ResourceQuotas;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.BacklogQuota.RetentionPolicy;
@@ -96,7 +98,7 @@ public class PulsarAdminToolTest {
         brokerStats.run(split("monitoring-metrics"));
         verify(mockBrokerStats).getMetrics();
     }
-    
+
     @Test
     void getOwnedNamespaces() throws Exception {
         PulsarAdmin admin = Mockito.mock(PulsarAdmin.class);
@@ -132,7 +134,7 @@ public class PulsarAdminToolTest {
 
         clusters.run(split("delete use"));
         verify(mockClusters).deleteCluster("use");
-        
+
         clusters.run(split("list-failure-domains use"));
         verify(mockClusters).getFailureDomains("use");
 
@@ -303,19 +305,19 @@ public class PulsarAdminToolTest {
 
         namespaces.run(split("get-message-ttl myprop/clust/ns1"));
         verify(mockNamespaces).getNamespaceMessageTTL("myprop/clust/ns1");
-        
+
         namespaces.run(split("set-anti-affinity-group myprop/clust/ns1 -g group"));
         verify(mockNamespaces).setNamespaceAntiAffinityGroup("myprop/clust/ns1", "group");
 
         namespaces.run(split("get-anti-affinity-group myprop/clust/ns1"));
         verify(mockNamespaces).getNamespaceAntiAffinityGroup("myprop/clust/ns1");
-        
+
         namespaces.run(split("get-anti-affinity-namespaces -p dummy -c cluster -g group"));
         verify(mockNamespaces).getAntiAffinityNamespaces("dummy", "cluster", "group");
 
         namespaces.run(split("delete-anti-affinity-group myprop/clust/ns1 "));
         verify(mockNamespaces).deleteNamespaceAntiAffinityGroup("myprop/clust/ns1");
-        
+
 
         namespaces.run(split("set-retention myprop/clust/ns1 -t 1h -s 1M"));
         verify(mockNamespaces).setRetention("myprop/clust/ns1", new RetentionPolicies(60, 1));
@@ -444,6 +446,9 @@ public class PulsarAdminToolTest {
         topics.run(split("expire-messages-all-subscriptions persistent://myprop/clust/ns1/ds1 -t 100"));
         verify(mockTopics).expireMessagesForAllSubscriptions("persistent://myprop/clust/ns1/ds1", 100);
 
+        topics.run(split("create-subscription persistent://myprop/clust/ns1/ds1 -s sub1 --messageId earliest"));
+        verify(mockTopics).createSubscription("persistent://myprop/clust/ns1/ds1", "sub1", MessageId.earliest);
+
         topics.run(split("create-partitioned-topic persistent://myprop/clust/ns1/ds1 --partitions 32"));
         verify(mockTopics).createPartitionedTopic("persistent://myprop/clust/ns1/ds1", 32);
 
@@ -494,10 +499,10 @@ public class PulsarAdminToolTest {
 
         topics.run(split("create-partitioned-topic non-persistent://myprop/clust/ns1/ds1 --partitions 32"));
         verify(mockTopics).createPartitionedTopic("non-persistent://myprop/clust/ns1/ds1", 32);
-        
+
         topics.run(split("list myprop/clust/ns1"));
         verify(mockTopics).getList("myprop/clust/ns1");
-        
+
         topics.run(split("list-in-bundle myprop/clust/ns1 --bundle 0x23d70a30_0x26666658"));
         verify(mockTopics).getListInBundle("myprop/clust/ns1", "0x23d70a30_0x26666658");
 


### PR DESCRIPTION
### Motivation

Added a way to create a subscription on a topic, forcing the creation if the topic doesn't exist.

This is primarily needed to simplify the logic of the "increase partitions" operation (#1143), though it makes also sense as a general tool, to let people pre-create subscriptions from CLI.

