### PR TITLE
Docker image for integration testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,8 @@ flexible messaging model and an intuitive client API.</description>
     <module>pulsar-client-kafka-compat</module>
     <module>pulsar-zookeeper</module>
     <module>all</module>
+    <module>docker</module>
+    <module>tests</module>
   </modules>
 
   <issueManagement>
@@ -124,6 +126,7 @@ flexible messaging model and an intuitive client API.</description>
     <bouncycastle.version>1.55</bouncycastle.version>
     <jackson.version>2.8.4</jackson.version>
     <puppycrawl.checkstyle.version>6.19</puppycrawl.checkstyle.version>
+    <dockerfile-maven.version>1.3.7</dockerfile-maven.version>
   </properties>
 
   <dependencyManagement>
@@ -975,6 +978,9 @@ flexible messaging model and an intuitive client API.</description>
           </plugin>
         </plugins>
       </reporting>
+    </profile>
+    <profile>
+      <id>docker</id>
     </profile>
   </profiles>
 

--- a/tests/docker-images/latest-version-image/Dockerfile
+++ b/tests/docker-images/latest-version-image/Dockerfile
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+FROM apachepulsar/pulsar:latest
+
+RUN apt-get update && apt-get install -y supervisor
+
+RUN mkdir -p /var/log/pulsar && mkdir -p /var/run/supervisor/
+
+COPY conf/supervisord.conf /etc/supervisord.conf
+COPY conf/global-zk.conf /etc/supervisord/conf.d/global-zk.conf
+COPY conf/local-zk.conf /etc/supervisord/conf.d/local-zk.conf
+COPY conf/bookie.conf /etc/supervisord/conf.d/bookie.conf
+COPY conf/broker.conf /etc/supervisord/conf.d/broker.conf
+COPY conf/proxy.conf /etc/supervisord/conf.d/proxy.conf
+
+COPY scripts/init-cluster.sh /pulsar/bin
+COPY scripts/run-global-zk.sh /pulsar/bin
+COPY scripts/run-local-zk.sh /pulsar/bin
+COPY scripts/run-bookie.sh /pulsar/bin
+COPY scripts/run-broker.sh /pulsar/bin
+COPY scripts/run-proxy.sh /pulsar/bin
+

--- a/tests/docker-images/latest-version-image/conf/bookie.conf
+++ b/tests/docker-images/latest-version-image/conf/bookie.conf
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+[program:bookie]
+autostart=false
+redirect_stderr=true
+stdout_logfile=/var/log/pulsar/bookie.log
+directory=/pulsar
+command=/pulsar/bin/pulsar bookie
+

--- a/tests/docker-images/latest-version-image/conf/broker.conf
+++ b/tests/docker-images/latest-version-image/conf/broker.conf
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+[program:broker]
+autostart=false
+redirect_stderr=true
+stdout_logfile=/var/log/pulsar/broker.log
+directory=/pulsar
+command=/pulsar/bin/pulsar broker
+

--- a/tests/docker-images/latest-version-image/conf/global-zk.conf
+++ b/tests/docker-images/latest-version-image/conf/global-zk.conf
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+[program:global-zk]
+autostart=false
+redirect_stderr=true
+stdout_logfile=/var/log/pulsar/global-zk.log
+directory=/pulsar
+command=/pulsar/bin/pulsar global-zookeeper
+

--- a/tests/docker-images/latest-version-image/conf/local-zk.conf
+++ b/tests/docker-images/latest-version-image/conf/local-zk.conf
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+[program:local-zk]
+autostart=false
+redirect_stderr=true
+stdout_logfile=/var/log/pulsar/local-zk.log
+directory=/pulsar
+command=/pulsar/bin/pulsar zookeeper
+

--- a/tests/docker-images/latest-version-image/conf/proxy.conf
+++ b/tests/docker-images/latest-version-image/conf/proxy.conf
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+[program:proxy]
+autostart=false
+redirect_stderr=true
+stdout_logfile=/var/log/pulsar/proxy.log
+directory=/pulsar
+command=/pulsar/bin/pulsar proxy
+

