### PR TITLE
Performance producer was not using the max producer queue size argument

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -269,6 +269,7 @@ public class PerformanceProducer {
         ProducerConfiguration producerConf = new ProducerConfiguration();
         producerConf.setSendTimeout(0, TimeUnit.SECONDS);
         producerConf.setCompressionType(arguments.compression);
+        producerConf.setMaxPendingMessages(arguments.maxOutstanding);
         // enable round robin message routing if it is a partitioned topic
         producerConf.setMessageRoutingMode(MessageRoutingMode.RoundRobinPartition);
         if (arguments.batchTime > 0) {


### PR DESCRIPTION
### Motivation

Perf producer tool is not using the max-outstanding messages parameter