### PR TITLE
Use advertisedAddress for bookies in pulsar standalone

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
@@ -148,7 +148,7 @@ public class PulsarStandaloneStarter {
 
         if (!onlyBroker) {
             // Start LocalBookKeeper
-            bkEnsemble = new LocalBookkeeperEnsemble(numOfBk, zkPort, bkPort, zkDir, bkDir, wipeData);
+            bkEnsemble = new LocalBookkeeperEnsemble(numOfBk, zkPort, bkPort, zkDir, bkDir, wipeData, config.getAdvertisedAddress());
             bkEnsemble.startStandalone();
         }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
@@ -107,19 +107,22 @@ public class PulsarStandaloneStarter {
 
         this.config = PulsarConfigurationLoader.create((new FileInputStream(configFile)), ServiceConfiguration.class);
 
-        // Set ZK server's host to localhost
-        config.setZookeeperServers("127.0.0.1:" + zkPort);
-        config.setGlobalZookeeperServers("127.0.0.1:" + zkPort);
+        String zkServers = "127.0.0.1";
 
         if (advertisedAddress != null) {
             // Use advertised address from command line
             config.setAdvertisedAddress(advertisedAddress);
+            zkServers = advertisedAddress;
         } else if (isBlank(config.getAdvertisedAddress())) {
             // Use advertised address as local hostname
             config.setAdvertisedAddress(ServiceConfigurationUtils.unsafeLocalhostResolve());
         } else {
             // Use advertised address from config file
         }
+
+        // Set ZK server's host to localhost
+        config.setZookeeperServers(zkServers + ":" + zkPort);
+        config.setGlobalZookeeperServers(zkServers + ":" + zkPort);
 
         Runtime.getRuntime().addShutdownHook(new Thread() {
             public void run() {

--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
@@ -69,6 +69,11 @@ public class LocalBookkeeperEnsemble {
 
     public LocalBookkeeperEnsemble(int numberOfBookies, int zkPort, int bkBasePort, String zkDataDirName,
             String bkDataDirName, boolean clearOldData) {
+        this(numberOfBookies, zkPort, bkBasePort, zkDataDirName, bkDataDirName, clearOldData, null);
+    }
+
+    public LocalBookkeeperEnsemble(int numberOfBookies, int zkPort, int bkBasePort, String zkDataDirName,
+            String bkDataDirName, boolean clearOldData, String advertisedAddress) {
         this.numberOfBookies = numberOfBookies;
         this.HOSTPORT = "127.0.0.1:" + zkPort;
         this.ZooKeeperDefaultPort = zkPort;
@@ -76,10 +81,12 @@ public class LocalBookkeeperEnsemble {
         this.zkDataDirName = zkDataDirName;
         this.bkDataDirName = bkDataDirName;
         this.clearOldData = clearOldData;
-        LOG.info("Running " + this.numberOfBookies + " bookie(s).");
+        this.advertisedAddress = null == advertisedAddress ? "127.0.0.1" : advertisedAddress;
+        LOG.info("Running {} bookie(s) and advertised them at {}.", this.numberOfBookies, advertisedAddress);
     }
 
     private final String HOSTPORT;
+    private final String advertisedAddress;
     NIOServerCnxnFactory serverFactory;
     ZooKeeperServer zks;
     ZooKeeper zkc;
@@ -224,7 +231,7 @@ public class LocalBookkeeperEnsemble {
         conf.setProperty("dbStorage_readAheadCacheMaxSizeMb", 64);
         conf.setFlushInterval(60000);
         conf.setProperty("journalMaxGroupWaitMSec", 1L);
-        conf.setAdvertisedAddress("127.0.0.1");
+        conf.setAdvertisedAddress(advertisedAddress);
 
         runZookeeper(1000);
         initializeZookeper();

--- a/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsembleTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsembleTest.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.zookeeper;
 import java.io.File;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.assertFalse;
 import org.testng.annotations.AfterMethod;
@@ -39,6 +40,21 @@ public class LocalBookkeeperEnsembleTest {
 
     @AfterMethod
     void teardown() throws Exception {
+    }
+
+    @Test
+    void testAdvertisedAddress() throws Exception {
+        final int numBk = 1;
+        final int zkPort = PortManager.nextFreePort();
+        final int bkPort = PortManager.nextFreePort();
+
+        LocalBookkeeperEnsemble ensemble = new LocalBookkeeperEnsemble(
+            numBk, zkPort, bkPort, null, null, true, "127.0.0.2");
+        ensemble.startStandalone();
+
+        assertNotNull(ensemble.getZkClient().exists("/ledgers/available/127.0.0.2:" + bkPort, false));
+
+        ensemble.stop();
     }
 
     @Test


### PR DESCRIPTION
*Problem*

current bookie advertised address is hardcoded in pulsar standalone. when using this in docker environment, those bookies are not available.

*Solution*

change pulsar standalone to use the advertised address settings in broker settings. so it will use same advertised address for both broker and bookie.