### PR TITLE
Add prefix setting for C++/Python reader

### DIFF
--- a/pulsar-client-cpp/include/pulsar/ReaderConfiguration.h
+++ b/pulsar-client-cpp/include/pulsar/ReaderConfiguration.h
@@ -83,6 +83,9 @@ class ReaderConfiguration {
     void setReaderName(const std::string& readerName);
     const std::string& getReaderName() const;
 
+    void setSubscriptionRolePrefix(const std::string& subscriptionRolePrefix);
+    const std::string& getSubscriptionRolePrefix() const;
+
    private:
     boost::shared_ptr<ReaderConfigurationImpl> impl_;
 };

--- a/pulsar-client-cpp/lib/ReaderConfiguration.cc
+++ b/pulsar-client-cpp/lib/ReaderConfiguration.cc
@@ -48,4 +48,8 @@ int ReaderConfiguration::getReceiverQueueSize() const { return impl_->receiverQu
 const std::string& ReaderConfiguration::getReaderName() const { return impl_->readerName; }
 
 void ReaderConfiguration::setReaderName(const std::string& readerName) { impl_->readerName = readerName; }
+
+const std::string& ReaderConfiguration::getSubscriptionRolePrefix() const { return impl_->subscriptionRolePrefix; }
+
+void ReaderConfiguration::setSubscriptionRolePrefix(const std::string& subscriptionRolePrefix) { impl_->subscriptionRolePrefix = subscriptionRolePrefix; }
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/ReaderConfiguration.cc
+++ b/pulsar-client-cpp/lib/ReaderConfiguration.cc
@@ -49,7 +49,11 @@ const std::string& ReaderConfiguration::getReaderName() const { return impl_->re
 
 void ReaderConfiguration::setReaderName(const std::string& readerName) { impl_->readerName = readerName; }
 
-const std::string& ReaderConfiguration::getSubscriptionRolePrefix() const { return impl_->subscriptionRolePrefix; }
+const std::string& ReaderConfiguration::getSubscriptionRolePrefix() const {
+    return impl_->subscriptionRolePrefix;
+}
 
-void ReaderConfiguration::setSubscriptionRolePrefix(const std::string& subscriptionRolePrefix) { impl_->subscriptionRolePrefix = subscriptionRolePrefix; }
+void ReaderConfiguration::setSubscriptionRolePrefix(const std::string& subscriptionRolePrefix) {
+    impl_->subscriptionRolePrefix = subscriptionRolePrefix;
+}
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/ReaderConfigurationImpl.h
+++ b/pulsar-client-cpp/lib/ReaderConfigurationImpl.h
@@ -28,7 +28,8 @@ struct ReaderConfigurationImpl {
     bool hasReaderListener;
     int receiverQueueSize;
     std::string readerName;
-    ReaderConfigurationImpl() : hasReaderListener(false), receiverQueueSize(1000), readerName() {}
+    std::string subscriptionRolePrefix;
+    ReaderConfigurationImpl() : hasReaderListener(false), receiverQueueSize(1000), readerName(), subscriptionRolePrefix() {}
 };
 }  // namespace pulsar
 #endif /* LIB_READERCONFIGURATIONIMPL_H_ */

--- a/pulsar-client-cpp/lib/ReaderConfigurationImpl.h
+++ b/pulsar-client-cpp/lib/ReaderConfigurationImpl.h
@@ -29,7 +29,8 @@ struct ReaderConfigurationImpl {
     int receiverQueueSize;
     std::string readerName;
     std::string subscriptionRolePrefix;
-    ReaderConfigurationImpl() : hasReaderListener(false), receiverQueueSize(1000), readerName(), subscriptionRolePrefix() {}
+    ReaderConfigurationImpl()
+        : hasReaderListener(false), receiverQueueSize(1000), readerName(), subscriptionRolePrefix() {}
 };
 }  // namespace pulsar
 #endif /* LIB_READERCONFIGURATIONIMPL_H_ */

--- a/pulsar-client-cpp/lib/ReaderImpl.cc
+++ b/pulsar-client-cpp/lib/ReaderImpl.cc
@@ -45,6 +45,9 @@ void ReaderImpl::start(const BatchMessageId& startMessageId) {
     }
 
     std::string subscription = "reader-" + generateRandomName();
+    if (!readerConf_.getSubscriptionRolePrefix().empty()) {
+        subscription = readerConf_.getSubscriptionRolePrefix() + "-" + subscription;
+    }
 
     consumer_ = boost::make_shared<ConsumerImpl>(
         client_.lock(), topic_, subscription, consumerConf, ExecutorServicePtr(), NonPartitioned,

--- a/pulsar-client-cpp/python/pulsar.py
+++ b/pulsar-client-cpp/python/pulsar.py
@@ -432,7 +432,8 @@ class Client:
     def create_reader(self, topic, start_message_id,
                       reader_listener=None,
                       receiver_queue_size=1000,
-                      reader_name=None
+                      reader_name=None,
+                      subscription_role_prefix=None
                       ):
         """
         Create a reader on a particular topic
@@ -476,11 +477,14 @@ class Client:
           memory utilization.
         * `reader_name`:
           Sets the reader name.
+        * `subscription_role_prefix`:
+          Sets the subscription role prefix.
         """
         _check_type(str, topic, 'topic')
         _check_type(_pulsar.MessageId, start_message_id, 'start_message_id')
         _check_type(int, receiver_queue_size, 'receiver_queue_size')
         _check_type_or_none(str, reader_name, 'reader_name')
+        _check_type_or_none(str, subscription_role_prefix, 'subscription_role_prefix')
 
         conf = _pulsar.ReaderConfiguration()
         if reader_listener:
@@ -488,6 +492,8 @@ class Client:
         conf.receiver_queue_size(receiver_queue_size)
         if reader_name:
             conf.reader_name(reader_name)
+        if subscription_role_prefix:
+            conf.subscription_role_prefix(subscription_role_prefix)
         c = Reader()
         c._reader = self._client.create_reader(topic, start_message_id, conf)
         c._client = self

--- a/pulsar-client-cpp/python/src/config.cc
+++ b/pulsar-client-cpp/python/src/config.cc
@@ -142,5 +142,7 @@ void export_config() {
             .def("receiver_queue_size", &ReaderConfiguration::setReceiverQueueSize)
             .def("reader_name", &ReaderConfiguration::getReaderName, return_value_policy<copy_const_reference>())
             .def("reader_name", &ReaderConfiguration::setReaderName)
+            .def("subscription_role_prefix", &ReaderConfiguration::getSubscriptionRolePrefix, return_value_policy<copy_const_reference>())
+            .def("subscription_role_prefix", &ReaderConfiguration::setSubscriptionRolePrefix)
             ;
 }


### PR DESCRIPTION
### Motivation
https://github.com/apache/incubator-pulsar/pull/1272
Now C++ reader cannot be used when subscription auth mode is prefix.

### Modifications

Add prefix setting for C++ reader.

### Result

C++ reader can be used when subscription auth mode is prefix.