### PR TITLE
Fix pulsar standalone script to allow zookeeper use 4letter commands

### DIFF
--- a/bin/pulsar
+++ b/bin/pulsar
@@ -220,7 +220,7 @@ elif [ $COMMAND == "websocket" ]; then
     exec $JAVA $OPTS -Dpulsar.log.file=$PULSAR_LOG_FILE org.apache.pulsar.websocket.service.WebSocketServiceStarter $PULSAR_WEBSOCKET_CONF $@
 elif [ $COMMAND == "standalone" ]; then
     PULSAR_LOG_FILE=${PULSAR_LOG_FILE:-"pulsar-standalone.log"}
-    exec $JAVA $OPTS -Dpulsar.log.file=$PULSAR_LOG_FILE org.apache.pulsar.PulsarStandaloneStarter --config $PULSAR_STANDALONE_CONF $@
+    exec $JAVA $OPTS -Dpulsar.log.file=$PULSAR_LOG_FILE -Dzookeeper.4lw.commands.whitelist='*' org.apache.pulsar.PulsarStandaloneStarter --config $PULSAR_STANDALONE_CONF $@
 elif [ $COMMAND == "initialize-cluster-metadata" ]; then
     exec $JAVA $OPTS org.apache.pulsar.PulsarClusterMetadataSetup $@
 elif [ $COMMAND == "zookeeper-shell" ]; then


### PR DESCRIPTION
### Motivation

In the new zookeeper version, zookeeper disabled 4letter commands for security concerns. The standalone starter is still using 4letter commands for checking connectivities with zookeeper.

### Modifications

add `-Dzookeeper.4lw.commands.whitelist='*'` for starting standalone to allow using 4lw commands.

### Result

pulsar functions can start correctly.
