### PR TITLE
Issue #1237: support builder for topicsConsumer

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
@@ -101,7 +101,7 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         final String topicName1 = "persistent://prop/use/ns-abc/topic-1-" + key;
         final String topicName2 = "persistent://prop/use/ns-abc/topic-2-" + key;
         final String topicName3 = "persistent://prop/use/ns-abc/topic-3-" + key;
-        List<String> topicNames = Lists.newArrayList(topicName1, topicName2, topicName3);
+        List<String> topicNames = Lists.newArrayList(topicName1, topicName2);
 
         admin.properties().createProperty("prop", new PropertyAdmin());
         admin.persistentTopics().createPartitionedTopic(topicName2, 2);
@@ -110,6 +110,7 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         // 2. Create consumer
         Consumer consumer = pulsarClient.newConsumer()
             .topics(topicNames)
+            .topic(topicName3)
             .subscriptionName(subscriptionName)
             .subscriptionType(SubscriptionType.Shared)
             .ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS)
@@ -545,28 +546,51 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         admin.persistentTopics().createPartitionedTopic(topicName2, 2);
         admin.persistentTopics().createPartitionedTopic(topicName3, 3);
 
-        // test failing builder with wrong parameter
+        // test failing builder with empty topics
         try {
             Consumer consumer1 = pulsarClient.newConsumer()
                 .subscriptionName(subscriptionName)
                 .subscriptionType(SubscriptionType.Shared)
                 .ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS)
                 .subscribe();
-            fail("subscribe with no topicName should fail.");
+            fail("subscribe1 with no topicName should fail.");
         } catch (PulsarClientException e) {
             // expected
         }
 
         try {
             Consumer consumer2 = pulsarClient.newConsumer()
-                .topic("fakeTopicName")
-                .topics(topicNames)
+                .topic()
                 .subscriptionName(subscriptionName)
                 .subscriptionType(SubscriptionType.Shared)
                 .ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS)
                 .subscribe();
-            fail("subscribe with both topicName and topicNames should fail.");
-        } catch (PulsarClientException e) {
+            fail("subscribe2 with no topicName should fail.");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+
+        try {
+            Consumer consumer3 = pulsarClient.newConsumer()
+                .topics(null)
+                .subscriptionName(subscriptionName)
+                .subscriptionType(SubscriptionType.Shared)
+                .ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS)
+                .subscribe();
+            fail("subscribe3 with no topicName should fail.");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+
+        try {
+            Consumer consumer4 = pulsarClient.newConsumer()
+                .topics(Lists.newArrayList())
+                .subscriptionName(subscriptionName)
+                .subscriptionType(SubscriptionType.Shared)
+                .ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS)
+                .subscribe();
+            fail("subscribe4 with no topicName should fail.");
+        } catch (IllegalArgumentException e) {
             // expected
         }
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
@@ -114,6 +114,7 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
             .subscriptionName(subscriptionName)
             .subscriptionType(SubscriptionType.Shared)
             .ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS)
+            .receiverQueueSize(4)
             .subscribe();
         assertTrue(consumer instanceof TopicsConsumerImpl);
 
@@ -164,6 +165,7 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
             .subscriptionName(subscriptionName)
             .subscriptionType(SubscriptionType.Shared)
             .ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS)
+            .receiverQueueSize(4)
             .subscribe();
         assertTrue(consumer instanceof TopicsConsumerImpl);
 
@@ -224,6 +226,7 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
             .subscriptionName(subscriptionName)
             .subscriptionType(SubscriptionType.Shared)
             .ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS)
+            .receiverQueueSize(4)
             .subscribe();
         assertTrue(consumer instanceof TopicsConsumerImpl);
 
@@ -302,6 +305,7 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
             .subscriptionName(subscriptionName)
             .subscriptionType(SubscriptionType.Shared)
             .ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS)
+            .receiverQueueSize(4)
             .subscribe();
         assertTrue(consumer instanceof TopicsConsumerImpl);
 
@@ -441,6 +445,7 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
             .subscriptionName(subscriptionName)
             .subscriptionType(SubscriptionType.Shared)
             .ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS)
+            .receiverQueueSize(4)
             .subscribe();
         assertTrue(consumer instanceof TopicsConsumerImpl);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TopicsConsumerImplTest.java