--- a/tests/docker-images/latest-version-image/conf/supervisord.conf
+++ b/tests/docker-images/latest-version-image/conf/supervisord.conf
@@ -1,0 +1,40 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+[supervisord]
+nodaemon=true
+logfile=/var/log/supervisord.log
+logfile_maxbytes=50MB
+logfile_backups=10
+loglevel=info
+pidfile=/var/run/supervisord.pid
+minfds=1024
+minprocs=200
+
+[unix_http_server]
+file=/var/run/supervisor/supervisor.sock
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[include]
+files = /etc/supervisord/conf.d/*.conf

--- a/tests/docker-images/latest-version-image/pom.xml
+++ b/tests/docker-images/latest-version-image/pom.xml
@@ -31,14 +31,6 @@
   <name>Apache Pulsar :: Tests :: Docker Images :: Latest Version Testing</name>
   <packaging>pom</packaging>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.apache.pulsar</groupId>
-      <artifactId>pulsar-docker-image</artifactId>
-      <version>${project.parent.version}</version>
-      <classifier>docker-info</classifier>
-    </dependency>
-  </dependencies>
   <profiles>
     <profile>
       <id>docker</id>
@@ -47,6 +39,14 @@
           <name>integrationTests</name>
         </property>
       </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.pulsar</groupId>
+          <artifactId>pulsar-docker-image</artifactId>
+          <version>${project.parent.version}</version>
+          <classifier>docker-info</classifier>
+        </dependency>
+      </dependencies>
       <build>
         <plugins>
           <plugin>

--- a/tests/docker-images/latest-version-image/pom.xml
+++ b/tests/docker-images/latest-version-image/pom.xml
@@ -1,0 +1,85 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.apache.pulsar.tests</groupId>
+    <artifactId>docker-images</artifactId>
+    <version>2.0.0-incubating-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.pulsar.tests</groupId>
+  <artifactId>latest-version-image</artifactId>
+  <name>Apache Pulsar :: Tests :: Docker Images :: Latest Version Testing</name>
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.pulsar</groupId>
+      <artifactId>pulsar-docker-image</artifactId>
+      <version>${project.parent.version}</version>
+      <classifier>docker-info</classifier>
+    </dependency>
+  </dependencies>
+  <profiles>
+    <profile>
+      <id>docker</id>
+      <activation>
+        <property>
+          <name>integrationTests</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>dockerfile-maven-plugin</artifactId>
+            <version>${dockerfile-maven.version}</version>
+            <executions>
+              <execution>
+                <id>default</id>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>add-latest-tag</id>
+                <goals>
+                  <goal>tag</goal>
+                </goals>
+                <configuration>
+                  <repository>apachepulsar/pulsar-test-latest-version</repository>
+                  <tag>latest</tag>
+                </configuration>
+              </execution>
+            </executions>
+            <configuration>
+              <repository>apachepulsar/pulsar-test-latest-version</repository>
+              <tag>${project.version}</tag>
+              <pullNewerImage>false</pullNewerImage>
+              <noCache>true</noCache>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/tests/docker-images/latest-version-image/scripts/init-cluster.sh
+++ b/tests/docker-images/latest-version-image/scripts/init-cluster.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+ZNODE="/initialized"
+
+bin/watch-znode.py -z $zkServers -p / -w
+
+bin/watch-znode.py -z $zkServers -p $ZNODE -e
+if [ $? != 0 ]; then
+    echo Initializing cluster
+    bin/apply-config-from-env.py conf/bookkeeper.conf &&
+        bin/pulsar initialize-cluster-metadata --cluster $cluster --zookeeper $zkServers \
+                   --global-zookeeper $globalZkServers --web-service-url http://$pulsarNode:8080/ \
+                   --broker-service-url http://$pulsarNode:6650/ &&
+        bin/watch-znode.py -z $zkServers -p $ZNODE -c
+    echo Initialized
+else
+    echo Already Initialized
+fi

--- a/tests/docker-images/latest-version-image/scripts/run-bookie.sh
+++ b/tests/docker-images/latest-version-image/scripts/run-bookie.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+bin/apply-config-from-env.py conf/bookkeeper.conf && \
+    bin/apply-config-from-env.py conf/pulsar_env.sh
+
+if [ -z "$NO_AUTOSTART" ]; then
+    sed -i 's/autostart=.*/autostart=true/' /etc/supervisord/conf.d/bookie.conf
+fi
+
+bin/watch-znode.py -z $zkServers -p /initialized -w
+exec /usr/bin/supervisord -c /etc/supervisord.conf
+

