### PR TITLE
Watch-znode script for docker image

### DIFF
--- a/docker/pulsar/Dockerfile
+++ b/docker/pulsar/Dockerfile
@@ -20,7 +20,7 @@
 FROM openjdk:8-jdk
 
 # Install some utilities
-RUN apt-get update && apt-get install -y netcat dnsutils
+RUN apt-get update && apt-get install -y netcat dnsutils python-kazoo
 
 ARG PULSAR_TARBALL
 
@@ -30,6 +30,7 @@ RUN mv /apache-pulsar-* /pulsar
 COPY scripts/apply-config-from-env.py /pulsar/bin
 COPY scripts/generate-zookeeper-config.sh /pulsar/bin
 COPY scripts/pulsar-zookeeper-ruok.sh /pulsar/bin
+COPY scripts/watch-znode.py /pulsar/bin
 
 WORKDIR /pulsar
 

--- a/docker/pulsar/scripts/watch-znode.py
+++ b/docker/pulsar/scripts/watch-znode.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import sys, getopt, time
+from kazoo.client import KazooClient
+
+def usage():
+    print >> sys.stderr, "\n%s -z <zookeeper> -p <path> [-w|-c|-e]" % (sys.argv[0])
+    print >> sys.stderr, "\nWait for, or create znode"
+    print >> sys.stderr, "\n-z Specify zookeeper connect string"
+    print >> sys.stderr, "\n-p Znode path to watch or create"
+    print >> sys.stderr, "\n-w Watch for path creation"
+    print >> sys.stderr, "\n-c Create path"
+    print >> sys.stderr, "\n-e Check if znode exists"
+
+try:
+    opts, args = getopt.getopt(sys.argv[1:], "z:p:cweh")
+except getopt.GetoptError as err:
+    print >> sys.stderr, str(err)
+    usage()
+    sys.exit(2)
+
+zookeeper = None
+znode = None
+create = False
+watch = False
+exists = False
+
+for o, a in opts:
+    if o in ("-h"):
+        usage()
+        sys.exit()
+    elif o in ("-z"):
+        zookeeper = a
+    elif o in ("-p"):
+        znode = a
+    elif o in ("-w"):
+        watch = True
+    elif o in ("-c"):
+        create = True
+    elif o in ("-e"):
+        exists = True
+    else:
+        assert False, "unhandled option"
+        usage()
+        sys.exit(2)
+
+if not zookeeper:
+    print >> sys.stderr, "Zookeeper must be specified"
+    usage()
+    sys.exit(3)
+
+if not znode:
+    print >> sys.stderr, "Znode must be specified"
+    usage()
+    sys.exit(4)
+
+if (not watch and not create and not exists):
+    print >> sys.stderr, "Exactly one of watch (-w), create (-c) or exists (-e) must be specified"
+    usage()
+    sys.exit(5)
+
+zk = KazooClient(hosts=zookeeper)
+zk.start()
+
+if create:
+    zk.create(znode)
+elif watch:
+    while not zk.exists(znode):
+        print "Waiting for %s" % znode
+        time.sleep(1)
+elif exists:
+    if zk.exists(znode):
+        sys.exit(0)
+    else:
+        sys.exit(-1)
+
+zk.stop()

--- a/docker/pulsar/scripts/watch-znode.py
+++ b/docker/pulsar/scripts/watch-znode.py
@@ -8,13 +8,14 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 #
 
 import sys, getopt, time


### PR DESCRIPTION
Docker compose doesn't have any way to run initialization like k8s
does, so you need to role your own solution. This script allows you to
wait for a znode to be created in zookeeper, check if it exists and
create it. It can be used to ensure that pulsar brokers and bookies do
not come up before metadata format has run.
