### PR TITLE
Added localhost as default advertised address in standalone.conf

### DIFF
--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -34,7 +34,7 @@ webServicePort=8080
 bindAddress=0.0.0.0
 
 # Hostname or IP address the service advertises to the outside world. If not set, the value of InetAddress.getLocalHost().getHostName() is used.
-advertisedAddress=
+advertisedAddress=localhost
 
 # Name of the cluster to which this broker belongs to
 clusterName=standalone


### PR DESCRIPTION
@rdhabalia , @saandrews and I are unable to use standalone broker unless we specify the advertisedAddress as localhost. 
I would suggest putting the default value as localhost.