### PR TITLE
Fix bundler version error

### DIFF
--- a/site/Makefile
+++ b/site/Makefile
@@ -1,5 +1,4 @@
-BUNDLER_VERSION = 1.16
-BUNDLE = bundle _$(BUNDLER_VERSION)_
+BUNDLE = bundle
 JEKYLL = $(BUNDLE) exec jekyll
 
 deep_clean:
@@ -24,7 +23,6 @@ clean_local:
 
 ruby_setup:
 	gem install bundler \
-		-v $(BUNDLER_VERSION) \
 		--no-rdoc \
 		--no-ri
 	NOKOGIRI_USE_SYSTEM_LIBRARIES=true $(BUNDLE) install \

--- a/site/scripts/build-all-versions.sh
+++ b/site/scripts/build-all-versions.sh
@@ -19,7 +19,7 @@
 #
 
 
-BUNDLER_VERSION=1.15.1
+BUNDLER_VERSION=1.16.0
 
 for version in $(cat VERSIONS); do
   JEKYLL_ENV=production bundle _${BUNDLER_VERSION}_ exec jekyll build \

--- a/site/scripts/build-all-versions.sh
+++ b/site/scripts/build-all-versions.sh
@@ -19,9 +19,7 @@
 #
 
 
-BUNDLER_VERSION=1.16.0
-
 for version in $(cat VERSIONS); do
-  JEKYLL_ENV=production bundle _${BUNDLER_VERSION}_ exec jekyll build \
+  JEKYLL_ENV=production bundle exec jekyll build \
     --config _config.yml,docs/$version/_config.version.yml
 done


### PR DESCRIPTION
### Motivation

A CI issue emerged due to mismatched [Bundler](http://bundler.io/) versions between the build script in `site/scripts/build-all-versions.sh` and the Ruby setup script in `site/Makefile`.

### Modifications

There shouldn't ever be a need to specify the Bundler version. The tool is stable enough that `latest` should always suffice for any task related to the website.

### Result

We *should* be able to avoid this category of error entirely in the future.