@@ -33,12 +33,9 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import org.apache.pulsar.client.api.Consumer;
-import org.apache.pulsar.client.api.ConsumerConfiguration;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
-import org.apache.pulsar.client.api.ProducerConfiguration;
-import org.apache.pulsar.client.api.ProducerConfiguration.MessageRoutingMode;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.SubscriptionType;
@@ -82,12 +79,13 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         admin.persistentTopics().createPartitionedTopic(topicName3, 3);
 
         // 2. Create consumer
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setReceiverQueueSize(4);
-        conf.setAckTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS);
-        conf.setSubscriptionType(SubscriptionType.Shared);
         try {
-            Consumer consumer = pulsarClient.subscribeAsync(topicNames, subscriptionName, conf).get();
+            Consumer consumer = pulsarClient.newConsumer()
+                .topics(topicNames)
+                .subscriptionName(subscriptionName)
+                .subscriptionType(SubscriptionType.Shared)
+                .ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS)
+                .subscribe();
             fail("subscribe for topics from different namespace should fail.");
         } catch (IllegalArgumentException e) {
             // expected for have different namespace
@@ -110,11 +108,12 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         admin.persistentTopics().createPartitionedTopic(topicName3, 3);
 
         // 2. Create consumer
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setReceiverQueueSize(4);
-        conf.setAckTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS);
-        conf.setSubscriptionType(SubscriptionType.Shared);
-        Consumer consumer = pulsarClient.subscribeAsync(topicNames, subscriptionName, conf).get();
+        Consumer consumer = pulsarClient.newConsumer()
+            .topics(topicNames)
+            .subscriptionName(subscriptionName)
+            .subscriptionType(SubscriptionType.Shared)
+            .ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS)
+            .subscribe();
         assertTrue(consumer instanceof TopicsConsumerImpl);
 
         List<String> topics = ((TopicsConsumerImpl) consumer).getPartitionedTopics();
@@ -148,20 +147,23 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         admin.persistentTopics().createPartitionedTopic(topicName2, 2);
         admin.persistentTopics().createPartitionedTopic(topicName3, 3);
 
-        ProducerConfiguration producerConfiguration = new ProducerConfiguration();
-        producerConfiguration.setMessageRoutingMode(MessageRoutingMode.RoundRobinPartition);
-
         // 1. producer connect
-        Producer producer1 = pulsarClient.createProducer(topicName1);
-        Producer producer2 = pulsarClient.createProducer(topicName2, producerConfiguration);
-        Producer producer3 = pulsarClient.createProducer(topicName3, producerConfiguration);
+        Producer producer1 = pulsarClient.newProducer().topic(topicName1)
+            .create();
+        Producer producer2 = pulsarClient.newProducer().topic(topicName2)
+            .messageRoutingMode(org.apache.pulsar.client.api.MessageRoutingMode.RoundRobinPartition)
+            .create();
+        Producer producer3 = pulsarClient.newProducer().topic(topicName3)
+            .messageRoutingMode(org.apache.pulsar.client.api.MessageRoutingMode.RoundRobinPartition)
+            .create();
 
         // 2. Create consumer
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setReceiverQueueSize(4);
-        conf.setAckTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS);
-        conf.setSubscriptionType(SubscriptionType.Shared);
-        Consumer consumer = pulsarClient.subscribeAsync(topicNames, subscriptionName, conf).get();
+        Consumer consumer = pulsarClient.newConsumer()
+            .topics(topicNames)
+            .subscriptionName(subscriptionName)
+            .subscriptionType(SubscriptionType.Shared)
+            .ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS)
+            .subscribe();
         assertTrue(consumer instanceof TopicsConsumerImpl);
 
         // 3. producer publish messages
@@ -205,20 +207,23 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         admin.persistentTopics().createPartitionedTopic(topicName2, 2);
         admin.persistentTopics().createPartitionedTopic(topicName3, 3);
 
-        ProducerConfiguration producerConfiguration = new ProducerConfiguration();
-        producerConfiguration.setMessageRoutingMode(MessageRoutingMode.RoundRobinPartition);
-
         // 1. producer connect
