### PR TITLE
Fixed managed ledger missing callback issue when unloading a topic

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerException.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerException.java
@@ -37,7 +37,7 @@ public class ManagedLedgerException extends Exception {
         }
         return new ManagedLedgerException(e);
     }
-    
+
     public static class MetaStoreException extends ManagedLedgerException {
         public MetaStoreException(Exception e) {
             super(e);
@@ -80,6 +80,12 @@ public class ManagedLedgerException extends Exception {
 
     public static class ConcurrentFindCursorPositionException extends ManagedLedgerException {
         public ConcurrentFindCursorPositionException(String msg) {
+            super(msg);
+        }
+    }
+
+    public static class ManagedLedgerAlreadyClosedException extends ManagedLedgerException {
+        public ManagedLedgerAlreadyClosedException(String msg) {
             super(msg);
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerServiceException.java
@@ -47,6 +47,12 @@ public class BrokerServiceException extends Exception {
         }
     }
 
+    public static class TopicClosedException extends BrokerServiceException {
+        public TopicClosedException(Throwable t) {
+            super(t);
+        }
+    }
+
     public static class PersistenceException extends BrokerServiceException {
         public PersistenceException(Throwable t) {
             super(t);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -30,6 +30,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import org.apache.bookkeeper.mledger.util.Rate;
+import org.apache.pulsar.broker.service.BrokerServiceException.TopicClosedException;
 import org.apache.pulsar.broker.service.BrokerServiceException.TopicTerminatedException;
 import org.apache.pulsar.broker.service.Topic.PublishContext;
 import org.apache.pulsar.broker.service.nonpersistent.NonPersistentTopic;
@@ -279,8 +280,12 @@ public class Producer {
                         ? ServerError.TopicTerminatedError : ServerError.PersistenceError;
 
                 producer.cnx.ctx().channel().eventLoop().execute(() -> {
-                    producer.cnx.ctx().writeAndFlush(Commands.newSendError(producer.producerId, sequenceId, serverError,
-                            exception.getMessage()));
+                    if (!(exception instanceof TopicClosedException)) {
+                        // For TopicClosed exception there's no need to send explicit error, since the client was
+                        // already notified
+                        producer.cnx.ctx().writeAndFlush(Commands.newSendError(producer.producerId, sequenceId,
+                                serverError, exception.getMessage()));
+                    }
                     producer.cnx.completedSendOperation(producer.isNonPersistentTopic);
                     producer.publishOperationCompleted();
                     recycle();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -44,6 +44,7 @@ import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedCursor.IndividualDeletedEntries;
 import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.bookkeeper.mledger.ManagedLedgerException.ManagedLedgerAlreadyClosedException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.ManagedLedgerFencedException;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.ManagedLedgerTerminatedException;
 import org.apache.bookkeeper.mledger.Position;
@@ -59,6 +60,7 @@ import org.apache.pulsar.broker.service.BrokerServiceException.PersistenceExcept
 import org.apache.pulsar.broker.service.BrokerServiceException.ServerMetadataException;
 import org.apache.pulsar.broker.service.BrokerServiceException.SubscriptionBusyException;
 import org.apache.pulsar.broker.service.BrokerServiceException.TopicBusyException;
+import org.apache.pulsar.broker.service.BrokerServiceException.TopicClosedException;
 import org.apache.pulsar.broker.service.BrokerServiceException.TopicFencedException;
 import org.apache.pulsar.broker.service.BrokerServiceException.TopicTerminatedException;
 import org.apache.pulsar.broker.service.BrokerServiceException.UnsupportedVersionException;
@@ -253,7 +255,18 @@ public class PersistentTopic implements Topic, AddEntryCallback {
     @Override
     public void addFailed(ManagedLedgerException exception, Object ctx) {
         PublishContext callback = (PublishContext) ctx;
-        log.error("[{}] Failed to persist msg in store: {}", topic, exception.getMessage());
+
+        if (exception instanceof ManagedLedgerAlreadyClosedException) {
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] Failed to persist msg in store: {}", topic, exception.getMessage());
+            }
+
+            callback.completed(new TopicClosedException(exception), -1, -1);
+            return;
+
+        } else {
+            log.warn("[{}] Failed to persist msg in store: {}", topic, exception.getMessage());
+        }
 
         if (exception instanceof ManagedLedgerTerminatedException) {
             // Signal the producer that this topic is no longer available


### PR DESCRIPTION
### Motivation

During topic unload we disconnect producers and consumers without forcing to close the TCP connection, but just by sending a notification to the client. At the same time, we force to close the underlying managed ledger for the topic and that will cause to fence the ledger and reject any subsequent pending write request. 

The current behavior is that the write callbacks for all the failed pending operation are not being triggered. That is generally not a problem, since the reconnection logic is already triggered by the close-producer notification.

The problem that arise, though, is that by not processing the callback, the number of outstanding write-operation is not being decreased. That counter is used to control the "auto-read" status on the connection, with the purpose of applying backpressure and not have unlimited pending writes on bokkeeper. By missing the decrement, after several unloads (without closing the TCP connection), the leaking counter will never be draining and it will stay in "auto-read=off" mode, essentially stalling the connection.

### Modifications

Ensure failure callbacks are triggered for each pending write operation at the managed ledger closure.