### PR TITLE
Debump netty version by 1 due to ObjectCleaner bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@ flexible messaging model and an intuitive client API.</description>
 
     <bookkeeper.version>4.3.1.85-yahoo</bookkeeper.version>
     <zookeeper.version>3.4.10</zookeeper.version>
-    <netty.version>4.1.20.Final</netty.version>
+    <netty.version>4.1.19.Final</netty.version>
     <storm.version>1.0.5</storm.version>
     <jetty.version>9.3.11.v20160721</jetty.version>
     <athenz.version>1.7.17</athenz.version>


### PR DESCRIPTION
The ObjectCleaner can possibly keep a process alive forever with netty
4.1.20 since it is not a daemon thread.

See: https://github.com/netty/netty/issues/7617

This causes initialize-cluster-metadata to hang forever. 4.1.19
doesn't have this issue, so we should drop down to that until the fix
is in a release.