-        Producer producer1 = pulsarClient.createProducer(topicName1);
-        Producer producer2 = pulsarClient.createProducer(topicName2, producerConfiguration);
-        Producer producer3 = pulsarClient.createProducer(topicName3, producerConfiguration);
+        Producer producer1 = pulsarClient.newProducer().topic(topicName1)
+            .create();
+        Producer producer2 = pulsarClient.newProducer().topic(topicName2)
+            .messageRoutingMode(org.apache.pulsar.client.api.MessageRoutingMode.RoundRobinPartition)
+            .create();
+        Producer producer3 = pulsarClient.newProducer().topic(topicName3)
+            .messageRoutingMode(org.apache.pulsar.client.api.MessageRoutingMode.RoundRobinPartition)
+            .create();
 
         // 2. Create consumer
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setReceiverQueueSize(4);
-        conf.setAckTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS);
-        conf.setSubscriptionType(SubscriptionType.Shared);
-        Consumer consumer = pulsarClient.subscribeAsync(topicNames, subscriptionName, conf).get();
+        Consumer consumer = pulsarClient.newConsumer()
+            .topics(topicNames)
+            .subscriptionName(subscriptionName)
+            .subscriptionType(SubscriptionType.Shared)
+            .ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS)
+            .subscribe();
         assertTrue(consumer instanceof TopicsConsumerImpl);
 
         // Asynchronously produce messages
@@ -280,20 +285,23 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         admin.persistentTopics().createPartitionedTopic(topicName2, 2);
         admin.persistentTopics().createPartitionedTopic(topicName3, 3);
 
-        ProducerConfiguration producerConfiguration = new ProducerConfiguration();
-        producerConfiguration.setMessageRoutingMode(MessageRoutingMode.RoundRobinPartition);
-
         // 1. producer connect
-        Producer producer1 = pulsarClient.createProducer(topicName1);
-        Producer producer2 = pulsarClient.createProducer(topicName2, producerConfiguration);
-        Producer producer3 = pulsarClient.createProducer(topicName3, producerConfiguration);
+        Producer producer1 = pulsarClient.newProducer().topic(topicName1)
+            .create();
+        Producer producer2 = pulsarClient.newProducer().topic(topicName2)
+            .messageRoutingMode(org.apache.pulsar.client.api.MessageRoutingMode.RoundRobinPartition)
+            .create();
+        Producer producer3 = pulsarClient.newProducer().topic(topicName3)
+            .messageRoutingMode(org.apache.pulsar.client.api.MessageRoutingMode.RoundRobinPartition)
+            .create();
 
         // 2. Create consumer
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setReceiverQueueSize(4);
-        conf.setAckTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS);
-        conf.setSubscriptionType(SubscriptionType.Shared);
-        Consumer consumer = pulsarClient.subscribeAsync(topicNames, subscriptionName, conf).get();
+        Consumer consumer = pulsarClient.newConsumer()
+            .topics(topicNames)
+            .subscriptionName(subscriptionName)
+            .subscriptionType(SubscriptionType.Shared)
+            .ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS)
+            .subscribe();
         assertTrue(consumer instanceof TopicsConsumerImpl);
 
         // 3. producer publish messages
@@ -416,20 +424,23 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         admin.persistentTopics().createPartitionedTopic(topicName2, 2);
         admin.persistentTopics().createPartitionedTopic(topicName3, 3);
 
-        ProducerConfiguration producerConfiguration = new ProducerConfiguration();
-        producerConfiguration.setMessageRoutingMode(MessageRoutingMode.RoundRobinPartition);
-
         // 1. producer connect
-        Producer producer1 = pulsarClient.createProducer(topicName1);
-        Producer producer2 = pulsarClient.createProducer(topicName2, producerConfiguration);
-        Producer producer3 = pulsarClient.createProducer(topicName3, producerConfiguration);
+        Producer producer1 = pulsarClient.newProducer().topic(topicName1)
+            .create();
+        Producer producer2 = pulsarClient.newProducer().topic(topicName2)
+            .messageRoutingMode(org.apache.pulsar.client.api.MessageRoutingMode.RoundRobinPartition)
+            .create();
+        Producer producer3 = pulsarClient.newProducer().topic(topicName3)
+            .messageRoutingMode(org.apache.pulsar.client.api.MessageRoutingMode.RoundRobinPartition)
+            .create();
 
         // 2. Create consumer
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setReceiverQueueSize(4);
-        conf.setAckTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS);
-        conf.setSubscriptionType(SubscriptionType.Shared);
-        Consumer consumer = pulsarClient.subscribeAsync(topicNames, subscriptionName, conf).get();
+        Consumer consumer = pulsarClient.newConsumer()
+            .topics(topicNames)
+            .subscriptionName(subscriptionName)
+            .subscriptionType(SubscriptionType.Shared)
+            .ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS)
+            .subscribe();
         assertTrue(consumer instanceof TopicsConsumerImpl);
 
         // 3. producer publish messages
