### PR TITLE
Moved the bk-tests dependency to parent pom

### DIFF
--- a/managed-ledger/pom.xml
+++ b/managed-ledger/pom.xml
@@ -52,20 +52,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    
-    <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
-      <artifactId>bookkeeper-server</artifactId>
-      <version>${bookkeeper.version}</version>
-      <classifier>tests</classifier>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
 
     <dependency>
       <groupId>org.apache.pulsar</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -657,6 +657,21 @@ flexible messaging model and an intuitive client API.</description>
       <version>1.16.20</version>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <!-- We use MockedBookKeeper in many unit tests -->
+      <groupId>org.apache.bookkeeper</groupId>
+      <artifactId>bookkeeper-server</artifactId>
+      <version>${bookkeeper.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -236,21 +236,6 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>org.apache.bookkeeper</groupId>
-      <artifactId>bookkeeper-server</artifactId>
-      <version>${bookkeeper.version}</version>
-      <classifier>tests</classifier>
-      <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/pulsar-client-tools/pom.xml
+++ b/pulsar-client-tools/pom.xml
@@ -102,20 +102,6 @@
 			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>
 		</dependency>
-
-        <dependency>
-          <groupId>org.apache.bookkeeper</groupId>
-          <artifactId>bookkeeper-server</artifactId>
-          <version>${bookkeeper.version}</version>
-          <classifier>tests</classifier>
-          <scope>test</scope>
-          <exclusions>
-            <exclusion>
-              <groupId>org.slf4j</groupId>
-              <artifactId>slf4j-log4j12</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
 	</dependencies>
 
 </project>

--- a/pulsar-spark/pom.xml
+++ b/pulsar-spark/pom.xml
@@ -83,7 +83,6 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
-
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
### Motivation

Since we moved `MockBookKeeper` into BookKeeper repo, we needed to add multiple times the same dependencies to `bookkeeper-server-tests` artifact (with scope `test`). 

Adding to parent pom for simplification.