### PR TITLE
Added instructions to verify the release artifacts signatures

### DIFF
--- a/site/download.md
+++ b/site/download.md
@@ -37,7 +37,14 @@ Release | Link | Crypto files
 Binary | [pulsar-{{ site.current_version }}-bin.tar.gz]({{ mirror_url }}-bin.tar.gz) | [asc]({{ dist_url }}-bin.tar.gz.asc), [md5]({{ dist_url }}-bin.tar.gz.md5), [sha512]({{ dist_url }}-bin.tar.gz.sha512)
 Source | [pulsar-{{ site.current_version }}-src.tar.gz]({{ mirror_url }}-src.tar.gz) | [asc]({{ dist_url }}-src.tar.gz.asc), [md5]({{ dist_url }}-src.tar.gz.md5), [sha512]({{ dist_url }}-src.tar.gz.sha512)
 
-{% include admonition.html type="info" content='You can download the [KEYS](http://www.apache.org/dev/release-signing#keys-policy) file for Pulsar <a href="https://www.apache.org/dist/incubator/pulsar/KEYS" download>here</a>.' %}
+### Release Integrity
+
+You must [verify](https://www.apache.org/info/verification.html) the integrity of the downloaded files.
+We provide OpenPGP signatures for every release file. This signature should be matched against the
+[KEYS](https://www.apache.org/dist/incubator/pulsar/KEYS) file which contains the OpenPGP keys of
+Pulsar's Release Managers. We also provide `MD5` and `SHA-512` checksums for every release file.
+After you download the file, you should calculate a checksum for your download, and make sure it is
+the same as ours.
 
 ### Release notes for the {{ site.current_version }} release
 


### PR DESCRIPTION
### Motivation

The last requirement specified in #986 was to add instructions for checking the integrity of the downloaded artifacts, with the example of the Tomcat download page :https://tomcat.apache.org/download-90.cgi#Release_Integrity