### PR TITLE
Fix redirect url on proxy to honor TLS

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/LookupProxyHandler.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/LookupProxyHandler.java
@@ -123,13 +123,11 @@ public class LookupProxyHandler {
             }
             clientCnx.newLookup(command,
                     requestId).thenAccept(result -> {
+                        String brokerUrl = connectWithTLS ? result.brokerUrlTls : result.brokerUrl;
                         if (result.redirect) {
                             // Need to try the lookup again on a different broker
-                            performLookup(clientRequestId, topic, result.brokerUrl, authoritative, numberOfRetries - 1);
+                            performLookup(clientRequestId, topic, brokerUrl, authoritative, numberOfRetries - 1);
                         } else {
-                            // We have the result immediately
-                            String brokerUrl = connectWithTLS ? result.brokerUrlTls : result.brokerUrl;
-
                             // Reply the same address for both TLS non-TLS. The reason is that whether we use TLS
                             // between proxy
                             // and broker is independent of whether the client itself uses TLS, but we need to force the


### PR DESCRIPTION
On lookup, if the proxy gets redirects then the proxy should connect to the new broker using TLS if TLS is enabled.