### PR TITLE
Upgrade to Netty-4.1.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@ flexible messaging model and an intuitive client API.</description>
 
     <bookkeeper.version>4.3.1.91-yahoo</bookkeeper.version>
     <zookeeper.version>3.4.10</zookeeper.version>
-    <netty.version>4.1.19.Final</netty.version>
+    <netty.version>4.1.21.Final</netty.version>
     <storm.version>1.0.5</storm.version>
     <jetty.version>9.3.11.v20160721</jetty.version>
     <athenz.version>1.7.17</athenz.version>


### PR DESCRIPTION
### Motivation

In #1169 we downgraded Netty from 4.1.20 to 4.1.19 because of the `ObjectCleaner` thread bug in netty/netty#7617

That issue was fixed in 4.1.21 and we should upgrade from 4.1.19 because of other issues like: netty/netty#7563