### PR TITLE
Fix the typo in shaded client-tools module

### DIFF
--- a/pulsar-client-tools-shaded/pom.xml
+++ b/pulsar-client-tools-shaded/pom.xml
@@ -60,7 +60,7 @@
               <artifactSet>
                 <includes>
                   <include>org.apache.pulsar:pulsar-common</include>
-                  <include>org.apache.bokkeeper:circe-checksum</include>
+                  <include>org.apache.bookkeeper:circe-checksum</include>
                   <include>org.apache.pulsar:pulsar-client-original</include>
                   <include>org.apache.pulsar:pulsar-client-admin-original</include>
                   <include>org.apache.pulsar:pulsar-client-tools</include>


### PR DESCRIPTION
*Problem*

Because of the typo, the `circe-checksum` is not included for shading. It will cause class conflicts on checksum classes when using `pulsar-client-tools-shaded` 

*Solution*

Fixed the typo.