### PR TITLE
Perf producer was overriding the producer max queue size

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -275,7 +275,6 @@ public class PerformanceProducer {
         if (arguments.batchTime > 0) {
             producerConf.setBatchingMaxPublishDelay(arguments.batchTime, TimeUnit.MILLISECONDS);
             producerConf.setBatchingEnabled(true);
-            producerConf.setMaxPendingMessages(arguments.msgRate);
         }
 
         // Block if queue is full else we will start seeing errors in sendAsync


### PR DESCRIPTION
### Motivation

The perf-producer is overriding the producer queue size that is being set as a CLI argument.