### PR TITLE
Add JsonIgnore to a few fields in configuration objects

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ClientConfiguration.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ClientConfiguration.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.client.api;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.io.Serializable;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -37,6 +38,7 @@ public class ClientConfiguration implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    @JsonIgnore
     private Authentication authentication = new AuthenticationDisabled();
     private long operationTimeoutMs = 30000;
     private long statsIntervalSeconds = 60;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerConfiguration.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerConfiguration.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.client.api;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
@@ -45,8 +46,10 @@ public class ConsumerConfiguration implements Serializable {
 
     private SubscriptionType subscriptionType = SubscriptionType.Exclusive;
 
+    @JsonIgnore
     private MessageListener messageListener;
 
+    @JsonIgnore
     private ConsumerEventListener consumerEventListener;
 
     private int receiverQueueSize = 1000;
@@ -59,6 +62,7 @@ public class ConsumerConfiguration implements Serializable {
 
     private int priorityLevel = 0;
 
+    @JsonIgnore
     private CryptoKeyReader cryptoKeyReader = null;
     private ConsumerCryptoFailureAction cryptoFailureAction = ConsumerCryptoFailureAction.FAIL;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ProducerConfiguration.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ProducerConfiguration.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.client.api;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
@@ -48,12 +49,15 @@ public class ProducerConfiguration implements Serializable {
     private int maxPendingMessagesAcrossPartitions = 50000;
     private MessageRoutingMode messageRouteMode = MessageRoutingMode.SinglePartition;
     private HashingScheme hashingScheme = HashingScheme.JavaStringHash;
+    @JsonIgnore
     private MessageRouter customMessageRouter = null;
     private long batchingMaxPublishDelayMs = 10;
     private int batchingMaxMessages = 1000;
     private boolean batchingEnabled = false; // disabled by default
 
+    @JsonIgnore
     private CryptoKeyReader cryptoKeyReader;
+    @JsonIgnore
     private ConcurrentOpenHashSet<String> encryptionKeys;
 
     private CompressionType compressionType = CompressionType.NONE;

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/api/ConsumerConfigurationTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/api/ConsumerConfigurationTest.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertFalse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+/**
+ * Unit test of {@link ConsumerConfiguration}.
+ */
+public class ConsumerConfigurationTest {
+
+    private static final Logger log = LoggerFactory.getLogger(ConsumerConfigurationTest.class);
+
+    @Test
+    public void testJsonIgnore() throws Exception {
+
+        ConsumerConfiguration conf = new ConsumerConfiguration()
+            .setConsumerEventListener(new ConsumerEventListener() {
+
+                @Override
+                public void becameActive(Consumer consumer, int partitionId) {
+                }
+
+                @Override
+                public void becameInactive(Consumer consumer, int partitionId) {
+                }
+            })
+            .setMessageListener((MessageListener) (consumer, msg) -> {
+            })
+            .setCryptoKeyReader(mock(CryptoKeyReader.class));
+
+        ObjectMapper m = new ObjectMapper();
+        m.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+        ObjectWriter w = m.writerWithDefaultPrettyPrinter();
+
+        String confAsString = w.writeValueAsString(conf);
+        log.info("conf : {}", confAsString);
+
+        assertFalse(confAsString.contains("messageListener"));
+        assertFalse(confAsString.contains("consumerEventListener"));
+        assertFalse(confAsString.contains("cryptoKeyReader"));
+    }
+
+}


### PR DESCRIPTION
*Problem*

We have seen NPE thrown when `ConsumerStats` tries to dump the configuration object with a customized ConsumerEventsListener.
The problem came from initialization sequence and when jackson tried to serialize the customized ConsumerEventsListener,
it fails with NPE.

In general, those customized implementation such as `MessageRouter`, `MessageListener` and `ConsumerEventsListener` are not
really needed to serialize as part of json.

*Solution*

Add @JsonIgnore to those fields to bypass json serialization