### PR TITLE
Add prefix setting for Java reader

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ReaderBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ReaderBuilder.java
@@ -137,4 +137,11 @@ public interface ReaderBuilder extends Serializable, Cloneable {
      * @param readerName
      */
     ReaderBuilder readerName(String readerName);
+
+    /**
+     * Set the subscription role prefix. The default prefix is "reader".
+     *
+     * @param subscriptionRolePrefix
+     */
+    ReaderBuilder subscriptionRolePrefix(String subscriptionRolePrefix);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ReaderConfiguration.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ReaderConfiguration.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.client.api;
 
+import org.apache.commons.lang3.StringUtils;
+
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -130,8 +132,26 @@ public class ReaderConfiguration implements Serializable {
      * @param readerName
      */
     public ReaderConfiguration setReaderName(String readerName) {
-        checkArgument(readerName != null && !readerName.equals(""));
+        checkArgument(StringUtils.isNotBlank(readerName));
         conf.setReaderName(readerName);
+        return this;
+    }
+
+    /**
+     * @return the subscription role prefix for subscription auth
+     */
+    public String getSubscriptionRolePrefix() {
+        return conf.getSubscriptionRolePrefix();
+    }
+
+    /**
+     * Set the subscription role prefix for subscription auth. The default prefix is "reader".
+     *
+     * @param subscriptionRolePrefix
+     */
+    public ReaderConfiguration setSubscriptionRolePrefix(String subscriptionRolePrefix) {
+        checkArgument(StringUtils.isNotBlank(subscriptionRolePrefix));
+        conf.setSubscriptionRolePrefix(subscriptionRolePrefix);
         return this;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderBuilderImpl.java
@@ -130,4 +130,10 @@ public class ReaderBuilderImpl implements ReaderBuilder {
         conf.setReaderName(readerName);
         return this;
     }
+
+    @Override
+    public ReaderBuilder subscriptionRolePrefix(String subscriptionRolePrefix) {
+        conf.setSubscriptionRolePrefix(subscriptionRolePrefix);
+        return this;
+    }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageListener;
@@ -44,6 +45,9 @@ public class ReaderImpl implements Reader {
             ExecutorService listenerExecutor, CompletableFuture<Consumer> consumerFuture) {
 
         String subscription = "reader-" + DigestUtils.sha1Hex(UUID.randomUUID().toString()).substring(0, 10);
+        if (StringUtils.isNotBlank(readerConfiguration.getSubscriptionRolePrefix())) {
+            subscription = readerConfiguration.getSubscriptionRolePrefix() + "-" + subscription;
+        }
 
         ConsumerConfigurationData consumerConfiguration = new ConsumerConfigurationData();
         consumerConfiguration.getTopicNames().add(readerConfiguration.getTopicName());

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ReaderConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ReaderConfigurationData.java
@@ -38,6 +38,7 @@ public class ReaderConfigurationData implements Serializable, Cloneable {
     private ReaderListener readerListener;
 
     private String readerName = null;
+    private String subscriptionRolePrefix = null;
 
     private CryptoKeyReader cryptoKeyReader = null;
     private ConsumerCryptoFailureAction cryptoFailureAction = ConsumerCryptoFailureAction.FAIL;


### PR DESCRIPTION
### Motivation

Now reader cannot be used when subscription auth mode is prefix.

### Modifications

Add prefix setting for Java reader.

### Result

Java reader can be used when subscription auth mode is prefix.
If the specification is acceptable, we are going to create another PR for C++ client.