### PR TITLE
Fix bug that consumer which specify incorrect subscription hangs up w…

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -669,6 +669,11 @@ public class ServerCnx extends PulsarHandler {
                         ctx.writeAndFlush(Commands.newError(requestId, ServerError.AuthorizationError, msg));
                     }
                     return null;
+                }).exceptionally(e -> {
+                    String msg = String.format("[%s] %s with role %s", remoteAddress, e.getMessage(), authRole);
+                    log.warn(msg);
+                    ctx.writeAndFlush(Commands.newError(requestId, ServerError.AuthorizationError, e.getMessage()));
+                    return null;
                 });
             } else {
                 final String msg = "Proxy Client is not authorized to subscribe";
@@ -854,6 +859,11 @@ public class ServerCnx extends PulsarHandler {
                         log.warn("[{}] {} with role {}", remoteAddress, msg, authRole);
                         ctx.writeAndFlush(Commands.newError(requestId, ServerError.AuthorizationError, msg));
                     }
+                    return null;
+                }).exceptionally(e -> {
+                    String msg = String.format("[%s] %s with role %s", remoteAddress, e.getMessage(), authRole);
+                    log.warn(msg);
+                    ctx.writeAndFlush(Commands.newError(requestId, ServerError.AuthorizationError, e.getMessage()));
                     return null;
                 });
             } else {


### PR DESCRIPTION
…hen subscription_auth_mode is Prefix

### Motivation

When `subscription_auth_mode` is `Prefix`, a consumer which use a subscription name that does NOT start with the auth role name hangs up forever without error.

cf. #899 

### Modifications

The cause of this issue is that ServerCnx is not handling the exception that is thrown if the subscription name is incorrect.
I have modified ServerCnx to catch the exception and return an error to the client.

### Result

If an incorrect subscription name is specified, subscribing will immediately fail.