### PR TITLE
Use log4j2 as slf4j binding for tests

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -36,4 +36,16 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>3.0.rc1</version>
+        <configuration>
+          <header>../src/license-header.txt</header>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -22,14 +22,9 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.apache.pulsar</groupId>
-    <artifactId>pulsar</artifactId>
-    <version>2.0.0-incubating-SNAPSHOT</version>
-    <relativePath>..</relativePath>
-  </parent>
-
+  <groupId>org.apache.pulsar</groupId>
   <artifactId>buildtools</artifactId>
+  <version>2.0.0-incubating-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Pulsar Build Tools</name>
 
@@ -37,6 +32,7 @@
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
+      <version>6.13.1</version>
     </dependency>
   </dependencies>
 

--- a/buildtools/src/main/resources/log4j2.yml
+++ b/buildtools/src/main/resources/log4j2.yml
@@ -1,0 +1,42 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+Configuration:
+  name: test
+
+  Appenders:
+
+    # Console
+    Console:
+      name: Console
+      target: SYSTEM_OUT
+      PatternLayout:
+        Pattern: "%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"
+
+  Loggers:
+
+    Root:
+      level: info
+      AppenderRef:
+        - ref: Console
+
+    Logger:
+      name: org.apache.bookkeeper.mledger
+      level: info
+      additivity: false

--- a/pom.xml
+++ b/pom.xml
@@ -360,12 +360,6 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
-        <groupId>com.fasterxml.jackson.dataformat</groupId>
-        <artifactId>jackson-dataformat-yaml</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
-
-      <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>2.5</version>
@@ -602,8 +596,24 @@ flexible messaging model and an intuitive client API.</description>
   <dependencies>
     <!-- These dependencies are common to all the submodules -->
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
+      <groupId>org.apache.pulsar</groupId>
+      <artifactId>buildtools</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -670,10 +680,6 @@ flexible messaging model and an intuitive client API.</description>
         <configuration>
           <argLine> -Xmx2G -XX:MaxDirectMemorySize=8G
             -Dio.netty.leakDetectionLevel=advanced
-            -Dorg.slf4j.simpleLogger.showDateTime=true
-            -Dorg.slf4j.simpleLogger.log.org.apache.zookeeper=off
-            -Dorg.slf4j.simpleLogger.log.org.apache.bookkeeper=off
-            -Dorg.slf4j.simpleLogger.log.org.apache.bookkeeper.mledger=info
           </argLine>
           <reuseForks>false</reuseForks>
           <forkCount>1</forkCount>


### PR DESCRIPTION
### Motivation

in pulsar-functions, we are using log4j2 routing appender for logging. so pulsar-functions is using log4j2, if we are using `slf4j-simple` in the tests, it will cause all the bindings conflict. so the change is propose to move tests to use log4j2 slf4j binding, instead of `slf4j-simple`

### Modifications

- replace `slf4j-simple` with log4j2 bindings in tests
- to avoid copying the log4j2 property files to every modules, we make a default log4j2 property file in buildtools module, and make buildtools module as a default test dependency for every modules.

### Result

- use log4j2 binding for tests
