### PR TITLE
Converted main part of code to use builder APIs with typed interface

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -104,24 +104,20 @@ public abstract class MockedPulsarServiceBaseTest {
 
     protected final void internalSetup() throws Exception {
         init();
-        org.apache.pulsar.client.api.ClientConfiguration clientConf = new org.apache.pulsar.client.api.ClientConfiguration();
-        clientConf.setStatsInterval(0, TimeUnit.SECONDS);
         lookupUrl = new URI(brokerUrl.toString());
         if (isTcpLookup) {
             lookupUrl = new URI("pulsar://localhost:" + BROKER_PORT);
         }
-        pulsarClient = PulsarClient.create(lookupUrl.toString(), clientConf);
+        pulsarClient = PulsarClient.builder().serviceUrl(lookupUrl.toString()).statsInterval(0, TimeUnit.SECONDS).build();
     }
 
     protected final void internalSetupForStatsTest() throws Exception {
         init();
-        org.apache.pulsar.client.api.ClientConfiguration clientConf = new org.apache.pulsar.client.api.ClientConfiguration();
-        clientConf.setStatsInterval(1, TimeUnit.SECONDS);
         String lookupUrl = brokerUrl.toString();
         if (isTcpLookup) {
             lookupUrl = new URI("pulsar://localhost:" + BROKER_PORT).toString();
         }
-        pulsarClient = PulsarClient.create(lookupUrl, clientConf);
+        pulsarClient = PulsarClient.builder().serviceUrl(lookupUrl.toString()).statsInterval(1, TimeUnit.SECONDS).build();
     }
 
     protected final void init() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumeBaseExceptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumeBaseExceptionTest.java
@@ -64,7 +64,7 @@ public class ConsumeBaseExceptionTest extends ProducerConsumerBase {
     public void testListener() throws PulsarClientException {
         Consumer consumer = null;
         ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setMessageListener((Consumer c, Message msg) -> {
+        conf.setMessageListener((Consumer<byte[]> c, Message<byte[]> msg) -> {
         });
         consumer = pulsarClient.subscribe("persistent://prop/cluster/ns/topicName", "my-subscription", conf);
         Assert.assertTrue(consumer.receiveAsync().isCompletedExceptionally());

--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/pulsar/client/kafka/compat/PulsarConsumerKafkaConfig.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/pulsar/client/kafka/compat/PulsarConsumerKafkaConfig.java
@@ -20,7 +20,8 @@ package org.apache.pulsar.client.kafka.compat;
 
 import java.util.Properties;
 
-import org.apache.pulsar.client.api.ConsumerConfiguration;
+import org.apache.pulsar.client.api.ConsumerBuilder;
+import org.apache.pulsar.client.api.PulsarClient;
 
 public class PulsarConsumerKafkaConfig {
 
@@ -29,22 +30,22 @@ public class PulsarConsumerKafkaConfig {
     public static final String RECEIVER_QUEUE_SIZE = "pulsar.consumer.receiver.queue.size";
     public static final String TOTAL_RECEIVER_QUEUE_SIZE_ACROSS_PARTITIONS = "pulsar.consumer.total.receiver.queue.size.across.partitions";
 
-    public static ConsumerConfiguration getConsumerConfiguration(Properties properties) {
-        ConsumerConfiguration conf = new ConsumerConfiguration();
+    public static ConsumerBuilder<byte[]> getConsumerBuilder(PulsarClient client, Properties properties) {
+        ConsumerBuilder<byte[]> consumerBuilder = client.newConsumer();
 
         if (properties.containsKey(CONSUMER_NAME)) {
-            conf.setConsumerName(properties.getProperty(CONSUMER_NAME));
+            consumerBuilder.consumerName(properties.getProperty(CONSUMER_NAME));
         }
 
         if (properties.containsKey(RECEIVER_QUEUE_SIZE)) {
-            conf.setReceiverQueueSize(Integer.parseInt(properties.getProperty(RECEIVER_QUEUE_SIZE)));
+            consumerBuilder.receiverQueueSize(Integer.parseInt(properties.getProperty(RECEIVER_QUEUE_SIZE)));
         }
 
         if (properties.containsKey(TOTAL_RECEIVER_QUEUE_SIZE_ACROSS_PARTITIONS)) {
-            conf.setMaxTotalReceiverQueueSizeAcrossPartitions(
+            consumerBuilder.maxTotalReceiverQueueSizeAcrossPartitions(
                     Integer.parseInt(properties.getProperty(TOTAL_RECEIVER_QUEUE_SIZE_ACROSS_PARTITIONS)));
         }
 
-        return conf;
+        return consumerBuilder;
     }
 }

--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/pulsar/client/kafka/compat/PulsarProducerKafkaConfig.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/pulsar/client/kafka/compat/PulsarProducerKafkaConfig.java
@@ -20,7 +20,8 @@ package org.apache.pulsar.client.kafka.compat;
 
 import java.util.Properties;
 
-import org.apache.pulsar.client.api.ProducerConfiguration;
+import org.apache.pulsar.client.api.ProducerBuilder;
+import org.apache.pulsar.client.api.PulsarClient;
 
 public class PulsarProducerKafkaConfig {
 
@@ -33,32 +34,32 @@ public class PulsarProducerKafkaConfig {
     public static final String BATCHING_ENABLED = "pulsar.producer.batching.enabled";
     public static final String BATCHING_MAX_MESSAGES = "pulsar.producer.batching.max.messages";
 
-    public static ProducerConfiguration getProducerConfiguration(Properties properties) {
-        ProducerConfiguration conf = new ProducerConfiguration();
+    public static ProducerBuilder<byte[]> getProducerBuilder(PulsarClient client, Properties properties) {
+        ProducerBuilder<byte[]> producerBuilder = client.newProducer();
 
         if (properties.containsKey(PRODUCER_NAME)) {
-            conf.setProducerName(properties.getProperty(PRODUCER_NAME));
+            producerBuilder.producerName(properties.getProperty(PRODUCER_NAME));
         }
 
         if (properties.containsKey(INITIAL_SEQUENCE_ID)) {
-            conf.setInitialSequenceId(Long.parseLong(properties.getProperty(INITIAL_SEQUENCE_ID)));
+            producerBuilder.initialSequenceId(Long.parseLong(properties.getProperty(INITIAL_SEQUENCE_ID)));
         }
 
         if (properties.containsKey(MAX_PENDING_MESSAGES)) {
-            conf.setMaxPendingMessages(Integer.parseInt(properties.getProperty(MAX_PENDING_MESSAGES)));
+            producerBuilder.maxPendingMessages(Integer.parseInt(properties.getProperty(MAX_PENDING_MESSAGES)));
         }
 
         if (properties.containsKey(MAX_PENDING_MESSAGES_ACROSS_PARTITIONS)) {
-            conf.setMaxPendingMessagesAcrossPartitions(
+            producerBuilder.maxPendingMessagesAcrossPartitions(
                     Integer.parseInt(properties.getProperty(MAX_PENDING_MESSAGES_ACROSS_PARTITIONS)));
         }
 
-        conf.setBatchingEnabled(Boolean.parseBoolean(properties.getProperty(BATCHING_ENABLED, "true")));
+        producerBuilder.enableBatching(Boolean.parseBoolean(properties.getProperty(BATCHING_ENABLED, "true")));
 
         if (properties.containsKey(BATCHING_MAX_MESSAGES)) {
-            conf.setBatchingMaxMessages(Integer.parseInt(properties.getProperty(BATCHING_MAX_MESSAGES)));
+            producerBuilder.batchingMaxMessages(Integer.parseInt(properties.getProperty(BATCHING_MAX_MESSAGES)));
         }
 
-        return conf;
+        return producerBuilder;
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -100,7 +100,7 @@ public interface ConsumerBuilder<T> extends Serializable, Cloneable {
      *
      * @param topicsPattern
      */
-    ConsumerBuilder topicsPattern(Pattern topicsPattern);
+    ConsumerBuilder<T> topicsPattern(Pattern topicsPattern);
 
     /**
      * Specify a pattern for topics that this consumer will subscribe on.
@@ -111,7 +111,7 @@ public interface ConsumerBuilder<T> extends Serializable, Cloneable {
      * @param topicsPattern
      *            given regular expression for topics pattern
      */
-    ConsumerBuilder topicsPattern(String topicsPattern);
+    ConsumerBuilder<T> topicsPattern(String topicsPattern);
 
     /**
      * Specify the subscription name for this consumer.
@@ -238,7 +238,7 @@ public interface ConsumerBuilder<T> extends Serializable, Cloneable {
      * @param periodInMinutes
      *            whether to read from the compacted topic
      */
-    ConsumerBuilder patternAutoDiscoveryPeriod(int periodInMinutes);
+    ConsumerBuilder<T> patternAutoDiscoveryPeriod(int periodInMinutes);
 
     /**
      * Sets priority level for the shared subscription consumers to which broker gives more priority while dispatching

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerConfiguration.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerConfiguration.java
@@ -95,7 +95,7 @@ public class ConsumerConfiguration implements Serializable {
     /**
      * @return the configured {@link MessageListener} for the consumer
      */
-    public MessageListener getMessageListener() {
+    public MessageListener<byte[]> getMessageListener() {
         return conf.getMessageListener();
     }
 
@@ -108,7 +108,7 @@ public class ConsumerConfiguration implements Serializable {
      * @param messageListener
      *            the listener object
      */
-    public ConsumerConfiguration setMessageListener(MessageListener messageListener) {
+    public ConsumerConfiguration setMessageListener(MessageListener<byte[]> messageListener) {
         checkNotNull(messageListener);
         conf.setMessageListener(messageListener);
         return this;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerEventListener.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerEventListener.java
@@ -26,11 +26,11 @@ public interface ConsumerEventListener {
     /**
      * Notified when the consumer group is changed, and the consumer becomes the active consumer.
      */
-    void becameActive(Consumer consumer, int partitionId);
+    void becameActive(Consumer<?> consumer, int partitionId);
 
     /**
      * Notified when the consumer group is changed, and the consumer is still inactive or becomes inactive.
      */
-    void becameInactive(Consumer consumer, int partitionId);
+    void becameInactive(Consumer<?> consumer, int partitionId);
 
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/MessageRouter.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/MessageRouter.java
@@ -30,7 +30,7 @@ public interface MessageRouter extends Serializable {
      * @deprecated since 1.22.0. Please use {@link #choosePartition(Message, TopicMetadata)} instead.
      */
     @Deprecated
-    default int choosePartition(Message msg) {
+    default int choosePartition(Message<?> msg) {
         throw new UnsupportedOperationException("Use #choosePartition(Message, TopicMetadata) instead");
     }
 
@@ -42,7 +42,7 @@ public interface MessageRouter extends Serializable {
      * @return the partition to route the message.
      * @since 1.22.0
      */
-    default int choosePartition(Message msg, TopicMetadata metadata) {
+    default int choosePartition(Message<?> msg, TopicMetadata metadata) {
         return choosePartition(msg);
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ProducerBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ProducerBuilder.java
@@ -262,7 +262,7 @@ public interface ProducerBuilder<T> extends Serializable, Cloneable {
      *            maximum number of messages in a batch
      * @return
      */
-    ProducerBuilder batchingMaxMessages(int batchMessagesMaxMessagesPerBatch);
+    ProducerBuilder<T> batchingMaxMessages(int batchMessagesMaxMessagesPerBatch);
 
     /**
      * Set the baseline for the sequence ids for messages published by the producer.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ReaderBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ReaderBuilder.java
@@ -99,7 +99,7 @@ public interface ReaderBuilder<T> extends Serializable, Cloneable {
      * @param readerListener
      *            the listener object
      */
-    ReaderBuilder<T> readerListener(ReaderListener readerListener);
+    ReaderBuilder<T> readerListener(ReaderListener<T> readerListener);
 
     /**
      * Sets a {@link CryptoKeyReader}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainer.java
@@ -53,7 +53,7 @@ class BatchMessageContainer {
     // sequence id for this batch which will be persisted as a single entry by broker
     long sequenceId = -1;
     ByteBuf batchedMessageMetadataAndPayload;
-    List<MessageImpl> messages = Lists.newArrayList();
+    List<MessageImpl<?>> messages = Lists.newArrayList();
     // keep track of callbacks for individual messages being published in a batch
     SendCallback firstCallback;
 
@@ -73,13 +73,13 @@ class BatchMessageContainer {
         this.producerName = producerName;
     }
 
-    boolean hasSpaceInBatch(MessageImpl msg) {
+    boolean hasSpaceInBatch(MessageImpl<?> msg) {
         int messageSize = msg.getDataBuffer().readableBytes();
         return ((messageSize + currentBatchSizeBytes) <= MAX_MESSAGE_BATCH_SIZE_BYTES
                 && numMessagesInBatch < maxNumMessagesInBatch);
     }
 
-    void add(MessageImpl msg, SendCallback callback) {
+    void add(MessageImpl<?> msg, SendCallback callback) {
 
         if (log.isDebugEnabled()) {
             log.debug("[{}] [{}] add message to batch, num messages in batch so far {}", topicName, producerName,

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
@@ -154,4 +154,8 @@ public class ClientBuilderImpl implements ClientBuilder {
         conf.setMaxNumberOfRejectedRequestPerConnection(maxNumberOfRejectedRequestPerConnection);
         return this;
     }
+
+    public ClientConfigurationData getClientConfigurationData() {
+        return conf;
+    }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -86,8 +86,8 @@ public class ClientCnx extends PulsarHandler {
     private final ConcurrentLongHashMap<CompletableFuture<List<String>>> pendingGetTopicsRequests = new ConcurrentLongHashMap<>(
         16, 1);
 
-    private final ConcurrentLongHashMap<ProducerImpl> producers = new ConcurrentLongHashMap<>(16, 1);
-    private final ConcurrentLongHashMap<ConsumerImpl> consumers = new ConcurrentLongHashMap<>(16, 1);
+    private final ConcurrentLongHashMap<ProducerImpl<?>> producers = new ConcurrentLongHashMap<>(16, 1);
+    private final ConcurrentLongHashMap<ConsumerImpl<?>> consumers = new ConcurrentLongHashMap<>(16, 1);
 
     private final CompletableFuture<Void> connectionFuture = new CompletableFuture<Void>();
     private final Semaphore pendingLookupRequestSemaphore;
@@ -253,7 +253,7 @@ public class ClientCnx extends PulsarHandler {
         if (log.isDebugEnabled()) {
             log.debug("{} Received a message from the server: {}", ctx.channel(), cmdMessage);
         }
-        ConsumerImpl consumer = consumers.get(cmdMessage.getConsumerId());
+        ConsumerImpl<?> consumer = consumers.get(cmdMessage.getConsumerId());
         if (consumer != null) {
             consumer.messageReceived(cmdMessage.getMessageId(), headersAndPayload, this);
         }
@@ -266,7 +266,7 @@ public class ClientCnx extends PulsarHandler {
         if (log.isDebugEnabled()) {
             log.debug("{} Received a consumer group change message from the server : {}", ctx.channel(), change);
         }
-        ConsumerImpl consumer = consumers.get(change.getConsumerId());
+        ConsumerImpl<?> consumer = consumers.get(change.getConsumerId());
         if (consumer != null) {
             consumer.activeConsumerChanged(change.getIsActive());
         }
@@ -398,7 +398,7 @@ public class ClientCnx extends PulsarHandler {
 
         log.info("[{}] Broker notification reached the end of topic: {}", remoteAddress, consumerId);
 
-        ConsumerImpl consumer = consumers.get(consumerId);
+        ConsumerImpl<?> consumer = consumers.get(consumerId);
         if (consumer != null) {
             consumer.setTerminated();
         }
@@ -472,7 +472,7 @@ public class ClientCnx extends PulsarHandler {
     protected void handleCloseProducer(CommandCloseProducer closeProducer) {
         log.info("[{}] Broker notification of Closed producer: {}", remoteAddress, closeProducer.getProducerId());
         final long producerId = closeProducer.getProducerId();
-        ProducerImpl producer = producers.get(producerId);
+        ProducerImpl<?> producer = producers.get(producerId);
         if (producer != null) {
             producer.connectionClosed(this);
         } else {
@@ -484,7 +484,7 @@ public class ClientCnx extends PulsarHandler {
     protected void handleCloseConsumer(CommandCloseConsumer closeConsumer) {
         log.info("[{}] Broker notification of Closed consumer: {}", remoteAddress, closeConsumer.getConsumerId());
         final long consumerId = closeConsumer.getConsumerId();
-        ConsumerImpl consumer = consumers.get(consumerId);
+        ConsumerImpl<?> consumer = consumers.get(consumerId);
         if (consumer != null) {
             consumer.connectionClosed(this);
         } else {
@@ -666,11 +666,11 @@ public class ClientCnx extends PulsarHandler {
         return false;
     }
 
-    void registerConsumer(final long consumerId, final ConsumerImpl consumer) {
+    void registerConsumer(final long consumerId, final ConsumerImpl<?> consumer) {
         consumers.put(consumerId, consumer);
     }
 
-    void registerProducer(final long producerId, final ProducerImpl producer) {
+    void registerProducer(final long producerId, final ProducerImpl<?> producer) {
         producers.put(producerId, producer);
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -50,7 +50,7 @@ public abstract class ConsumerBase<T> extends HandlerBase implements Consumer<T>
     }
 
     protected final String subscription;
-    protected final ConsumerConfigurationData conf;
+    protected final ConsumerConfigurationData<T> conf;
     protected final String consumerName;
     protected final CompletableFuture<Consumer<T>> subscribeFuture;
     protected final MessageListener<T> listener;
@@ -168,7 +168,7 @@ public abstract class ConsumerBase<T> extends HandlerBase implements Consumer<T>
     abstract protected Message<T> internalReceive(int timeout, TimeUnit unit) throws PulsarClientException;
 
     @Override
-    public void acknowledge(Message message) throws PulsarClientException {
+    public void acknowledge(Message<?> message) throws PulsarClientException {
         try {
             acknowledge(message.getMessageId());
         } catch (NullPointerException npe) {
@@ -194,7 +194,7 @@ public abstract class ConsumerBase<T> extends HandlerBase implements Consumer<T>
     }
 
     @Override
-    public void acknowledgeCumulative(Message message) throws PulsarClientException {
+    public void acknowledgeCumulative(Message<?> message) throws PulsarClientException {
         try {
             acknowledgeCumulative(message.getMessageId());
         } catch (NullPointerException npe) {
@@ -220,7 +220,7 @@ public abstract class ConsumerBase<T> extends HandlerBase implements Consumer<T>
     }
 
     @Override
-    public CompletableFuture<Void> acknowledgeAsync(Message message) {
+    public CompletableFuture<Void> acknowledgeAsync(Message<?> message) {
         try {
             return acknowledgeAsync(message.getMessageId());
         } catch (NullPointerException npe) {
@@ -229,7 +229,7 @@ public abstract class ConsumerBase<T> extends HandlerBase implements Consumer<T>
     }
 
     @Override
-    public CompletableFuture<Void> acknowledgeCumulativeAsync(Message message) {
+    public CompletableFuture<Void> acknowledgeCumulativeAsync(Message<?> message) {
         try {
             return acknowledgeCumulativeAsync(message.getMessageId());
         } catch (NullPointerException npe) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -206,9 +206,8 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
     }
 
     @Override
-    public ConsumerBuilder patternAutoDiscoveryPeriod(int periodInMinutes) {
+    public ConsumerBuilder<T> patternAutoDiscoveryPeriod(int periodInMinutes) {
         conf.setPatternAutoDiscoveryPeriod(periodInMinutes);
         return this;
     }
-
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStats.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStats.java
@@ -41,7 +41,7 @@ public class ConsumerStats implements Serializable {
     private static final long serialVersionUID = 1L;
     private TimerTask stat;
     private Timeout statTimeout;
-    private ConsumerImpl consumer;
+    private ConsumerImpl<?> consumer;
     private PulsarClientImpl pulsarClient;
     private long oldTime;
     private long statsIntervalSeconds;
@@ -74,7 +74,7 @@ public class ConsumerStats implements Serializable {
         throughputFormat = null;
     }
 
-    public ConsumerStats(PulsarClientImpl pulsarClient, ConsumerConfigurationData conf, ConsumerImpl consumer) {
+    public ConsumerStats(PulsarClientImpl pulsarClient, ConsumerConfigurationData<?> conf, ConsumerImpl<?> consumer) {
         this.pulsarClient = pulsarClient;
         this.consumer = consumer;
         this.statsIntervalSeconds = pulsarClient.getConfiguration().getStatsIntervalSeconds();
@@ -92,7 +92,7 @@ public class ConsumerStats implements Serializable {
         init(conf);
     }
 
-    private void init(ConsumerConfigurationData conf) {
+    private void init(ConsumerConfigurationData<?> conf) {
         ObjectMapper m = new ObjectMapper();
         m.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         ObjectWriter w = m.writerWithDefaultPrettyPrinter();
@@ -149,7 +149,7 @@ public class ConsumerStats implements Serializable {
         statTimeout = pulsarClient.timer().newTimeout(stat, statsIntervalSeconds, TimeUnit.SECONDS);
     }
 
-    void updateNumMsgsReceived(Message message) {
+    void updateNumMsgsReceived(Message<?> message) {
         if (message != null) {
             numMsgsReceived.increment();
             numBytesReceived.add(message.getData().length);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsDisabled.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerStatsDisabled.java
@@ -24,7 +24,7 @@ public class ConsumerStatsDisabled extends ConsumerStats {
     private static final long serialVersionUID = 1L;
 
     @Override
-    void updateNumMsgsReceived(Message message) {
+    void updateNumMsgsReceived(Message<?> message) {
         // Do nothing
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -56,7 +56,8 @@ public class MessageImpl<T> implements Message<T> {
 
     // Constructor for out-going message
     static <T> MessageImpl<T> create(MessageMetadata.Builder msgMetadataBuilder, ByteBuffer payload, Schema<T> schema) {
-        MessageImpl<T> msg = RECYCLER.get();
+        @SuppressWarnings("unchecked")
+        MessageImpl<T> msg = (MessageImpl<T>) RECYCLER.get();
         msg.msgMetadataBuilder = msgMetadataBuilder;
         msg.messageId = null;
         msg.cnx = null;
@@ -67,7 +68,8 @@ public class MessageImpl<T> implements Message<T> {
     }
 
     static MessageImpl<byte[]> create(MessageMetadata.Builder msgMetadataBuilder, ByteBuffer payload) {
-        MessageImpl<byte[]> msg = RECYCLER.get();
+        @SuppressWarnings("unchecked")
+        MessageImpl<byte[]> msg = (MessageImpl<byte[]>) RECYCLER.get();
         msg.msgMetadataBuilder = msgMetadataBuilder;
         msg.messageId = null;
         msg.cnx = null;
@@ -141,8 +143,9 @@ public class MessageImpl<T> implements Message<T> {
         this.properties = Collections.unmodifiableMap(properties);
     }
 
-    public static MessageImpl deserialize(ByteBuf headersAndPayload) throws IOException {
-        MessageImpl msg = RECYCLER.get();
+    public static MessageImpl<byte[]> deserialize(ByteBuf headersAndPayload) throws IOException {
+        @SuppressWarnings("unchecked")
+        MessageImpl<byte[]> msg = (MessageImpl<byte[]>) RECYCLER.get();
         MessageMetadata msgMetadata = Commands.parseMessageMetadata(headersAndPayload);
 
         msg.msgMetadataBuilder = MessageMetadata.newBuilder(msgMetadata);
@@ -287,16 +290,16 @@ public class MessageImpl<T> implements Message<T> {
         }
     }
 
-    private MessageImpl(Handle<MessageImpl> recyclerHandle) {
+    private MessageImpl(Handle<MessageImpl<?>> recyclerHandle) {
         this.recyclerHandle = recyclerHandle;
     }
 
-    private Handle<MessageImpl> recyclerHandle;
+    private Handle<MessageImpl<?>> recyclerHandle;
 
-    private final static Recycler<MessageImpl> RECYCLER = new Recycler<MessageImpl>() {
+    private final static Recycler<MessageImpl<?>> RECYCLER = new Recycler<MessageImpl<?>>() {
         @Override
-        protected MessageImpl newObject(Handle<MessageImpl> handle) {
-            return new MessageImpl(handle);
+        protected MessageImpl<?> newObject(Handle<MessageImpl<?>> handle) {
+            return new MessageImpl<>(handle);
         }
     };
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
@@ -161,14 +161,8 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
 
     @Override
     public boolean isConnected() {
-        for (ProducerImpl producer : producers) {
-            // returns false if any of the partition is not connected
-            if (!producer.isConnected()) {
-                return false;
-            }
-        }
-
-        return true;
+        // returns false if any of the partition is not connected
+        return producers.stream().allMatch(ProducerImpl::isConnected);
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerStats.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerStats.java
@@ -41,7 +41,7 @@ public class ProducerStats implements Serializable {
     private static final long serialVersionUID = 1L;
     private TimerTask stat;
     private Timeout statTimeout;
-    private ProducerImpl producer;
+    private ProducerImpl<?> producer;
     private PulsarClientImpl pulsarClient;
     private long oldTime;
     private long statsIntervalSeconds;
@@ -74,7 +74,7 @@ public class ProducerStats implements Serializable {
         ds = null;
     }
 
-    public ProducerStats(PulsarClientImpl pulsarClient, ProducerConfigurationData conf, ProducerImpl producer) {
+    public ProducerStats(PulsarClientImpl pulsarClient, ProducerConfigurationData conf, ProducerImpl<?> producer) {
         this.pulsarClient = pulsarClient;
         this.statsIntervalSeconds = pulsarClient.getConfiguration().getStatsIntervalSeconds();
         this.producer = producer;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderBuilderImpl.java
@@ -43,16 +43,17 @@ public class ReaderBuilderImpl<T> implements ReaderBuilder<T> {
     private final Schema<T> schema;
 
     ReaderBuilderImpl(PulsarClientImpl client, Schema<T> schema) {
-        this(client, new ReaderConfigurationData(), schema);
+        this(client, new ReaderConfigurationData<T>(), schema);
     }
 
-    private ReaderBuilderImpl(PulsarClientImpl client, ReaderConfigurationData conf, Schema<T> schema) {
+    private ReaderBuilderImpl(PulsarClientImpl client, ReaderConfigurationData<T> conf, Schema<T> schema) {
         this.client = client;
         this.conf = conf;
         this.schema = schema;
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public ReaderBuilder<T> clone() {
         try {
             return (ReaderBuilder<T>) super.clone();
@@ -106,7 +107,7 @@ public class ReaderBuilderImpl<T> implements ReaderBuilder<T> {
     }
 
     @Override
-    public ReaderBuilder<T> readerListener(ReaderListener readerListener) {
+    public ReaderBuilder<T> readerListener(ReaderListener<T> readerListener) {
         conf.setReaderListener(readerListener);
         return this;
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
@@ -90,7 +90,7 @@ public class ReaderImpl<T> implements Reader<T> {
         return consumer.getTopic();
     }
 
-    public ConsumerImpl getConsumer() {
+    public ConsumerImpl<T> getConsumer() {
         return consumer;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/RoundRobinPartitionMessageRouterImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/RoundRobinPartitionMessageRouterImpl.java
@@ -39,7 +39,7 @@ public class RoundRobinPartitionMessageRouterImpl extends MessageRouterBase {
     }
 
     @Override
-    public int choosePartition(Message msg, TopicMetadata topicMetadata) {
+    public int choosePartition(Message<?> msg, TopicMetadata topicMetadata) {
         // If the message has a key, it supersedes the round robin routing policy
         if (msg.hasKey()) {
             return hash.makeHash(msg.getKey()) % topicMetadata.numPartitions();

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
@@ -31,9 +31,10 @@ import org.apache.pulsar.broker.authentication.AuthenticationService;
 import org.apache.pulsar.broker.authorization.AuthorizationService;
 import org.apache.pulsar.broker.cache.ConfigurationCacheService;
 import org.apache.pulsar.client.api.Authentication;
-import org.apache.pulsar.client.api.ClientConfiguration;
+import org.apache.pulsar.client.api.AuthenticationFactory;
 import org.apache.pulsar.client.impl.ConnectionPool;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
 import org.apache.pulsar.common.util.netty.EventLoopUtil;
 import org.apache.pulsar.zookeeper.LocalZooKeeperConnectionService;
@@ -95,19 +96,20 @@ public class ProxyService implements Closeable {
         this.acceptorGroup  = EventLoopUtil.newEventLoopGroup(1, acceptorThreadFactory);
         this.workerGroup = EventLoopUtil.newEventLoopGroup(numThreads, workersThreadFactory);
 
-        ClientConfiguration clientConfiguration = new ClientConfiguration();
+        ClientConfigurationData clientConf = new ClientConfigurationData();
+        clientConf.setServiceUrl(serviceUrl);
         if (proxyConfig.getBrokerClientAuthenticationPlugin() != null) {
-            clientConfiguration.setAuthentication(proxyConfig.getBrokerClientAuthenticationPlugin(),
-                    proxyConfig.getBrokerClientAuthenticationParameters());
+            clientConf.setAuthentication(AuthenticationFactory.create(proxyConfig.getBrokerClientAuthenticationPlugin(),
+                    proxyConfig.getBrokerClientAuthenticationParameters()));
         }
         if (proxyConfig.isTlsEnabledWithBroker()) {
-            clientConfiguration.setUseTls(true);
-            clientConfiguration.setTlsTrustCertsFilePath(proxyConfig.getBrokerClientTrustCertsFilePath());
-            clientConfiguration.setTlsAllowInsecureConnection(proxyConfig.isTlsAllowInsecureConnection());
+            clientConf.setUseTls(true);
+            clientConf.setTlsTrustCertsFilePath(proxyConfig.getBrokerClientTrustCertsFilePath());
+            clientConf.setTlsAllowInsecureConnection(proxyConfig.isTlsAllowInsecureConnection());
         }
 
-        this.client = new PulsarClientImpl(serviceUrl, clientConfiguration, workerGroup);
-        this.clientAuthentication = clientConfiguration.getAuthentication();
+        this.client = new PulsarClientImpl(clientConf, workerGroup);
+        this.clientAuthentication = clientConf.getAuthentication();
     }
 
     public void start() throws Exception {

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyForwardAuthDataTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyForwardAuthDataTest.java
@@ -25,11 +25,9 @@ import java.util.Set;
 
 import org.apache.bookkeeper.test.PortManager;
 import org.apache.pulsar.client.admin.PulsarAdmin;
-import org.apache.pulsar.client.api.ConsumerConfiguration;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
-import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.PropertyAdmin;
 import org.apache.pulsar.proxy.server.ProxyRolesEnforcementTest.BasicAuthentication;
@@ -142,8 +140,7 @@ public class ProxyForwardAuthDataTest extends ProducerConsumerBase {
     }
 
     private PulsarClient createPulsarClient(String proxyServiceUrl, String authParams) throws PulsarClientException {
-        org.apache.pulsar.client.api.ClientConfiguration clientConf = new org.apache.pulsar.client.api.ClientConfiguration();
-        clientConf.setAuthentication(BasicAuthentication.class.getName(), authParams);
-        return PulsarClient.create(proxyServiceUrl, clientConf);
+        return PulsarClient.builder().serviceUrl(proxyServiceUrl)
+                .authentication(BasicAuthentication.class.getName(), authParams).build();
     }
 }

--- a/pulsar-storm/src/main/java/org/apache/pulsar/storm/MessageToValuesMapper.java
+++ b/pulsar-storm/src/main/java/org/apache/pulsar/storm/MessageToValuesMapper.java
@@ -33,7 +33,7 @@ public interface MessageToValuesMapper extends Serializable {
      * @param msg
      * @return
      */
-    public Values toValues(Message msg);
+    public Values toValues(Message<byte[]> msg);
 
     /**
      * Declare the output schema for the spout.

--- a/pulsar-storm/src/main/java/org/apache/pulsar/storm/SharedPulsarClient.java
+++ b/pulsar-storm/src/main/java/org/apache/pulsar/storm/SharedPulsarClient.java
@@ -18,36 +18,37 @@
  */
 package org.apache.pulsar.storm;
 
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
+import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Maps;
-import org.apache.pulsar.client.api.ClientConfiguration;
-import org.apache.pulsar.client.api.PulsarClient;
-import org.apache.pulsar.client.api.PulsarClientException;
-import org.apache.pulsar.client.api.Consumer;
-import org.apache.pulsar.client.api.ConsumerConfiguration;
-import org.apache.pulsar.client.api.Producer;
-import org.apache.pulsar.client.api.ProducerConfiguration;
 
 public class SharedPulsarClient {
     private static final Logger LOG = LoggerFactory.getLogger(SharedPulsarClient.class);
     private static final ConcurrentMap<String, SharedPulsarClient> instances = Maps.newConcurrentMap();
 
     private final String componentId;
-    private final PulsarClient client;
+    private final PulsarClientImpl client;
     private final AtomicInteger counter = new AtomicInteger();
 
-    private Consumer consumer;
-    private Producer producer;
+    private Consumer<byte[]> consumer;
+    private Producer<byte[]> producer;
 
-    private SharedPulsarClient(String componentId, String serviceUrl, ClientConfiguration clientConf)
+    private SharedPulsarClient(String componentId, ClientConfigurationData clientConf)
             throws PulsarClientException {
-        this.client = PulsarClient.create(serviceUrl, clientConf);
+        this.client = new PulsarClientImpl(clientConf);
         this.componentId = componentId;
     }
 
@@ -62,13 +63,13 @@ public class SharedPulsarClient {
      * @return
      * @throws PulsarClientException
      */
-    public static SharedPulsarClient get(String componentId, String serviceUrl, ClientConfiguration clientConf)
+    public static SharedPulsarClient get(String componentId, ClientConfigurationData clientConf)
             throws PulsarClientException {
         AtomicReference<PulsarClientException> exception = new AtomicReference<PulsarClientException>();
         instances.computeIfAbsent(componentId, pulsarClient -> {
             SharedPulsarClient sharedPulsarClient = null;
             try {
-                sharedPulsarClient = new SharedPulsarClient(componentId, serviceUrl, clientConf);
+                sharedPulsarClient = new SharedPulsarClient(componentId, clientConf);
                 LOG.info("[{}] Created a new Pulsar Client.", componentId);
             } catch (PulsarClientException e) {
                 exception.set(e);
@@ -81,33 +82,41 @@ public class SharedPulsarClient {
         return instances.get(componentId);
     }
 
-    public PulsarClient getClient() {
+    public PulsarClientImpl getClient() {
         counter.incrementAndGet();
         return client;
     }
 
-    public Consumer getSharedConsumer(String topic, String subscription, ConsumerConfiguration consumerConf)
+    public Consumer<byte[]> getSharedConsumer(ConsumerConfigurationData<byte[]> consumerConf)
             throws PulsarClientException {
         counter.incrementAndGet();
         synchronized (this) {
             if (consumer == null) {
-                consumer = client.subscribe(topic, subscription, consumerConf);
-                LOG.info("[{}] Created a new Pulsar Consumer on {}", componentId, topic);
+                try {
+                    consumer = client.subscribeAsync(consumerConf).join();
+                } catch (CompletionException e) {
+                    throw (PulsarClientException) e.getCause();
+                }
+                LOG.info("[{}] Created a new Pulsar Consumer on {}", componentId, consumerConf.getSingleTopic());
             } else {
-                LOG.info("[{}] Using a shared consumer on {}", componentId, topic);
+                LOG.info("[{}] Using a shared consumer on {}", componentId, consumerConf.getSingleTopic());
             }
         }
         return consumer;
     }
 
-    public Producer getSharedProducer(String topic, ProducerConfiguration producerConf) throws PulsarClientException {
+    public Producer<byte[]> getSharedProducer(ProducerConfigurationData producerConf) throws PulsarClientException {
         counter.incrementAndGet();
         synchronized (this) {
             if (producer == null) {
-                producer = client.createProducer(topic, producerConf);
-                LOG.info("[{}] Created a new Pulsar Producer on {}", componentId, topic);
+                try {
+                    producer = client.createProducerAsync(producerConf).join();
+                } catch (CompletionException e) {
+                    throw (PulsarClientException) e.getCause();
+                }
+                LOG.info("[{}] Created a new Pulsar Producer on {}", componentId, producerConf.getTopicName());
             } else {
-                LOG.info("[{}] Using a shared producer on {}", componentId, topic);
+                LOG.info("[{}] Using a shared producer on {}", componentId, producerConf.getTopicName());
             }
         }
         return producer;


### PR DESCRIPTION
### Motivation

As part of PIP-12, in #1089 we have introduced a builder style interface to create client/producer/consumer.

Here changing the core part of code to start using the new preferred API.