### PR TITLE
add httpcore dep required by httpclient in hostname-verification

### DIFF
--- a/all/src/assemble/LICENSE.bin.txt
+++ b/all/src/assemble/LICENSE.bin.txt
@@ -333,6 +333,7 @@ The Apache Software License, Version 2.0
  * SnakeYaml -- org.yaml-snakeyaml-*.jar
  * RocksDB - org.rocksdb.*.jar
  * HttpClient - org.apache.httpcomponents.httpclient.jar
+ * HttCore - org.apache.httpcomponents.httpcore.jar
  * CommonsLogging - commons-logging-*.jar
 
 BSD 3-clause "New" or "Revised" License

--- a/pulsar-broker-shaded/pom.xml
+++ b/pulsar-broker-shaded/pom.xml
@@ -106,6 +106,7 @@
                   <include>com.wordnik:swagger-annotations</include>
                   <include>org.apache.httpcomponents:httpclient</include>
                   <include>commons-logging:commons-logging</include>
+                  <include>org.apache.httpcomponents:httpcore</include>
                 </includes>
               </artifactSet>
               <filters>
@@ -120,6 +121,12 @@
                   <includes>
                     <include>**</include>
                   </includes>
+                </filter>
+                <filter>
+                   <artifact>commons-logging:commons-logging</artifact>
+                   <includes>
+                       <include>**</include>
+                   </includes>
                 </filter>
               </filters>
               <relocations>

--- a/pulsar-client-kafka-compat/pulsar-client-kafka/pom.xml
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/pom.xml
@@ -127,8 +127,17 @@
                   <include>com.yahoo.datasketches:sketches-core</include>
                   <include>org.apache.httpcomponents:httpclient</include>
                   <include>commons-logging:commons-logging</include>
+                  <include>org.apache.httpcomponents:httpcore</include>
                 </includes>
               </artifactSet>
+               <filters>
+                <filter>
+                   <artifact>commons-logging:commons-logging</artifact>
+                   <includes>
+                       <include>**</include>
+                   </includes>
+                </filter>
+              </filters>
               <relocations>
                 <relocation>
                   <pattern>org.apache.kafka.clients.producer.KafkaProducer</pattern>

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -83,6 +83,7 @@
                   <include>com.yahoo.datasketches:sketches-core</include>
                   <include>org.apache.httpcomponents:httpclient</include>
                   <include>commons-logging:commons-logging</include>
+                  <include>org.apache.httpcomponents:httpcore</include>
                 </includes>
               </artifactSet>
               <filters>
@@ -97,6 +98,12 @@
                   <includes>
                     <include>**</include>
                   </includes>
+                </filter>
+                <filter>
+                   <artifact>commons-logging:commons-logging</artifact>
+                   <includes>
+                       <include>**</include>
+                   </includes>
                 </filter>
               </filters>
               <relocations>

--- a/pulsar-client/pom.xml
+++ b/pulsar-client/pom.xml
@@ -86,11 +86,16 @@
       </exclusions>
     </dependency>
     
-    <!-- httpclient uses it for logging --> 
+    <!-- httpclient-hostname-verification depends on below dependencies  --> 
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
       <version>1.1.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <version>4.4.9</version>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
### Motivation

- when a broker's tls certificate present, httpclient's DefaultHostnameVerifier requires httpcore dependencies to use `org.apache.http.util.Args` class.

```
11:12:33.486 [pulsar-discovery-io-2-3] WARN  o.a.p.p.server.DirectProxyHandler    - [[id: 0x300e8efa, L:/10.213.246.124:6651 - R:/10.215.134.167:51374]] [[id: 0x2b69265f, L:/10.213.246.124:48686 - R:perbs
java.lang.NoClassDefFoundError: org/apache/http/util/Args
        at org.apache.http.conn.ssl.SubjectName.<init>(SubjectName.java:48) ~[httpclient-4.5.5.jar:4.5.5]
        at org.apache.http.conn.ssl.DefaultHostnameVerifier.getSubjectAltNames(DefaultHostnameVerifier.java:310) ~[httpclient-4.5.5.jar:4.5.5]
        at org.apache.http.conn.ssl.DefaultHostnameVerifier.verify(DefaultHostnameVerifier.java:112) ~[httpclient-4.5.5.jar:4.5.5]
        at org.apache.http.conn.ssl.DefaultHostnameVerifier.verify(DefaultHostnameVerifier.java:99) ~[httpclient-4.5.5.jar:4.5.5]
        at 
```
- Also `DefaultHostnameVerifier` requires all classes of commons-logging.

### Modifications
add httpcore dependencies into client/proxy where hostname verification happens.

### Result

It fixes `java.lang.NoClassDefFoundError: org/apache/http/util/Args` while hostname verification.
Note: I will cherry-pick in 1.22 branch as well.
