### PR TITLE
Fixed missing '"' sign in system metrics for Prometheus

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -85,14 +85,13 @@ public class PrometheusMetricsGenerator {
             for (int i = 0; i < metricFamily.samples.size(); i++) {
                 Sample sample = metricFamily.samples.get(i);
                 stream.write(sample.name);
-                stream.write("{cluster=\"").write(cluster).write("\",");
+                stream.write("{cluster=\"").write(cluster).write('"');
                 for (int j = 0; j < sample.labelNames.size(); j++) {
+                    stream.write(", ");
                     stream.write(sample.labelNames.get(j));
                     stream.write("=\"");
                     stream.write(sample.labelValues.get(j));
-                    if (j != sample.labelNames.size() - 1) {
-                        stream.write("\",");
-                    }
+                    stream.write('"');
                 }
 
                 stream.write("} ");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -90,6 +90,11 @@ public class PrometheusMetricsTest extends BrokerTestBase {
         assertEquals(cm.get(1).tags.get("topic"), "persistent://my-property/use/my-ns/my-topic1");
         assertEquals(cm.get(1).tags.get("namespace"), "my-property/use/my-ns");
 
+        cm = (List<Metric>) metrics.get("topic_load_times_count");
+        assertEquals(cm.size(), 1);
+        assertEquals(cm.get(0).value, 2.0);
+        assertEquals(cm.get(0).tags.get("cluster"), "test");
+
         p1.close();
         p2.close();
     }


### PR DESCRIPTION
### Motivation

There was a bug in #1185 that was removing the final '"' for metrics reported to Prometheus make the parser to reject them.