### PR TITLE
ProxyForwardAuthDataTest shouldn't reuse pulsar client

### DIFF
--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyForwardAuthDataTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyForwardAuthDataTest.java
@@ -47,7 +47,7 @@ public class ProxyForwardAuthDataTest extends ProducerConsumerBase {
     private static final Logger log = LoggerFactory.getLogger(ProxyForwardAuthDataTest.class);
     private int webServicePort;
     private int servicePort;
-    
+
     @BeforeMethod
     @Override
     protected void setup() throws Exception {
@@ -59,11 +59,11 @@ public class ProxyForwardAuthDataTest extends ProducerConsumerBase {
         conf.setBrokerClientAuthenticationPlugin(BasicAuthentication.class.getName());
         conf.setBrokerClientAuthenticationParameters("authParam:broker");
         conf.setAuthenticateOriginalAuthData(true);
-        
+
         Set<String> superUserRoles = new HashSet<String>();
         superUserRoles.add("admin");
         conf.setSuperUserRoles(superUserRoles);
-        
+
         Set<String> providers = new HashSet<String>();
         providers.add(BasicAuthenticationProvider.class.getName());
         conf.setAuthenticationProviders(providers);
@@ -78,9 +78,9 @@ public class ProxyForwardAuthDataTest extends ProducerConsumerBase {
 
     @Override
     protected void cleanup() throws Exception {
-        super.internalCleanup();       
+        super.internalCleanup();
     }
-    
+
     @Test
     void testForwardAuthData() throws Exception {
         log.info("-- Starting {} test --", methodName);
@@ -94,15 +94,13 @@ public class ProxyForwardAuthDataTest extends ProducerConsumerBase {
         String subscriptionName = "my-subscriber-name";
         String clientAuthParams = "authParam:client";
         String proxyAuthParams = "authParam:proxy";
-        
+
         admin.properties().createProperty("my-property",
                 new PropertyAdmin(Lists.newArrayList("appid1", "appid2"), Sets.newHashSet("use")));
         admin.namespaces().createNamespace(namespaceName);
-        
         admin.namespaces().grantPermissionOnNamespace(namespaceName, "proxy", Sets.newHashSet(AuthAction.consume, AuthAction.produce));
         admin.namespaces().grantPermissionOnNamespace(namespaceName, "client", Sets.newHashSet(AuthAction.consume, AuthAction.produce));
 
-        
         // Step 2: Run Pulsar Proxy without forwarding authData - expect Exception
         ProxyConfiguration proxyConfig = new ProxyConfiguration();
         proxyConfig.setAuthenticationEnabled(true);
@@ -110,7 +108,6 @@ public class ProxyForwardAuthDataTest extends ProducerConsumerBase {
         proxyConfig.setServicePort(servicePort);
         proxyConfig.setWebServicePort(webServicePort);
         proxyConfig.setBrokerServiceURL("pulsar://localhost:" + BROKER_PORT);
-        
         proxyConfig.setBrokerClientAuthenticationPlugin(BasicAuthentication.class.getName());
         proxyConfig.setBrokerClientAuthenticationParameters(proxyAuthParams);
 
@@ -141,9 +138,9 @@ public class ProxyForwardAuthDataTest extends ProducerConsumerBase {
         org.apache.pulsar.client.api.ClientConfiguration clientConf = new org.apache.pulsar.client.api.ClientConfiguration();
         clientConf.setAuthentication(BasicAuthentication.class.getName(), adminAuthParams);
 
-        admin = spy(new PulsarAdmin(brokerUrl, clientConf));        
+        admin = spy(new PulsarAdmin(brokerUrl, clientConf));
     }
-    
+
     private PulsarClient createPulsarClient(String proxyServiceUrl, String authParams) throws PulsarClientException {
         org.apache.pulsar.client.api.ClientConfiguration clientConf = new org.apache.pulsar.client.api.ClientConfiguration();
         clientConf.setAuthentication(BasicAuthentication.class.getName(), authParams);


### PR DESCRIPTION
This test was flaking due to the pulsar client being reused. The test
starts a proxy service, subscribes to a topic, stops the proxy, starts
a new proxy and tries to subscribe again.

If using the same client for both connections, the client will have an
open connection to the first proxy, which, when the proxy is stopped,
will be closed by netty asynchronously. This can race with the second
subscription attempt, and cause it to fail with
ConnectionClosedException. Specifically, if the subscription attempt
runs before the netty callback runs, the subscription attempt will try
to subscribe on a dead connection.

The immediate fix for this test, to stop the flaking, is just to use a
different client for each attempt.
