### PR TITLE
Add get-peer clusters admin api

### DIFF
--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Clusters.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Clusters.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.client.admin;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.pulsar.client.admin.PulsarAdminException.ConflictException;
 import org.apache.pulsar.client.admin.PulsarAdminException.NotAuthorizedException;
@@ -133,6 +134,28 @@ public interface Clusters {
      *             Unexpected error
      */
     void updatePeerClusterNames(String cluster, LinkedHashSet<String> peerClusterNames) throws PulsarAdminException;
+    
+    /**
+     * Get peer-cluster names
+     * <p>
+     *
+     * @param cluster
+     *            Cluster name
+     * @return
+     * @throws NotAuthorizedException
+     *             You don't have admin permission to create the cluster
+     *
+     * @throws NotFoundException
+     *             Domain doesn't exist
+     *
+     * @throws PreconditionFailedException
+     *             Cluster doesn't exist
+     *
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    Set<String> getPeerClusterNames(String cluster) throws PulsarAdminException;
+    
 
     /**
      * Delete an existing cluster

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ClustersImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ClustersImpl.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.client.admin.internal;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
@@ -94,6 +95,15 @@ public class ClustersImpl extends BaseResource implements Clusters {
         
     }
 
+	@Override
+	public Set<String> getPeerClusterNames(String cluster) throws PulsarAdminException {
+		try {
+			return request(clusters.path(cluster).path("peers")).get(LinkedHashSet.class);
+		} catch (Exception e) {
+			throw getApiException(e);
+		}
+	}
+    
     @Override
     public void deleteCluster(String cluster) throws PulsarAdminException {
         try {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdClusters.java
@@ -127,6 +127,19 @@ public class CmdClusters extends CmdBase {
         }
     }
 
+    @Parameters(commandDescription = "Get list of peer-clusters")
+    private class GetPeerClusters extends CliCommand {
+        
+        @Parameter(description = "cluster-name\n", required = true)
+        private java.util.List<String> params;
+        
+        void run() throws PulsarAdminException {
+            String cluster = getOneArgument(params);
+            print(admin.clusters().getPeerClusterNames(cluster));
+        }
+    }
+    
+    
     @Parameters(commandDescription = "Create a new failure-domain for a cluster. updates it if already created.")
     private class CreateFailureDomain extends CliCommand {
         @Parameter(description = "cluster-name\n", required = true)
@@ -213,6 +226,7 @@ public class CmdClusters extends CmdBase {
         jcommander.addCommand("delete", new Delete());
         jcommander.addCommand("list", new List());
         jcommander.addCommand("update-peer-clusters", new UpdatePeerClusters());
+        jcommander.addCommand("get-peer-clusters", new GetPeerClusters());
         jcommander.addCommand("get-failure-domain", new GetFailureDomain());
         jcommander.addCommand("create-failure-domain", new CreateFailureDomain());
         jcommander.addCommand("update-failure-domain", new UpdateFailureDomain());

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -175,6 +175,9 @@ public class PulsarAdminToolTest {
 
         clusters.run(split("update-peer-clusters my-cluster --peer-clusters c1,c2"));
         verify(mockClusters).updatePeerClusterNames("my-cluster", Sets.newLinkedHashSet(Lists.newArrayList("c1", "c2")));
+        
+        clusters.run(split("get-peer-clusters my-cluster"));
+        verify(mockClusters).getPeerClusterNames("my-cluster");
     }
 
     @Test


### PR DESCRIPTION
### Motivation

Right now, after adding peer-clusters, we don't have admin api to get configured peer-cluster for the verification.

### Modifications

Add admin-api to get peer-clusters.

