### PR TITLE
Fix lookup problem with partions in a non-persistent topics

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -1094,8 +1094,8 @@ public class PersistentTopicsBase extends AdminResource {
                 throw ex;
             }
 
-            String path = path(PARTITIONED_TOPIC_PATH_ZNODE, dn.getNamespace(),
-                    "persistent", dn.getEncodedLocalName());
+            String path = path(PARTITIONED_TOPIC_PATH_ZNODE, dn.getNamespace(), dn.getDomain().toString(),
+                    dn.getEncodedLocalName());
 
             // validates global-namespace contains local/peer cluster: if peer/local cluster present then lookup can
             // serve/redirect request else fail partitioned-metadata-request so, client fails while creating

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
@@ -186,6 +186,56 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
 
     }
 
+    @Test(dataProvider = "subscriptionType")
+    public void testPartitionedNonPersistentTopicWithTcpLookup(SubscriptionType type) throws Exception {
+        log.info("-- Starting {} test --", methodName);
+
+        final int numPartitions = 5;
+        final String topic = "non-persistent://my-property/use/my-ns/partitioned-topic";
+        admin.nonPersistentTopics().createPartitionedTopic(topic, numPartitions);
+
+        PulsarClient client = PulsarClient.builder().serviceUrl("pulsar://localhost:" + BROKER_PORT)
+                .statsInterval(0, TimeUnit.SECONDS).build();
+        Consumer consumer = client.newConsumer().topic(topic).subscriptionName("subscriber-1").subscriptionType(type)
+                .subscribe();
+
+        Producer producer = client.newProducer().topic(topic).create();
+
+        // Ensure all partitions exist
+        for (int i = 0; i < numPartitions; i++) {
+            DestinationName partition = DestinationName.get(topic).getPartition(i);
+            assertNotNull(pulsar.getBrokerService().getTopicReference(partition.toString()));
+        }
+
+        int totalProduceMsg = 500;
+        for (int i = 0; i < totalProduceMsg; i++) {
+            String message = "my-message-" + i;
+            producer.send(message.getBytes());
+            Thread.sleep(10);
+        }
+
+        Message msg = null;
+        Set<String> messageSet = Sets.newHashSet();
+        for (int i = 0; i < totalProduceMsg; i++) {
+            msg = consumer.receive(1, TimeUnit.SECONDS);
+            if (msg != null) {
+                consumer.acknowledge(msg);
+                String receivedMessage = new String(msg.getData());
+                log.debug("Received message: [{}]", receivedMessage);
+                String expectedMessage = "my-message-" + i;
+                testMessageOrderAndDuplicates(messageSet, receivedMessage, expectedMessage);
+            } else {
+                break;
+            }
+        }
+        assertEquals(messageSet.size(), totalProduceMsg);
+
+        producer.close();
+        consumer.close();
+        log.info("-- Exiting {} test --", methodName);
+        client.close();
+    }
+
     /**
      * It verifies that broker doesn't dispatch messages if consumer runs out of permits
      * filled out with messages


### PR DESCRIPTION
### Motivation

Lookup for non-persistent partitioned topic was broken under the probuf binary lookup, due to a hard-coded "persistent" in the path. The unit tests were only testing with the HTTP lookup for non-persistent case.

Fixes #1250 