### PR TITLE
BatchMessageIdImpl can be compared to MessageIdImpl

### DIFF
--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageIdCompareToTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageIdCompareToTest.java
@@ -106,18 +106,16 @@ public class MessageIdCompareToTest  {
 
     @Test
     public void testCompareDifferentType() {
-        // Expected throw IllegalArgumentException
         MessageIdImpl messageIdImpl = new MessageIdImpl(123L, 345L, 567);
-        BatchMessageIdImpl batchMessageId = new BatchMessageIdImpl(123L, 345L, 567, 789);
-
-        assertTrue( messageIdImpl.compareTo(batchMessageId) == 0, "Expected to be equal");
-
-        try {
-            batchMessageId.compareTo(messageIdImpl);
-            fail("Should throw IllegalArgumentException when compare different type");
-        } catch (IllegalArgumentException e) {
-            // expected
-        }
+        BatchMessageIdImpl batchMessageId1 = new BatchMessageIdImpl(123L, 345L, 566, 789);
+        BatchMessageIdImpl batchMessageId2 = new BatchMessageIdImpl(123L, 345L, 567, 789);
+        BatchMessageIdImpl batchMessageId3 = new BatchMessageIdImpl(messageIdImpl);
+        assertTrue(messageIdImpl.compareTo(batchMessageId1) > 0, "Expected to be greater than");
+        assertTrue(messageIdImpl.compareTo(batchMessageId2) == 0, "Expected to be equal");
+        assertTrue(messageIdImpl.compareTo(batchMessageId3) == 0, "Expected to be equal");
+        assertTrue(batchMessageId1.compareTo(messageIdImpl) < 0, "Expected to be less than");
+        assertTrue(batchMessageId2.compareTo(messageIdImpl) > 0, "Expected to be greater than");
+        assertTrue(batchMessageId3.compareTo(messageIdImpl) == 0, "Expected to be equal");
     }
 
 }


### PR DESCRIPTION
A batch message id is a MessageIdImpl with a batchIndex >=
0. Therefore, they can be compared to MessageIdImpl. If all fields
other than the batchIndex are equal to a messageId, the
BatchMessageIdImpl can compare its batchIndex with -1. If it is -1, it
matches the MessageIdImpl. If it is greater than -1, then it is
greater than the MessageIdImpl.
