### PR TITLE
Regenerated the PulsarApi from proto with latest protoc

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
@@ -279,13 +279,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements MessageIdDataOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use MessageIdData.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private MessageIdData(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<MessageIdData> handle;
+    private MessageIdData(io.netty.util.Recycler.Handle<MessageIdData> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<MessageIdData> RECYCLER = new io.netty.util.Recycler<MessageIdData>() {
-            protected MessageIdData newObject(Handle handle) {
+            protected MessageIdData newObject(Handle<MessageIdData> handle) {
               return new MessageIdData(handle);
             }
           };
@@ -295,10 +295,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private MessageIdData(boolean noInit) {}
+    private MessageIdData(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final MessageIdData defaultInstance;
     public static MessageIdData getDefaultInstance() {
@@ -506,20 +508,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.MessageIdDataOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -778,13 +780,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements KeyValueOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use KeyValue.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private KeyValue(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<KeyValue> handle;
+    private KeyValue(io.netty.util.Recycler.Handle<KeyValue> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<KeyValue> RECYCLER = new io.netty.util.Recycler<KeyValue>() {
-            protected KeyValue newObject(Handle handle) {
+            protected KeyValue newObject(Handle<KeyValue> handle) {
               return new KeyValue(handle);
             }
           };
@@ -794,10 +796,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private KeyValue(boolean noInit) {}
+    private KeyValue(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final KeyValue defaultInstance;
     public static KeyValue getDefaultInstance() {
@@ -1013,20 +1017,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.KeyValue, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.KeyValueOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.KeyValue.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -1245,13 +1249,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements KeyLongValueOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use KeyLongValue.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private KeyLongValue(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<KeyLongValue> handle;
+    private KeyLongValue(io.netty.util.Recycler.Handle<KeyLongValue> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<KeyLongValue> RECYCLER = new io.netty.util.Recycler<KeyLongValue>() {
-            protected KeyLongValue newObject(Handle handle) {
+            protected KeyLongValue newObject(Handle<KeyLongValue> handle) {
               return new KeyLongValue(handle);
             }
           };
@@ -1261,10 +1265,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private KeyLongValue(boolean noInit) {}
+    private KeyLongValue(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final KeyLongValue defaultInstance;
     public static KeyLongValue getDefaultInstance() {
@@ -1458,20 +1464,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValueOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.KeyLongValue.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -1681,13 +1687,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements EncryptionKeysOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use EncryptionKeys.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private EncryptionKeys(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<EncryptionKeys> handle;
+    private EncryptionKeys(io.netty.util.Recycler.Handle<EncryptionKeys> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<EncryptionKeys> RECYCLER = new io.netty.util.Recycler<EncryptionKeys>() {
-            protected EncryptionKeys newObject(Handle handle) {
+            protected EncryptionKeys newObject(Handle<EncryptionKeys> handle) {
               return new EncryptionKeys(handle);
             }
           };
@@ -1697,10 +1703,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private EncryptionKeys(boolean noInit) {}
+    private EncryptionKeys(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final EncryptionKeys defaultInstance;
     public static EncryptionKeys getDefaultInstance() {
@@ -1929,20 +1937,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.EncryptionKeys, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.EncryptionKeysOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.EncryptionKeys.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -2320,13 +2328,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements MessageMetadataOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use MessageMetadata.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private MessageMetadata(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<MessageMetadata> handle;
+    private MessageMetadata(io.netty.util.Recycler.Handle<MessageMetadata> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<MessageMetadata> RECYCLER = new io.netty.util.Recycler<MessageMetadata>() {
-            protected MessageMetadata newObject(Handle handle) {
+            protected MessageMetadata newObject(Handle<MessageMetadata> handle) {
               return new MessageMetadata(handle);
             }
           };
@@ -2336,10 +2344,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private MessageMetadata(boolean noInit) {}
+    private MessageMetadata(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final MessageMetadata defaultInstance;
     public static MessageMetadata getDefaultInstance() {
@@ -2862,20 +2872,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadataOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -3774,13 +3784,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements SingleMessageMetadataOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use SingleMessageMetadata.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private SingleMessageMetadata(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<SingleMessageMetadata> handle;
+    private SingleMessageMetadata(io.netty.util.Recycler.Handle<SingleMessageMetadata> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<SingleMessageMetadata> RECYCLER = new io.netty.util.Recycler<SingleMessageMetadata>() {
-            protected SingleMessageMetadata newObject(Handle handle) {
+            protected SingleMessageMetadata newObject(Handle<SingleMessageMetadata> handle) {
               return new SingleMessageMetadata(handle);
             }
           };
@@ -3790,10 +3800,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private SingleMessageMetadata(boolean noInit) {}
+    private SingleMessageMetadata(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final SingleMessageMetadata defaultInstance;
     public static SingleMessageMetadata getDefaultInstance() {
@@ -4018,20 +4030,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.SingleMessageMetadata, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.SingleMessageMetadataOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.SingleMessageMetadata.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -4377,13 +4389,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandConnectOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandConnect.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandConnect(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandConnect> handle;
+    private CommandConnect(io.netty.util.Recycler.Handle<CommandConnect> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandConnect> RECYCLER = new io.netty.util.Recycler<CommandConnect>() {
-            protected CommandConnect newObject(Handle handle) {
+            protected CommandConnect newObject(Handle<CommandConnect> handle) {
               return new CommandConnect(handle);
             }
           };
@@ -4393,10 +4405,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandConnect(boolean noInit) {}
+    private CommandConnect(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandConnect defaultInstance;
     public static CommandConnect getDefaultInstance() {
@@ -4822,20 +4836,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandConnect, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandConnectOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandConnect.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -5365,13 +5379,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandConnectedOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandConnected.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandConnected(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandConnected> handle;
+    private CommandConnected(io.netty.util.Recycler.Handle<CommandConnected> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandConnected> RECYCLER = new io.netty.util.Recycler<CommandConnected>() {
-            protected CommandConnected newObject(Handle handle) {
+            protected CommandConnected newObject(Handle<CommandConnected> handle) {
               return new CommandConnected(handle);
             }
           };
@@ -5381,10 +5395,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandConnected(boolean noInit) {}
+    private CommandConnected(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandConnected defaultInstance;
     public static CommandConnected getDefaultInstance() {
@@ -5574,20 +5590,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandConnected, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandConnectedOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandConnected.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -5825,13 +5841,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandSubscribeOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandSubscribe.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandSubscribe(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandSubscribe> handle;
+    private CommandSubscribe(io.netty.util.Recycler.Handle<CommandSubscribe> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandSubscribe> RECYCLER = new io.netty.util.Recycler<CommandSubscribe>() {
-            protected CommandSubscribe newObject(Handle handle) {
+            protected CommandSubscribe newObject(Handle<CommandSubscribe> handle) {
               return new CommandSubscribe(handle);
             }
           };
@@ -5841,10 +5857,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandSubscribe(boolean noInit) {}
+    private CommandSubscribe(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandSubscribe defaultInstance;
     public static CommandSubscribe getDefaultInstance() {
@@ -6323,20 +6341,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribeOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -7032,13 +7050,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandPartitionedTopicMetadataOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandPartitionedTopicMetadata.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandPartitionedTopicMetadata(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandPartitionedTopicMetadata> handle;
+    private CommandPartitionedTopicMetadata(io.netty.util.Recycler.Handle<CommandPartitionedTopicMetadata> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandPartitionedTopicMetadata> RECYCLER = new io.netty.util.Recycler<CommandPartitionedTopicMetadata>() {
-            protected CommandPartitionedTopicMetadata newObject(Handle handle) {
+            protected CommandPartitionedTopicMetadata newObject(Handle<CommandPartitionedTopicMetadata> handle) {
               return new CommandPartitionedTopicMetadata(handle);
             }
           };
@@ -7048,10 +7066,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandPartitionedTopicMetadata(boolean noInit) {}
+    private CommandPartitionedTopicMetadata(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandPartitionedTopicMetadata defaultInstance;
     public static CommandPartitionedTopicMetadata getDefaultInstance() {
@@ -7365,20 +7385,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandPartitionedTopicMetadata, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandPartitionedTopicMetadataOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandPartitionedTopicMetadata.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -7744,13 +7764,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandPartitionedTopicMetadataResponseOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandPartitionedTopicMetadataResponse.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandPartitionedTopicMetadataResponse(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandPartitionedTopicMetadataResponse> handle;
+    private CommandPartitionedTopicMetadataResponse(io.netty.util.Recycler.Handle<CommandPartitionedTopicMetadataResponse> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandPartitionedTopicMetadataResponse> RECYCLER = new io.netty.util.Recycler<CommandPartitionedTopicMetadataResponse>() {
-            protected CommandPartitionedTopicMetadataResponse newObject(Handle handle) {
+            protected CommandPartitionedTopicMetadataResponse newObject(Handle<CommandPartitionedTopicMetadataResponse> handle) {
               return new CommandPartitionedTopicMetadataResponse(handle);
             }
           };
@@ -7760,10 +7780,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandPartitionedTopicMetadataResponse(boolean noInit) {}
+    private CommandPartitionedTopicMetadataResponse(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandPartitionedTopicMetadataResponse defaultInstance;
     public static CommandPartitionedTopicMetadataResponse getDefaultInstance() {
@@ -8048,20 +8070,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandPartitionedTopicMetadataResponse, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandPartitionedTopicMetadataResponseOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandPartitionedTopicMetadataResponse.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -8396,13 +8418,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandLookupTopicOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandLookupTopic.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandLookupTopic(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandLookupTopic> handle;
+    private CommandLookupTopic(io.netty.util.Recycler.Handle<CommandLookupTopic> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandLookupTopic> RECYCLER = new io.netty.util.Recycler<CommandLookupTopic>() {
-            protected CommandLookupTopic newObject(Handle handle) {
+            protected CommandLookupTopic newObject(Handle<CommandLookupTopic> handle) {
               return new CommandLookupTopic(handle);
             }
           };
@@ -8412,10 +8434,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandLookupTopic(boolean noInit) {}
+    private CommandLookupTopic(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandLookupTopic defaultInstance;
     public static CommandLookupTopic getDefaultInstance() {
@@ -8747,20 +8771,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandLookupTopic, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandLookupTopicOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandLookupTopic.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -9173,13 +9197,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandLookupTopicResponseOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandLookupTopicResponse.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandLookupTopicResponse(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandLookupTopicResponse> handle;
+    private CommandLookupTopicResponse(io.netty.util.Recycler.Handle<CommandLookupTopicResponse> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandLookupTopicResponse> RECYCLER = new io.netty.util.Recycler<CommandLookupTopicResponse>() {
-            protected CommandLookupTopicResponse newObject(Handle handle) {
+            protected CommandLookupTopicResponse newObject(Handle<CommandLookupTopicResponse> handle) {
               return new CommandLookupTopicResponse(handle);
             }
           };
@@ -9189,10 +9213,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandLookupTopicResponse(boolean noInit) {}
+    private CommandLookupTopicResponse(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandLookupTopicResponse defaultInstance;
     public static CommandLookupTopicResponse getDefaultInstance() {
@@ -9578,20 +9604,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandLookupTopicResponse, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandLookupTopicResponseOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandLookupTopicResponse.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -10063,13 +10089,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandProducerOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandProducer.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandProducer(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandProducer> handle;
+    private CommandProducer(io.netty.util.Recycler.Handle<CommandProducer> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandProducer> RECYCLER = new io.netty.util.Recycler<CommandProducer>() {
-            protected CommandProducer newObject(Handle handle) {
+            protected CommandProducer newObject(Handle<CommandProducer> handle) {
               return new CommandProducer(handle);
             }
           };
@@ -10079,10 +10105,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandProducer(boolean noInit) {}
+    private CommandProducer(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandProducer defaultInstance;
     public static CommandProducer getDefaultInstance() {
@@ -10391,20 +10419,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandProducer, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandProducerOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandProducer.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -10854,13 +10882,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandSendOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandSend.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandSend(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandSend> handle;
+    private CommandSend(io.netty.util.Recycler.Handle<CommandSend> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandSend> RECYCLER = new io.netty.util.Recycler<CommandSend>() {
-            protected CommandSend newObject(Handle handle) {
+            protected CommandSend newObject(Handle<CommandSend> handle) {
               return new CommandSend(handle);
             }
           };
@@ -10870,10 +10898,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandSend(boolean noInit) {}
+    private CommandSend(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandSend defaultInstance;
     public static CommandSend getDefaultInstance() {
@@ -11063,20 +11093,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandSend, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandSendOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandSend.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -11304,13 +11334,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandSendReceiptOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandSendReceipt.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandSendReceipt(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandSendReceipt> handle;
+    private CommandSendReceipt(io.netty.util.Recycler.Handle<CommandSendReceipt> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandSendReceipt> RECYCLER = new io.netty.util.Recycler<CommandSendReceipt>() {
-            protected CommandSendReceipt newObject(Handle handle) {
+            protected CommandSendReceipt newObject(Handle<CommandSendReceipt> handle) {
               return new CommandSendReceipt(handle);
             }
           };
@@ -11320,10 +11350,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandSendReceipt(boolean noInit) {}
+    private CommandSendReceipt(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandSendReceipt defaultInstance;
     public static CommandSendReceipt getDefaultInstance() {
@@ -11519,20 +11551,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandSendReceipt, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandSendReceiptOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandSendReceipt.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -11797,13 +11829,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandSendErrorOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandSendError.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandSendError(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandSendError> handle;
+    private CommandSendError(io.netty.util.Recycler.Handle<CommandSendError> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandSendError> RECYCLER = new io.netty.util.Recycler<CommandSendError>() {
-            protected CommandSendError newObject(Handle handle) {
+            protected CommandSendError newObject(Handle<CommandSendError> handle) {
               return new CommandSendError(handle);
             }
           };
@@ -11813,10 +11845,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandSendError(boolean noInit) {}
+    private CommandSendError(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandSendError defaultInstance;
     public static CommandSendError getDefaultInstance() {
@@ -12054,20 +12088,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandSendError, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandSendErrorOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandSendError.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -12356,13 +12390,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandMessageOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandMessage.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandMessage(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandMessage> handle;
+    private CommandMessage(io.netty.util.Recycler.Handle<CommandMessage> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandMessage> RECYCLER = new io.netty.util.Recycler<CommandMessage>() {
-            protected CommandMessage newObject(Handle handle) {
+            protected CommandMessage newObject(Handle<CommandMessage> handle) {
               return new CommandMessage(handle);
             }
           };
@@ -12372,10 +12406,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandMessage(boolean noInit) {}
+    private CommandMessage(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandMessage defaultInstance;
     public static CommandMessage getDefaultInstance() {
@@ -12551,20 +12587,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandMessage, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandMessageOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandMessage.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -12798,13 +12834,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandAckOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandAck.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandAck(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandAck> handle;
+    private CommandAck(io.netty.util.Recycler.Handle<CommandAck> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandAck> RECYCLER = new io.netty.util.Recycler<CommandAck>() {
-            protected CommandAck newObject(Handle handle) {
+            protected CommandAck newObject(Handle<CommandAck> handle) {
               return new CommandAck(handle);
             }
           };
@@ -12814,10 +12850,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandAck(boolean noInit) {}
+    private CommandAck(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandAck defaultInstance;
     public static CommandAck getDefaultInstance() {
@@ -13159,20 +13197,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandAck, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandAckOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -13598,13 +13636,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandFlowOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandFlow.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandFlow(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandFlow> handle;
+    private CommandFlow(io.netty.util.Recycler.Handle<CommandFlow> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandFlow> RECYCLER = new io.netty.util.Recycler<CommandFlow>() {
-            protected CommandFlow newObject(Handle handle) {
+            protected CommandFlow newObject(Handle<CommandFlow> handle) {
               return new CommandFlow(handle);
             }
           };
@@ -13614,10 +13652,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandFlow(boolean noInit) {}
+    private CommandFlow(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandFlow defaultInstance;
     public static CommandFlow getDefaultInstance() {
@@ -13789,20 +13829,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandFlow, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandFlowOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandFlow.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -13991,13 +14031,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandUnsubscribeOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandUnsubscribe.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandUnsubscribe(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandUnsubscribe> handle;
+    private CommandUnsubscribe(io.netty.util.Recycler.Handle<CommandUnsubscribe> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandUnsubscribe> RECYCLER = new io.netty.util.Recycler<CommandUnsubscribe>() {
-            protected CommandUnsubscribe newObject(Handle handle) {
+            protected CommandUnsubscribe newObject(Handle<CommandUnsubscribe> handle) {
               return new CommandUnsubscribe(handle);
             }
           };
@@ -14007,10 +14047,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandUnsubscribe(boolean noInit) {}
+    private CommandUnsubscribe(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandUnsubscribe defaultInstance;
     public static CommandUnsubscribe getDefaultInstance() {
@@ -14182,20 +14224,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandUnsubscribe, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandUnsubscribeOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandUnsubscribe.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -14388,13 +14430,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandSeekOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandSeek.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandSeek(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandSeek> handle;
+    private CommandSeek(io.netty.util.Recycler.Handle<CommandSeek> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandSeek> RECYCLER = new io.netty.util.Recycler<CommandSeek>() {
-            protected CommandSeek newObject(Handle handle) {
+            protected CommandSeek newObject(Handle<CommandSeek> handle) {
               return new CommandSeek(handle);
             }
           };
@@ -14404,10 +14446,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandSeek(boolean noInit) {}
+    private CommandSeek(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandSeek defaultInstance;
     public static CommandSeek getDefaultInstance() {
@@ -14603,20 +14647,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandSeekOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -14869,13 +14913,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandReachedEndOfTopicOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandReachedEndOfTopic.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandReachedEndOfTopic(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandReachedEndOfTopic> handle;
+    private CommandReachedEndOfTopic(io.netty.util.Recycler.Handle<CommandReachedEndOfTopic> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandReachedEndOfTopic> RECYCLER = new io.netty.util.Recycler<CommandReachedEndOfTopic>() {
-            protected CommandReachedEndOfTopic newObject(Handle handle) {
+            protected CommandReachedEndOfTopic newObject(Handle<CommandReachedEndOfTopic> handle) {
               return new CommandReachedEndOfTopic(handle);
             }
           };
@@ -14885,10 +14929,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandReachedEndOfTopic(boolean noInit) {}
+    private CommandReachedEndOfTopic(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandReachedEndOfTopic defaultInstance;
     public static CommandReachedEndOfTopic getDefaultInstance() {
@@ -15038,20 +15084,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopicOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandReachedEndOfTopic.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -15201,13 +15247,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandCloseProducerOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandCloseProducer.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandCloseProducer(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandCloseProducer> handle;
+    private CommandCloseProducer(io.netty.util.Recycler.Handle<CommandCloseProducer> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandCloseProducer> RECYCLER = new io.netty.util.Recycler<CommandCloseProducer>() {
-            protected CommandCloseProducer newObject(Handle handle) {
+            protected CommandCloseProducer newObject(Handle<CommandCloseProducer> handle) {
               return new CommandCloseProducer(handle);
             }
           };
@@ -15217,10 +15263,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandCloseProducer(boolean noInit) {}
+    private CommandCloseProducer(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandCloseProducer defaultInstance;
     public static CommandCloseProducer getDefaultInstance() {
@@ -15392,20 +15440,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandCloseProducer, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandCloseProducerOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandCloseProducer.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -15594,13 +15642,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandCloseConsumerOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandCloseConsumer.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandCloseConsumer(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandCloseConsumer> handle;
+    private CommandCloseConsumer(io.netty.util.Recycler.Handle<CommandCloseConsumer> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandCloseConsumer> RECYCLER = new io.netty.util.Recycler<CommandCloseConsumer>() {
-            protected CommandCloseConsumer newObject(Handle handle) {
+            protected CommandCloseConsumer newObject(Handle<CommandCloseConsumer> handle) {
               return new CommandCloseConsumer(handle);
             }
           };
@@ -15610,10 +15658,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandCloseConsumer(boolean noInit) {}
+    private CommandCloseConsumer(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandCloseConsumer defaultInstance;
     public static CommandCloseConsumer getDefaultInstance() {
@@ -15785,20 +15835,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandCloseConsumer, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandCloseConsumerOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandCloseConsumer.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -15989,13 +16039,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandRedeliverUnacknowledgedMessagesOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandRedeliverUnacknowledgedMessages.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandRedeliverUnacknowledgedMessages(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandRedeliverUnacknowledgedMessages> handle;
+    private CommandRedeliverUnacknowledgedMessages(io.netty.util.Recycler.Handle<CommandRedeliverUnacknowledgedMessages> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandRedeliverUnacknowledgedMessages> RECYCLER = new io.netty.util.Recycler<CommandRedeliverUnacknowledgedMessages>() {
-            protected CommandRedeliverUnacknowledgedMessages newObject(Handle handle) {
+            protected CommandRedeliverUnacknowledgedMessages newObject(Handle<CommandRedeliverUnacknowledgedMessages> handle) {
               return new CommandRedeliverUnacknowledgedMessages(handle);
             }
           };
@@ -16005,10 +16055,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandRedeliverUnacknowledgedMessages(boolean noInit) {}
+    private CommandRedeliverUnacknowledgedMessages(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandRedeliverUnacknowledgedMessages defaultInstance;
     public static CommandRedeliverUnacknowledgedMessages getDefaultInstance() {
@@ -16193,20 +16245,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandRedeliverUnacknowledgedMessages, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandRedeliverUnacknowledgedMessagesOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandRedeliverUnacknowledgedMessages.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -16470,13 +16522,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandSuccessOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandSuccess.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandSuccess(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandSuccess> handle;
+    private CommandSuccess(io.netty.util.Recycler.Handle<CommandSuccess> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandSuccess> RECYCLER = new io.netty.util.Recycler<CommandSuccess>() {
-            protected CommandSuccess newObject(Handle handle) {
+            protected CommandSuccess newObject(Handle<CommandSuccess> handle) {
               return new CommandSuccess(handle);
             }
           };
@@ -16486,10 +16538,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandSuccess(boolean noInit) {}
+    private CommandSuccess(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandSuccess defaultInstance;
     public static CommandSuccess getDefaultInstance() {
@@ -16639,20 +16693,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandSuccess, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandSuccessOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandSuccess.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -16806,13 +16860,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandProducerSuccessOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandProducerSuccess.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandProducerSuccess(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandProducerSuccess> handle;
+    private CommandProducerSuccess(io.netty.util.Recycler.Handle<CommandProducerSuccess> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandProducerSuccess> RECYCLER = new io.netty.util.Recycler<CommandProducerSuccess>() {
-            protected CommandProducerSuccess newObject(Handle handle) {
+            protected CommandProducerSuccess newObject(Handle<CommandProducerSuccess> handle) {
               return new CommandProducerSuccess(handle);
             }
           };
@@ -16822,10 +16876,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandProducerSuccess(boolean noInit) {}
+    private CommandProducerSuccess(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandProducerSuccess defaultInstance;
     public static CommandProducerSuccess getDefaultInstance() {
@@ -17037,20 +17093,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandProducerSuccess, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandProducerSuccessOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandProducerSuccess.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -17293,13 +17349,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandErrorOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandError.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandError(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandError> handle;
+    private CommandError(io.netty.util.Recycler.Handle<CommandError> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandError> RECYCLER = new io.netty.util.Recycler<CommandError>() {
-            protected CommandError newObject(Handle handle) {
+            protected CommandError newObject(Handle<CommandError> handle) {
               return new CommandError(handle);
             }
           };
@@ -17309,10 +17365,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandError(boolean noInit) {}
+    private CommandError(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandError defaultInstance;
     public static CommandError getDefaultInstance() {
@@ -17528,20 +17586,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandError, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandErrorOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandError.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -17783,13 +17841,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandPingOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandPing.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandPing(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandPing> handle;
+    private CommandPing(io.netty.util.Recycler.Handle<CommandPing> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandPing> RECYCLER = new io.netty.util.Recycler<CommandPing>() {
-            protected CommandPing newObject(Handle handle) {
+            protected CommandPing newObject(Handle<CommandPing> handle) {
               return new CommandPing(handle);
             }
           };
@@ -17798,10 +17856,12 @@ public final class PulsarApi {
             this.initFields();
             this.memoizedIsInitialized = -1;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandPing(boolean noInit) {}
+    private CommandPing(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandPing defaultInstance;
     public static CommandPing getDefaultInstance() {
@@ -17928,20 +17988,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandPing, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandPingOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandPing.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -18040,13 +18100,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandPongOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandPong.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandPong(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandPong> handle;
+    private CommandPong(io.netty.util.Recycler.Handle<CommandPong> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandPong> RECYCLER = new io.netty.util.Recycler<CommandPong>() {
-            protected CommandPong newObject(Handle handle) {
+            protected CommandPong newObject(Handle<CommandPong> handle) {
               return new CommandPong(handle);
             }
           };
@@ -18055,10 +18115,12 @@ public final class PulsarApi {
             this.initFields();
             this.memoizedIsInitialized = -1;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandPong(boolean noInit) {}
+    private CommandPong(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandPong defaultInstance;
     public static CommandPong getDefaultInstance() {
@@ -18185,20 +18247,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandPong, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandPongOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandPong.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -18305,13 +18367,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandConsumerStatsOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandConsumerStats.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandConsumerStats(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandConsumerStats> handle;
+    private CommandConsumerStats(io.netty.util.Recycler.Handle<CommandConsumerStats> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandConsumerStats> RECYCLER = new io.netty.util.Recycler<CommandConsumerStats>() {
-            protected CommandConsumerStats newObject(Handle handle) {
+            protected CommandConsumerStats newObject(Handle<CommandConsumerStats> handle) {
               return new CommandConsumerStats(handle);
             }
           };
@@ -18321,10 +18383,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandConsumerStats(boolean noInit) {}
+    private CommandConsumerStats(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandConsumerStats defaultInstance;
     public static CommandConsumerStats getDefaultInstance() {
@@ -18496,20 +18560,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandConsumerStats, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandConsumerStatsOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandConsumerStats.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -18750,13 +18814,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements CommandConsumerStatsResponseOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use CommandConsumerStatsResponse.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private CommandConsumerStatsResponse(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<CommandConsumerStatsResponse> handle;
+    private CommandConsumerStatsResponse(io.netty.util.Recycler.Handle<CommandConsumerStatsResponse> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<CommandConsumerStatsResponse> RECYCLER = new io.netty.util.Recycler<CommandConsumerStatsResponse>() {
-            protected CommandConsumerStatsResponse newObject(Handle handle) {
+            protected CommandConsumerStatsResponse newObject(Handle<CommandConsumerStatsResponse> handle) {
               return new CommandConsumerStatsResponse(handle);
             }
           };
@@ -18766,10 +18830,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private CommandConsumerStatsResponse(boolean noInit) {}
+    private CommandConsumerStatsResponse(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final CommandConsumerStatsResponse defaultInstance;
     public static CommandConsumerStatsResponse getDefaultInstance() {
@@ -19281,20 +19347,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.CommandConsumerStatsResponse, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.CommandConsumerStatsResponseOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.CommandConsumerStatsResponse.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {
@@ -20120,13 +20186,13 @@ public final class PulsarApi {
       com.google.protobuf.GeneratedMessageLite
       implements BaseCommandOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream.ByteBufGeneratedMessage  {
     // Use BaseCommand.newBuilder() to construct.
-    private io.netty.util.Recycler.Handle handle;
-    private BaseCommand(io.netty.util.Recycler.Handle handle) {
+    private final io.netty.util.Recycler.Handle<BaseCommand> handle;
+    private BaseCommand(io.netty.util.Recycler.Handle<BaseCommand> handle) {
       this.handle = handle;
     }
     
      private static final io.netty.util.Recycler<BaseCommand> RECYCLER = new io.netty.util.Recycler<BaseCommand>() {
-            protected BaseCommand newObject(Handle handle) {
+            protected BaseCommand newObject(Handle<BaseCommand> handle) {
               return new BaseCommand(handle);
             }
           };
@@ -20136,10 +20202,12 @@ public final class PulsarApi {
             this.memoizedIsInitialized = -1;
             this.bitField0_ = 0;
             this.memoizedSerializedSize = -1;
-            if (handle != null) { RECYCLER.recycle(this, handle); }
+            handle.recycle(this);
         }
          
-    private BaseCommand(boolean noInit) {}
+    private BaseCommand(boolean noInit) {
+        this.handle = null;
+    }
     
     private static final BaseCommand defaultInstance;
     public static BaseCommand getDefaultInstance() {
@@ -21041,20 +21109,20 @@ public final class PulsarApi {
           org.apache.pulsar.common.api.proto.PulsarApi.BaseCommand, Builder>
         implements org.apache.pulsar.common.api.proto.PulsarApi.BaseCommandOrBuilder, org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream.ByteBufMessageBuilder  {
       // Construct using org.apache.pulsar.common.api.proto.PulsarApi.BaseCommand.newBuilder()
-      private final io.netty.util.Recycler.Handle handle;
-      private Builder(io.netty.util.Recycler.Handle handle) {
+      private final io.netty.util.Recycler.Handle<Builder> handle;
+      private Builder(io.netty.util.Recycler.Handle<Builder> handle) {
         this.handle = handle;
         maybeForceBuilderInitialization();
       }
       private final static io.netty.util.Recycler<Builder> RECYCLER = new io.netty.util.Recycler<Builder>() {
-         protected Builder newObject(io.netty.util.Recycler.Handle handle) {
+         protected Builder newObject(io.netty.util.Recycler.Handle<Builder> handle) {
                return new Builder(handle);
              }
             };
       
        public void recycle() {
                 clear();
-                if (handle != null) {RECYCLER.recycle(this, handle);}
+                handle.recycle(this);
             }
       
       private void maybeForceBuilderInitialization() {


### PR DESCRIPTION
### Motivation

In #1200 the `PulsarApi.java` was regenerated with a protoc that didn't have the latest patch with the fixes for Netty-4.1