### PR TITLE
Remove deprecated newConnect methods

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -58,6 +58,7 @@ import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.bookkeeper.tools.cli.helpers.Command;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.admin.AdminResource;
@@ -75,6 +76,7 @@ import org.apache.pulsar.common.api.ByteBufPair;
 import org.apache.pulsar.common.api.Commands;
 import org.apache.pulsar.common.api.Commands.ChecksumType;
 import org.apache.pulsar.common.api.PulsarHandler;
+import org.apache.pulsar.common.api.proto.PulsarApi;
 import org.apache.pulsar.common.api.proto.PulsarApi.AuthMethod;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandConnected;
@@ -210,6 +212,24 @@ public class ServerCnxTest {
         channel.finish();
     }
 
+    private static ByteBuf newConnect(AuthMethod authMethod, String authData, int protocolVersion) {
+        PulsarApi.CommandConnect.Builder connectBuilder = PulsarApi.CommandConnect.newBuilder();
+        connectBuilder.setClientVersion("Pulsar Client");
+        connectBuilder.setAuthMethod(authMethod);
+        connectBuilder.setAuthData(ByteString.copyFromUtf8(authData));
+        connectBuilder.setProtocolVersion(protocolVersion);
+        PulsarApi.CommandConnect connect = connectBuilder.build();
+        ByteBuf res = Commands.serializeWithSize(PulsarApi.BaseCommand.newBuilder().setType(PulsarApi.BaseCommand.Type.CONNECT).setConnect(connect));
+        connect.recycle();
+        connectBuilder.recycle();
+        return res;
+    }
+
+    /**
+     * Ensure that old clients may still connect to new servers
+     *
+     * @throws Exception
+     */
     @Test(timeOut = 30000)
     public void testConnectCommandWithEnum() throws Exception {
         resetChannel();
@@ -217,8 +237,7 @@ public class ServerCnxTest {
         assertEquals(serverCnx.getState(), State.Start);
 
         // test server response to CONNECT
-        @SuppressWarnings("deprecation") // We're actually testing that the deprecated method still works
-        ByteBuf clientCommand = Commands.newConnect(AuthMethod.AuthMethodNone, "");
+        ByteBuf clientCommand = newConnect(AuthMethod.AuthMethodNone, "", Commands.getCurrentProtocolVersion());
         channel.writeInbound(clientCommand);
 
         assertEquals(serverCnx.getState(), State.Connected);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -211,6 +211,22 @@ public class ServerCnxTest {
     }
 
     @Test(timeOut = 30000)
+    public void testConnectCommandWithEnum() throws Exception {
+        resetChannel();
+        assertTrue(channel.isActive());
+        assertEquals(serverCnx.getState(), State.Start);
+
+        // test server response to CONNECT
+        @SuppressWarnings("deprecation") // We're actually testing that the deprecated method still works
+        ByteBuf clientCommand = Commands.newConnect(AuthMethod.AuthMethodNone, "");
+        channel.writeInbound(clientCommand);
+
+        assertEquals(serverCnx.getState(), State.Connected);
+        assertTrue(getResponse() instanceof CommandConnected);
+        channel.finish();
+    }
+
+    @Test(timeOut = 30000)
     public void testConnectCommandWithProtocolVersion() throws Exception {
         resetChannel();
         assertTrue(channel.isActive());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -211,22 +211,6 @@ public class ServerCnxTest {
     }
 
     @Test(timeOut = 30000)
-    public void testConnectCommandWithEnum() throws Exception {
-        resetChannel();
-        assertTrue(channel.isActive());
-        assertEquals(serverCnx.getState(), State.Start);
-
-        // test server response to CONNECT
-        @SuppressWarnings("deprecation") // We're actually testing that the deprecated method still works
-        ByteBuf clientCommand = Commands.newConnect(AuthMethod.AuthMethodNone, "");
-        channel.writeInbound(clientCommand);
-
-        assertEquals(serverCnx.getState(), State.Connected);
-        assertTrue(getResponse() instanceof CommandConnected);
-        channel.finish();
-    }
-
-    @Test(timeOut = 30000)
     public void testConnectCommandWithProtocolVersion() throws Exception {
         resetChannel();
         assertTrue(channel.isActive());

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/Commands.java
@@ -136,33 +136,6 @@ public class Commands {
         return res;
     }
 
-    /**
-     * @deprecated AuthMethod has been deprecated. Use {@link #newConnect(String authMethodName, String authData)}
-     *             instead.
-     */
-    @Deprecated
-    public static ByteBuf newConnect(AuthMethod authMethod, String authData) {
-        return newConnect(authMethod, authData, getCurrentProtocolVersion());
-    }
-
-    /**
-     * @deprecated AuthMethod has been deprecated. Use
-     *             {@link #newConnect(String authMethodName, String authData, int protocolVersion)} instead.
-     */
-    @Deprecated
-    public static ByteBuf newConnect(AuthMethod authMethod, String authData, int protocolVersion) {
-        CommandConnect.Builder connectBuilder = CommandConnect.newBuilder();
-        connectBuilder.setClientVersion("Pulsar Client");
-        connectBuilder.setAuthMethod(authMethod);
-        connectBuilder.setAuthData(ByteString.copyFromUtf8(authData));
-        connectBuilder.setProtocolVersion(protocolVersion);
-        CommandConnect connect = connectBuilder.build();
-        ByteBuf res = serializeWithSize(BaseCommand.newBuilder().setType(Type.CONNECT).setConnect(connect));
-        connect.recycle();
-        connectBuilder.recycle();
-        return res;
-    }
-
     public static ByteBuf newConnected(int clientProtocolVersion) {
         CommandConnected.Builder connectedBuilder = CommandConnected.newBuilder();
         connectedBuilder.setServerVersion("Pulsar Server");

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/Commands.java
@@ -136,6 +136,33 @@ public class Commands {
         return res;
     }
 
+    /**
+     * @deprecated AuthMethod has been deprecated. Use {@link #newConnect(String authMethodName, String authData)}
+     *             instead.
+     */
+    @Deprecated
+    public static ByteBuf newConnect(AuthMethod authMethod, String authData) {
+        return newConnect(authMethod, authData, getCurrentProtocolVersion());
+    }
+
+    /**
+     * @deprecated AuthMethod has been deprecated. Use
+     *             {@link #newConnect(String authMethodName, String authData, int protocolVersion)} instead.
+     */
+    @Deprecated
+    public static ByteBuf newConnect(AuthMethod authMethod, String authData, int protocolVersion) {
+        CommandConnect.Builder connectBuilder = CommandConnect.newBuilder();
+        connectBuilder.setClientVersion("Pulsar Client");
+        connectBuilder.setAuthMethod(authMethod);
+        connectBuilder.setAuthData(ByteString.copyFromUtf8(authData));
+        connectBuilder.setProtocolVersion(protocolVersion);
+        CommandConnect connect = connectBuilder.build();
+        ByteBuf res = serializeWithSize(BaseCommand.newBuilder().setType(Type.CONNECT).setConnect(connect));
+        connect.recycle();
+        connectBuilder.recycle();
+        return res;
+    }
+
     public static ByteBuf newConnected(int clientProtocolVersion) {
         CommandConnected.Builder connectedBuilder = CommandConnected.newBuilder();
         connectedBuilder.setServerVersion("Pulsar Server");

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/Commands.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.common.api;
 import static com.scurrilous.circe.checksum.Crc32cIntChecksum.computeChecksum;
 import static com.scurrilous.circe.checksum.Crc32cIntChecksum.resumeChecksum;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ByteString;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
@@ -128,33 +129,6 @@ public class Commands {
         if (originalAuthMethod != null) {
             connectBuilder.setOriginalAuthMethod(originalAuthMethod);
         }
-        connectBuilder.setProtocolVersion(protocolVersion);
-        CommandConnect connect = connectBuilder.build();
-        ByteBuf res = serializeWithSize(BaseCommand.newBuilder().setType(Type.CONNECT).setConnect(connect));
-        connect.recycle();
-        connectBuilder.recycle();
-        return res;
-    }
-
-    /**
-     * @deprecated AuthMethod has been deprecated. Use {@link #newConnect(String authMethodName, String authData)}
-     *             instead.
-     */
-    @Deprecated
-    public static ByteBuf newConnect(AuthMethod authMethod, String authData) {
-        return newConnect(authMethod, authData, getCurrentProtocolVersion());
-    }
-
-    /**
-     * @deprecated AuthMethod has been deprecated. Use
-     *             {@link #newConnect(String authMethodName, String authData, int protocolVersion)} instead.
-     */
-    @Deprecated
-    public static ByteBuf newConnect(AuthMethod authMethod, String authData, int protocolVersion) {
-        CommandConnect.Builder connectBuilder = CommandConnect.newBuilder();
-        connectBuilder.setClientVersion("Pulsar Client");
-        connectBuilder.setAuthMethod(authMethod);
-        connectBuilder.setAuthData(ByteString.copyFromUtf8(authData));
         connectBuilder.setProtocolVersion(protocolVersion);
         CommandConnect connect = connectBuilder.build();
         ByteBuf res = serializeWithSize(BaseCommand.newBuilder().setType(Type.CONNECT).setConnect(connect));
@@ -702,7 +676,8 @@ public class Commands {
         return res;
     }
 
-    private static ByteBuf serializeWithSize(BaseCommand.Builder cmdBuilder) {
+    @VisibleForTesting
+    public static ByteBuf serializeWithSize(BaseCommand.Builder cmdBuilder) {
         // / Wire format
         // [TOTAL_SIZE] [CMD_SIZE][CMD]
         BaseCommand cmd = cmdBuilder.build();
@@ -941,7 +916,8 @@ public class Commands {
         return (ByteBufPair) ByteBufPair.get(headers, metadataAndPayload);
     }
 
-    private static int getCurrentProtocolVersion() {
+    @VisibleForTesting
+    public static int getCurrentProtocolVersion() {
         // Return the last ProtocolVersion enum value
         return ProtocolVersion.values()[ProtocolVersion.values().length - 1].getNumber();
     }


### PR DESCRIPTION
The only piece of code using these methods is a test that is testing to make sure a deprecated method still works. If there is something I'm missing please feel free to enlighten me.