--- a/tests/docker-images/latest-version-image/scripts/run-broker.sh
+++ b/tests/docker-images/latest-version-image/scripts/run-broker.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+bin/apply-config-from-env.py conf/broker.conf && \
+    bin/apply-config-from-env.py conf/pulsar_env.sh
+
+if [ -z "$NO_AUTOSTART" ]; then
+    sed -i 's/autostart=.*/autostart=true/' /etc/supervisord/conf.d/broker.conf
+fi
+
+bin/watch-znode.py -z $zookeeperServers -p /initialized -w
+exec /usr/bin/supervisord -c /etc/supervisord.conf
+

--- a/tests/docker-images/latest-version-image/scripts/run-global-zk.sh
+++ b/tests/docker-images/latest-version-image/scripts/run-global-zk.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+bin/apply-config-from-env.py conf/zookeeper.conf && \
+    bin/apply-config-from-env.py conf/pulsar_env.sh && \
+    bin/generate-zookeeper-config.sh conf/global_zookeeper.conf
+
+if [ -z "$NO_AUTOSTART" ]; then
+    sed -i 's/autostart=.*/autostart=true/' /etc/supervisord/conf.d/global-zk.conf
+fi
+
+exec /usr/bin/supervisord -c /etc/supervisord.conf

--- a/tests/docker-images/latest-version-image/scripts/run-local-zk.sh
+++ b/tests/docker-images/latest-version-image/scripts/run-local-zk.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+bin/apply-config-from-env.py conf/zookeeper.conf && \
+    bin/apply-config-from-env.py conf/pulsar_env.sh && \
+    bin/generate-zookeeper-config.sh conf/zookeeper.conf
+
+if [ -z "$NO_AUTOSTART" ]; then
+    sed -i 's/autostart=.*/autostart=true/' /etc/supervisord/conf.d/local-zk.conf
+fi
+
+exec /usr/bin/supervisord -c /etc/supervisord.conf

--- a/tests/docker-images/latest-version-image/scripts/run-proxy.sh
+++ b/tests/docker-images/latest-version-image/scripts/run-proxy.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+bin/apply-config-from-env.py conf/proxy.conf && \
+    bin/apply-config-from-env.py conf/pulsar_env.sh
+
+if [ -z "$NO_AUTOSTART" ]; then
+    sed -i 's/autostart=.*/autostart=true/' /etc/supervisord/conf.d/proxy.conf
+fi
+
+bin/watch-znode.py -z $zookeeperServers -p /initialized -w
+exec /usr/bin/supervisord -c /etc/supervisord.conf
+

--- a/tests/docker-images/pom.xml
+++ b/tests/docker-images/pom.xml
@@ -24,18 +24,14 @@
   <packaging>pom</packaging>
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.apache.pulsar</groupId>
-    <artifactId>pulsar</artifactId>
+    <groupId>org.apache.pulsar.tests</groupId>
+    <artifactId>tests-parent</artifactId>
     <version>2.0.0-incubating-SNAPSHOT</version>
   </parent>
-  <groupId>org.apache.pulsar</groupId>
+  <groupId>org.apache.pulsar.tests</groupId>
   <artifactId>docker-images</artifactId>
-  <name>Apache Pulsar :: Docker Images</name>
-  <properties>
-    <docker.organization>apachepulsar</docker.organization>
-  </properties>
+  <name>Apache Pulsar :: Tests :: Docker Images</name>
   <modules>
-    <module>pulsar</module>
-    <module>grafana</module>
+    <module>latest-version-image</module>
   </modules>
 </project>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -28,14 +28,21 @@
     <artifactId>pulsar</artifactId>
     <version>2.0.0-incubating-SNAPSHOT</version>
   </parent>
-  <groupId>org.apache.pulsar</groupId>
-  <artifactId>docker-images</artifactId>
-  <name>Apache Pulsar :: Docker Images</name>
-  <properties>
-    <docker.organization>apachepulsar</docker.organization>
-  </properties>
+  <groupId>org.apache.pulsar.tests</groupId>
+  <artifactId>tests-parent</artifactId>
+  <name>Apache Pulsar :: Tests</name>
   <modules>
-    <module>pulsar</module>
-    <module>grafana</module>
+    <module>docker-images</module>
   </modules>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
A docker image built with the pulsar distribution tarball. The same
image can be used to run zookeeper, bookkeeper, the broker or a
proxy. Scripts are provided to run each. There is also a script to
initialize the cluster, and another script to coordinate the
containers so that, for example, the broker doesn't start before the
cluster is initialized.

All services are run with supervisor, so that tests will be able to
start and stop the services.
