### PR TITLE
Use double to configure loadBalancerOverrideBrokerNicSpeedGbps

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -360,7 +360,8 @@ loadBalancerNamespaceMaximumBundles=128
 # reported by Linux is not reflecting the real bandwidth available to the broker.
 # Since the network usage is employed by the load manager to decide when a broker
 # is overloaded, it is important to make sure the info is correct or override it 
-# with the right value here.
+# with the right value here. The configured value can be a double (eg: 0.8) and that
+# can be used to trigger load-shedding even before hitting on NIC limits.
 loadBalancerOverrideBrokerNicSpeedGbps=
 
 # Name of load manager to use

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -349,7 +349,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private String loadManagerClassName = "org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl";
 
     // Option to override the auto-detected network interfaces max speed
-    private Integer loadBalancerOverrideBrokerNicSpeedGbps;
+    private Double loadBalancerOverrideBrokerNicSpeedGbps;
 
     /**** --- Replication --- ****/
     // Enable replication metrics
@@ -1220,11 +1220,11 @@ public class ServiceConfiguration implements PulsarConfiguration {
         return this.loadBalancerNamespaceMaximumBundles;
     }
 
-    public Optional<Integer> getLoadBalancerOverrideBrokerNicSpeedGbps() {
+    public Optional<Double> getLoadBalancerOverrideBrokerNicSpeedGbps() {
         return Optional.ofNullable(loadBalancerOverrideBrokerNicSpeedGbps);
     }
 
-    public void setLoadBalancerOverrideBrokerNicSpeedGbps(int loadBalancerOverrideBrokerNicSpeedGbps) {
+    public void setLoadBalancerOverrideBrokerNicSpeedGbps(double loadBalancerOverrideBrokerNicSpeedGbps) {
         this.loadBalancerOverrideBrokerNicSpeedGbps = loadBalancerOverrideBrokerNicSpeedGbps;
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LinuxBrokerHostUsageImpl.java
@@ -55,7 +55,7 @@ public class LinuxBrokerHostUsageImpl implements BrokerHostUsage {
     private OperatingSystemMXBean systemBean;
     private SystemResourceUsage usage;
 
-    private final Optional<Integer> overrideBrokerNicSpeedGbps;
+    private final Optional<Double> overrideBrokerNicSpeedGbps;
 
     private static final Logger LOG = LoggerFactory.getLogger(LinuxBrokerHostUsageImpl.class);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadReportNetworkLimit.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadReportNetworkLimit.java
@@ -32,7 +32,7 @@ public class LoadReportNetworkLimit extends MockedPulsarServiceBaseTest {
     @Override
     public void setup() throws Exception {
         conf.setLoadBalancerEnabled(true);
-        conf.setLoadBalancerOverrideBrokerNicSpeedGbps(5);
+        conf.setLoadBalancerOverrideBrokerNicSpeedGbps(5.4);
         super.internalSetup();
     }
 
@@ -49,8 +49,8 @@ public class LoadReportNetworkLimit extends MockedPulsarServiceBaseTest {
         LoadManagerReport report = admin.brokerStats().getLoadReport();
 
         if (SystemUtils.IS_OS_LINUX) {
-            assertEquals(report.getBandwidthIn().limit, 5.0 * 1024 * 1024);
-            assertEquals(report.getBandwidthOut().limit, 5.0 * 1024 * 1024);
+            assertEquals(report.getBandwidthIn().limit, 5.4 * 1024 * 1024);
+            assertEquals(report.getBandwidthOut().limit, 5.4 * 1024 * 1024);
         } else {
             // On non-Linux system we don't report the network usage
             assertEquals(report.getBandwidthIn().limit, -1.0);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/ServiceConfigurationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/ServiceConfigurationTest.java
@@ -73,7 +73,7 @@ public class ServiceConfigurationTest {
         String confFile = "loadBalancerOverrideBrokerNicSpeedGbps=5\n";
         InputStream stream = new ByteArrayInputStream(confFile.getBytes());
         final ServiceConfiguration config = PulsarConfigurationLoader.create(stream, ServiceConfiguration.class);
-        assertEquals(config.getLoadBalancerOverrideBrokerNicSpeedGbps(), Optional.of(5));
+        assertEquals(config.getLoadBalancerOverrideBrokerNicSpeedGbps(), Optional.of(5.0));
     }
 
     /**

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/FieldParser.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/FieldParser.java
@@ -219,7 +219,12 @@ public final class FieldParser {
      * @return The converted Double value.
      */
     public static Double stringToDouble(String val) {
-        return Double.valueOf(trim(val));
+        String v = trim(val);
+        if (StringUtil.isNullOrEmpty(v)) {
+            return null;
+        } else {
+            return Double.valueOf(v);
+        }
     }
 
     /**


### PR DESCRIPTION
### Motivation

In some cases the network traffic might get rate limited before actually hitting the 1Gbps limit. It's better to allow users to configure <1Gbps NIC speed limit to trigger load shedding earlier.