### PR TITLE
Allow superuser to consume without subscription_auth_mode check

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/PulsarAuthorizationProvider.java
@@ -109,7 +109,7 @@ public class PulsarAuthorizationProvider implements AuthorizationProvider {
                         log.debug("Policies node couldn't be found for destination : {}", destination);
                     }
                 } else {
-                    if (isNotBlank(subscription)) {
+                    if (isNotBlank(subscription) && !isSuperUser(role)) {
                         switch (policies.get().subscription_auth_mode) {
                         case Prefix:
                             if (!subscription.startsWith(role)) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/AuthorizationTest.java
@@ -49,6 +49,7 @@ public class AuthorizationTest extends MockedPulsarServiceBaseTest {
         conf.setClusterName("c1");
         conf.setAuthorizationEnabled(true);
         conf.setAuthorizationAllowWildcardsMatching(true);
+        conf.setSuperUserRoles(Sets.newHashSet("pulsar.super_user"));
         internalSetup();
     }
 
@@ -206,6 +207,7 @@ public class AuthorizationTest extends MockedPulsarServiceBaseTest {
 
         assertEquals(auth.canConsume(DestinationName.get("persistent://p1/c1/ns1/ds1"), "role1", null, "role1-sub1"), true);
         assertEquals(auth.canConsume(DestinationName.get("persistent://p1/c1/ns1/ds1"), "role2", null, "role2-sub2"), true);
+        assertEquals(auth.canConsume(DestinationName.get("persistent://p1/c1/ns1/ds1"), "pulsar.super_user", null, "role3-sub1"), true);
 
         admin.namespaces().deleteNamespace("p1/c1/ns1");
         admin.properties().deleteProperty("p1");


### PR DESCRIPTION
### Motivation
In our environment, websocket client can't subscribe topics whose namespace has subscription_auth_mode policy.
This cause is that broker checks subscription_auth_mode even though role is superuser.
Websocket proxy connects to broker with superuser role in our environment.

### Modifications
Allow superuser to consume without subscription_auth_mode check.

### Result
We can subscribe those topics through websocket proxy.