### PR TITLE
Use duplicates when writing from ByteBuf pair to avoid multiple threads issues

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/ByteBufPair.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/ByteBufPair.java
@@ -121,8 +121,8 @@ public final class ByteBufPair extends AbstractReferenceCounted {
                 // ByteBuf are automatically released after a write. If the ByteBufPair ref count is increased and it
                 // gets written multiple times, the individual buffers refcount should be reflected as well.
                 try {
-                    ctx.write(b.getFirst().retain(), ctx.voidPromise());
-                    ctx.write(b.getSecond().retain(), promise);
+                    ctx.write(b.getFirst().retainedDuplicate(), ctx.voidPromise());
+                    ctx.write(b.getSecond().retainedDuplicate(), promise);
                 } finally {
                     ReferenceCountUtil.safeRelease(b);
                 }


### PR DESCRIPTION
### Motivation

This is a fix for #1201.

The truncation happens when, during an unload, the topic moves from one broker to another. If the write operation on the previous connection was still ongoing, it can cause issues when the new IO (associated with the "new" connection) will start writing on the new socket.

### Modifications

Take a duplicate of the`ByteBuf` so that each thread will have its own `readerIndex` on the buffer.