### PR TITLE
fix bug in seek if no messages in topic

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -1259,6 +1259,9 @@ public class ConsumerImpl extends ConsumerBase {
 
         long requestId = client.newRequestId();
         MessageIdImpl msgId = (MessageIdImpl) messageId;
+        if (msgId.getEntryId() == -1) {
+            msgId = (MessageIdImpl) MessageId.earliest;
+        }
         ByteBuf seek = Commands.newSeek(consumerId, requestId, msgId.getLedgerId(), msgId.getEntryId());
         ClientCnx cnx = cnx();
 


### PR DESCRIPTION
If you call getLastMessageId and then use that messageId to seek, the seek will throw an exception since the ledgerId will exist but the entryId will be -1
