### PR TITLE
Cancel keep-alive timer task after the proxy switch to TCP proxy

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/PulsarHandler.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/PulsarHandler.java
@@ -67,9 +67,7 @@ public abstract class PulsarHandler extends PulsarDecoder {
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-        if (keepAliveTask != null) {
-            keepAliveTask.cancel(false);
-        }
+        cancelKeepAliveTask();
     }
 
     @Override
@@ -110,6 +108,13 @@ public abstract class PulsarHandler extends PulsarDecoder {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] Peer doesn't support keep-alive", ctx.channel());
             }
+        }
+    }
+
+    protected void cancelKeepAliveTask() {
+        if (keepAliveTask != null) {
+            keepAliveTask.cancel(false);
+            keepAliveTask = null;
         }
     }
 

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConnection.java
@@ -168,6 +168,7 @@ public class ProxyConnection extends PulsarHandler implements FutureListener<Voi
             // there and just pass bytes in both directions
             state = State.ProxyConnectionToBroker;
             directProxyHandler = new DirectProxyHandler(service, this, connect.getProxyToBrokerUrl());
+            cancelKeepAliveTask();
         } else {
             // Client is doing a lookup, we can consider the handshake complete and we'll take care of just topics and
             // partitions metadata lookups


### PR DESCRIPTION
### Motivation

After initial handshake, the Pulsar proxy switches to TCP proxy mode, by just copying buffers between the 2 connections and avoiding all parsing. 

When that happens, for keep-alive messages, we rely on what the client and broker are exchanging, so they will be able to detect a stale connection client-proxy or proxy-broker. 
Currently, we're not removing the keep-alive timer in the proxy, so it's forcefully closing the connection after 60s, even though client and broker are perfectly fine.