@@ -521,11 +532,9 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
 
 
     @Test(timeOut = testTimeout)
-    public void testTopicsNameSubscribeWithBuilder() throws Exception {
+    public void testTopicsNameSubscribeWithBuilderFail() throws Exception {
         String key = "TopicsNameSubscribeWithBuilder";
         final String subscriptionName = "my-ex-subscription-" + key;
-        final String messagePredicate = "my-message-" + key + "-";
-        final int totalMessages = 30;
 
         final String topicName1 = "persistent://prop/use/ns-abc/topic-1-" + key;
         final String topicName2 = "persistent://prop/use/ns-abc/topic-2-" + key;
@@ -538,7 +547,7 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
 
         // test failing builder with wrong parameter
         try {
-            Consumer consumer2 = pulsarClient.newConsumer()
+            Consumer consumer1 = pulsarClient.newConsumer()
                 .subscriptionName(subscriptionName)
                 .subscriptionType(SubscriptionType.Shared)
                 .ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS)
@@ -549,7 +558,7 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         }
 
         try {
-            Consumer consumer3 = pulsarClient.newConsumer()
+            Consumer consumer2 = pulsarClient.newConsumer()
                 .topic("fakeTopicName")
                 .topics(topicNames)
                 .subscriptionName(subscriptionName)
@@ -560,50 +569,6 @@ public class TopicsConsumerImplTest extends ProducerConsumerBase {
         } catch (PulsarClientException e) {
             // expected
         }
-
-        // 1. Create consumer with builder
-        Consumer consumer = pulsarClient.newConsumer()
-            .topics(topicNames)
-            .subscriptionName(subscriptionName)
-            .subscriptionType(SubscriptionType.Shared)
-            .ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS)
-            .subscribe();
-        assertTrue(consumer instanceof TopicsConsumerImpl);
-
-        // 2. create producer with builder
-        Producer producer1 = pulsarClient.newProducer().topic(topicName1)
-            .messageRoutingMode(org.apache.pulsar.client.api.MessageRoutingMode.RoundRobinPartition)
-            .create();
-        Producer producer2 = pulsarClient.newProducer().topic(topicName2)
-            .messageRoutingMode(org.apache.pulsar.client.api.MessageRoutingMode.RoundRobinPartition)
-            .create();
-        Producer producer3 = pulsarClient.newProducer().topic(topicName3)
-            .messageRoutingMode(org.apache.pulsar.client.api.MessageRoutingMode.RoundRobinPartition)
-            .create();
-
-        // 3. producer publish messages, verify all messages received
-        for (int i = 0; i < totalMessages / 3; i++) {
-            producer1.send((messagePredicate + "producer1-" + i).getBytes());
-            producer2.send((messagePredicate + "producer2-" + i).getBytes());
-            producer3.send((messagePredicate + "producer3-" + i).getBytes());
-        }
-
-        int messageSet = 0;
-        Message message = consumer.receive();
-        do {
-            assertTrue(message instanceof TopicMessageImpl);
-            messageSet ++;
-            consumer.acknowledge(message);
-            log.debug("Consumer acknowledged : " + new String(message.getData()));
-            message = consumer.receive(500, TimeUnit.MILLISECONDS);
-        } while (message != null);
-        assertEquals(messageSet, totalMessages);
-
-        consumer.unsubscribe();
-        consumer.close();
-        producer1.close();
-        producer2.close();
-        producer3.close();
     }
 
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -78,13 +78,13 @@ public interface ConsumerBuilder extends Serializable, Cloneable {
     CompletableFuture<Consumer> subscribeAsync();
 
     /**
-     * Specify the topic this consumer will subscribe on.
+     * Specify the topics this consumer will subscribe on.
      * <p>
      * This argument is required when constructing the consumer.
      *
-     * @param topicName
+     * @param topicNames
      */
-    ConsumerBuilder topic(String topicName);
+    ConsumerBuilder topic(String... topicNames);
 
     /**
      * Specify a list of topics that this consumer will subscribe on.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.client.api;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -84,6 +85,15 @@ public interface ConsumerBuilder extends Serializable, Cloneable {
      * @param topicName
      */
     ConsumerBuilder topic(String topicName);
+
+    /**
+     * Specify a list of topics that this consumer will subscribe on.
+     * <p>
+     * This argument is required when constructing the consumer.
+     *
+     * @param topicNames
+     */
+    ConsumerBuilder topics(List<String> topicNames);
 
     /**
      * Specify the subscription name for this consumer.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/PulsarClient.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/PulsarClient.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.client.api;
 
 import java.io.Closeable;
-import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.pulsar.client.impl.ClientBuilderImpl;
@@ -321,60 +320,4 @@ public interface PulsarClient extends Closeable {
      *             if the forceful shutdown fails
      */
     void shutdown() throws PulsarClientException;
-
-
-    /**
-     * Subscribe to the given topic and subscription combination with default {@code ConsumerConfiguration}
-     *
-     * @param topics
-     *            The collection of topic names, they should be under same namespace
-     * @param subscription
-     *            The name of the subscription
-     * @return The {@code Consumer} object
-     * @throws PulsarClientException
-     */
-    Consumer subscribe(Collection<String> topics, String subscription) throws PulsarClientException;
-
-    /**
-     * Asynchronously subscribe to the given topics and subscription combination with
-     * default {@code ConsumerConfiguration}
-     *
-     * @param topics
-     *            The collection of topic names, they should be under same namespace
-     * @param subscription
-     *            The name of the subscription
-     * @return Future of the {@code Consumer} object
-     */
-    CompletableFuture<Consumer> subscribeAsync(Collection<String> topics, String subscription);
-
-    /**
-     * Subscribe to the given topics and subscription combination using given {@code ConsumerConfiguration}
-     *
-     * @param topics
-     *            The collection of topic names, they should be under same namespace
-     * @param subscription
-     *            The name of the subscription
-     * @param conf
-     *            The {@code ConsumerConfiguration} object
-     * @return Future of the {@code Consumer} object
-     */
-    Consumer subscribe(Collection<String> topics, String subscription, ConsumerConfiguration conf)
-        throws PulsarClientException;
-
-    /**
-     * Asynchronously subscribe to the given topics and subscription combination using given
-     * {@code ConsumerConfiguration}
-     *
-     * @param topics
-     *            The collection of topic names, they should be under same namespace
-     * @param subscription
-     *            The name of the subscription
-     * @param conf
-     *            The {@code ConsumerConfiguration} object
-     * @return Future of the {@code Consumer} object
-     */
-    CompletableFuture<Consumer> subscribeAsync(Collection<String> topics,
-                                               String subscription,
-                                               ConsumerConfiguration conf);
-
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -308,38 +308,6 @@ public class PulsarClientImpl implements PulsarClient {
         return consumerSubscribedFuture;
     }
 
-
-    @Override
-    public Consumer subscribe(Collection<String> topics, final String subscription) throws PulsarClientException {
-        return subscribe(topics, subscription, new ConsumerConfiguration());
-    }
-
-    @Override
-    public Consumer subscribe(Collection<String> topics,
-                              String subscription,
-                              ConsumerConfiguration conf)
-        throws PulsarClientException {
-        try {
-            return subscribeAsync(topics, subscription, conf).get();
-        } catch (ExecutionException e) {
-            Throwable t = e.getCause();
-            if (t instanceof PulsarClientException) {
-                throw (PulsarClientException) t;
-            } else {
-                throw new PulsarClientException(t);
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarClientException(e);
-        }
-    }
-
-    @Override
-    public CompletableFuture<Consumer> subscribeAsync(Collection<String> topics, String subscription) {
-        return subscribeAsync(topics, subscription, new ConsumerConfiguration());
-    }
-
-    @Override
     public CompletableFuture<Consumer> subscribeAsync(Collection<String> topics,
                                                       String subscription,
                                                       ConsumerConfiguration conf) {


### PR DESCRIPTION
### Motivation

According to PIP-12, we need to support builder for topicsConsumer

### Modifications

- add `ConsumerBuilder topics(List<String> topicNames)` in ConsumerBuilder
- add test for the builder

### Result
user could subscribe topics with builder mode.