### PR TITLE
Fix v2 namespace policies znode path in proxy handlers

### DIFF
--- a/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/BrokerDiscoveryProvider.java
+++ b/pulsar-discovery-service/src/main/java/org/apache/pulsar/discovery/service/BrokerDiscoveryProvider.java
@@ -103,8 +103,8 @@ public class BrokerDiscoveryProvider implements Closeable {
         CompletableFuture<PartitionedTopicMetadata> metadataFuture = new CompletableFuture<>();
         try {
             checkAuthorization(service, destination, role, authenticationData);
-            final String path = path(PARTITIONED_TOPIC_PATH_ZNODE, destination.getProperty(), destination.getCluster(),
-                    destination.getNamespacePortion(), "persistent", destination.getEncodedLocalName());
+            final String path = path(PARTITIONED_TOPIC_PATH_ZNODE,
+                    destination.getNamespaceObject().toString(), "persistent", destination.getEncodedLocalName());
             // gets the number of partitions from the zk cache
             globalZkCache
                     .getDataAsync(path,

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/BrokerDiscoveryProvider.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/BrokerDiscoveryProvider.java
@@ -102,8 +102,8 @@ public class BrokerDiscoveryProvider implements Closeable {
         CompletableFuture<PartitionedTopicMetadata> metadataFuture = new CompletableFuture<>();
         try {
             checkAuthorization(service, destination, role, authenticationData);
-            final String path = path(PARTITIONED_TOPIC_PATH_ZNODE, destination.getProperty(), destination.getCluster(),
-                    destination.getNamespacePortion(), "persistent", destination.getEncodedLocalName());
+            final String path = path(PARTITIONED_TOPIC_PATH_ZNODE,
+                    destination.getNamespaceObject().toString(), "persistent", destination.getEncodedLocalName());
             // gets the number of partitions from the zk cache
             globalZkCache
                     .getDataAsync(path,


### PR DESCRIPTION
For v2 namespaces to work, we need to always use the `NamespaceName` utility class for handling.