### PR TITLE
Enable specification of TLS Protocol Versions and Cipher Suites

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -179,8 +179,8 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private String tlsTrustCertsFilePath = "";
     // Accept untrusted TLS certificate from client
     private boolean tlsAllowInsecureConnection = false;
-    // Specify the tls version and cipher the broker will use to negotiate during TLS Handshake.
-    private Set<String> tlsVersions = Sets.newTreeSet();
+    // Specify the tls protocols and cipher the broker will use to negotiate during TLS Handshake.
+    private Set<String> tlsProtocols = Sets.newTreeSet();
     private Set<String> tlsCiphers = Sets.newTreeSet();
     
     /***** --- Authentication --- ****/
@@ -1393,19 +1393,19 @@ public class ServiceConfiguration implements PulsarConfiguration {
         this.authenticateOriginalAuthData = authenticateOriginalAuthData;
     }
     
-    public Set<String> getTlsVersions() {
-        return tlsVersions;
+    public Set<String> getTlsProtocols() {
+        return tlsProtocols;
     }
 
-    public void setTlsVersions(Set<String> tlsVersions) {
-        this.tlsVersions = tlsVersions;
+    public void setTlsProtocols(Set<String> tlsProtocols) {
+        this.tlsProtocols = tlsProtocols;
     }
 
     public Set<String> getTlsCiphers() {
         return tlsCiphers;
     }
 
-    public void setTlsCipher(Set<String> tlsCiphers) {
+    public void setTlsCiphers(Set<String> tlsCiphers) {
         this.tlsCiphers = tlsCiphers;
     }
 }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -179,8 +179,12 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private String tlsTrustCertsFilePath = "";
     // Accept untrusted TLS certificate from client
     private boolean tlsAllowInsecureConnection = false;
-    // Specify the tls protocols and cipher the broker will use to negotiate during TLS Handshake.
+    // Specify the tls protocols the broker will use to negotiate during TLS Handshake.
+    // Example:- [TLSv1.2, TLSv1.1, TLSv1]
     private Set<String> tlsProtocols = Sets.newTreeSet();
+    // Specify the tls cipher the broker will use to negotiate during TLS Handshake.
+    // Example:- [TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256]
+
     private Set<String> tlsCiphers = Sets.newTreeSet();
     
     /***** --- Authentication --- ****/

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -184,7 +184,6 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private Set<String> tlsProtocols = Sets.newTreeSet();
     // Specify the tls cipher the broker will use to negotiate during TLS Handshake.
     // Example:- [TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256]
-
     private Set<String> tlsCiphers = Sets.newTreeSet();
     
     /***** --- Authentication --- ****/

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -179,7 +179,10 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private String tlsTrustCertsFilePath = "";
     // Accept untrusted TLS certificate from client
     private boolean tlsAllowInsecureConnection = false;
-
+    // Specify the tls version and cipher the broker will use to negotiate during TLS Handshake.
+    private Set<String> tlsVersions = Sets.newTreeSet();
+    private Set<String> tlsCiphers = Sets.newTreeSet();
+    
     /***** --- Authentication --- ****/
     // Enable authentication
     private boolean authenticationEnabled = false;
@@ -1388,5 +1391,21 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     public void setAuthenticateOriginalAuthData(boolean authenticateOriginalAuthData) {
         this.authenticateOriginalAuthData = authenticateOriginalAuthData;
+    }
+    
+    public Set<String> getTlsVersions() {
+        return tlsVersions;
+    }
+
+    public void setTlsVersions(Set<String> tlsVersions) {
+        this.tlsVersions = tlsVersions;
+    }
+
+    public Set<String> getTlsCiphers() {
+        return tlsCiphers;
+    }
+
+    public void setTlsCipher(Set<String> tlsCiphers) {
+        this.tlsCiphers = tlsCiphers;
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarChannelInitializer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarChannelInitializer.java
@@ -18,10 +18,14 @@
  */
 package org.apache.pulsar.broker.service;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.common.api.ByteBufPair;
 import org.apache.pulsar.common.api.PulsarDecoder;
 import org.apache.pulsar.common.util.SecurityUtility;
+import org.testng.collections.Lists;
 
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.socket.SocketChannel;
@@ -50,7 +54,10 @@ public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> 
     @Override
     protected void initChannel(SocketChannel ch) throws Exception {
         if (enableTLS) {
-            SslContext sslCtx = SecurityUtility.createNettySslContextForServer(serviceConfig.isTlsAllowInsecureConnection(), serviceConfig.getTlsTrustCertsFilePath(), serviceConfig.getTlsCertificateFilePath(), serviceConfig.getTlsKeyFilePath());
+            SslContext sslCtx = SecurityUtility.createNettySslContextForServer(
+                    serviceConfig.isTlsAllowInsecureConnection(), serviceConfig.getTlsTrustCertsFilePath(),
+                    serviceConfig.getTlsCertificateFilePath(), serviceConfig.getTlsKeyFilePath(),
+                    serviceConfig.getTlsCiphers(), serviceConfig.getTlsVersions());
             ch.pipeline().addLast(TLS_HANDLER, sslCtx.newHandler(ch.alloc()));
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarChannelInitializer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/PulsarChannelInitializer.java
@@ -18,14 +18,10 @@
  */
 package org.apache.pulsar.broker.service;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.common.api.ByteBufPair;
 import org.apache.pulsar.common.api.PulsarDecoder;
 import org.apache.pulsar.common.util.SecurityUtility;
-import org.testng.collections.Lists;
 
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.socket.SocketChannel;
@@ -57,7 +53,7 @@ public class PulsarChannelInitializer extends ChannelInitializer<SocketChannel> 
             SslContext sslCtx = SecurityUtility.createNettySslContextForServer(
                     serviceConfig.isTlsAllowInsecureConnection(), serviceConfig.getTlsTrustCertsFilePath(),
                     serviceConfig.getTlsCertificateFilePath(), serviceConfig.getTlsKeyFilePath(),
-                    serviceConfig.getTlsCiphers(), serviceConfig.getTlsVersions());
+                    serviceConfig.getTlsCiphers(), serviceConfig.getTlsProtocols());
             ch.pipeline().addLast(TLS_HANDLER, sslCtx.newHandler(ch.alloc()));
         }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -249,13 +249,13 @@ public abstract class MockedPulsarServiceBaseTest {
         }
     };
 
-    public static void retryStrategically(Predicate<Void> predicate, int retryCount, long intSleepTime)
+    public static void retryStrategically(Predicate<Void> predicate, int retryCount, long intSleepTimeInMillis)
             throws Exception {
         for (int i = 0; i < retryCount; i++) {
             if (predicate.test(null) || i == (retryCount - 1)) {
                 break;
             }
-            Thread.sleep(intSleepTime + (intSleepTime * i));
+            Thread.sleep(intSleepTimeInMillis + (intSleepTimeInMillis * i));
         }
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -564,6 +564,10 @@ public class ClientCnx extends PulsarHandler {
         SSLSession sslSession = null;
         if (sslHandler != null) {
             sslSession = ((SslHandler) sslHandler).engine().getSession();
+            if (log.isDebugEnabled()) {
+                log.debug("Verifying HostName for {}, Cipher {}, Protocols {}", hostname, sslSession.getCipherSuite(),
+                        sslSession.getProtocol());
+            }
             return hostnameVerifier.verify(hostname, sslSession);
         }
         return false;

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
@@ -37,6 +37,8 @@ import java.security.spec.KeySpec;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Base64;
 import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
@@ -95,12 +97,22 @@ public class SecurityUtility {
     }
 
     public static SslContext createNettySslContextForServer(boolean allowInsecureConnection, String trustCertsFilePath,
-            String certFilePath, String keyFilePath)
+            String certFilePath, String keyFilePath, Set<String> ciphers, Set<String> protocols)
             throws GeneralSecurityException, SSLException, FileNotFoundException {
         X509Certificate[] certificates = loadCertificatesFromPemFile(certFilePath);
         PrivateKey privateKey = loadPrivateKeyFromPemFile(keyFilePath);
 
         SslContextBuilder builder = SslContextBuilder.forServer(privateKey, (X509Certificate[]) certificates);
+        if (ciphers != null && ciphers.size() > 0) {
+            builder.ciphers(ciphers);
+        }
+
+        if (protocols != null && protocols.size() > 0) {
+            String[] protocolsArray = new String[protocols.size()];
+            protocolsArray = protocols.toArray(protocolsArray);
+            builder.protocols(protocolsArray);
+        }
+        
         if (allowInsecureConnection) {
             builder.trustManager(InsecureTrustManagerFactory.INSTANCE);
         } else {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
@@ -108,8 +108,7 @@ public class SecurityUtility {
         }
 
         if (protocols != null && protocols.size() > 0) {
-            String[] protocolsArray = new String[protocols.size()];
-            builder.protocols(protocols.toArray(protocolsArray));
+            builder.protocols((String[]) protocols.toArray());
         }
         
         if (allowInsecureConnection) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
@@ -108,7 +108,8 @@ public class SecurityUtility {
         }
 
         if (protocols != null && protocols.size() > 0) {
-            builder.protocols((String[]) protocols.toArray());
+            String[] protocolsArray = new String[protocols.size()];
+            builder.protocols(protocols.toArray(protocolsArray));
         }
         
         if (allowInsecureConnection) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/SecurityUtility.java
@@ -109,8 +109,7 @@ public class SecurityUtility {
 
         if (protocols != null && protocols.size() > 0) {
             String[] protocolsArray = new String[protocols.size()];
-            protocolsArray = protocols.toArray(protocolsArray);
-            builder.protocols(protocolsArray);
+            builder.protocols(protocols.toArray(protocolsArray));
         }
         
         if (allowInsecureConnection) {

--- a/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/ServiceChannelInitializer.java
+++ b/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/ServiceChannelInitializer.java
@@ -51,7 +51,8 @@ public class ServiceChannelInitializer extends ChannelInitializer<SocketChannel>
         if (enableTLS) {
             SslContext sslCtx = SecurityUtility.createNettySslContextForServer(
                     serviceConfig.isTlsAllowInsecureConnection(), serviceConfig.getTlsTrustCertsFilePath(),
-                    serviceConfig.getTlsCertificateFilePath(), serviceConfig.getTlsKeyFilePath());
+                    serviceConfig.getTlsCertificateFilePath(), serviceConfig.getTlsKeyFilePath(),
+                    serviceConfig.getTlsCiphers(), serviceConfig.getTlsProtocols());
             ch.pipeline().addLast(TLS_HANDLER, sslCtx.newHandler(ch.alloc()));
         }
         ch.pipeline().addLast("frameDecoder", new LengthFieldBasedFrameDecoder(PulsarDecoder.MaxFrameSize, 0, 4, 0, 4));

--- a/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/server/ServiceConfig.java
+++ b/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/server/ServiceConfig.java
@@ -79,7 +79,10 @@ public class ServiceConfig implements PulsarConfiguration {
     private String tlsTrustCertsFilePath = "";
     // Accept untrusted TLS certificate from client
     private boolean tlsAllowInsecureConnection = false;
-
+    // Specify the tls protocols and cipher the broker will use to negotiate during TLS Handshake.
+    private Set<String> tlsProtocols = Sets.newTreeSet();
+    private Set<String> tlsCiphers = Sets.newTreeSet();
+    
     private Properties properties = new Properties();
 
     public String getZookeeperServers() {
@@ -232,5 +235,21 @@ public class ServiceConfig implements PulsarConfiguration {
 
     public void setProperties(Properties properties) {
         this.properties = properties;
+    }
+    
+    public Set<String> getTlsProtocols() {
+        return tlsProtocols;
+    }
+
+    public void setTlsProtocols(Set<String> tlsProtocols) {
+        this.tlsProtocols = tlsProtocols;
+    }
+
+    public Set<String> getTlsCiphers() {
+        return tlsCiphers;
+    }
+
+    public void setTlsCiphers(Set<String> tlsCiphers) {
+        this.tlsCiphers = tlsCiphers;
     }
 }

--- a/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/server/ServiceConfig.java
+++ b/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/server/ServiceConfig.java
@@ -79,8 +79,11 @@ public class ServiceConfig implements PulsarConfiguration {
     private String tlsTrustCertsFilePath = "";
     // Accept untrusted TLS certificate from client
     private boolean tlsAllowInsecureConnection = false;
-    // Specify the tls protocols and cipher the broker will use to negotiate during TLS Handshake.
+    // Specify the tls protocols the broker will use to negotiate during TLS Handshake.
+    // Example:- [TLSv1.2, TLSv1.1, TLSv1]
     private Set<String> tlsProtocols = Sets.newTreeSet();
+    // Specify the tls cipher the broker will use to negotiate during TLS Handshake.
+    // Example:- [TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256]
     private Set<String> tlsCiphers = Sets.newTreeSet();
     
     private Properties properties = new Properties();

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -84,7 +84,10 @@ public class ProxyConfiguration implements PulsarConfiguration {
     private boolean tlsAllowInsecureConnection = false;
     // Validates hostname when proxy creates tls connection with broker
     private boolean tlsHostnameVerificationEnabled = false;
-
+    // Specify the tls version and cipher the broker will use to negotiate during TLS Handshake.
+    private Set<String> tlsVersions = Sets.newTreeSet();
+    private Set<String> tlsCiphers = Sets.newTreeSet();
+    
     private Properties properties = new Properties();
 
     public boolean forwardAuthorizationCredentials() {
@@ -277,5 +280,22 @@ public class ProxyConfiguration implements PulsarConfiguration {
 
     public void setProperties(Properties properties) {
         this.properties = properties;
+    }
+    
+    
+    public Set<String> getTlsVersions() {
+        return tlsVersions;
+    }
+
+    public void setTlsVersions(Set<String> tlsVersions) {
+        this.tlsVersions = tlsVersions;
+    }
+
+    public Set<String> getTlsCiphers() {
+        return tlsCiphers;
+    }
+
+    public void setTlsCipher(Set<String> tlsCiphers) {
+        this.tlsCiphers = tlsCiphers;
     }
 }

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -84,8 +84,8 @@ public class ProxyConfiguration implements PulsarConfiguration {
     private boolean tlsAllowInsecureConnection = false;
     // Validates hostname when proxy creates tls connection with broker
     private boolean tlsHostnameVerificationEnabled = false;
-    // Specify the tls version and cipher the broker will use to negotiate during TLS Handshake.
-    private Set<String> tlsVersions = Sets.newTreeSet();
+    // Specify the tls protocols and cipher the broker will use to negotiate during TLS Handshake.
+    private Set<String> tlsProtocols = Sets.newTreeSet();
     private Set<String> tlsCiphers = Sets.newTreeSet();
     
     private Properties properties = new Properties();
@@ -282,20 +282,19 @@ public class ProxyConfiguration implements PulsarConfiguration {
         this.properties = properties;
     }
     
-    
-    public Set<String> getTlsVersions() {
-        return tlsVersions;
+    public Set<String> getTlsProtocols() {
+        return tlsProtocols;
     }
 
-    public void setTlsVersions(Set<String> tlsVersions) {
-        this.tlsVersions = tlsVersions;
+    public void setTlsProtocols(Set<String> tlsProtocols) {
+        this.tlsProtocols = tlsProtocols;
     }
 
     public Set<String> getTlsCiphers() {
         return tlsCiphers;
     }
 
-    public void setTlsCipher(Set<String> tlsCiphers) {
+    public void setTlsCiphers(Set<String> tlsCiphers) {
         this.tlsCiphers = tlsCiphers;
     }
 }

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -84,8 +84,11 @@ public class ProxyConfiguration implements PulsarConfiguration {
     private boolean tlsAllowInsecureConnection = false;
     // Validates hostname when proxy creates tls connection with broker
     private boolean tlsHostnameVerificationEnabled = false;
-    // Specify the tls protocols and cipher the broker will use to negotiate during TLS Handshake.
+    // Specify the tls protocols the broker will use to negotiate during TLS Handshake.
+    // Example:- [TLSv1.2, TLSv1.1, TLSv1]
     private Set<String> tlsProtocols = Sets.newTreeSet();
+    // Specify the tls cipher the broker will use to negotiate during TLS Handshake.
+    // Example:- [TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256]
     private Set<String> tlsCiphers = Sets.newTreeSet();
     
     private Properties properties = new Properties();

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ServiceChannelInitializer.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ServiceChannelInitializer.java
@@ -18,8 +18,11 @@
  */
 package org.apache.pulsar.proxy.server;
 
+import java.util.List;
+
 import org.apache.pulsar.common.api.PulsarDecoder;
 import org.apache.pulsar.common.util.SecurityUtility;
+import org.testng.collections.Lists;
 
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.socket.SocketChannel;
@@ -46,10 +49,11 @@ public class ServiceChannelInitializer extends ChannelInitializer<SocketChannel>
 
     @Override
     protected void initChannel(SocketChannel ch) throws Exception {
+        
         if (enableTLS) {
             SslContext sslCtx = SecurityUtility.createNettySslContextForServer(true /* to allow InsecureConnection */,
                     serviceConfig.getTlsTrustCertsFilePath(), serviceConfig.getTlsCertificateFilePath(),
-                    serviceConfig.getTlsKeyFilePath());
+                    serviceConfig.getTlsKeyFilePath(), serviceConfig.getTlsCiphers(), serviceConfig.getTlsVersions());
             ch.pipeline().addLast(TLS_HANDLER, sslCtx.newHandler(ch.alloc()));
         }
 

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ServiceChannelInitializer.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ServiceChannelInitializer.java
@@ -18,11 +18,8 @@
  */
 package org.apache.pulsar.proxy.server;
 
-import java.util.List;
-
 import org.apache.pulsar.common.api.PulsarDecoder;
 import org.apache.pulsar.common.util.SecurityUtility;
-import org.testng.collections.Lists;
 
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.socket.SocketChannel;
@@ -53,7 +50,7 @@ public class ServiceChannelInitializer extends ChannelInitializer<SocketChannel>
         if (enableTLS) {
             SslContext sslCtx = SecurityUtility.createNettySslContextForServer(true /* to allow InsecureConnection */,
                     serviceConfig.getTlsTrustCertsFilePath(), serviceConfig.getTlsCertificateFilePath(),
-                    serviceConfig.getTlsKeyFilePath(), serviceConfig.getTlsCiphers(), serviceConfig.getTlsVersions());
+                    serviceConfig.getTlsKeyFilePath(), serviceConfig.getTlsCiphers(), serviceConfig.getTlsProtocols());
             ch.pipeline().addLast(TLS_HANDLER, sslCtx.newHandler(ch.alloc()));
         }
 

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ServiceChannelInitializer.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ServiceChannelInitializer.java
@@ -46,7 +46,6 @@ public class ServiceChannelInitializer extends ChannelInitializer<SocketChannel>
 
     @Override
     protected void initChannel(SocketChannel ch) throws Exception {
-        
         if (enableTLS) {
             SslContext sslCtx = SecurityUtility.createNettySslContextForServer(true /* to allow InsecureConnection */,
                     serviceConfig.getTlsTrustCertsFilePath(), serviceConfig.getTlsCertificateFilePath(),

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithProxyAuthorizationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithProxyAuthorizationTest.java
@@ -75,8 +75,63 @@ public class ProxyWithProxyAuthorizationTest extends ProducerConsumerBase {
     private ProxyConfiguration proxyConfig = new ProxyConfiguration();
 
     @DataProvider(name = "hostnameVerification")
-    public Object[][] codecProvider() {
+    public Object[][] hostnameVerificationCodecProvider() {
         return new Object[][] { { Boolean.TRUE }, { Boolean.FALSE } };
+    }
+    
+    @DataProvider(name = "protocolsCiphersProvider")
+    public Object[][] protocolsCiphersProviderCodecProvider() {
+        // Test using defaults
+        Set<String> ciphers_1 = Sets.newTreeSet();
+        Set<String> protocols_1 = Sets.newTreeSet();
+        
+        // Test explicitly specifying protocols defaults
+        Set<String> ciphers_2 = Sets.newTreeSet();
+        Set<String> protocols_2 = Sets.newTreeSet();
+        protocols_2.add("TLSv1.2");
+        protocols_2.add("TLSv1.1");
+        protocols_2.add("TLSv1");
+
+        // Test for invalid ciphers
+        Set<String> ciphers_3 = Sets.newTreeSet();
+        Set<String> protocols_3 = Sets.newTreeSet();
+        ciphers_3.add("INVALID_PROTOCOL");
+
+        // Incorrect Config since TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 was introduced in TLSv1.2
+        Set<String> ciphers_4 = Sets.newTreeSet();
+        Set<String> protocols_4 = Sets.newTreeSet();
+        ciphers_4.add("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
+        protocols_4.add("TLSv1.1");
+
+        // Incorrect Config since TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 was introduced in TLSv1.2
+        Set<String> ciphers_5 = Sets.newTreeSet();
+        Set<String> protocols_5 = Sets.newTreeSet();
+        ciphers_5.add("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
+        protocols_5.add("TLSv1");
+
+        // Correct Config
+        Set<String> ciphers_6 = Sets.newTreeSet();
+        Set<String> protocols_6 = Sets.newTreeSet();
+        ciphers_6.add("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
+        protocols_6.add("TLSv1.2");
+
+        // In correct config - JDK 8 doesn't support TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        Set<String> ciphers_7 = Sets.newTreeSet();
+        Set<String> protocols_7 = Sets.newTreeSet();
+        protocols_7.add("TLSv1.2");
+        ciphers_7.add("TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384");
+
+        // Correct config - Atlease one of the Cipher Suite is supported 
+        Set<String> ciphers_8 = Sets.newTreeSet();
+        Set<String> protocols_8 = Sets.newTreeSet();
+        protocols_8.add("TLSv1.2");
+        ciphers_8.add("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
+        ciphers_8.add("TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384");
+        
+        return new Object[][] { { ciphers_1, protocols_1, Boolean.FALSE }, { ciphers_2, protocols_2, Boolean.FALSE },
+                { ciphers_3, protocols_3, Boolean.TRUE }, { ciphers_4, protocols_4, Boolean.TRUE },
+                { ciphers_5, protocols_5, Boolean.TRUE }, { ciphers_6, protocols_6, Boolean.FALSE }, 
+                { ciphers_7, protocols_7, Boolean.TRUE }, { ciphers_8, protocols_8, Boolean.FALSE }};
     }
     
     @BeforeMethod
@@ -162,15 +217,14 @@ public class ProxyWithProxyAuthorizationTest extends ProducerConsumerBase {
      * @throws Exception
      */
     @Test
-    public void textProxyAuthorization() throws Exception {
+    public void testProxyAuthorization() throws Exception {
         log.info("-- Starting {} test --", methodName);
 
         startProxy();
         createAdminClient();
         final String proxyServiceUrl = "pulsar://localhost:" + proxyConfig.getServicePortTls();
         // create a client which connects to proxy over tls and pass authData
-        ClientConfiguration clientConf = new ClientConfiguration();
-        PulsarClient proxyClient = createPulsarClient(proxyServiceUrl, clientConf);
+        PulsarClient proxyClient = createPulsarClient(proxyServiceUrl, new ClientConfiguration());
 
         String namespaceName = "my-property/proxy-authorization/my-ns";
         
@@ -215,7 +269,7 @@ public class ProxyWithProxyAuthorizationTest extends ProducerConsumerBase {
     }
 
     @Test(dataProvider = "hostnameVerification")
-    public void textTlsHostVerificationProxyToClient(boolean hostnameVerificationEnabled) throws Exception {
+    public void testTlsHostVerificationProxyToClient(boolean hostnameVerificationEnabled) throws Exception {
         log.info("-- Starting {} test --", methodName);
 
         startProxy();
@@ -266,7 +320,7 @@ public class ProxyWithProxyAuthorizationTest extends ProducerConsumerBase {
      * @throws Exception
      */
     @Test(dataProvider = "hostnameVerification")
-    public void textTlsHostVerificationProxyToBroker(boolean hostnameVerificationEnabled) throws Exception {
+    public void testTlsHostVerificationProxyToBroker(boolean hostnameVerificationEnabled) throws Exception {
         log.info("-- Starting {} test --", methodName);
 
         proxyConfig.setTlsHostnameVerificationEnabled(hostnameVerificationEnabled);
@@ -303,6 +357,79 @@ public class ProxyWithProxyAuthorizationTest extends ProducerConsumerBase {
             }
         }
 
+        log.info("-- Exiting {} test --", methodName);
+    }
+    
+    /* 
+     * This test verifies whether the Client and Proxy honor the protocols and ciphers specified.
+     * Details description of test cases can be found in protocolsCiphersProviderCodecProvider
+     */
+    @Test(dataProvider = "protocolsCiphersProvider")
+    public void tlsCiphersAndProtocols(Set<String> tlsCiphers, Set<String> tlsProtocols, boolean expectFailure) throws Exception {
+        log.info("-- Starting {} test --", methodName);
+        String namespaceName = "my-property/proxy-authorization/my-ns";
+        createAdminClient();
+
+        admin.properties().createProperty("my-property",
+                new PropertyAdmin(Lists.newArrayList("appid1", "appid2"), Sets.newHashSet("proxy-authorization")));
+        admin.namespaces().createNamespace(namespaceName);
+
+        admin.namespaces().grantPermissionOnNamespace(namespaceName, "Proxy",
+                Sets.newHashSet(AuthAction.consume, AuthAction.produce));
+        admin.namespaces().grantPermissionOnNamespace(namespaceName, "Client",
+                Sets.newHashSet(AuthAction.consume, AuthAction.produce));
+        
+        ProxyConfiguration proxyConfig = new ProxyConfiguration();
+        proxyConfig.setAuthenticationEnabled(true);
+        proxyConfig.setAuthorizationEnabled(false);
+        proxyConfig.setBrokerServiceURL("pulsar://localhost:" + BROKER_PORT);
+        proxyConfig.setBrokerServiceURLTLS("pulsar://localhost:" + BROKER_PORT_TLS);
+
+        proxyConfig.setServicePort(PortManager.nextFreePort());
+        proxyConfig.setServicePortTls(PortManager.nextFreePort());
+        proxyConfig.setWebServicePort(PortManager.nextFreePort());
+        proxyConfig.setWebServicePortTls(PortManager.nextFreePort());
+        proxyConfig.setTlsEnabledInProxy(true);
+        proxyConfig.setTlsEnabledWithBroker(true);
+
+        // enable tls and auth&auth at proxy
+        proxyConfig.setTlsCertificateFilePath(TLS_PROXY_CERT_FILE_PATH);
+        proxyConfig.setTlsKeyFilePath(TLS_PROXY_KEY_FILE_PATH);
+        proxyConfig.setTlsTrustCertsFilePath(TLS_PROXY_TRUST_CERT_FILE_PATH);
+
+        proxyConfig.setBrokerClientAuthenticationPlugin(AuthenticationTls.class.getName());
+        proxyConfig.setBrokerClientAuthenticationParameters(
+                "tlsCertFile:" + TLS_PROXY_CERT_FILE_PATH + "," + "tlsKeyFile:" + TLS_PROXY_KEY_FILE_PATH);
+
+        Set<String> providers = new HashSet<>();
+        providers.add(AuthenticationProviderTls.class.getName());
+        conf.setAuthenticationProviders(providers);
+        proxyConfig.setAuthenticationProviders(providers);
+        proxyConfig.setTlsProtocols(tlsProtocols);
+        proxyConfig.setTlsCiphers(tlsCiphers);
+        ProxyService proxyService = Mockito.spy(new ProxyService(proxyConfig));
+        proxyService.start();
+        Thread.sleep(1000);
+        try {
+
+            final String proxyServiceUrl = "pulsar://localhost:" + proxyConfig.getServicePortTls();
+            ClientConfiguration clientConf = new ClientConfiguration();
+            PulsarClient proxyClient = createPulsarClient(proxyServiceUrl, clientConf);
+            clientConf.setTlsHostnameVerificationEnable(true);
+            Consumer consumer = proxyClient.subscribe("persistent://my-property/proxy-authorization/my-ns/my-topic1",
+                    "my-subscriber-name", new ConsumerConfiguration());
+
+            if (expectFailure) {
+                Assert.fail("Failure expected for this test case");
+            }
+            consumer.close();
+            proxyClient.close();
+        } catch (Exception ex) {
+            if (!expectFailure) {
+                Assert.fail("This test case should not fail");
+            }
+        }
+        admin.close();
         log.info("-- Exiting {} test --", methodName);
     }
     


### PR DESCRIPTION
### Motivation

Enable listening services (Broker, Proxy, Discovery Provider) to specify which TLS Protocol Versions and Cipher Suites they will negotiate with.
This is useful when you don't want the client to use downgraded protocols or ciphers which are weak.

### Modifications
Major code change is in SecurityUtility.createNettySslContextForServer rest is just config changes and tests.

### Result
Clients can't force servers (Broker, Proxy, Discovery Provider)  to use downgraded protocols or ciphers which are weak.
