### PR TITLE
Refactored all unit tests to use new typed API with builders for configuration

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderBasic.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authentication/AuthenticationProviderBasic.java
@@ -24,6 +24,8 @@ import org.apache.commons.codec.digest.Md5Crypt;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.ServiceConfiguration;
 
+import lombok.Cleanup;
+
 import javax.naming.AuthenticationException;
 import java.io.BufferedReader;
 import java.io.File;
@@ -49,7 +51,8 @@ public class AuthenticationProviderBasic implements AuthenticationProvider {
         } else if (!confFile.isFile()) {
             throw new IOException("The path is not a file");
         }
-        BufferedReader reader = new BufferedReader(new FileReader(confFile));
+
+        @Cleanup BufferedReader reader = new BufferedReader(new FileReader(confFile));
         users = new HashMap<>();
         for (String line : reader.lines().toArray(s -> new String[s])) {
             List<String> splitLine = Arrays.asList(line.split(":"));
@@ -58,7 +61,6 @@ public class AuthenticationProviderBasic implements AuthenticationProvider {
             }
             users.put(splitLine.get(0), splitLine.get(1));
         }
-        reader.close();
     }
 
     @Override

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/authorization/AuthorizationService.java
@@ -21,27 +21,20 @@ package org.apache.pulsar.broker.authorization;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.pulsar.zookeeper.ZooKeeperCache.cacheTimeOutInSec;
 
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
 import org.apache.pulsar.broker.cache.ConfigurationCacheService;
-import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.Maps;
 
 /**
  * Authorization service that manages pluggable authorization provider and authorize requests accordingly.

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
@@ -44,13 +44,10 @@ import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.admin.PulsarAdminException.PreconditionFailedException;
-import org.apache.pulsar.client.api.ClientConfiguration;
 import org.apache.pulsar.client.api.Consumer;
-import org.apache.pulsar.client.api.ConsumerConfiguration;
 import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.client.api.Producer;
-import org.apache.pulsar.client.api.ProducerConfiguration;
-import org.apache.pulsar.client.api.ProducerConfiguration.MessageRoutingMode;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.MessageIdImpl;
@@ -65,8 +62,6 @@ import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.policies.data.PersistentTopicStats;
 import org.apache.pulsar.common.policies.data.PropertyAdmin;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -75,12 +70,10 @@ import org.testng.annotations.Test;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import static org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.retryStrategically;
 
 public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
 
     private MockedPulsarService mockPulsarSetup;
-
 
     @BeforeMethod
     @Override
@@ -109,8 +102,7 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
 
     @DataProvider(name = "topicType")
     public Object[][] topicTypeProvider() {
-        return new Object[][] { { TopicDomain.persistent.value() },
-                { TopicDomain.non_persistent.value() } };
+        return new Object[][] { { TopicDomain.persistent.value() }, { TopicDomain.non_persistent.value() } };
     }
 
     @DataProvider(name = "namespaceNames")
@@ -137,8 +129,8 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
     @Test
     public void testIncrementPartitionsOfTopic() throws Exception {
         final String topicName = "increment-partitionedTopic";
-        final String subName1 = topicName + "-my-sub 1";
-        final String subName2 = topicName + "-my-sub 2";
+        final String subName1 = topicName + "-my-sub-1";
+        final String subName2 = topicName + "-my-sub-2";
         final int startPartitions = 4;
         final int newPartitions = 8;
         final String partitionedTopicName = "persistent://prop-xyz/use/ns1/" + topicName;
@@ -151,12 +143,12 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
                 startPartitions);
 
         // create consumer and subscriptions : check subscriptions
-        PulsarClient client = PulsarClient.create(pulsarUrl.toString());
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Shared);
-        Consumer consumer1 = client.subscribe(partitionedTopicName, subName1, conf);
+        PulsarClient client = PulsarClient.builder().serviceUrl(pulsarUrl.toString()).build();
+        Consumer<byte[]> consumer1 = client.newConsumer().topic(partitionedTopicName).subscriptionName(subName1)
+                .subscriptionType(SubscriptionType.Shared).subscribe();
         assertEquals(admin.persistentTopics().getSubscriptions(partitionedTopicName), Lists.newArrayList(subName1));
-        Consumer consumer2 = client.subscribe(partitionedTopicName, subName2, conf);
+        Consumer<byte[]> consumer2 = client.newConsumer().topic(partitionedTopicName).subscriptionName(subName2)
+                .subscriptionType(SubscriptionType.Shared).subscribe();
         assertEquals(Sets.newHashSet(admin.persistentTopics().getSubscriptions(partitionedTopicName)),
                 Sets.newHashSet(subName1, subName2));
 
@@ -172,9 +164,8 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
                 .toString();
 
         // (3) produce messages to all partitions including newly created partitions (RoundRobin)
-        ProducerConfiguration prodConf = new ProducerConfiguration();
-        prodConf.setMessageRoutingMode(MessageRoutingMode.RoundRobinPartition);
-        Producer producer = client.createProducer(partitionedTopicName, prodConf);
+        Producer<byte[]> producer = client.newProducer().topic(partitionedTopicName)
+                .messageRoutingMode(MessageRoutingMode.RoundRobinPartition).create();
         final int totalMessages = newPartitions * 2;
         for (int i = 0; i < totalMessages; i++) {
             String message = "message-" + i;
@@ -184,7 +175,8 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         // (4) verify existing subscription has not lost any message: create new consumer with sub-2: it will load all
         // newly created partition topics
         consumer2.close();
-        consumer2 = client.subscribe(partitionedTopicName, subName2, conf);
+        consumer2 = client.newConsumer().topic(partitionedTopicName).subscriptionName(subName2)
+                .subscriptionType(SubscriptionType.Shared).subscribe();
         // sometime: mockZk fails to refresh ml-cache: so, invalidate the cache to get fresh data
         pulsar.getLocalZkCacheService().managedLedgerListCache().clearTree();
         assertEquals(Sets.newHashSet(admin.persistentTopics().getSubscriptions(newPartitionTopicName)),
@@ -222,10 +214,9 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         consumer2.close();
     }
 
-
     /**
-     * verifies admin api command for non-persistent topic.
-     * It verifies: partitioned-topic, stats
+     * verifies admin api command for non-persistent topic. It verifies: partitioned-topic, stats
+     *
      * @throws Exception
      */
     @Test
@@ -238,12 +229,10 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
 
         // create consumer and subscription
         URL pulsarUrl = new URL("http://127.0.0.1" + ":" + BROKER_WEBSERVICE_PORT);
-        ClientConfiguration clientConf = new ClientConfiguration();
-        clientConf.setStatsInterval(0, TimeUnit.SECONDS);
-        PulsarClient client = PulsarClient.create(pulsarUrl.toString(), clientConf);
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-        Consumer consumer = client.subscribe(persistentTopicName, "my-sub", conf);
+        PulsarClient client = PulsarClient.builder().serviceUrl(pulsarUrl.toString()).statsInterval(0, TimeUnit.SECONDS)
+                .build();
+        Consumer<byte[]> consumer = client.newConsumer().topic(persistentTopicName).subscriptionName("my-sub")
+                .subscribe();
 
         publishMessagesOnTopic("non-persistent://prop-xyz/use/ns1/" + topicName, 10, 0);
 
@@ -270,7 +259,7 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
     }
 
     private void publishMessagesOnTopic(String topicName, int messages, int startIdx) throws Exception {
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
 
         for (int i = startIdx; i < (messages + startIdx); i++) {
             String message = "message-" + i;
@@ -333,8 +322,8 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         admin.namespaces().setPersistence(namespace, new PersistencePolicies(3, 3, 3, 50.0));
         assertEquals(admin.namespaces().getPersistence(namespace), new PersistencePolicies(3, 3, 3, 50.0));
 
-        Producer producer = pulsarClient.createProducer(topicName);
-        Consumer consumer = pulsarClient.subscribe(topicName, "my-sub");
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName("my-sub").subscribe();
 
         PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getTopic(topicName).get();
         ManagedLedgerImpl managedLedger = (ManagedLedgerImpl) topic.getManagedLedger();
@@ -344,7 +333,7 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         final int newEnsembleSize = 5;
         admin.namespaces().setPersistence(namespace, new PersistencePolicies(newEnsembleSize, 3, 3, newThrottleRate));
 
-        retryStrategically((test) -> managedLedger.getConfig().getEnsembleSize() != newEnsembleSize
+        retryStrategically((test) -> managedLedger.getConfig().getEnsembleSize() == newEnsembleSize
                 && cursor.getThrottleMarkDelete() != newThrottleRate, 5, 200);
 
         // (1) verify cursor.markDelete has been updated
@@ -370,7 +359,7 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         admin.namespaces().createNamespace(namespace);
 
         // create a topic by creating a producer
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         producer.close();
 
         Topic topic = pulsar.getBrokerService().getTopicReference(topicName);
@@ -384,7 +373,7 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         assertNull(topic);
 
         // recreation of producer will load the topic again
-        producer = pulsarClient.createProducer(topicName);
+        producer = pulsarClient.newProducer().topic(topicName).create();
         topic = pulsar.getBrokerService().getTopicReference(topicName);
         assertNotNull(topic);
         // unload the topic
@@ -431,18 +420,17 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         admin.namespaces().setRetention("prop-xyz/use/ns1", new RetentionPolicies(10, 10));
 
         // create consumer and subscription
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Shared);
-        Consumer consumer = pulsarClient.subscribe(topicName, "my-sub", conf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName("my-sub")
+                .subscriptionType(SubscriptionType.Shared).subscribe();
 
         assertEquals(admin.persistentTopics().getSubscriptions(topicName), Lists.newArrayList("my-sub"));
 
         publishMessagesOnPersistentTopic(topicName, totalProducedMessages, 0);
 
-        List<Message> messages = admin.persistentTopics().peekMessages(topicName, "my-sub", 10);
+        List<Message<byte[]>> messages = admin.persistentTopics().peekMessages(topicName, "my-sub", 10);
         assertEquals(messages.size(), 10);
 
-        Message message = null;
+        Message<byte[]> message = null;
         MessageIdImpl resetMessageId = null;
         int resetPositionId = 10;
         for (int i = 0; i < 20; i++) {
@@ -461,7 +449,8 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         // reset position at resetMessageId
         admin.persistentTopics().resetCursor(topicName, "my-sub", messageId);
 
-        consumer = pulsarClient.subscribe(topicName, "my-sub", conf);
+        consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName("my-sub")
+                .subscriptionType(SubscriptionType.Shared).subscribe();
         MessageIdImpl msgId2 = (MessageIdImpl) consumer.receive(1, TimeUnit.SECONDS).getMessageId();
         assertEquals(resetMessageId, msgId2);
 
@@ -506,7 +495,7 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
     }
 
     private void publishMessagesOnPersistentTopic(String topicName, int messages, int startIdx) throws Exception {
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
 
         for (int i = startIdx; i < (messages + startIdx); i++) {
             String message = "message-" + i;
@@ -719,7 +708,7 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         Set<String> topicNames = Sets.newHashSet();
         for (int i = 0; i < totalTopics; i++) {
             topicNames.add(topicName + i);
-            Producer producer = pulsarClient.createProducer(topicName + i);
+            Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName + i).create();
             producer.close();
         }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/CreateSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/CreateSubscriptionTest.java
@@ -65,7 +65,7 @@ public class CreateSubscriptionTest extends MockedPulsarServiceBaseTest {
 
         assertEquals(admin.persistentTopics().getSubscriptions(topic), Lists.newArrayList("sub-1"));
 
-        Producer p1 = pulsarClient.createProducer(topic);
+        Producer<byte[]> p1 = pulsarClient.newProducer().topic(topic).create();
         p1.send("test-1".getBytes());
         p1.send("test-2".getBytes());
         MessageId m3 = p1.send("test-3".getBytes());
@@ -98,8 +98,7 @@ public class CreateSubscriptionTest extends MockedPulsarServiceBaseTest {
         }
 
         for (int i = 0; i < 10; i++) {
-            assertEquals(
-                    admin.persistentTopics().getSubscriptions(TopicName.get(topic).getPartition(i).toString()),
+            assertEquals(admin.persistentTopics().getSubscriptions(TopicName.get(topic).getPartition(i).toString()),
                     Lists.newArrayList("sub-1"));
         }
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/IncrementPartitionsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/IncrementPartitionsTest.java
@@ -80,15 +80,14 @@ public class IncrementPartitionsTest extends MockedPulsarServiceBaseTest {
         admin.persistentTopics().createPartitionedTopic(partitionedTopicName, 10);
         assertEquals(admin.persistentTopics().getPartitionedTopicMetadata(partitionedTopicName).partitions, 10);
 
-        Consumer consumer = pulsarClient.subscribe(partitionedTopicName, "sub-1");
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(partitionedTopicName).subscriptionName("sub-1")
+                .subscribe();
 
         admin.persistentTopics().updatePartitionedTopic(partitionedTopicName, 20);
         assertEquals(admin.persistentTopics().getPartitionedTopicMetadata(partitionedTopicName).partitions, 20);
 
-        assertEquals(
-                admin.persistentTopics()
-                        .getSubscriptions(TopicName.get(partitionedTopicName).getPartition(15).toString()),
-                Lists.newArrayList("sub-1"));
+        assertEquals(admin.persistentTopics().getSubscriptions(
+                TopicName.get(partitionedTopicName).getPartition(15).toString()), Lists.newArrayList("sub-1"));
 
         consumer.close();
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/AntiAffinityNamespaceGroupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/AntiAffinityNamespaceGroupTest.java
@@ -24,7 +24,6 @@ import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 
 import java.lang.reflect.Field;
-import java.net.InetAddress;
 import java.net.URL;
 import java.util.Map;
 import java.util.Set;
@@ -511,8 +510,9 @@ public class AntiAffinityNamespaceGroupTest {
             admin1.namespaces().setNamespaceAntiAffinityGroup(ns, namespaceAntiAffinityGroup);
         }
 
-        PulsarClient pulsarClient = PulsarClient.create(pulsar1.getWebServiceAddress());
-        Producer producer = pulsarClient.createProducer("persistent://" + namespace + "0/my-topic1");
+        PulsarClient pulsarClient = PulsarClient.builder().serviceUrl(pulsar1.getWebServiceAddress()).build();
+        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://" + namespace + "0/my-topic1")
+                .create();
         ModularLoadManagerImpl loadManager = (ModularLoadManagerImpl) ((ModularLoadManagerWrapper) pulsar1
                 .getLoadManager().get()).getLoadManager();
 
@@ -527,6 +527,7 @@ public class AntiAffinityNamespaceGroupTest {
     private boolean isLoadManagerUpdatedDomainCache(ModularLoadManagerImpl loadManager) throws Exception {
         Field mapField = ModularLoadManagerImpl.class.getDeclaredField("brokerToFailureDomainMap");
         mapField.setAccessible(true);
+        @SuppressWarnings("unchecked")
         Map<String, String> map = (Map<String, String>) mapField.get(loadManager);
         return !map.isEmpty();
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadBalancerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadBalancerTest.java
@@ -195,6 +195,7 @@ public class LoadBalancerTest {
      * those load reports can be deserialized and are in valid format tests if the rankings are populated from the load
      * reports are not, both broker will have zero rank
      */
+    @SuppressWarnings("unchecked")
     @Test
     public void testLoadReportsWrittenOnZK() throws Exception {
         ZooKeeper zkc = bkEnsemble.getZkClient();
@@ -289,6 +290,7 @@ public class LoadBalancerTest {
         Field ranking = ((SimpleLoadManagerImpl) pulsar.getLoadManager().get()).getClass()
                 .getDeclaredField("sortedRankings");
         ranking.setAccessible(true);
+        @SuppressWarnings("unchecked")
         AtomicReference<Map<Long, Set<ResourceUnit>>> sortedRanking = (AtomicReference<Map<Long, Set<ResourceUnit>>>) ranking
                 .get(pulsar.getLoadManager().get());
         return sortedRanking;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerImplTest.java
@@ -23,8 +23,8 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 
 import java.lang.reflect.Field;
@@ -76,7 +76,6 @@ import org.apache.zookeeper.ZooDefs;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -616,5 +615,7 @@ public class ModularLoadManagerImplTest {
         } catch (PulsarServerException e) {
             //Ok.
         }
+
+        pulsar.close();
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/SimpleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/SimpleLoadManagerImplTest.java
@@ -234,7 +234,7 @@ public class SimpleLoadManagerImplTest {
 
     }
 
-    private void setObjectField(Class objClass, Object objInstance, String fieldName, Object newValue)
+    private void setObjectField(Class<?> objClass, Object objInstance, String fieldName, Object newValue)
             throws Exception {
         Field field = objClass.getDeclaredField(fieldName);
         field.setAccessible(true);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceUnloadingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceUnloadingTest.java
@@ -53,7 +53,8 @@ public class NamespaceUnloadingTest extends BrokerTestBase {
     public void testUnloadPartiallyLoadedNamespace() throws Exception {
         admin.namespaces().createNamespace("prop/use/ns-test-2", 16);
 
-        Producer producer = pulsarClient.createProducer("persistent://prop/use/ns-test-2/my-topic");
+        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://prop/use/ns-test-2/my-topic")
+                .create();
 
         assertTrue(admin.namespaces().getNamespaces("prop", "use").contains("prop/use/ns-test-2"));
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AddMissingPatchVersionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/AddMissingPatchVersionTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.broker.service;
 
-import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.utils.PulsarBrokerVersionStringUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
@@ -31,11 +31,9 @@ import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.Authentication;
-import org.apache.pulsar.client.api.ClientConfiguration;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
-import org.apache.pulsar.client.api.ProducerConfiguration;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
@@ -129,18 +127,17 @@ public class BacklogQuotaManagerTest {
         assertEquals(admin.namespaces().getBacklogQuotaMap("prop/usc/ns-quota"), Maps.newTreeMap());
         admin.namespaces().setBacklogQuota("prop/usc/ns-quota",
                 new BacklogQuota(10 * 1024, BacklogQuota.RetentionPolicy.consumer_backlog_eviction));
-        ClientConfiguration clientConf = new ClientConfiguration();
-        clientConf.setStatsInterval(0, TimeUnit.SECONDS);
-        PulsarClient client = PulsarClient.create(adminUrl.toString(), clientConf);
+        PulsarClient client = PulsarClient.builder().serviceUrl(adminUrl.toString()).statsInterval(0, TimeUnit.SECONDS)
+                .build();
 
         final String topic1 = "persistent://prop/usc/ns-quota/topic1";
         final String subName1 = "c1";
         final String subName2 = "c2";
         final int numMsgs = 20;
 
-        Consumer consumer1 = client.subscribe(topic1, subName1);
-        Consumer consumer2 = client.subscribe(topic1, subName2);
-        org.apache.pulsar.client.api.Producer producer = client.createProducer(topic1);
+        Consumer<byte[]> consumer1 = client.newConsumer().topic(topic1).subscriptionName(subName1).subscribe();
+        Consumer<byte[]> consumer2 = client.newConsumer().topic(topic1).subscriptionName(subName2).subscribe();
+        org.apache.pulsar.client.api.Producer<byte[]> producer = client.newProducer().topic(topic1).create();
         byte[] content = new byte[1024];
         for (int i = 0; i < numMsgs; i++) {
             producer.send(content);
@@ -161,16 +158,16 @@ public class BacklogQuotaManagerTest {
         assertEquals(admin.namespaces().getBacklogQuotaMap("prop/usc/ns-quota"), Maps.newTreeMap());
         admin.namespaces().setBacklogQuota("prop/usc/ns-quota",
                 new BacklogQuota(10 * 1024, BacklogQuota.RetentionPolicy.consumer_backlog_eviction));
-        PulsarClient client = PulsarClient.create(adminUrl.toString());
+        PulsarClient client = PulsarClient.builder().serviceUrl(adminUrl.toString()).build();
 
         final String topic1 = "persistent://prop/usc/ns-quota/topic11";
         final String subName1 = "c11";
         final String subName2 = "c21";
         final int numMsgs = 20;
 
-        Consumer consumer1 = client.subscribe(topic1, subName1);
-        Consumer consumer2 = client.subscribe(topic1, subName2);
-        org.apache.pulsar.client.api.Producer producer = client.createProducer(topic1);
+        Consumer<byte[]> consumer1 = client.newConsumer().topic(topic1).subscriptionName(subName1).subscribe();
+        Consumer<byte[]> consumer2 = client.newConsumer().topic(topic1).subscriptionName(subName2).subscribe();
+        org.apache.pulsar.client.api.Producer<byte[]> producer = client.newProducer().topic(topic1).create();
         byte[] content = new byte[1024];
         for (int i = 0; i < numMsgs; i++) {
             producer.send(content);
@@ -201,18 +198,19 @@ public class BacklogQuotaManagerTest {
         final CyclicBarrier barrier = new CyclicBarrier(2);
         final CountDownLatch counter = new CountDownLatch(2);
         final AtomicBoolean gotException = new AtomicBoolean(false);
-        ClientConfiguration clientConf = new ClientConfiguration();
-        clientConf.setStatsInterval(0, TimeUnit.SECONDS);
-        PulsarClient client = PulsarClient.create(adminUrl.toString(), clientConf);
-        PulsarClient client2 = PulsarClient.create(adminUrl.toString(), clientConf);
-        Consumer consumer1 = client2.subscribe(topic1, subName1);
-        Consumer consumer2 = client2.subscribe(topic1, subName2);
+        PulsarClient client = PulsarClient.builder().serviceUrl(adminUrl.toString()).statsInterval(0, TimeUnit.SECONDS)
+                .build();
+        PulsarClient client2 = PulsarClient.builder().serviceUrl(adminUrl.toString()).statsInterval(0, TimeUnit.SECONDS)
+                .build();
+        Consumer<byte[]> consumer1 = client2.newConsumer().topic(topic1).subscriptionName(subName1).subscribe();
+        Consumer<byte[]> consumer2 = client2.newConsumer().topic(topic1).subscriptionName(subName2).subscribe();
 
         Thread producerThread = new Thread() {
             public void run() {
                 try {
                     barrier.await();
-                    final org.apache.pulsar.client.api.Producer producer = client.createProducer(topic1);
+                    org.apache.pulsar.client.api.Producer<byte[]> producer = client.newProducer().topic(topic1)
+                            .create();
                     byte[] content = new byte[1024];
                     for (int i = 0; i < numMsgs; i++) {
                         producer.send(content);
@@ -272,19 +270,20 @@ public class BacklogQuotaManagerTest {
         final CyclicBarrier barrier = new CyclicBarrier(2);
         final CountDownLatch counter = new CountDownLatch(2);
         final AtomicBoolean gotException = new AtomicBoolean(false);
-        final ClientConfiguration clientConf = new ClientConfiguration();
-        clientConf.setStatsInterval(0, TimeUnit.SECONDS);
-        final PulsarClient client = PulsarClient.create(adminUrl.toString(), clientConf);
+        final PulsarClient client = PulsarClient.builder().serviceUrl(adminUrl.toString())
+                .statsInterval(0, TimeUnit.SECONDS).build();
 
-        final Consumer consumer1 = client.subscribe(topic1, subName1);
-        final Consumer consumer2 = client.subscribe(topic1, subName2);
-        final PulsarClient client2 = PulsarClient.create(adminUrl.toString(), clientConf);
+        final Consumer<byte[]> consumer1 = client.newConsumer().topic(topic1).subscriptionName(subName1).subscribe();
+        final Consumer<byte[]> consumer2 = client.newConsumer().topic(topic1).subscriptionName(subName2).subscribe();
+        final PulsarClient client2 = PulsarClient.builder().serviceUrl(adminUrl.toString())
+                .statsInterval(0, TimeUnit.SECONDS).build();
 
         Thread producerThread = new Thread() {
             public void run() {
                 try {
                     barrier.await();
-                    org.apache.pulsar.client.api.Producer producer = client2.createProducer(topic1);
+                    org.apache.pulsar.client.api.Producer<byte[]> producer = client2.newProducer().topic(topic1)
+                            .create();
                     byte[] content = new byte[1024];
                     for (int i = 0; i < numMsgs; i++) {
                         producer.send(content);
@@ -336,20 +335,22 @@ public class BacklogQuotaManagerTest {
         final CyclicBarrier barrier = new CyclicBarrier(4);
         final CountDownLatch counter = new CountDownLatch(4);
         final AtomicBoolean gotException = new AtomicBoolean(false);
-        final ClientConfiguration clientConf = new ClientConfiguration();
-        clientConf.setStatsInterval(0, TimeUnit.SECONDS);
-        final PulsarClient client = PulsarClient.create(adminUrl.toString(), clientConf);
+        final PulsarClient client = PulsarClient.builder().serviceUrl(adminUrl.toString())
+                .statsInterval(0, TimeUnit.SECONDS).build();
 
-        final Consumer consumer1 = client.subscribe(topic1, subName1);
-        final Consumer consumer2 = client.subscribe(topic1, subName2);
-        final PulsarClient client3 = PulsarClient.create(adminUrl.toString(), clientConf);
-        final PulsarClient client2 = PulsarClient.create(adminUrl.toString(), clientConf);
+        final Consumer<byte[]> consumer1 = client.newConsumer().topic(topic1).subscriptionName(subName1).subscribe();
+        final Consumer<byte[]> consumer2 = client.newConsumer().topic(topic1).subscriptionName(subName2).subscribe();
+        final PulsarClient client3 = PulsarClient.builder().serviceUrl(adminUrl.toString())
+                .statsInterval(0, TimeUnit.SECONDS).build();
+        final PulsarClient client2 = PulsarClient.builder().serviceUrl(adminUrl.toString())
+                .statsInterval(0, TimeUnit.SECONDS).build();
 
         Thread producerThread1 = new Thread() {
             public void run() {
                 try {
                     barrier.await();
-                    org.apache.pulsar.client.api.Producer producer = client2.createProducer(topic1);
+                    org.apache.pulsar.client.api.Producer<byte[]> producer = client2.newProducer().topic(topic1)
+                            .create();
                     byte[] content = new byte[1024];
                     for (int i = 0; i < numMsgs; i++) {
                         producer.send(content);
@@ -367,7 +368,8 @@ public class BacklogQuotaManagerTest {
             public void run() {
                 try {
                     barrier.await();
-                    org.apache.pulsar.client.api.Producer producer = client3.createProducer(topic1);
+                    org.apache.pulsar.client.api.Producer<byte[]> producer = client3.newProducer().topic(topic1)
+                            .create();
                     byte[] content = new byte[1024];
                     for (int i = 0; i < numMsgs; i++) {
                         producer.send(content);
@@ -432,19 +434,16 @@ public class BacklogQuotaManagerTest {
         assertEquals(admin.namespaces().getBacklogQuotaMap("prop/usc/quotahold"), Maps.newTreeMap());
         admin.namespaces().setBacklogQuota("prop/usc/quotahold",
                 new BacklogQuota(10 * 1024, BacklogQuota.RetentionPolicy.producer_request_hold));
-        final ClientConfiguration clientConf = new ClientConfiguration();
-        clientConf.setStatsInterval(0, TimeUnit.SECONDS);
-        final PulsarClient client = PulsarClient.create(adminUrl.toString(), clientConf);
+        final PulsarClient client = PulsarClient.builder().serviceUrl(adminUrl.toString())
+                .statsInterval(0, TimeUnit.SECONDS).build();
         final String topic1 = "persistent://prop/usc/quotahold/hold";
         final String subName1 = "c1hold";
         final int numMsgs = 10;
 
-        Consumer consumer = client.subscribe(topic1, subName1);
-        ProducerConfiguration producerConfiguration = new ProducerConfiguration();
-        producerConfiguration.setSendTimeout(2, TimeUnit.SECONDS);
+        Consumer<byte[]> consumer = client.newConsumer().topic(topic1).subscriptionName(subName1).subscribe();
 
         byte[] content = new byte[1024];
-        Producer producer = client.createProducer(topic1, producerConfiguration);
+        Producer<byte[]> producer = client.newProducer().topic(topic1).sendTimeout(2, TimeUnit.SECONDS).create();
         for (int i = 0; i <= numMsgs; i++) {
             try {
                 producer.send(content);
@@ -473,19 +472,16 @@ public class BacklogQuotaManagerTest {
         assertEquals(admin.namespaces().getBacklogQuotaMap("prop/usc/quotahold"), Maps.newTreeMap());
         admin.namespaces().setBacklogQuota("prop/usc/quotahold",
                 new BacklogQuota(10 * 1024, BacklogQuota.RetentionPolicy.producer_request_hold));
-        final ClientConfiguration clientConf = new ClientConfiguration();
-        clientConf.setStatsInterval(0, TimeUnit.SECONDS);
-        final PulsarClient client = PulsarClient.create(adminUrl.toString(), clientConf);
+        final PulsarClient client = PulsarClient.builder().serviceUrl(adminUrl.toString())
+                .statsInterval(0, TimeUnit.SECONDS).build();
         final String topic1 = "persistent://prop/usc/quotahold/holdtimeout";
         final String subName1 = "c1holdtimeout";
         boolean gotException = false;
 
-        client.subscribe(topic1, subName1);
-        ProducerConfiguration producerConfiguration = new ProducerConfiguration();
-        producerConfiguration.setSendTimeout(2, TimeUnit.SECONDS);
+        client.newConsumer().topic(topic1).subscriptionName(subName1).subscribe();
 
         byte[] content = new byte[1024];
-        Producer producer = client.createProducer(topic1, producerConfiguration);
+        Producer<byte[]> producer = client.newProducer().topic(topic1).sendTimeout(2, TimeUnit.SECONDS).create();
         for (int i = 0; i < 10; i++) {
             producer.send(content);
         }
@@ -510,19 +506,16 @@ public class BacklogQuotaManagerTest {
         assertEquals(admin.namespaces().getBacklogQuotaMap("prop/usc/quotahold"), Maps.newTreeMap());
         admin.namespaces().setBacklogQuota("prop/usc/quotahold",
                 new BacklogQuota(10 * 1024, BacklogQuota.RetentionPolicy.producer_exception));
-        final ClientConfiguration clientConf = new ClientConfiguration();
-        clientConf.setStatsInterval(0, TimeUnit.SECONDS);
-        final PulsarClient client = PulsarClient.create(adminUrl.toString(), clientConf);
+        final PulsarClient client = PulsarClient.builder().serviceUrl(adminUrl.toString())
+                .statsInterval(0, TimeUnit.SECONDS).build();
         final String topic1 = "persistent://prop/usc/quotahold/except";
         final String subName1 = "c1except";
         boolean gotException = false;
 
-        client.subscribe(topic1, subName1);
-        ProducerConfiguration producerConfiguration = new ProducerConfiguration();
-        producerConfiguration.setSendTimeout(2, TimeUnit.SECONDS);
+        client.newConsumer().topic(topic1).subscriptionName(subName1).subscribe();
 
         byte[] content = new byte[1024];
-        Producer producer = client.createProducer(topic1, producerConfiguration);
+        Producer<byte[]> producer = client.newProducer().topic(topic1).sendTimeout(2, TimeUnit.SECONDS).create();
         for (int i = 0; i < 10; i++) {
             producer.send(content);
         }
@@ -549,19 +542,16 @@ public class BacklogQuotaManagerTest {
         assertEquals(admin.namespaces().getBacklogQuotaMap("prop/usc/quotahold"), Maps.newTreeMap());
         admin.namespaces().setBacklogQuota("prop/usc/quotahold",
                 new BacklogQuota(10 * 1024, BacklogQuota.RetentionPolicy.producer_exception));
-        final ClientConfiguration clientConf = new ClientConfiguration();
-        clientConf.setStatsInterval(0, TimeUnit.SECONDS);
-        final PulsarClient client = PulsarClient.create(adminUrl.toString(), clientConf);
+        final PulsarClient client = PulsarClient.builder().serviceUrl(adminUrl.toString())
+                .statsInterval(0, TimeUnit.SECONDS).build();
         final String topic1 = "persistent://prop/usc/quotahold/exceptandunblock";
         final String subName1 = "c1except";
         boolean gotException = false;
 
-        Consumer consumer = client.subscribe(topic1, subName1);
-        ProducerConfiguration producerConfiguration = new ProducerConfiguration();
-        producerConfiguration.setSendTimeout(2, TimeUnit.SECONDS);
+        Consumer<byte[]> consumer = client.newConsumer().topic(topic1).subscriptionName(subName1).subscribe();
 
         byte[] content = new byte[1024];
-        Producer producer = client.createProducer(topic1, producerConfiguration);
+        Producer<byte[]> producer = client.newProducer().topic(topic1).sendTimeout(2, TimeUnit.SECONDS).create();
         for (int i = 0; i < 10; i++) {
             producer.send(content);
         }
@@ -586,7 +576,7 @@ public class BacklogQuotaManagerTest {
         int backlog = (int) stats.subscriptions.get(subName1).msgBacklog;
 
         for (int i = 0; i < backlog; i++) {
-            Message msg = consumer.receive();
+            Message<?> msg = consumer.receive();
             consumer.acknowledge(msg);
         }
         Thread.sleep((TIME_TO_CHECK_BACKLOG_QUOTA + 1) * 1000);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -55,16 +55,14 @@ import org.apache.pulsar.broker.service.BrokerServiceException.PersistenceExcept
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.BrokerStats;
 import org.apache.pulsar.client.api.Authentication;
-import org.apache.pulsar.client.api.ClientConfiguration;
 import org.apache.pulsar.client.api.Consumer;
-import org.apache.pulsar.client.api.ConsumerConfiguration;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.auth.AuthenticationTls;
-import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.naming.NamespaceBundle;
+import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.BundlesData;
 import org.apache.pulsar.common.policies.data.LocalPolicies;
 import org.apache.pulsar.common.policies.data.PersistentTopicStats;
@@ -76,6 +74,8 @@ import org.testng.annotations.Test;
 import com.google.common.collect.Lists;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+
+import lombok.Cleanup;
 
 /**
  */
@@ -140,9 +140,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         PersistentTopicStats stats;
         SubscriptionStats subStats;
 
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-        Consumer consumer = pulsarClient.subscribe(topicName, subName, conf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName).subscribe();
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
@@ -157,7 +155,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         assertEquals(subStats.msgBacklog, 0);
         assertEquals(subStats.consumers.size(), 1);
 
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
 
         for (int i = 0; i < 10; i++) {
@@ -195,7 +193,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         assertEquals(stats.msgThroughputOut, subStats.consumers.get(0).msgThroughputOut);
         assertNotNull(subStats.consumers.get(0).clientVersion);
 
-        Message msg;
+        Message<byte[]> msg;
         for (int i = 0; i < 10; i++) {
             msg = consumer.receive();
             consumer.acknowledge(msg);
@@ -218,9 +216,8 @@ public class BrokerServiceTest extends BrokerTestBase {
         PersistentTopicStats stats;
         SubscriptionStats subStats;
 
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Shared);
-        Consumer consumer = pulsarClient.subscribe(topicName, subName, conf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                .subscriptionType(SubscriptionType.Shared).subscribe();
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
@@ -235,7 +232,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         assertEquals(subStats.msgBacklog, 0);
         assertEquals(subStats.consumers.size(), 1);
 
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
 
         for (int i = 0; i < 10; i++) {
@@ -285,7 +282,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         assertTrue(subStats.msgRateRedeliver > 0.0);
         assertEquals(subStats.msgRateRedeliver, subStats.consumers.get(0).msgRateRedeliver);
 
-        Message msg;
+        Message<byte[]> msg;
         for (int i = 0; i < 10; i++) {
             msg = consumer.receive();
             consumer.acknowledge(msg);
@@ -306,12 +303,10 @@ public class BrokerServiceTest extends BrokerTestBase {
         final String subName = "newSub";
         BrokerStats brokerStatsClient = admin.brokerStats();
 
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-        Consumer consumer = pulsarClient.subscribe(topicName, subName, conf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName).subscribe();
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
 
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
 
         for (int i = 0; i < 10; i++) {
@@ -319,7 +314,7 @@ public class BrokerServiceTest extends BrokerTestBase {
             producer.send(message.getBytes());
         }
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
-        Message msg = null;
+        Message<byte[]> msg = null;
         for (int i = 0; i < 10; i++) {
             msg = consumer.receive();
             consumer.acknowledge(msg);
@@ -333,7 +328,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         // is the order really relevant here?
         boolean namespaceDimensionFound = false;
         boolean topicLoadTimesDimensionFound = false;
-        for ( int i=0; i<metrics.size(); i++ ) {
+        for (int i = 0; i < metrics.size(); i++) {
             try {
                 String data = metrics.get(i).getAsJsonObject().get("dimensions").toString();
                 if (!namespaceDimensionFound && data.contains("prop/use/ns-abc")) {
@@ -342,7 +337,8 @@ public class BrokerServiceTest extends BrokerTestBase {
                 if (!topicLoadTimesDimensionFound && data.contains("prop/use/ns-abc")) {
                     topicLoadTimesDimensionFound = true;
                 }
-            } catch (Exception e) { /* it's possible there's no dimensions */ }
+            } catch (Exception e) {
+                /* it's possible there's no dimensions */ }
         }
 
         assertTrue(namespaceDimensionFound && topicLoadTimesDimensionFound);
@@ -350,7 +346,6 @@ public class BrokerServiceTest extends BrokerTestBase {
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void testBrokerServiceNamespaceStats() throws Exception {
         final int numBundles = 4;
@@ -358,16 +353,16 @@ public class BrokerServiceTest extends BrokerTestBase {
         final String ns2 = "prop/use/stats2";
 
         List<String> nsList = Lists.newArrayList(ns1, ns2);
-        List<Producer> producerList = Lists.newArrayList();
+        List<Producer<byte[]>> producerList = Lists.newArrayList();
 
         BrokerStats brokerStatsClient = admin.brokerStats();
 
         for (String ns : nsList) {
             admin.namespaces().createNamespace(ns, numBundles);
             String topic1 = String.format("persistent://%s/topic1", ns);
-            producerList.add(pulsarClient.createProducer(topic1));
+            producerList.add(pulsarClient.newProducer().topic(topic1).create());
             String topic2 = String.format("persistent://%s/topic2", ns);
-            producerList.add(pulsarClient.createProducer(topic2));
+            producerList.add(pulsarClient.newProducer().topic(topic2).create());
         }
 
         rolloverPerIntervalStats();
@@ -378,8 +373,7 @@ public class BrokerServiceTest extends BrokerTestBase {
             JsonObject nsObject = topicStats.getAsJsonObject(ns);
             List<String> topicList = admin.namespaces().getTopics(ns);
             for (String topic : topicList) {
-                NamespaceBundle bundle = (NamespaceBundle) pulsar.getNamespaceService()
-                        .getBundle(TopicName.get(topic));
+                NamespaceBundle bundle = (NamespaceBundle) pulsar.getNamespaceService().getBundle(TopicName.get(topic));
                 JsonObject bundleObject = nsObject.getAsJsonObject(bundle.getBundleRange());
                 JsonObject topicObject = bundleObject.getAsJsonObject("persistent");
                 AtomicBoolean topicPresent = new AtomicBoolean();
@@ -392,9 +386,10 @@ public class BrokerServiceTest extends BrokerTestBase {
             }
         }
 
-        for (Producer producer : producerList) {
+        for (Producer<?> producer : producerList) {
             producer.close();
         }
+
         for (String ns : nsList) {
             List<String> topics = admin.namespaces().getTopics(ns);
             for (String dest : topics) {
@@ -408,9 +403,6 @@ public class BrokerServiceTest extends BrokerTestBase {
     public void testTlsDisabled() throws Exception {
         final String topicName = "persistent://prop/use/ns-abc/newTopic";
         final String subName = "newSub";
-        ClientConfiguration clientConfig;
-        ConsumerConfiguration consumerConfig;
-        Consumer consumer;
         PulsarClient pulsarClient = null;
 
         conf.setAuthenticationEnabled(false);
@@ -419,13 +411,11 @@ public class BrokerServiceTest extends BrokerTestBase {
 
         // Case 1: Access without TLS
         try {
-            clientConfig = new ClientConfiguration();
-            clientConfig.setStatsInterval(0, TimeUnit.SECONDS);
-            pulsarClient = PulsarClient.create(brokerUrl.toString(), clientConfig);
-            consumerConfig = new ConsumerConfiguration();
-            consumerConfig.setSubscriptionType(SubscriptionType.Exclusive);
-            consumer = pulsarClient.subscribe(topicName, subName, consumerConfig);
-            consumer.close();
+            pulsarClient = PulsarClient.builder().serviceUrl(brokerUrl.toString()).statsInterval(0, TimeUnit.SECONDS)
+                    .build();
+            @Cleanup
+            Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                    .subscribe();
         } catch (Exception e) {
             fail("should not fail");
         } finally {
@@ -434,14 +424,13 @@ public class BrokerServiceTest extends BrokerTestBase {
 
         // Case 2: Access with TLS
         try {
-            clientConfig = new ClientConfiguration();
-            clientConfig.setUseTls(true);
-            clientConfig.setStatsInterval(0, TimeUnit.SECONDS);
-            pulsarClient = PulsarClient.create(brokerUrlTls.toString(), clientConfig);
-            consumerConfig = new ConsumerConfiguration();
-            consumerConfig.setSubscriptionType(SubscriptionType.Exclusive);
-            consumer = pulsarClient.subscribe(topicName, subName, consumerConfig);
-            consumer.close();
+            pulsarClient = PulsarClient.builder().serviceUrl(brokerUrlTls.toString()).enableTls(true)
+                    .statsInterval(0, TimeUnit.SECONDS).build();
+
+            @Cleanup
+            Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                    .subscribe();
+
             fail("TLS connection should fail");
         } catch (Exception e) {
             assertTrue(e.getMessage().contains("ConnectException"));
@@ -454,9 +443,6 @@ public class BrokerServiceTest extends BrokerTestBase {
     public void testTlsEnabled() throws Exception {
         final String topicName = "persistent://prop/use/ns-abc/newTopic";
         final String subName = "newSub";
-        ClientConfiguration clientConfig;
-        ConsumerConfiguration consumerConfig;
-        Consumer consumer;
 
         conf.setAuthenticationEnabled(false);
         conf.setTlsEnabled(true);
@@ -467,13 +453,11 @@ public class BrokerServiceTest extends BrokerTestBase {
         // Case 1: Access without TLS
         PulsarClient pulsarClient = null;
         try {
-            clientConfig = new ClientConfiguration();
-            clientConfig.setStatsInterval(0, TimeUnit.SECONDS);
-            pulsarClient = PulsarClient.create(brokerUrl.toString(), clientConfig);
-            consumerConfig = new ConsumerConfiguration();
-            consumerConfig.setSubscriptionType(SubscriptionType.Exclusive);
-            consumer = pulsarClient.subscribe(topicName, subName, consumerConfig);
-            consumer.close();
+            pulsarClient = PulsarClient.builder().serviceUrl(brokerUrl.toString()).statsInterval(0, TimeUnit.SECONDS)
+                    .build();
+            @Cleanup
+            Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                    .subscribe();
         } catch (Exception e) {
             fail("should not fail");
         } finally {
@@ -482,15 +466,13 @@ public class BrokerServiceTest extends BrokerTestBase {
 
         // Case 2: Access with TLS (Allow insecure TLS connection)
         try {
-            clientConfig = new ClientConfiguration();
-            clientConfig.setUseTls(true);
-            clientConfig.setTlsAllowInsecureConnection(true);
-            clientConfig.setStatsInterval(0, TimeUnit.SECONDS);
-            pulsarClient = PulsarClient.create(brokerUrlTls.toString(), clientConfig);
-            consumerConfig = new ConsumerConfiguration();
-            consumerConfig.setSubscriptionType(SubscriptionType.Exclusive);
-            consumer = pulsarClient.subscribe(topicName, subName, consumerConfig);
-            consumer.close();
+            pulsarClient = PulsarClient.builder().serviceUrl(brokerUrlTls.toString()).enableTls(true)
+                    .allowTlsInsecureConnection(true).statsInterval(0, TimeUnit.SECONDS).build();
+
+            @Cleanup
+            Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                    .subscribe();
+
         } catch (Exception e) {
             fail("should not fail");
         } finally {
@@ -499,15 +481,13 @@ public class BrokerServiceTest extends BrokerTestBase {
 
         // Case 3: Access with TLS (Disallow insecure TLS connection)
         try {
-            clientConfig = new ClientConfiguration();
-            clientConfig.setUseTls(true);
-            clientConfig.setTlsAllowInsecureConnection(false);
-            clientConfig.setStatsInterval(0, TimeUnit.SECONDS);
-            pulsarClient = PulsarClient.create(brokerUrlTls.toString(), clientConfig);
-            consumerConfig = new ConsumerConfiguration();
-            consumerConfig.setSubscriptionType(SubscriptionType.Exclusive);
-            consumer = pulsarClient.subscribe(topicName, subName, consumerConfig);
-            consumer.close();
+            pulsarClient = PulsarClient.builder().serviceUrl(brokerUrlTls.toString()).enableTls(true)
+                    .allowTlsInsecureConnection(false).statsInterval(0, TimeUnit.SECONDS).build();
+
+            @Cleanup
+            Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                    .subscribe();
+
             fail("should fail");
         } catch (Exception e) {
             assertTrue(e.getMessage().contains("General OpenSslEngine problem"));
@@ -517,16 +497,13 @@ public class BrokerServiceTest extends BrokerTestBase {
 
         // Case 4: Access with TLS (Use trusted certificates)
         try {
-            clientConfig = new ClientConfiguration();
-            clientConfig.setUseTls(true);
-            clientConfig.setTlsAllowInsecureConnection(false);
-            clientConfig.setTlsTrustCertsFilePath(TLS_SERVER_CERT_FILE_PATH);
-            clientConfig.setStatsInterval(0, TimeUnit.SECONDS);
-            pulsarClient = PulsarClient.create(brokerUrlTls.toString(), clientConfig);
-            consumerConfig = new ConsumerConfiguration();
-            consumerConfig.setSubscriptionType(SubscriptionType.Exclusive);
-            consumer = pulsarClient.subscribe(topicName, subName, consumerConfig);
-            consumer.close();
+            pulsarClient = PulsarClient.builder().serviceUrl(brokerUrlTls.toString()).enableTls(true)
+                    .allowTlsInsecureConnection(false).tlsTrustCertsFilePath(TLS_SERVER_CERT_FILE_PATH)
+                    .statsInterval(0, TimeUnit.SECONDS).build();
+
+            @Cleanup
+            Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                    .subscribe();
         } catch (Exception e) {
             fail("should not fail");
         } finally {
@@ -534,13 +511,11 @@ public class BrokerServiceTest extends BrokerTestBase {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testTlsAuthAllowInsecure() throws Exception {
         final String topicName = "persistent://prop/usw/my-ns/newTopic";
         final String subName = "newSub";
-        ClientConfiguration clientConfig;
-        ConsumerConfiguration consumerConfig;
-        Consumer consumer;
         Authentication auth;
 
         Set<String> providers = new HashSet<>();
@@ -562,15 +537,13 @@ public class BrokerServiceTest extends BrokerTestBase {
 
         // Case 1: Access without client certificate
         try {
-            clientConfig = new ClientConfiguration();
-            clientConfig.setUseTls(true);
-            clientConfig.setTlsAllowInsecureConnection(true);
-            clientConfig.setStatsInterval(0, TimeUnit.SECONDS);
-            pulsarClient = PulsarClient.create(brokerUrlTls.toString(), clientConfig);
-            consumerConfig = new ConsumerConfiguration();
-            consumerConfig.setSubscriptionType(SubscriptionType.Exclusive);
-            consumer = pulsarClient.subscribe(topicName, subName, consumerConfig);
-            consumer.close();
+            pulsarClient = PulsarClient.builder().serviceUrl(brokerUrlTls.toString()).enableTls(true)
+                    .allowTlsInsecureConnection(true).statsInterval(0, TimeUnit.SECONDS).build();
+
+            @Cleanup
+            Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                    .subscribe();
+
             fail("should fail");
         } catch (Exception e) {
             assertTrue(e.getMessage().contains("Authentication required"));
@@ -582,16 +555,14 @@ public class BrokerServiceTest extends BrokerTestBase {
         try {
             auth = new AuthenticationTls();
             auth.configure(authParams);
-            clientConfig = new ClientConfiguration();
-            clientConfig.setAuthentication(auth);
-            clientConfig.setUseTls(true);
-            clientConfig.setTlsAllowInsecureConnection(true);
-            clientConfig.setStatsInterval(0, TimeUnit.SECONDS);
-            pulsarClient = PulsarClient.create(brokerUrlTls.toString(), clientConfig);
-            consumerConfig = new ConsumerConfiguration();
-            consumerConfig.setSubscriptionType(SubscriptionType.Exclusive);
-            consumer = pulsarClient.subscribe(topicName, subName, consumerConfig);
-            consumer.close();
+
+            pulsarClient = PulsarClient.builder().authentication(auth).serviceUrl(brokerUrlTls.toString())
+                    .enableTls(true).allowTlsInsecureConnection(true).statsInterval(0, TimeUnit.SECONDS).build();
+
+            @Cleanup
+            Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                    .subscribe();
+
         } catch (Exception e) {
             fail("should not fail");
         } finally {
@@ -599,13 +570,11 @@ public class BrokerServiceTest extends BrokerTestBase {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testTlsAuthDisallowInsecure() throws Exception {
         final String topicName = "persistent://prop/usw/my-ns/newTopic";
         final String subName = "newSub";
-        ClientConfiguration clientConfig;
-        ConsumerConfiguration consumerConfig;
-        Consumer consumer;
         Authentication auth;
 
         Set<String> providers = new HashSet<>();
@@ -627,15 +596,13 @@ public class BrokerServiceTest extends BrokerTestBase {
 
         // Case 1: Access without client certificate
         try {
-            clientConfig = new ClientConfiguration();
-            clientConfig.setUseTls(true);
-            clientConfig.setTlsAllowInsecureConnection(true);
-            clientConfig.setStatsInterval(0, TimeUnit.SECONDS);
-            pulsarClient = PulsarClient.create(brokerUrlTls.toString(), clientConfig);
-            consumerConfig = new ConsumerConfiguration();
-            consumerConfig.setSubscriptionType(SubscriptionType.Exclusive);
-            consumer = pulsarClient.subscribe(topicName, subName, consumerConfig);
-            consumer.close();
+            pulsarClient = PulsarClient.builder().serviceUrl(brokerUrlTls.toString()).enableTls(true)
+                    .allowTlsInsecureConnection(true).statsInterval(0, TimeUnit.SECONDS).build();
+
+            @Cleanup
+            Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                    .subscribe();
+
             fail("should fail");
         } catch (Exception e) {
             assertTrue(e.getMessage().contains("Authentication required"));
@@ -647,16 +614,12 @@ public class BrokerServiceTest extends BrokerTestBase {
         try {
             auth = new AuthenticationTls();
             auth.configure(authParams);
-            clientConfig = new ClientConfiguration();
-            clientConfig.setAuthentication(auth);
-            clientConfig.setUseTls(true);
-            clientConfig.setTlsAllowInsecureConnection(true);
-            clientConfig.setStatsInterval(0, TimeUnit.SECONDS);
-            pulsarClient = PulsarClient.create(brokerUrlTls.toString(), clientConfig);
-            consumerConfig = new ConsumerConfiguration();
-            consumerConfig.setSubscriptionType(SubscriptionType.Exclusive);
-            consumer = pulsarClient.subscribe(topicName, subName, consumerConfig);
-            consumer.close();
+            pulsarClient = PulsarClient.builder().authentication(auth).serviceUrl(brokerUrlTls.toString())
+                    .enableTls(true).allowTlsInsecureConnection(true).statsInterval(0, TimeUnit.SECONDS).build();
+
+            @Cleanup
+            Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                    .subscribe();
             fail("should fail");
         } catch (Exception e) {
             assertTrue(e.getMessage().contains("Authentication required"));
@@ -665,13 +628,11 @@ public class BrokerServiceTest extends BrokerTestBase {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testTlsAuthUseTrustCert() throws Exception {
         final String topicName = "persistent://prop/usw/my-ns/newTopic";
         final String subName = "newSub";
-        ClientConfiguration clientConfig;
-        ConsumerConfiguration consumerConfig;
-        Consumer consumer;
         Authentication auth;
 
         Set<String> providers = new HashSet<>();
@@ -694,15 +655,12 @@ public class BrokerServiceTest extends BrokerTestBase {
 
         // Case 1: Access without client certificate
         try {
-            clientConfig = new ClientConfiguration();
-            clientConfig.setUseTls(true);
-            clientConfig.setTlsAllowInsecureConnection(true);
-            clientConfig.setStatsInterval(0, TimeUnit.SECONDS);
-            pulsarClient = PulsarClient.create(brokerUrlTls.toString(), clientConfig);
-            consumerConfig = new ConsumerConfiguration();
-            consumerConfig.setSubscriptionType(SubscriptionType.Exclusive);
-            consumer = pulsarClient.subscribe(topicName, subName, consumerConfig);
-            consumer.close();
+            pulsarClient = PulsarClient.builder().serviceUrl(brokerUrlTls.toString()).enableTls(true)
+                    .allowTlsInsecureConnection(true).statsInterval(0, TimeUnit.SECONDS).build();
+
+            @Cleanup
+            Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                    .subscribe();
             fail("should fail");
         } catch (Exception e) {
             assertTrue(e.getMessage().contains("Authentication required"));
@@ -714,16 +672,12 @@ public class BrokerServiceTest extends BrokerTestBase {
         try {
             auth = new AuthenticationTls();
             auth.configure(authParams);
-            clientConfig = new ClientConfiguration();
-            clientConfig.setAuthentication(auth);
-            clientConfig.setUseTls(true);
-            clientConfig.setTlsAllowInsecureConnection(true);
-            clientConfig.setStatsInterval(0, TimeUnit.SECONDS);
-            pulsarClient = PulsarClient.create(brokerUrlTls.toString(), clientConfig);
-            consumerConfig = new ConsumerConfiguration();
-            consumerConfig.setSubscriptionType(SubscriptionType.Exclusive);
-            consumer = pulsarClient.subscribe(topicName, subName, consumerConfig);
-            consumer.close();
+            pulsarClient = PulsarClient.builder().authentication(auth).serviceUrl(brokerUrlTls.toString())
+                    .enableTls(true).allowTlsInsecureConnection(true).statsInterval(0, TimeUnit.SECONDS).build();
+
+            @Cleanup
+            Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                    .subscribe();
         } catch (Exception e) {
             fail("should not fail");
         } finally {
@@ -740,14 +694,12 @@ public class BrokerServiceTest extends BrokerTestBase {
     public void testLookupThrottlingForClientByClient() throws Exception {
         final String topicName = "persistent://prop/usw/my-ns/newTopic";
 
-        org.apache.pulsar.client.api.ClientConfiguration clientConf = new org.apache.pulsar.client.api.ClientConfiguration();
-        clientConf.setStatsInterval(0, TimeUnit.SECONDS);
-        clientConf.setConcurrentLookupRequest(0);
         String lookupUrl = new URI("pulsar://localhost:" + BROKER_PORT).toString();
-        PulsarClient pulsarClient = PulsarClient.create(lookupUrl, clientConf);
+        PulsarClient pulsarClient = PulsarClient.builder().serviceUrl(lookupUrl).statsInterval(0, TimeUnit.SECONDS)
+                .maxConcurrentLookupRequests(0).build();
 
         try {
-            Consumer consumer = pulsarClient.subscribe(topicName, "mysub", new ConsumerConfiguration());
+            pulsarClient.newConsumer().topic(topicName).subscriptionName("mysub").subscribe();
             fail("It should fail as throttling should not receive any request");
         } catch (org.apache.pulsar.client.api.PulsarClientException.TooManyRequestsException e) {
             // ok as throttling set to 0
@@ -762,7 +714,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         // own namespace bundle
         final String topicName = "persistent://" + namespace + "/my-topic";
         TopicName topic = TopicName.get(topicName);
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         producer.close();
 
         // disable namespace-bundle
@@ -796,7 +748,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         // let this broker own this namespace bundle by creating a topic
         try {
             final String successfulTopic = "persistent://" + namespace + "/ownBundleTopic";
-            Producer producer = pulsarClient.createProducer(successfulTopic);
+            Producer<byte[]> producer = pulsarClient.newProducer().topic(successfulTopic).create();
             producer.close();
         } catch (Exception e) {
             fail(e.getMessage());
@@ -839,7 +791,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         // let this broker own this namespace bundle by creating a topic
         try {
             final String successfulTopic = "persistent://" + namespace + "/ownBundleTopic";
-            Producer producer = pulsarClient.createProducer(successfulTopic);
+            Producer<byte[]> producer = pulsarClient.newProducer().topic(successfulTopic).create();
             producer.close();
         } catch (Exception e) {
             fail(e.getMessage());
@@ -856,6 +808,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         // fail managed-ledger future
         Field ledgerField = ManagedLedgerFactoryImpl.class.getDeclaredField("ledgers");
         ledgerField.setAccessible(true);
+        @SuppressWarnings("unchecked")
         ConcurrentHashMap<String, CompletableFuture<ManagedLedgerImpl>> ledgers = (ConcurrentHashMap<String, CompletableFuture<ManagedLedgerImpl>>) ledgerField
                 .get(pulsar.getManagedLedgerFactory());
         CompletableFuture<ManagedLedgerImpl> future = new CompletableFuture<>();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PeerReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PeerReplicatorTest.java
@@ -28,13 +28,10 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.PulsarAdminException;
-import org.apache.pulsar.client.api.ClientConfiguration;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.policies.data.PersistentTopicStats;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -73,9 +70,9 @@ public class PeerReplicatorTest extends ReplicatorTestBase {
      * 5. Try to create producer using broker in cluster r3
      * 6. Success : "r3" finds "r1" in peer cluster which owns n1 and redirects to "r1"
      * 7. call admin-api to "r3" which redirects request to "r1"
-     * 
+     *
      * </pre>
-     * 
+     *
      * @param protocol
      * @throws Exception
      */
@@ -99,14 +96,11 @@ public class PeerReplicatorTest extends ReplicatorTestBase {
 
         final String topic1 = "persistent://" + namespace1 + "/topic1";
         final String topic2 = "persistent://" + namespace2 + "/topic2";
-        ClientConfiguration conf = new ClientConfiguration();
-        conf.setStatsInterval(0, TimeUnit.SECONDS);
 
-        PulsarClient client3 = PulsarClient.create(serviceUrl, conf);
-        Producer producer;
+        PulsarClient client3 = PulsarClient.builder().serviceUrl(serviceUrl).statsInterval(0, TimeUnit.SECONDS).build();
         try {
             // try to create producer for topic1 (part of cluster: r1) by calling cluster: r3
-            producer = client3.createProducer(topic1);
+            client3.newProducer().topic(topic1).create();
             fail("should have failed as cluster:r3 doesn't own namespace");
         } catch (PulsarClientException e) {
             // Ok
@@ -114,7 +108,7 @@ public class PeerReplicatorTest extends ReplicatorTestBase {
 
         try {
             // try to create producer for topic2 (part of cluster: r2) by calling cluster: r3
-            producer = client3.createProducer(topic2);
+            client3.newProducer().topic(topic2).create();
             fail("should have failed as cluster:r3 doesn't own namespace");
         } catch (PulsarClientException e) {
             // Ok
@@ -122,7 +116,7 @@ public class PeerReplicatorTest extends ReplicatorTestBase {
 
         // set peer-clusters : r3->r1
         admin1.clusters().updatePeerClusterNames("r3", Sets.newLinkedHashSet(Lists.newArrayList("r1")));
-        producer = client3.createProducer(topic1);
+        Producer<byte[]> producer = client3.newProducer().topic(topic1).create();
         PersistentTopic topic = (PersistentTopic) pulsar1.getBrokerService().getTopic(topic1).get();
         assertNotNull(topic);
         pulsar1.getBrokerService().updateRates();
@@ -137,7 +131,7 @@ public class PeerReplicatorTest extends ReplicatorTestBase {
 
         // set peer-clusters : r3->r2
         admin2.clusters().updatePeerClusterNames("r3", Sets.newLinkedHashSet(Lists.newArrayList("r2")));
-        producer = client3.createProducer(topic2);
+        producer = client3.newProducer().topic(topic2).create();
         topic = (PersistentTopic) pulsar2.getBrokerService().getTopic(topic2).get();
         assertNotNull(topic);
         pulsar2.getBrokerService().updateRates();
@@ -169,7 +163,4 @@ public class PeerReplicatorTest extends ReplicatorTestBase {
 		}, 5, 100);
 		assertEquals(admin1.clusters().getPeerClusterNames(mainClusterName), peerClusters);
 	}
-    
-    private static final Logger log = LoggerFactory.getLogger(PeerReplicatorTest.class);
-
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
@@ -409,7 +409,7 @@ public class PersistentDispatcherFailoverConsumerTest {
         // 11. With only one consumer, unsubscribe is allowed
         assertTrue(pdfc.canUnsubscribe(consumer1));
     }
-    
+
     @Test
     public void testMultipleDispatcherGetNextConsumerWithDifferentPriorityLevel() throws Exception {
 
@@ -561,14 +561,15 @@ public class PersistentDispatcherFailoverConsumerTest {
         Assert.assertEquals(getNextConsumer(dispatcher), null);
     }
 
+    @SuppressWarnings("unchecked")
     private Consumer getNextConsumer(PersistentDispatcherMultipleConsumers dispatcher) throws Exception {
-        
+
         Consumer consumer = dispatcher.getNextConsumer();
-        
+
         if (consumer != null) {
             Field field = Consumer.class.getDeclaredField("MESSAGE_PERMITS_UPDATER");
             field.setAccessible(true);
-            AtomicIntegerFieldUpdater<Consumer> messagePermits = (AtomicIntegerFieldUpdater) field.get(consumer);
+            AtomicIntegerFieldUpdater<Consumer> messagePermits = (AtomicIntegerFieldUpdater<Consumer>) field.get(consumer);
             messagePermits.decrementAndGet(consumer);
             return consumer;
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentFailoverE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentFailoverE2ETest.java
@@ -24,7 +24,6 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
-import com.google.common.collect.Sets;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -36,15 +35,14 @@ import org.apache.pulsar.broker.service.persistent.PersistentDispatcherSingleAct
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.api.Consumer;
-import org.apache.pulsar.client.api.ConsumerConfiguration;
+import org.apache.pulsar.client.api.ConsumerBuilder;
 import org.apache.pulsar.client.api.ConsumerEventListener;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.client.api.Producer;
-import org.apache.pulsar.client.api.ProducerConfiguration;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.SubscriptionType;
-import org.apache.pulsar.client.api.ProducerConfiguration.MessageRoutingMode;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 import org.apache.pulsar.common.naming.TopicName;
@@ -55,6 +53,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 public class PersistentFailoverE2ETest extends BrokerTestBase {
 
@@ -78,7 +77,7 @@ public class PersistentFailoverE2ETest extends BrokerTestBase {
         final LinkedBlockingQueue<Integer> inActiveQueue = new LinkedBlockingQueue<>();
 
         @Override
-        public void becameActive(Consumer consumer, int partitionId) {
+        public void becameActive(Consumer<?> consumer, int partitionId) {
             try {
                 activeQueue.put(partitionId);
             } catch (InterruptedException e) {
@@ -86,7 +85,7 @@ public class PersistentFailoverE2ETest extends BrokerTestBase {
         }
 
         @Override
-        public void becameInactive(Consumer consumer, int partitionId) {
+        public void becameInactive(Consumer<?> consumer, int partitionId) {
             try {
                 inActiveQueue.put(partitionId);
             } catch (InterruptedException e) {
@@ -115,13 +114,13 @@ public class PersistentFailoverE2ETest extends BrokerTestBase {
         private final Set<Integer> inactivePtns = Sets.newHashSet();
 
         @Override
-        public synchronized void becameActive(Consumer consumer, int partitionId) {
+        public synchronized void becameActive(Consumer<?> consumer, int partitionId) {
             activePtns.add(partitionId);
             inactivePtns.remove(partitionId);
         }
 
         @Override
-        public synchronized void becameInactive(Consumer consumer, int partitionId) {
+        public synchronized void becameInactive(Consumer<?> consumer, int partitionId) {
             activePtns.remove(partitionId);
             inactivePtns.add(partitionId);
         }
@@ -134,20 +133,17 @@ public class PersistentFailoverE2ETest extends BrokerTestBase {
         final int numMsgs = 100;
 
         TestConsumerStateEventListener listener1 = new TestConsumerStateEventListener();
-        ConsumerConfiguration consumerConf1 = new ConsumerConfiguration();
-        consumerConf1.setSubscriptionType(SubscriptionType.Failover);
-        consumerConf1.setConsumerName("1");
-        consumerConf1.setConsumerEventListener(listener1);
-
         TestConsumerStateEventListener listener2 = new TestConsumerStateEventListener();
-        ConsumerConfiguration consumerConf2 = new ConsumerConfiguration();
-        consumerConf2.setSubscriptionType(SubscriptionType.Failover);
-        consumerConf2.setConsumerName("2");
-        consumerConf2.setConsumerEventListener(listener2);
+        ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                .subscriptionType(SubscriptionType.Failover);
+
 
         // 1. two consumers on the same subscription
-        Consumer consumer1 = pulsarClient.subscribe(topicName, subName, consumerConf1);
-        Consumer consumer2 = pulsarClient.subscribe(topicName, subName, consumerConf2);
+        ConsumerBuilder<byte[]> consumerBulder1 = consumerBuilder.clone().consumerName("1")
+                .consumerEventListener(listener1);
+        Consumer<byte[]> consumer1 = consumerBulder1.subscribe();
+        Consumer<byte[]> consumer2 = consumerBuilder.clone().consumerName("2").consumerEventListener(listener2)
+                .subscribe();
         verifyConsumerActive(listener1, -1);
         verifyConsumerInactive(listener2, -1);
 
@@ -162,7 +158,7 @@ public class PersistentFailoverE2ETest extends BrokerTestBase {
         assertEquals(subRef.getDispatcher().getType(), SubType.Failover);
 
         List<CompletableFuture<MessageId>> futures = Lists.newArrayListWithCapacity(numMsgs);
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         for (int i = 0; i < numMsgs; i++) {
             String message = "my-message-" + i;
             futures.add(producer.sendAsync(message.getBytes()));
@@ -176,7 +172,7 @@ public class PersistentFailoverE2ETest extends BrokerTestBase {
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
 
         // 3. consumer1 should have all the messages while consumer2 should have no messages
-        Message msg = null;
+        Message<byte[]> msg = null;
         Assert.assertNull(consumer2.receive(1, TimeUnit.SECONDS));
         for (int i = 0; i < numMsgs; i++) {
             msg = consumer1.receive(1, TimeUnit.SECONDS);
@@ -242,7 +238,7 @@ public class PersistentFailoverE2ETest extends BrokerTestBase {
             Assert.assertEquals(new String(msg.getData()), "my-message-" + i);
             consumer2.acknowledge(msg);
         }
-        consumer1 = pulsarClient.subscribe(topicName, subName, consumerConf1);
+        consumer1 = consumerBulder1.subscribe();
         Thread.sleep(CONSUMER_ADD_OR_REMOVE_WAIT_TIME);
         for (int i = 5; i < numMsgs; i++) {
             msg = consumer1.receive(1, TimeUnit.SECONDS);
@@ -264,18 +260,15 @@ public class PersistentFailoverE2ETest extends BrokerTestBase {
         futures.clear();
 
         // 7. consumer subscription should not send messages to the new consumer if its name is not highest in the list
-        TestConsumerStateEventListener listener3 = new TestConsumerStateEventListener();
-        ConsumerConfiguration consumerConf3 = new ConsumerConfiguration();
-        consumerConf3.setSubscriptionType(SubscriptionType.Failover);
-        consumerConf3.setConsumerName("3");
-        consumerConf3.setConsumerEventListener(listener3);
         for (int i = 0; i < 5; i++) {
             msg = consumer1.receive(1, TimeUnit.SECONDS);
             Assert.assertNotNull(msg);
             Assert.assertEquals(new String(msg.getData()), "my-message-" + i);
             consumer1.acknowledge(msg);
         }
-        Consumer consumer3 = pulsarClient.subscribe(topicName, subName, consumerConf3);
+        TestConsumerStateEventListener listener3 = new TestConsumerStateEventListener();
+        Consumer<byte[]> consumer3 = consumerBuilder.clone().consumerName("3").consumerEventListener(listener3)
+                .subscribe();
         Thread.sleep(CONSUMER_ADD_OR_REMOVE_WAIT_TIME);
 
         verifyConsumerInactive(listener3, -1);
@@ -333,24 +326,18 @@ public class PersistentFailoverE2ETest extends BrokerTestBase {
 
         admin.persistentTopics().createPartitionedTopic(topicName, numPartitions);
 
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-        producerConf.setMessageRoutingMode(MessageRoutingMode.RoundRobinPartition);
+        ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                .subscriptionType(SubscriptionType.Failover);
 
-        ActiveInactiveListenerEvent listener1 = new ActiveInactiveListenerEvent();
-        ConsumerConfiguration consumerConf1 = new ConsumerConfiguration();
-        consumerConf1.setSubscriptionType(SubscriptionType.Failover);
-        consumerConf1.setConsumerName("1");
-        consumerConf1.setConsumerEventListener(listener1);
-
-        ActiveInactiveListenerEvent listener2 = new ActiveInactiveListenerEvent();
-        ConsumerConfiguration consumerConf2 = new ConsumerConfiguration();
-        consumerConf2.setSubscriptionType(SubscriptionType.Failover);
-        consumerConf2.setConsumerName("2");
-        consumerConf2.setConsumerEventListener(listener2);
 
         // 1. two consumers on the same subscription
-        Consumer consumer1 = pulsarClient.subscribe(topicName, subName, consumerConf1);
-        Consumer consumer2 = pulsarClient.subscribe(topicName, subName, consumerConf2);
+        ActiveInactiveListenerEvent listener1 = new ActiveInactiveListenerEvent();
+        ActiveInactiveListenerEvent listener2 = new ActiveInactiveListenerEvent();
+
+        Consumer<byte[]> consumer1 = consumerBuilder.clone().consumerName("1").consumerEventListener(listener1)
+                .subscribe();
+        Consumer<byte[]> consumer2 = consumerBuilder.clone().consumerName("2").consumerEventListener(listener2)
+                .subscribe();
 
         PersistentTopic topicRef;
         topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(destName.getPartition(0).toString());
@@ -367,7 +354,8 @@ public class PersistentFailoverE2ETest extends BrokerTestBase {
                 .getSubscription(subName).getDispatcher();
 
         List<CompletableFuture<MessageId>> futures = Lists.newArrayListWithCapacity(numMsgs);
-        Producer producer = pulsarClient.createProducer(topicName, producerConf);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName)
+                .messageRoutingMode(MessageRoutingMode.RoundRobinPartition).create();
         for (int i = 0; i < numMsgs; i++) {
             String message = "my-message-" + i;
             futures.add(producer.sendAsync(message.getBytes()));
@@ -377,7 +365,7 @@ public class PersistentFailoverE2ETest extends BrokerTestBase {
 
         // equal distribution between both consumers
         int totalMessages = 0;
-        Message msg = null;
+        Message<byte[]> msg = null;
         Set<Integer> receivedPtns = Sets.newHashSet();
         while (true) {
             msg = consumer1.receive(1, TimeUnit.SECONDS);
@@ -410,10 +398,10 @@ public class PersistentFailoverE2ETest extends BrokerTestBase {
         assertTrue(Sets.difference(listener2.activePtns, receivedPtns).isEmpty());
 
         Assert.assertEquals(totalMessages, numMsgs);
-        Assert.assertEquals(disp0.getActiveConsumer().consumerName(), consumerConf1.getConsumerName());
-        Assert.assertEquals(disp1.getActiveConsumer().consumerName(), consumerConf2.getConsumerName());
-        Assert.assertEquals(disp2.getActiveConsumer().consumerName(), consumerConf1.getConsumerName());
-        Assert.assertEquals(disp3.getActiveConsumer().consumerName(), consumerConf2.getConsumerName());
+        Assert.assertEquals(disp0.getActiveConsumer().consumerName(), "1");
+        Assert.assertEquals(disp1.getActiveConsumer().consumerName(), "2");
+        Assert.assertEquals(disp2.getActiveConsumer().consumerName(), "1");
+        Assert.assertEquals(disp3.getActiveConsumer().consumerName(), "2");
         totalMessages = 0;
 
         for (int i = 0; i < numMsgs; i++) {
@@ -424,16 +412,13 @@ public class PersistentFailoverE2ETest extends BrokerTestBase {
         futures.clear();
 
         // add a consumer
-        ConsumerConfiguration consumerConf3 = new ConsumerConfiguration();
-        consumerConf3.setSubscriptionType(SubscriptionType.Failover);
-        consumerConf3.setConsumerName("3");
         for (int i = 0; i < 20; i++) {
             msg = consumer1.receive(1, TimeUnit.SECONDS);
             Assert.assertNotNull(msg);
             uniqueMessages.add(new String(msg.getData()));
             consumer1.acknowledge(msg);
         }
-        Consumer consumer3 = pulsarClient.subscribe(topicName, subName, consumerConf3);
+        Consumer<byte[]> consumer3 = consumerBuilder.clone().consumerName("3").subscribe();
         Thread.sleep(CONSUMER_ADD_OR_REMOVE_WAIT_TIME);
         int consumer1Messages = 0;
         while (true) {
@@ -470,10 +455,10 @@ public class PersistentFailoverE2ETest extends BrokerTestBase {
         }
 
         Assert.assertEquals(uniqueMessages.size(), numMsgs);
-        Assert.assertEquals(disp0.getActiveConsumer().consumerName(), consumerConf1.getConsumerName());
-        Assert.assertEquals(disp1.getActiveConsumer().consumerName(), consumerConf2.getConsumerName());
-        Assert.assertEquals(disp2.getActiveConsumer().consumerName(), consumerConf3.getConsumerName());
-        Assert.assertEquals(disp3.getActiveConsumer().consumerName(), consumerConf1.getConsumerName());
+        Assert.assertEquals(disp0.getActiveConsumer().consumerName(), "1");
+        Assert.assertEquals(disp1.getActiveConsumer().consumerName(), "2");
+        Assert.assertEquals(disp2.getActiveConsumer().consumerName(), "3");
+        Assert.assertEquals(disp3.getActiveConsumer().consumerName(), "1");
         uniqueMessages.clear();
 
         for (int i = 0; i < numMsgs; i++) {
@@ -516,10 +501,10 @@ public class PersistentFailoverE2ETest extends BrokerTestBase {
         }
 
         Assert.assertEquals(uniqueMessages.size(), numMsgs);
-        Assert.assertEquals(disp0.getActiveConsumer().consumerName(), consumerConf2.getConsumerName());
-        Assert.assertEquals(disp1.getActiveConsumer().consumerName(), consumerConf3.getConsumerName());
-        Assert.assertEquals(disp2.getActiveConsumer().consumerName(), consumerConf2.getConsumerName());
-        Assert.assertEquals(disp3.getActiveConsumer().consumerName(), consumerConf3.getConsumerName());
+        Assert.assertEquals(disp0.getActiveConsumer().consumerName(), "2");
+        Assert.assertEquals(disp1.getActiveConsumer().consumerName(), "3");
+        Assert.assertEquals(disp2.getActiveConsumer().consumerName(), "2");
+        Assert.assertEquals(disp3.getActiveConsumer().consumerName(), "3");
 
         producer.close();
         consumer2.close();
@@ -533,48 +518,35 @@ public class PersistentFailoverE2ETest extends BrokerTestBase {
         final String topicName = "persistent://prop/use/ns-abc/failover-topic3";
         final String subName = "sub1";
         final int numMsgs = 100;
-        List<Message> receivedMessages = Lists.newArrayList();
+        List<Message<byte[]>> receivedMessages = Lists.newArrayList();
 
-        ConsumerConfiguration consumerConf1 = new ConsumerConfiguration();
-        consumerConf1.setSubscriptionType(SubscriptionType.Failover);
-        consumerConf1.setConsumerName("1");
-        consumerConf1.setMessageListener((consumer, msg) -> {
-            try {
-                synchronized (receivedMessages) {
-                    receivedMessages.add(msg);
-                }
-                consumer.acknowledge(msg);
-            } catch (Exception e) {
-                fail("Should not fail");
-            }
-        });
+        ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                .subscriptionType(SubscriptionType.Failover).messageListener((consumer, msg) -> {
+                    try {
+                        synchronized (receivedMessages) {
+                            receivedMessages.add(msg);
+                        }
+                        consumer.acknowledge(msg);
+                    } catch (Exception e) {
+                        fail("Should not fail");
+                    }
+                });
 
-        ConsumerConfiguration consumerConf2 = new ConsumerConfiguration();
-        consumerConf2.setSubscriptionType(SubscriptionType.Failover);
-        consumerConf2.setConsumerName("2");
-        consumerConf2.setMessageListener((consumer, msg) -> {
-            try {
-                synchronized (receivedMessages) {
-                    receivedMessages.add(msg);
-                }
-                consumer.acknowledge(msg);
-            } catch (Exception e) {
-                fail("Should not fail");
-            }
-        });
+        ConsumerBuilder<byte[]> consumerBuilder1 = consumerBuilder.clone().consumerName("1");
+        ConsumerBuilder<byte[]> consumerBuilder2 = consumerBuilder.clone().consumerName("2");
 
         conf.setActiveConsumerFailoverDelayTimeMillis(500);
         restartBroker();
 
         // create subscription
-        Consumer consumer = pulsarClient.subscribe(topicName, subName, consumerConf1);
+        Consumer<byte[]> consumer = consumerBuilder1.subscribe();
         consumer.close();
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
         PersistentSubscription subRef = topicRef.getSubscription(subName);
 
         // enqueue messages
         List<CompletableFuture<MessageId>> futures = Lists.newArrayListWithCapacity(numMsgs);
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         for (int i = 0; i < numMsgs; i++) {
             String message = "my-message-" + i;
             futures.add(producer.sendAsync(message.getBytes()));
@@ -584,8 +556,8 @@ public class PersistentFailoverE2ETest extends BrokerTestBase {
         producer.close();
 
         // two consumers subscribe at almost the same time
-        CompletableFuture<Consumer<byte[]>> subscribeFuture2 = pulsarClient.subscribeAsync(topicName, subName, consumerConf2);
-        CompletableFuture<Consumer<byte[]>> subscribeFuture1 = pulsarClient.subscribeAsync(topicName, subName, consumerConf1);
+        CompletableFuture<Consumer<byte[]>> subscribeFuture2 = consumerBuilder2.subscribeAsync();
+        CompletableFuture<Consumer<byte[]>> subscribeFuture1 = consumerBuilder1.subscribeAsync();
 
         // wait for all messages to be dequeued
         int retry = 20;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentQueueE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentQueueE2ETest.java
@@ -36,15 +36,13 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.api.Consumer;
-import org.apache.pulsar.client.api.ConsumerConfiguration;
+import org.apache.pulsar.client.api.ConsumerBuilder;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
-import org.apache.pulsar.client.api.ProducerConfiguration;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.ConsumerImpl;
-import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 import org.apache.pulsar.common.policies.data.ConsumerStats;
 import org.apache.pulsar.common.policies.data.PersistentTopicStats;
@@ -83,12 +81,12 @@ public class PersistentQueueE2ETest extends BrokerTestBase {
         final String subName = "sub1";
         final int numMsgs = 100;
 
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Shared);
+        ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                .subscriptionType(SubscriptionType.Shared);
 
         // 1. two consumers on the same subscription
-        Consumer consumer1 = pulsarClient.subscribe(topicName, subName, conf);
-        Consumer consumer2 = pulsarClient.subscribe(topicName, subName, conf);
+        Consumer<byte[]> consumer1 = consumerBuilder.subscribe();
+        Consumer<byte[]> consumer2 = consumerBuilder.subscribe();
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
         PersistentSubscription subRef = topicRef.getSubscription(subName);
@@ -101,7 +99,7 @@ public class PersistentQueueE2ETest extends BrokerTestBase {
         assertEquals(subRef.getDispatcher().getType(), SubType.Shared);
 
         List<CompletableFuture<MessageId>> futures = Lists.newArrayListWithCapacity(numMsgs * 2);
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         for (int i = 0; i < numMsgs * 2; i++) {
             String message = "my-message-" + i;
             futures.add(producer.sendAsync(message.getBytes()));
@@ -114,14 +112,15 @@ public class PersistentQueueE2ETest extends BrokerTestBase {
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
 
         // both consumers will together consumer all messages
-        Message msg;
-        Consumer c = consumer1;
+        Message<byte[]> msg;
+        Consumer<byte[]> c = consumer1;
         while (true) {
             try {
                 msg = c.receive(1, TimeUnit.SECONDS);
                 c.acknowledge(msg);
             } catch (PulsarClientException e) {
                 if (c.equals(consumer1)) {
+                    consumer1.close();
                     c = consumer2;
                 } else {
                     break;
@@ -181,34 +180,24 @@ public class PersistentQueueE2ETest extends BrokerTestBase {
         final List<String> messagesProduced = Lists.newArrayListWithCapacity(numMsgs);
         final List<String> messagesConsumed = new BlockingArrayQueue<>(numMsgs);
 
-        ConsumerConfiguration conf1 = new ConsumerConfiguration();
-        conf1.setSubscriptionType(SubscriptionType.Shared);
-        conf1.setMessageListener((consumer, msg) -> {
-            try {
-                consumer.acknowledge(msg);
-                messagesConsumed.add(new String(msg.getData()));
-            } catch (Exception e) {
-                fail("Should not fail");
-            }
-        });
-
-        ConsumerConfiguration conf2 = new ConsumerConfiguration();
-        conf2.setSubscriptionType(SubscriptionType.Shared);
-        conf2.setMessageListener((consumer, msg) -> {
-            try {
-                // do nothing
-            } catch (Exception e) {
-                fail("Should not fail");
-            }
-        });
-
-        Consumer consumer1 = pulsarClient.subscribe(topicName, subName, conf1);
+        Consumer<byte[]> consumer1 = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                .subscriptionType(SubscriptionType.Shared).messageListener((consumer, msg) -> {
+                    try {
+                        consumer.acknowledge(msg);
+                        messagesConsumed.add(new String(msg.getData()));
+                    } catch (Exception e) {
+                        fail("Should not fail");
+                    }
+                }).subscribe();
 
         // consumer2 does not ack messages
-        Consumer consumer2 = pulsarClient.subscribe(topicName, subName, conf2);
+        Consumer<byte[]> consumer2 = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                .subscriptionType(SubscriptionType.Shared).messageListener((consumer, msg) -> {
+                    // do notthing
+                }).subscribe();
 
         List<CompletableFuture<MessageId>> futures = Lists.newArrayListWithCapacity(numMsgs * 2);
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         for (int i = 0; i < numMsgs; i++) {
             String message = "msg-" + i;
             futures.add(producer.sendAsync(message.getBytes()));
@@ -241,40 +230,34 @@ public class PersistentQueueE2ETest extends BrokerTestBase {
         final CountDownLatch latch = new CountDownLatch(numMsgs);
 
         int recvQ1 = 10;
-        ConsumerConfiguration conf1 = new ConsumerConfiguration();
-        conf1.setSubscriptionType(SubscriptionType.Shared);
-        conf1.setReceiverQueueSize(recvQ1);
-        conf1.setMessageListener((consumer, msg) -> {
-            msgCountConsumer1.incrementAndGet();
-            try {
-                consumer.acknowledge(msg);
-                latch.countDown();
-            } catch (PulsarClientException e) {
-                fail("Should not fail");
-            }
-        });
+        Consumer<byte[]> consumer1 = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                .subscriptionType(SubscriptionType.Shared).receiverQueueSize(recvQ1)
+                .messageListener((consumer, msg) -> {
+                    msgCountConsumer1.incrementAndGet();
+                    try {
+                        consumer.acknowledge(msg);
+                        latch.countDown();
+                    } catch (PulsarClientException e) {
+                        fail("Should not fail");
+                    }
+                }).subscribe();
 
         int recvQ2 = 1;
-        ConsumerConfiguration conf2 = new ConsumerConfiguration();
-        conf2.setSubscriptionType(SubscriptionType.Shared);
-        conf2.setReceiverQueueSize(recvQ2);
-        conf2.setMessageListener((consumer, msg) -> {
-            msgCountConsumer2.incrementAndGet();
-            try {
-                consumer.acknowledge(msg);
-                latch.countDown();
-            } catch (PulsarClientException e) {
-                fail("Should not fail");
-            }
-        });
-
-        Consumer consumer1 = pulsarClient.subscribe(topicName, subName, conf1);
-        Consumer consumer2 = pulsarClient.subscribe(topicName, subName, conf2);
+        Consumer<byte[]> consumer2 = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                .subscriptionType(SubscriptionType.Shared).receiverQueueSize(recvQ2)
+                .messageListener((consumer, msg) -> {
+                    msgCountConsumer2.incrementAndGet();
+                    try {
+                        consumer.acknowledge(msg);
+                        latch.countDown();
+                    } catch (PulsarClientException e) {
+                        fail("Should not fail");
+                    }
+                }).subscribe();
 
         List<CompletableFuture<MessageId>> futures = Lists.newArrayListWithCapacity(numMsgs);
-        ProducerConfiguration conf = new ProducerConfiguration();
-        conf.setMaxPendingMessages(numMsgs + 1);
-        Producer producer = pulsarClient.createProducer(topicName, conf);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).maxPendingMessages(numMsgs + 1)
+                .create();
         for (int i = 0; i < numMsgs; i++) {
             String message = "msg-" + i;
             futures.add(producer.sendAsync(message.getBytes()));
@@ -307,10 +290,10 @@ public class PersistentQueueE2ETest extends BrokerTestBase {
 
         final CountDownLatch latch = new CountDownLatch(numMsgs * 3);
 
-        ConsumerConfiguration conf1 = new ConsumerConfiguration();
-        conf1.setSubscriptionType(SubscriptionType.Shared);
-        conf1.setReceiverQueueSize(10);
-        conf1.setMessageListener((consumer, msg) -> {
+        ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                .receiverQueueSize(10).subscriptionType(SubscriptionType.Shared);
+
+        Consumer<byte[]> consumer1 = consumerBuilder.clone().messageListener((consumer, msg) -> {
             try {
                 counter1.incrementAndGet();
                 consumer.acknowledge(msg);
@@ -318,12 +301,9 @@ public class PersistentQueueE2ETest extends BrokerTestBase {
             } catch (Exception e) {
                 fail("Should not fail");
             }
-        });
+        }).subscribe();
 
-        ConsumerConfiguration conf2 = new ConsumerConfiguration();
-        conf2.setSubscriptionType(SubscriptionType.Shared);
-        conf2.setReceiverQueueSize(10);
-        conf2.setMessageListener((consumer, msg) -> {
+        Consumer<byte[]> consumer2 = consumerBuilder.clone().messageListener((consumer, msg) -> {
             try {
                 counter2.incrementAndGet();
                 consumer.acknowledge(msg);
@@ -331,29 +311,20 @@ public class PersistentQueueE2ETest extends BrokerTestBase {
             } catch (Exception e) {
                 fail("Should not fail");
             }
-        });
+        }).subscribe();
 
-        ConsumerConfiguration conf3 = new ConsumerConfiguration();
-        conf3.setSubscriptionType(SubscriptionType.Shared);
-        conf3.setReceiverQueueSize(10);
-        conf3.setMessageListener((consumer, msg) -> {
+        Consumer<byte[]> consumer3 = consumerBuilder.clone().messageListener((consumer, msg) -> {
             try {
-                counter3.incrementAndGet();
+                counter1.incrementAndGet();
                 consumer.acknowledge(msg);
                 latch.countDown();
             } catch (Exception e) {
                 fail("Should not fail");
             }
-        });
-
-        // subscribe and close, so that distribution can be checked after
-        // all messages are published
-        Consumer consumer1 = pulsarClient.subscribe(topicName, subName, conf1);
-        Consumer consumer2 = pulsarClient.subscribe(topicName, subName, conf2);
-        Consumer consumer3 = pulsarClient.subscribe(topicName, subName, conf3);
+        }).subscribe();
 
         List<CompletableFuture<MessageId>> futures = Lists.newArrayListWithCapacity(numMsgs);
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         for (int i = 0; i < numMsgs * 3; i++) {
             String message = "msg-" + i;
             futures.add(producer.sendAsync(message.getBytes()));
@@ -386,17 +357,16 @@ public class PersistentQueueE2ETest extends BrokerTestBase {
         final int totalMessages = 50;
 
         // 1. producer connect
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
         assertNotNull(topicRef);
         assertEquals(topicRef.getProducers().size(), 1);
 
         // 2. Create consumer
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setReceiverQueueSize(10);
-        conf.setSubscriptionType(SubscriptionType.Shared);
-        Consumer consumer1 = pulsarClient.subscribe(topicName, subscriptionName, conf);
-        Consumer consumer2 = pulsarClient.subscribe(topicName, subscriptionName, conf);
+        ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer().topic(topicName)
+                .subscriptionName(subscriptionName).receiverQueueSize(10).subscriptionType(SubscriptionType.Shared);
+        Consumer<byte[]> consumer1 = consumerBuilder.subscribe();
+        Consumer<byte[]> consumer2 = consumerBuilder.subscribe();
 
         // 3. Producer publishes messages
         for (int i = 0; i < totalMessages; i++) {
@@ -407,8 +377,8 @@ public class PersistentQueueE2ETest extends BrokerTestBase {
 
         // 4. Receive messages
         int receivedConsumer1 = 0, receivedConsumer2 = 0;
-        Message message1 = consumer1.receive();
-        Message message2 = consumer2.receive();
+        Message<byte[]> message1 = consumer1.receive();
+        Message<byte[]> message2 = consumer2.receive();
         do {
             if (message1 != null) {
                 log.info("Consumer 1 Received: " + new String(message1.getData()));
@@ -453,17 +423,16 @@ public class PersistentQueueE2ETest extends BrokerTestBase {
         final int totalMessages = 10;
 
         // 1. producer connect
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
         assertNotNull(topicRef);
         assertEquals(topicRef.getProducers().size(), 1);
 
         // 2. Create consumer
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setReceiverQueueSize(1000);
-        conf.setSubscriptionType(SubscriptionType.Shared);
-        Consumer consumer1 = pulsarClient.subscribe(topicName, subscriptionName, conf);
-        Consumer consumer2 = pulsarClient.subscribe(topicName, subscriptionName, conf);
+        ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer().topic(topicName)
+                .subscriptionName(subscriptionName).receiverQueueSize(1000).subscriptionType(SubscriptionType.Shared);
+        Consumer<byte[]> consumer1 = consumerBuilder.subscribe();
+        Consumer<byte[]> consumer2 = consumerBuilder.subscribe();
 
         // 3. Producer publishes messages
         for (int i = 0; i < totalMessages; i++) {
@@ -474,8 +443,8 @@ public class PersistentQueueE2ETest extends BrokerTestBase {
 
         // 4. Receive messages
         int receivedConsumer1 = 0, receivedConsumer2 = 0;
-        Message message1 = consumer1.receive();
-        Message message2 = consumer2.receive();
+        Message<byte[]> message1 = consumer1.receive();
+        Message<byte[]> message2 = consumer2.receive();
         do {
             if (message1 != null) {
                 log.info("Consumer 1 Received: " + new String(message1.getData()));
@@ -508,7 +477,7 @@ public class PersistentQueueE2ETest extends BrokerTestBase {
         }
 
         // 7. Consumer reconnects
-        consumer1 = pulsarClient.subscribe(topicName, subscriptionName, conf);
+        consumer1 = consumerBuilder.subscribe();
 
         // 8. Check number of messages received
         receivedConsumer1 = 0;
@@ -528,12 +497,11 @@ public class PersistentQueueE2ETest extends BrokerTestBase {
         final String subName = "sub3";
         final int numMsgs = 10;
 
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
 
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Shared);
-        conf.setReceiverQueueSize(0);
-        ConsumerImpl consumer1 = (ConsumerImpl) pulsarClient.subscribe(topicName, subName, conf);
+        ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                .receiverQueueSize(10).subscriptionType(SubscriptionType.Shared);
+        ConsumerImpl<byte[]> consumer1 = (ConsumerImpl<byte[]>) consumerBuilder.subscribe();
 
         for (int i = 0; i < numMsgs; i++) {
             producer.send(("hello-" + i).getBytes());
@@ -547,7 +515,7 @@ public class PersistentQueueE2ETest extends BrokerTestBase {
         }
 
         // C-2 will not get any message initially, since everything went to C-1 already
-        Consumer consumer2 = pulsarClient.subscribe(topicName, subName, conf);
+        Consumer<byte[]> consumer2 = consumerBuilder.subscribe();
 
         // Trigger C-1 to redeliver everything, half will go C-1 again and the other half to C-2
         consumer1.redeliverUnacknowledgedMessages(c1_receivedMessages);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicConcurrentTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicConcurrentTest.java
@@ -65,7 +65,9 @@ public class PersistentTopicConcurrentTest extends MockedBookKeeperTestCase {
     private BrokerService brokerService;
     private ManagedLedgerFactory mlFactoryMock;
     private ServerCnx serverCnx;
+    @SuppressWarnings("unused")
     private ManagedLedger ledgerMock;
+    @SuppressWarnings("unused")
     private ManagedCursor cursorMock;
 
     final String successTopicName = "persistent://prop/use/ns-abc/successTopic";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicE2ETest.java
@@ -18,12 +18,6 @@
  */
 package org.apache.pulsar.broker.service;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -32,10 +26,8 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import java.lang.reflect.Field;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeSet;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -46,26 +38,20 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.bookkeeper.mledger.ManagedCursor;
-import org.apache.bookkeeper.mledger.ManagedLedger;
-import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
-import org.apache.bookkeeper.mledger.AsyncCallbacks.OpenLedgerCallback;
 import org.apache.bookkeeper.mledger.impl.EntryCacheImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
-import org.apache.bookkeeper.mledger.impl.PositionImpl;
-import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.CompressionType;
 import org.apache.pulsar.client.api.Consumer;
-import org.apache.pulsar.client.api.ConsumerConfiguration;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageBuilder;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
-import org.apache.pulsar.client.api.ProducerConfiguration;
+import org.apache.pulsar.client.api.ProducerBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.PulsarClientException.ProducerBusyException;
@@ -79,15 +65,11 @@ import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.stats.Metrics;
 import org.apache.pulsar.common.util.collections.ConcurrentLongPairSet;
 import org.apache.pulsar.policies.data.loadbalancer.NamespaceBundleStats;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.Sets;
 
 /**
  */
@@ -110,7 +92,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         final String topicName = "persistent://prop/use/ns-abc/topic0";
 
         // 1. producer connect
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
         assertNotNull(topicRef);
@@ -138,11 +120,8 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         final String subName = "sub1";
         final int numMsgs = 10;
 
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-
         // 1. client connect
-        Consumer consumer = pulsarClient.subscribe(topicName, subName, conf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName).subscribe();
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
         PersistentSubscription subRef = topicRef.getSubscription(subName);
@@ -154,7 +133,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
         assertEquals(getAvailablePermits(subRef), 1000 /* default */);
 
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         for (int i = 0; i < numMsgs * 2; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
@@ -168,7 +147,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
         assertEquals(getAvailablePermits(subRef), 1000 - numMsgs * 2);
 
-        Message msg = null;
+        Message<byte[]> msg = null;
         for (int i = 0; i < numMsgs; i++) {
             msg = consumer.receive();
             // 3. in-order message delivery
@@ -223,15 +202,12 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         final String topicName = "persistent://prop/use/ns-abc/topic2";
         final String subName = "sub2";
 
-        Message msg;
+        Message<byte[]> msg;
         int recvQueueSize = 4;
 
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-        conf.setReceiverQueueSize(recvQueueSize);
-
-        Consumer consumer = pulsarClient.subscribe(topicName, subName, conf);
-        Producer producer = pulsarClient.createProducer(topicName);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                .receiverQueueSize(recvQueueSize).subscribe();
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
         assertNotNull(topicRef);
@@ -269,16 +245,13 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         final String topicName = "persistent://prop/use/ns-abc/topic2";
         final String subName = "sub2";
 
-        Message msg;
+        Message<byte[]> msg;
         int recvQueueSize = 4;
 
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-        conf.setReceiverQueueSize(recvQueueSize);
-
         // (1) Create subscription
-        Consumer consumer = pulsarClient.subscribe(topicName, subName, conf);
-        Producer producer = pulsarClient.createProducer(topicName);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                .receiverQueueSize(recvQueueSize).subscribe();
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
 
         // (2) Produce Messages
         for (int i = 0; i < recvQueueSize / 2; i++) {
@@ -329,10 +302,6 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         final int recvQueueSize = 100;
         final int numConsumersThreads = 10;
 
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-        conf.setReceiverQueueSize(recvQueueSize);
-
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final CyclicBarrier barrier = new CyclicBarrier(numConsumersThreads + 1);
@@ -342,9 +311,10 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
                 public Void call() throws Exception {
                     barrier.await();
 
-                    Consumer consumer = pulsarClient.subscribe(topicName, subName, conf);
+                    Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                            .receiverQueueSize(recvQueueSize).subscribe();
                     for (int i = 0; i < recvQueueSize / numConsumersThreads; i++) {
-                        Message msg = consumer.receive();
+                        Message<byte[]> msg = consumer.receive();
                         consumer.acknowledge(msg);
                     }
                     return null;
@@ -352,7 +322,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
             });
         }
 
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         for (int i = 0; i < recvQueueSize * numConsumersThreads; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
@@ -370,6 +340,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         // 2. flow control works the same as single consumer single thread
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
         assertEquals(getAvailablePermits(subRef), recvQueueSize);
+        executor.shutdown();
     }
 
     @Test(enabled = false)
@@ -378,7 +349,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         final String topicName = "persistent://prop/use/ns-abc/topic4";
         final String subName = "sub4";
 
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
@@ -405,14 +376,12 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         // wait for the spawned thread to complete
         latch.await();
 
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-        Consumer consumer = pulsarClient.subscribe(topicName, subName, conf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName).subscribe();
 
         PersistentSubscription subRef = topicRef.getSubscription(subName);
         assertNotNull(subRef);
 
-        Message msg = null;
+        Message<byte[]> msg = null;
         for (int i = 0; i < 10; i++) {
             msg = consumer.receive();
         }
@@ -433,6 +402,8 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         consumer.close();
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
         assertTrue(subRef.getDispatcher().isConsumerConnected());
+
+        executor.shutdown();
     }
 
     @Test
@@ -440,18 +411,15 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         final String topicName = "persistent://prop/use/ns-abc/topic5";
         final String subName = "sub5";
 
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-
-        Consumer consumer = pulsarClient.subscribe(topicName, subName, conf);
-        Producer producer = pulsarClient.createProducer(topicName);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName).subscribe();
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
         assertNotNull(topicRef);
         PersistentSubscription subRef = topicRef.getSubscription(subName);
         assertNotNull(subRef);
 
-        Message msg;
+        Message<byte[]> msg;
         for (int i = 0; i < 10; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
@@ -471,13 +439,10 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         final String topicName = "persistent://prop/use/ns-abc/topic6";
         final String subName = "sub6";
 
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-
-        pulsarClient.subscribe(topicName, subName, conf);
-        pulsarClient.createProducer(topicName);
+        pulsarClient.newConsumer().topic(topicName).subscriptionName(subName).subscribe();
+        pulsarClient.newProducer().topic(topicName).create();
         try {
-            pulsarClient.subscribe(topicName, subName, conf);
+            pulsarClient.newConsumer().topic(topicName).subscriptionName(subName).subscribe();
             fail("Should have thrown an exception since one consumer is already connected");
         } catch (PulsarClientException cce) {
             Assert.assertTrue(cce.getMessage().contains("Exclusive consumer is already connected"));
@@ -489,19 +454,16 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         final String topicName = "persistent://prop/use/ns-abc/topic7";
         final String subName = "sub7";
 
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-
-        PulsarClient client1 = PulsarClient.create(brokerUrl.toString());
-        PulsarClient client2 = PulsarClient.create(brokerUrl.toString());
+        PulsarClient client1 = PulsarClient.builder().serviceUrl(brokerUrl.toString()).build();
+        PulsarClient client2 = PulsarClient.builder().serviceUrl(brokerUrl.toString()).build();
 
         try {
-            client1.subscribe(topicName, subName, conf);
-            client1.createProducer(topicName);
+            client1.newConsumer().topic(topicName).subscriptionName(subName).subscribe();
+            client1.newProducer().topic(topicName).create();
 
-            client2.createProducer(topicName);
+            client2.newProducer().topic(topicName).create();
 
-            client2.subscribe(topicName, subName, conf);
+            client2.newConsumer().topic(topicName).subscriptionName(subName).subscribe();
             fail("Should have thrown an exception since one consumer is already connected");
         } catch (PulsarClientException cce) {
             Assert.assertTrue(cce.getMessage().contains("Exclusive consumer is already connected"));
@@ -516,11 +478,8 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         final String topicName = "persistent://prop/use/ns-abc/topic8";
         final String subName = "sub1";
 
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-
         // 1. client connect
-        Consumer consumer = pulsarClient.subscribe(topicName, subName, conf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName).subscribe();
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
         PersistentSubscription subRef = topicRef.getSubscription(subName);
@@ -550,7 +509,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
     public void testUnloadNamespace() throws Exception {
         String topic = "persistent://prop/use/ns-abc/topic-9";
         TopicName topicName = TopicName.get(topic);
-        pulsarClient.createProducer(topic);
+        pulsarClient.newProducer().topic(topic).create();
         pulsarClient.close();
 
         assertTrue(pulsar.getBrokerService().getTopicReference(topic) != null);
@@ -579,7 +538,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
     public void testGC() throws Exception {
         // 1. Simple successful GC
         String topicName = "persistent://prop/use/ns-abc/topic-10";
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         producer.close();
 
         assertNotNull(pulsar.getBrokerService().getTopicReference(topicName));
@@ -587,10 +546,8 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         assertNull(pulsar.getBrokerService().getTopicReference(topicName));
 
         // 2. Topic is not GCed with live connection
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
         String subName = "sub1";
-        Consumer consumer = pulsarClient.subscribe(topicName, subName, conf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName).subscribe();
 
         runGC();
         assertNotNull(pulsar.getBrokerService().getTopicReference(topicName));
@@ -609,8 +566,8 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
     }
 
     /**
-     * A topic that has retention policy set to non-0, should not be GCed
-     * until it has been inactive for at least the retention time.
+     * A topic that has retention policy set to non-0, should not be GCed until it has been inactive for at least the
+     * retention time.
      */
     @Test
     public void testGcAndRetentionPolicy() throws Exception {
@@ -620,7 +577,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
         // 1. Simple successful GC
         String topicName = "persistent://prop/use/ns-abc/topic-10";
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         producer.close();
 
         assertNotNull(pulsar.getBrokerService().getTopicReference(topicName));
@@ -628,16 +585,13 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         // Should not have been deleted, since we have retention
         assertNotNull(pulsar.getBrokerService().getTopicReference(topicName));
 
-
         // Remove retention
         admin.namespaces().setRetention("prop/use/ns-abc", new RetentionPolicies(0, 10));
         Thread.sleep(300);
 
         // 2. Topic is not GCed with live connection
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
         String subName = "sub1";
-        Consumer consumer = pulsarClient.subscribe(topicName, subName, conf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName).subscribe();
 
         runGC();
         assertNotNull(pulsar.getBrokerService().getTopicReference(topicName));
@@ -656,9 +610,8 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
     }
 
     /**
-     * A topic that has retention policy set to -1, should not be GCed
-     * until it has been inactive for at least the retention time and the data
-     * should never be deleted
+     * A topic that has retention policy set to -1, should not be GCed until it has been inactive for at least the
+     * retention time and the data should never be deleted
      */
     @Test
     public void testInfiniteRetentionPolicy() throws Exception {
@@ -667,7 +620,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
         // 1. Simple successful GC
         String topicName = "persistent://prop/use/ns-abc/topic-10";
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         producer.close();
 
         assertNotNull(pulsar.getBrokerService().getTopicReference(topicName));
@@ -675,16 +628,13 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         // Should not have been deleted, since we have retention
         assertNotNull(pulsar.getBrokerService().getTopicReference(topicName));
 
-
         // Remove retention
         admin.namespaces().setRetention("prop/use/ns-abc", new RetentionPolicies(0, 10));
         Thread.sleep(300);
 
         // 2. Topic is not GCed with live connection
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
         String subName = "sub1";
-        Consumer consumer = pulsarClient.subscribe(topicName, subName, conf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName).subscribe();
 
         runGC();
         assertNotNull(pulsar.getBrokerService().getTopicReference(topicName));
@@ -714,10 +664,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         final String subName = "sub1";
         final int numMsgs = 10;
 
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-
-        Consumer consumer = pulsarClient.subscribe(topicName, subName, conf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName).subscribe();
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
         PersistentSubscription subRef = topicRef.getSubscription(subName);
@@ -725,7 +672,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         consumer.close();
         assertFalse(subRef.getDispatcher().isConsumerConnected());
 
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         for (int i = 0; i < numMsgs; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
@@ -760,17 +707,14 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         final String subName = "sub1";
         final int numMsgs = 10;
 
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-
-        pulsarClient.subscribe(topicName, subName, conf);
+        pulsarClient.newConsumer().topic(topicName).subscriptionName(subName).subscribe();
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
         PersistentSubscription subRef = topicRef.getSubscription(subName);
 
         assertTrue(subRef.getDispatcher().isConsumerConnected());
 
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         for (int i = 0; i < numMsgs; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
@@ -795,25 +739,18 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         final String topicName = "persistent://prop/use/ns-abc/shared-topic2";
         final String subName = "sub2";
 
-        ConsumerConfiguration conf1 = new ConsumerConfiguration();
-        conf1.setSubscriptionType(SubscriptionType.Exclusive);
-
-        ConsumerConfiguration conf2 = new ConsumerConfiguration();
-        conf2.setSubscriptionType(SubscriptionType.Shared);
-
-        ConsumerConfiguration conf3 = new ConsumerConfiguration();
-        conf3.setSubscriptionType(SubscriptionType.Failover);
-
-        Consumer consumer1 = pulsarClient.subscribe(topicName, subName, conf1);
-        Consumer consumer2 = null;
-        Consumer consumer3 = null;
+        Consumer<byte[]> consumer1 = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                .subscriptionType(SubscriptionType.Exclusive).subscribe();
+        Consumer<byte[]> consumer2 = null;
+        Consumer<byte[]> consumer3 = null;
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
         PersistentSubscription subRef = topicRef.getSubscription(subName);
 
         // 1. shared consumer on an exclusive sub fails
         try {
-            consumer2 = pulsarClient.subscribe(topicName, subName, conf2);
+            consumer2 = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                    .subscriptionType(SubscriptionType.Shared).subscribe();
             fail("should have failed");
         } catch (PulsarClientException e) {
             assertTrue(e.getMessage().contains("Subscription is of different type"));
@@ -821,7 +758,8 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
         // 2. failover consumer on an exclusive sub fails
         try {
-            consumer3 = pulsarClient.subscribe(topicName, subName, conf3);
+            consumer3 = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                    .subscriptionType(SubscriptionType.Failover).subscribe();
             fail("should have failed");
         } catch (PulsarClientException e) {
             assertTrue(e.getMessage().contains("Subscription is of different type"));
@@ -830,7 +768,8 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         // 3. disconnected sub can be converted in shared
         consumer1.close();
         try {
-            consumer2 = pulsarClient.subscribe(topicName, subName, conf2);
+            consumer2 = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                    .subscriptionType(SubscriptionType.Shared).subscribe();
             assertEquals(subRef.getDispatcher().getType(), SubType.Shared);
         } catch (PulsarClientException e) {
             fail("should not fail");
@@ -838,7 +777,8 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
         // 4. exclusive fails on shared sub
         try {
-            consumer1 = pulsarClient.subscribe(topicName, subName, conf1);
+            consumer1 = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                    .subscriptionType(SubscriptionType.Exclusive).subscribe();
             fail("should have failed");
         } catch (PulsarClientException e) {
             assertTrue(e.getMessage().contains("Subscription is of different type"));
@@ -847,7 +787,8 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         // 5. disconnected sub can be converted in failover
         consumer2.close();
         try {
-            consumer3 = pulsarClient.subscribe(topicName, subName, conf3);
+            consumer3 = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                    .subscriptionType(SubscriptionType.Failover).subscribe();
             assertEquals(subRef.getDispatcher().getType(), SubType.Failover);
         } catch (PulsarClientException e) {
             fail("should not fail");
@@ -856,7 +797,8 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         // 5. exclusive consumer can connect after failover disconnects
         consumer3.close();
         try {
-            consumer1 = pulsarClient.subscribe(topicName, subName, conf1);
+            consumer1 = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                    .subscriptionType(SubscriptionType.Exclusive).subscribe();
             assertEquals(subRef.getDispatcher().getType(), SubType.Exclusive);
         } catch (PulsarClientException e) {
             fail("should not fail");
@@ -871,16 +813,13 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         final String topicName = "persistent://prop/use/ns-abc/topic-receive-timeout";
         final String subName = "sub";
 
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-        conf.setReceiverQueueSize(1000);
-
-        ConsumerImpl consumer = (ConsumerImpl) pulsarClient.subscribe(topicName, subName, conf);
-        Producer producer = pulsarClient.createProducer(topicName);
+        ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(topicName)
+                .subscriptionName(subName).receiverQueueSize(1000).subscribe();
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
 
         assertEquals(consumer.getAvailablePermits(), 0);
 
-        Message msg = consumer.receive(10, TimeUnit.MILLISECONDS);
+        Message<byte[]> msg = consumer.receive(10, TimeUnit.MILLISECONDS);
         assertNull(msg);
         assertEquals(consumer.getAvailablePermits(), 0);
 
@@ -903,7 +842,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         final String topicName = "persistent://prop/use/ns-abc/topic-xyz";
 
         // 1. producer connect
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
         assertNotNull(topicRef);
@@ -927,7 +866,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
 
         for (int i = SyncMessages; i < (SyncMessages + AsyncMessages); i++) {
             String content = "my-message-" + i;
-            Message msg = MessageBuilder.create().setContent(content.getBytes()).build();
+            Message<byte[]> msg = MessageBuilder.create().setContent(content.getBytes()).build();
             final int index = i;
 
             producer.sendAsync(msg).thenRun(() -> {
@@ -949,12 +888,11 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         final String topicName = "persistent://prop/use/ns-abc/topic-xyzx";
         final int messages = 10;
 
-        PulsarClient client = PulsarClient.create(brokerUrl.toString());
+        PulsarClient client = PulsarClient.builder().serviceUrl(brokerUrl.toString()).build();
 
         // 1. Producer connect
-        ProducerConfiguration producerConfiguration = new ProducerConfiguration().setMaxPendingMessages(messages)
-                .setBlockIfQueueFull(true).setSendTimeout(1, TimeUnit.SECONDS);
-        ProducerImpl producer = (ProducerImpl) client.createProducer(topicName, producerConfiguration);
+        ProducerImpl<byte[]> producer = (ProducerImpl<byte[]>) client.newProducer().topic(topicName)
+                .maxPendingMessages(messages).blockIfQueueFull(true).sendTimeout(1, TimeUnit.SECONDS).create();
 
         // 2. Stop broker
         cleanup();
@@ -993,10 +931,9 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         final int messages = 10;
 
         // 1. Producer connect
-        PulsarClient client = PulsarClient.create(brokerUrl.toString());
-        ProducerConfiguration producerConfiguration = new ProducerConfiguration().setMaxPendingMessages(messages)
-                .setBlockIfQueueFull(false).setSendTimeout(1, TimeUnit.SECONDS);
-        ProducerImpl producer = (ProducerImpl) client.createProducer(topicName, producerConfiguration);
+        PulsarClient client = PulsarClient.builder().serviceUrl(brokerUrl.toString()).build();
+        ProducerImpl<byte[]> producer = (ProducerImpl<byte[]>) client.newProducer().topic(topicName)
+                .maxPendingMessages(messages).blockIfQueueFull(false).sendTimeout(1, TimeUnit.SECONDS).create();
 
         // 2. Stop broker
         cleanup();
@@ -1038,8 +975,9 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         BrokerService brokerService = pulsar.getBrokerService();
 
         // 1. producers connect
-        Producer producer1 = pulsarClient.createProducer("persistent://prop/use/ns-abc/topic-1");
-        Producer producer2 = pulsarClient.createProducer("persistent://prop/use/ns-abc/topic-2");
+        Producer<byte[]> producer1 = pulsarClient.newProducer().topic("persistent://prop/use/ns-abc/topic-1").create();
+        /* Producer<byte[]> producer2 = */ pulsarClient.newProducer().topic("persistent://prop/use/ns-abc/topic-2")
+                .create();
 
         brokerService.updateRates();
 
@@ -1078,11 +1016,9 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         final String topicName = "persistent://prop/use/ns-abc/topic0" + compressionType;
 
         // 1. producer connect
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-        producerConf.setCompressionType(compressionType);
-        Producer producer = pulsarClient.createProducer(topicName, producerConf);
-
-        Consumer consumer = pulsarClient.subscribe(topicName, "my-sub");
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).compressionType(compressionType)
+                .create();
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName("my-sub").subscribe();
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
         assertNotNull(topicRef);
@@ -1095,7 +1031,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         }
 
         for (int i = 0; i < 10; i++) {
-            Message msg = consumer.receive(5, TimeUnit.SECONDS);
+            Message<byte[]> msg = consumer.receive(5, TimeUnit.SECONDS);
             assertNotNull(msg);
             assertEquals(msg.getData(), ("my-message-" + i).getBytes());
         }
@@ -1116,8 +1052,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         statsUpdater.shutdown();
 
         final String namespace = "prop/use/ns-abc";
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-        Producer producer = pulsarClient.createProducer("persistent://" + namespace + "/topic0", producerConf);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://" + namespace + "/topic0").create();
         // 1. producer publish messages
         for (int i = 0; i < 10; i++) {
             String message = "my-message-" + i;
@@ -1146,11 +1081,10 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         final String topicName = "persistent://prop/use/ns-abc/topic1";
 
         // 1. producer connect
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName("my-sub").subscribe();
 
-        Consumer consumer = pulsarClient.subscribe(topicName, "my-sub");
-
-        Message msg1 = MessageBuilder.create().setContent("message-1".getBytes()).build();
+        Message<byte[]> msg1 = MessageBuilder.create().setContent("message-1".getBytes()).build();
         CompletableFuture<MessageId> future1 = producer.sendAsync(msg1);
 
         // Stop the broker, and publishes messages. Messages are accumulated in the producer queue and they're checksums
@@ -1158,8 +1092,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         // checksum validation error
         stopBroker();
 
-
-        Message msg2 = MessageBuilder.create().setContent("message-2".getBytes()).build();
+        Message<byte[]> msg2 = MessageBuilder.create().setContent("message-2".getBytes()).build();
         CompletableFuture<MessageId> future2 = producer.sendAsync(msg2);
 
         // Taint msg2
@@ -1178,7 +1111,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         }
 
         // We should only receive msg1
-        Message msg = consumer.receive(1, TimeUnit.SECONDS);
+        Message<byte[]> msg = consumer.receive(1, TimeUnit.SECONDS);
         assertEquals(new String(msg.getData()), "message-1");
 
         while ((msg = consumer.receive(1, TimeUnit.SECONDS)) != null) {
@@ -1187,25 +1120,23 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
     }
 
     /**
-     * Verify: Broker should not replay already acknowledged messages again and should clear them from messageReplay bucket
+     * Verify: Broker should not replay already acknowledged messages again and should clear them from messageReplay
+     * bucket
      *
-     * 1. produce messages
-     * 2. consume messages and ack all except 1 msg
-     * 3. Verification: should replay only 1 unacked message
+     * 1. produce messages 2. consume messages and ack all except 1 msg 3. Verification: should replay only 1 unacked
+     * message
      */
     @Test()
     public void testMessageRedelivery() throws Exception {
         final String topicName = "persistent://prop/use/ns-abc/topic2";
         final String subName = "sub2";
 
-        Message msg;
+        Message<byte[]> msg;
         int totalMessages = 10;
 
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Shared);
-
-        Consumer consumer = pulsarClient.subscribe(topicName, subName, conf);
-        Producer producer = pulsarClient.createProducer(topicName);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                .subscriptionType(SubscriptionType.Shared).subscribe();
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
 
         // (1) Produce messages
         for (int i = 0; i < totalMessages; i++) {
@@ -1213,8 +1144,8 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
             producer.send(message.getBytes());
         }
 
-        //(2) Consume and ack messages except first message
-        Message unAckedMsg = null;
+        // (2) Consume and ack messages except first message
+        Message<byte[]> unAckedMsg = null;
         for (int i = 0; i < totalMessages; i++) {
             msg = consumer.receive();
             if (i == 0) {
@@ -1243,10 +1174,8 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
     }
 
     /**
-     * Verify:
-     * 1. Broker should not replay already acknowledged messages
-     * 2. Dispatcher should not stuck while dispatching new messages due to previous-replay
-     * of invalid/already-acked messages
+     * Verify: 1. Broker should not replay already acknowledged messages 2. Dispatcher should not stuck while
+     * dispatching new messages due to previous-replay of invalid/already-acked messages
      *
      * @throws Exception
      */
@@ -1256,16 +1185,13 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         final String topicName = "persistent://prop/use/ns-abc/topic2";
         final String subName = "sub2";
 
-        Message msg;
+        Message<byte[]> msg;
         int totalMessages = 10;
         int replayIndex = totalMessages / 2;
 
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Shared);
-        conf.setReceiverQueueSize(1);
-
-        Consumer consumer = pulsarClient.subscribe(topicName, subName, conf);
-        Producer producer = pulsarClient.createProducer(topicName);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                .subscriptionType(SubscriptionType.Shared).receiverQueueSize(1).subscribe();
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
         assertNotNull(topicRef);
@@ -1327,13 +1253,12 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
     public void testCreateProducerWithSameName() throws Exception {
         String topic = "persistent://prop/use/ns-abc/testCreateProducerWithSameName";
 
-        ProducerConfiguration conf = new ProducerConfiguration();
-        conf.setProducerName("test-producer-a");
-
-        Producer p1 = pulsarClient.createProducer(topic, conf);
+        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer().topic(topic)
+                .producerName("test-producer-a");
+        Producer<byte[]> p1 = producerBuilder.create();
 
         try {
-            pulsarClient.createProducer(topic, conf);
+            producerBuilder.create();
             fail("Should have thrown ProducerBusyException");
         } catch (ProducerBusyException e) {
             // Expected
@@ -1342,7 +1267,7 @@ public class PersistentTopicE2ETest extends BrokerTestBase {
         p1.close();
 
         // Now p2 should succeed
-        Producer p2 = pulsarClient.createProducer(topic, conf);
+        Producer<byte[]> p2 = producerBuilder.create();
 
         p2.close();
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -39,7 +39,6 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -91,8 +90,8 @@ import org.apache.pulsar.common.api.proto.PulsarApi.EncryptionKeys;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
 import org.apache.pulsar.common.api.proto.PulsarApi.ProtocolVersion;
 import org.apache.pulsar.common.api.proto.PulsarApi.ServerError;
-import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.naming.NamespaceBundle;
+import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.zookeeper.ZooKeeperDataCache;
@@ -100,8 +99,6 @@ import org.apache.zookeeper.ZooKeeper;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -117,6 +114,7 @@ import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 /**
  */
 @Test
+@SuppressWarnings("unchecked")
 public class ServerCnxTest {
     protected EmbeddedChannel channel;
     private ServiceConfiguration svcConfig;
@@ -159,7 +157,6 @@ public class ServerCnxTest {
         doReturn(createMockBookKeeper(mockZk)).when(pulsar).getBookKeeperClient();
 
         configCacheService = mock(ConfigurationCacheService.class);
-        @SuppressWarnings("unchecked")
         ZooKeeperDataCache<Policies> zkDataCache = mock(ZooKeeperDataCache.class);
         doReturn(Optional.empty()).when(zkDataCache).get(anyObject());
         doReturn(zkDataCache).when(configCacheService).policiesCache();
@@ -473,7 +470,6 @@ public class ServerCnxTest {
         assertEquals(topicRef.getProducers().size(), 0);
     }
 
-    @SuppressWarnings("unchecked")
     @Test(timeOut = 30000)
     public void testNonExistentTopic() throws Exception {
         ZooKeeperDataCache<Policies> zkDataCache = mock(ZooKeeperDataCache.class);
@@ -1560,6 +1556,4 @@ public class ServerCnxTest {
 
         channel.finish();
     }
-
-    private static final Logger log = LoggerFactory.getLogger(ServerCnxTest.class);
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
@@ -27,7 +27,6 @@ import java.util.List;
 
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
-import org.apache.pulsar.client.api.ConsumerConfiguration;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -55,14 +54,11 @@ public class SubscriptionSeekTest extends BrokerTestBase {
     public void testSeek() throws Exception {
         final String topicName = "persistent://prop/use/ns-abc/testSeek";
 
-        Producer producer = pulsarClient.createProducer(topicName);
-
-        ConsumerConfiguration consumerConf = new ConsumerConfiguration();
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
 
         // Disable pre-fetch in consumer to track the messages received
-        consumerConf.setReceiverQueueSize(0);
-        org.apache.pulsar.client.api.Consumer consumer = pulsarClient.subscribe(topicName, "my-subscription",
-                consumerConf);
+        org.apache.pulsar.client.api.Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName)
+                .subscriptionName("my-subscription").receiverQueueSize(0).subscribe();
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
         assertNotNull(topicRef);
@@ -97,7 +93,8 @@ public class SubscriptionSeekTest extends BrokerTestBase {
         final String topicName = "persistent://prop/use/ns-abc/testSeekPartitions";
 
         admin.persistentTopics().createPartitionedTopic(topicName, 2);
-        org.apache.pulsar.client.api.Consumer consumer = pulsarClient.subscribe(topicName, "my-subscription");
+        org.apache.pulsar.client.api.Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName)
+                .subscriptionName("my-subscription").subscribe();
 
         try {
             consumer.seek(MessageId.latest);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ChecksumTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/ChecksumTest.java
@@ -59,7 +59,7 @@ public class ChecksumTest extends BrokerTestBase {
     public void verifyChecksumStoredInManagedLedger() throws Exception {
         final String topicName = "persistent://prop/use/ns-abc/topic0";
 
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
 
         PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
 
@@ -86,7 +86,7 @@ public class ChecksumTest extends BrokerTestBase {
     public void verifyChecksumSentToConsumer() throws Exception {
         final String topicName = "persistent://prop/use/ns-abc/topic-1";
 
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         RawReader reader = RawReader.create(pulsarClient, topicName, "sub").get();
 
         producer.send("Hello".getBytes());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ManagedLedgerMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ManagedLedgerMetricsTest.java
@@ -58,7 +58,8 @@ public class ManagedLedgerMetricsTest extends BrokerTestBase {
         List<Metrics> list1 = metrics.generate();
         Assert.assertTrue(list1.isEmpty());
 
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic1");
+        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic1")
+                .create();
         for (int i = 0; i < 10; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/PrometheusMetricsTest.java
@@ -55,8 +55,8 @@ public class PrometheusMetricsTest extends BrokerTestBase {
 
     @Test
     public void testPerTopicStats() throws Exception {
-        Producer p1 = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic1");
-        Producer p2 = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic2");
+        Producer<byte[]> p1 = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic1").create();
+        Producer<byte[]> p2 = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic2").create();
         for (int i = 0; i < 10; i++) {
             String message = "my-message-" + i;
             p1.send(message.getBytes());
@@ -101,8 +101,8 @@ public class PrometheusMetricsTest extends BrokerTestBase {
 
     @Test
     public void testPerNamespaceStats() throws Exception {
-        Producer p1 = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic1");
-        Producer p2 = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic2");
+        Producer<byte[]> p1 = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic1").create();
+        Producer<byte[]> p2 = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic2").create();
         for (int i = 0; i < 10; i++) {
             String message = "my-message-" + i;
             p1.send(message.getBytes());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ZooKeeperClientAspectJTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/zookeeper/ZooKeeperClientAspectJTest.java
@@ -189,7 +189,7 @@ public class ZooKeeperClientAspectJTest {
             PulsarClient pulsarClient = mockPulsar.getClient();
             PulsarService pulsar = mockPulsar.getPulsar();
 
-            pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic1");
+            pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic1").create();
             Metrics zkOpMetric = getMetric(pulsar, "zk_write_latency");
             Assert.assertNotNull(zkOpMetric);
             Assert.assertTrue(zkOpMetric.getMetrics().containsKey("brk_zk_write_rate_s"));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthenticatedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthenticatedProducerConsumerTest.java
@@ -109,7 +109,9 @@ public class AuthenticatedProducerConsumerTest extends ProducerConsumerBase {
         } else {
             lookupUrl = new URI("pulsar+ssl://localhost:" + BROKER_PORT_TLS).toString();
         }
-        pulsarClient = PulsarClient.create(lookupUrl, clientConf);
+        pulsarClient = PulsarClient.builder().serviceUrl(lookupUrl).statsInterval(0, TimeUnit.SECONDS)
+                .tlsTrustCertsFilePath(TLS_TRUST_CERT_FILE_PATH).allowTlsInsecureConnection(true).authentication(auth)
+                .enableTls(true).build();
     }
 
     @AfterMethod
@@ -124,26 +126,24 @@ public class AuthenticatedProducerConsumerTest extends ProducerConsumerBase {
     }
 
     public void testSyncProducerAndConsumer(int batchMessageDelayMs) throws Exception {
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic", "my-subscriber-name",
-                conf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/my-topic")
+                .subscriptionName("my-subscriber-name").subscribe();
 
-        ProducerConfiguration producerConf = new ProducerConfiguration();
+        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic");
 
         if (batchMessageDelayMs != 0) {
-            producerConf.setBatchingEnabled(true);
-            producerConf.setBatchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
-            producerConf.setBatchingMaxMessages(5);
+            producerBuilder.enableBatching(true);
+            producerBuilder.batchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
+            producerBuilder.batchingMaxMessages(5);
         }
 
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic", producerConf);
+        Producer<byte[]> producer = producerBuilder.create();
         for (int i = 0; i < 10; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
 
-        Message msg = null;
+        Message<byte[]> msg = null;
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 0; i < 10; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);
@@ -184,8 +184,8 @@ public class AuthenticatedProducerConsumerTest extends ProducerConsumerBase {
         authPassword.configure("{\"userId\":\"superUser\",\"password\":\"supepass\"}");
         internalSetup(authPassword);
 
-        admin.properties()
-                .createProperty("my-property", new PropertyAdmin(Lists.newArrayList(), Sets.newHashSet("use")));
+        admin.properties().createProperty("my-property",
+                new PropertyAdmin(Lists.newArrayList(), Sets.newHashSet("use")));
         admin.namespaces().createNamespace("my-property/use/my-ns");
 
         testSyncProducerAndConsumer(batchMessageDelayMs);
@@ -200,15 +200,14 @@ public class AuthenticatedProducerConsumerTest extends ProducerConsumerBase {
         authPassword.configure("{\"userId\":\"superUser2\",\"password\":\"superpassword\"}");
         internalSetup(authPassword);
 
-        admin.properties()
-                .createProperty("my-property", new PropertyAdmin(Lists.newArrayList(), Sets.newHashSet("use")));
+        admin.properties().createProperty("my-property",
+                new PropertyAdmin(Lists.newArrayList(), Sets.newHashSet("use")));
         admin.namespaces().createNamespace("my-property/use/my-ns");
 
         testSyncProducerAndConsumer(batchMessageDelayMs);
 
         log.info("-- Exiting {} test --", methodName);
     }
-
 
     @Test(dataProvider = "batch")
     public void testAnonymousSyncProducerAndConsumer(int batchMessageDelayMs) throws Exception {
@@ -232,17 +231,19 @@ public class AuthenticatedProducerConsumerTest extends ProducerConsumerBase {
         clientConf.setOperationTimeout(1, TimeUnit.SECONDS);
         admin = spy(new PulsarAdmin(brokerUrl, clientConf));
         admin.namespaces().createNamespace("my-property/use/my-ns");
-        admin.persistentTopics().grantPermission("persistent://my-property/use/my-ns/my-topic", "anonymousUser", EnumSet
-                .allOf(AuthAction.class));
+        admin.persistentTopics().grantPermission("persistent://my-property/use/my-ns/my-topic", "anonymousUser",
+                EnumSet.allOf(AuthAction.class));
 
         // setup the client
         pulsarClient.close();
-        pulsarClient = PulsarClient.create("pulsar://localhost:" + BROKER_PORT, clientConf);
+        pulsarClient = PulsarClient.builder().serviceUrl("pulsar://localhost:" + BROKER_PORT)
+                .operationTimeout(1, TimeUnit.SECONDS).build();
 
         // unauthorized topic test
         Exception pulsarClientException = null;
         try {
-            pulsarClient.subscribe("persistent://my-property/use/my-ns/other-topic", "my-subscriber-name");
+            pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/other-topic")
+                    .subscriptionName("my-subscriber-name").subscribe();
         } catch (Exception e) {
             pulsarClientException = e;
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/BrokerServiceLookupTest.java
@@ -70,11 +70,10 @@ import org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerImpl;
 import org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerWrapper;
 import org.apache.pulsar.broker.loadbalance.impl.SimpleResourceUnit;
 import org.apache.pulsar.broker.namespace.NamespaceService;
-import org.apache.pulsar.client.api.ProducerConfiguration.MessageRoutingMode;
 import org.apache.pulsar.client.impl.auth.AuthenticationTls;
-import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.ServiceUnitId;
+import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.partition.PartitionedTopicMetadata;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.PropertyAdmin;
@@ -105,6 +104,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import lombok.Cleanup;
 
 public class BrokerServiceLookupTest extends ProducerConsumerBase {
     private static final Logger log = LoggerFactory.getLogger(BrokerServiceLookupTest.class);
@@ -114,10 +114,9 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
     protected void setup() throws Exception {
         conf.setDefaultNumberOfNamespaceBundles(1);
         super.init();
-        org.apache.pulsar.client.api.ClientConfiguration clientConf = new org.apache.pulsar.client.api.ClientConfiguration();
-        clientConf.setStatsInterval(0, TimeUnit.SECONDS);
         URI brokerServiceUrl = new URI("pulsar://localhost:" + BROKER_PORT);
-        pulsarClient = PulsarClient.create(brokerServiceUrl.toString(), clientConf);
+        pulsarClient = PulsarClient.builder().serviceUrl(brokerServiceUrl.toString()).statsInterval(0, TimeUnit.SECONDS)
+                .build();
         super.producerBaseSetup();
     }
 
@@ -127,14 +126,13 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
         super.internalCleanup();
     }
 
-
     /**
      * UsecaseL Multiple Broker => Lookup Redirection test
      *
-     * 1. Broker1 is a leader
-     * 2. Lookup request reaches to Broker2 which redirects to leader (Broker1) with authoritative = false
-     * 3. Leader (Broker1) finds out least loaded broker as Broker2 and redirects request to Broker2 with authoritative = true
-     * 4. Broker2 receives final request to own a bundle with authoritative = true and client connects to Broker2
+     * 1. Broker1 is a leader 2. Lookup request reaches to Broker2 which redirects to leader (Broker1) with
+     * authoritative = false 3. Leader (Broker1) finds out least loaded broker as Broker2 and redirects request to
+     * Broker2 with authoritative = true 4. Broker2 receives final request to own a bundle with authoritative = true and
+     * client connects to Broker2
      *
      * @throws Exception
      */
@@ -156,7 +154,6 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
         pulsar.getLoadManager().get().writeLoadReportOnZookeeper();
         pulsar2.getLoadManager().get().writeLoadReportOnZookeeper();
 
-
         LoadManager loadManager1 = spy(pulsar.getLoadManager().get());
         LoadManager loadManager2 = spy(pulsar2.getLoadManager().get());
         Field loadManagerField = NamespaceService.class.getDeclaredField("loadManager");
@@ -175,19 +172,20 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
         /**** started broker-2 ****/
 
         URI brokerServiceUrl = new URI("pulsar://localhost:" + conf2.getBrokerServicePort());
-        PulsarClient pulsarClient2 = PulsarClient.create(brokerServiceUrl.toString(), new ClientConfiguration());
+        PulsarClient pulsarClient2 = PulsarClient.builder().serviceUrl(brokerServiceUrl.toString()).build();
 
         // load namespace-bundle by calling Broker2
-        Consumer consumer = pulsarClient2.subscribe("persistent://my-property/use/my-ns/my-topic1", "my-subscriber-name",
-                new ConsumerConfiguration());
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic1", new ProducerConfiguration());
+        Consumer<byte[]> consumer = pulsarClient2.newConsumer().topic("persistent://my-property/use/my-ns/my-topic1")
+                .subscriptionName("my-subscriber-name").subscribe();
+        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic1")
+                .create();
 
         for (int i = 0; i < 10; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
 
-        Message msg = null;
+        Message<byte[]> msg = null;
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 0; i < 10; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);
@@ -209,11 +207,9 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
     }
 
     /**
-     * Usecase: Redirection due to different cluster
-     * 1. Broker1 runs on cluster: "use" and Broker2 runs on cluster: "use2"
-     * 2. Broker1 receives "use2" cluster request => Broker1 reads "/clusters" from global-zookkeeper and
-     * redirects request to Broker2 whch serves "use2"
-     * 3. Broker2 receives redirect request and own namespace bundle
+     * Usecase: Redirection due to different cluster 1. Broker1 runs on cluster: "use" and Broker2 runs on cluster:
+     * "use2" 2. Broker1 receives "use2" cluster request => Broker1 reads "/clusters" from global-zookkeeper and
+     * redirects request to Broker2 whch serves "use2" 3. Broker2 receives redirect request and own namespace bundle
      *
      * @throws Exception
      */
@@ -235,18 +231,18 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
         conf2.setZookeeperServers("localhost:2181");
         String broker2ServiceUrl = "pulsar://localhost:" + conf2.getBrokerServicePort();
 
-        admin.clusters().createCluster(newCluster, new ClusterData("http://127.0.0.1:" + BROKER_WEBSERVICE_PORT, null, broker2ServiceUrl, null));
+        admin.clusters().createCluster(newCluster,
+                new ClusterData("http://127.0.0.1:" + BROKER_WEBSERVICE_PORT, null, broker2ServiceUrl, null));
         admin.properties().createProperty(property,
                 new PropertyAdmin(Lists.newArrayList("appid1", "appid2"), Sets.newHashSet(newCluster)));
         admin.namespaces().createNamespace(property + "/" + newCluster + "/my-ns");
-
 
         PulsarService pulsar2 = startBroker(conf2);
         pulsar.getLoadManager().get().writeLoadReportOnZookeeper();
         pulsar2.getLoadManager().get().writeLoadReportOnZookeeper();
 
         URI brokerServiceUrl = new URI(broker2ServiceUrl);
-        PulsarClient pulsarClient2 = PulsarClient.create(brokerServiceUrl.toString(), new ClientConfiguration());
+        PulsarClient pulsarClient2 = PulsarClient.builder().serviceUrl(brokerServiceUrl.toString()).build();
 
         // enable authorization: so, broker can validate cluster and redirect if finds different cluster
         pulsar.getConfiguration().setAuthorizationEnabled(true);
@@ -266,16 +262,17 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
         /**** started broker-2 ****/
 
         // load namespace-bundle by calling Broker2
-        Consumer consumer = pulsarClient.subscribe("persistent://my-property2/use2/my-ns/my-topic1", "my-subscriber-name",
-                new ConsumerConfiguration());
-        Producer producer = pulsarClient2.createProducer("persistent://my-property2/use2/my-ns/my-topic1", new ProducerConfiguration());
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property2/use2/my-ns/my-topic1")
+                .subscriptionName("my-subscriber-name").subscribe();
+        Producer<byte[]> producer = pulsarClient2.newProducer().topic("persistent://my-property2/use2/my-ns/my-topic1")
+                .create();
 
         for (int i = 0; i < 10; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
 
-        Message msg = null;
+        Message<byte[]> msg = null;
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 0; i < 10; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);
@@ -298,10 +295,8 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
     }
 
     /**
-     * Create #PartitionedTopic and let it served by multiple brokers which requries
-     * a. tcp partitioned-metadata-lookup
-     * b. multiple topic-lookup
-     * c. partitioned producer-consumer
+     * Create #PartitionedTopic and let it served by multiple brokers which requries a. tcp partitioned-metadata-lookup
+     * b. multiple topic-lookup c. partitioned producer-consumer
      *
      * @throws Exception
      */
@@ -311,9 +306,6 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
 
         int numPartitions = 8;
         TopicName topicName = TopicName.get("persistent://my-property/use/my-ns/my-partitionedtopic1");
-
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
 
         admin.persistentTopics().createPartitionedTopic(topicName.toString(), numPartitions);
 
@@ -331,7 +323,6 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
         pulsar.getLoadManager().get().writeLoadReportOnZookeeper();
         pulsar2.getLoadManager().get().writeLoadReportOnZookeeper();
 
-
         LoadManager loadManager1 = spy(pulsar.getLoadManager().get());
         LoadManager loadManager2 = spy(pulsar2.getLoadManager().get());
         Field loadManagerField = NamespaceService.class.getDeclaredField("loadManager");
@@ -344,20 +335,20 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
         // mock: redirect request to leader
         doReturn(true).when(loadManager2).isCentralized();
         loadManagerField.set(pulsar2.getNamespaceService(), new AtomicReference<>(loadManager2));
-        /****  broker-2 started ****/
+        /**** broker-2 started ****/
 
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-        producerConf.setMessageRoutingMode(MessageRoutingMode.RoundRobinPartition);
-        Producer producer = pulsarClient.createProducer(topicName.toString(), producerConf);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName.toString())
+                .messageRoutingMode(MessageRoutingMode.RoundRobinPartition).create();
 
-        Consumer consumer = pulsarClient.subscribe(topicName.toString(), "my-partitioned-subscriber", conf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName.toString())
+                .subscriptionName("my-partitioned-subscriber").subscribe();
 
         for (int i = 0; i < 20; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
 
-        Message msg = null;
+        Message<byte[]> msg = null;
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 0; i < 20; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);
@@ -380,109 +371,105 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
     }
 
     /**
-     * 1. Start broker1 and broker2 with tls enable
-     * 2. Hit HTTPS lookup url at broker2 which redirects to HTTPS broker1
+     * 1. Start broker1 and broker2 with tls enable 2. Hit HTTPS lookup url at broker2 which redirects to HTTPS broker1
      *
      * @throws Exception
      */
     @Test
-	public void testWebserviceServiceTls() throws Exception {
-		log.info("-- Starting {} test --", methodName);
-		final String TLS_SERVER_CERT_FILE_PATH = "./src/test/resources/certificate/server.crt";
-		final String TLS_SERVER_KEY_FILE_PATH = "./src/test/resources/certificate/server.key";
-		final String TLS_CLIENT_CERT_FILE_PATH = "./src/test/resources/certificate/client.crt";
-		final String TLS_CLIENT_KEY_FILE_PATH = "./src/test/resources/certificate/client.key";
+    public void testWebserviceServiceTls() throws Exception {
+        log.info("-- Starting {} test --", methodName);
+        final String TLS_SERVER_CERT_FILE_PATH = "./src/test/resources/certificate/server.crt";
+        final String TLS_SERVER_KEY_FILE_PATH = "./src/test/resources/certificate/server.key";
+        final String TLS_CLIENT_CERT_FILE_PATH = "./src/test/resources/certificate/client.crt";
+        final String TLS_CLIENT_KEY_FILE_PATH = "./src/test/resources/certificate/client.key";
 
-		/**** start broker-2 ****/
-		ServiceConfiguration conf2 = new ServiceConfiguration();
-		conf2.setAdvertisedAddress("localhost");
-		conf2.setBrokerServicePort(PortManager.nextFreePort());
-		conf2.setBrokerServicePortTls(PortManager.nextFreePort());
-		conf2.setWebServicePort(PortManager.nextFreePort());
-		conf2.setWebServicePortTls(PortManager.nextFreePort());
-		conf2.setAdvertisedAddress("localhost");
-		conf2.setTlsAllowInsecureConnection(true);
-		conf2.setTlsEnabled(true);
-		conf2.setTlsCertificateFilePath(TLS_SERVER_CERT_FILE_PATH);
-		conf2.setTlsKeyFilePath(TLS_SERVER_KEY_FILE_PATH);
-		conf2.setClusterName(conf.getClusterName());
-		conf2.setZookeeperServers("localhost:2181");
-		PulsarService pulsar2 = startBroker(conf2);
+        /**** start broker-2 ****/
+        ServiceConfiguration conf2 = new ServiceConfiguration();
+        conf2.setAdvertisedAddress("localhost");
+        conf2.setBrokerServicePort(PortManager.nextFreePort());
+        conf2.setBrokerServicePortTls(PortManager.nextFreePort());
+        conf2.setWebServicePort(PortManager.nextFreePort());
+        conf2.setWebServicePortTls(PortManager.nextFreePort());
+        conf2.setAdvertisedAddress("localhost");
+        conf2.setTlsAllowInsecureConnection(true);
+        conf2.setTlsEnabled(true);
+        conf2.setTlsCertificateFilePath(TLS_SERVER_CERT_FILE_PATH);
+        conf2.setTlsKeyFilePath(TLS_SERVER_KEY_FILE_PATH);
+        conf2.setClusterName(conf.getClusterName());
+        conf2.setZookeeperServers("localhost:2181");
+        PulsarService pulsar2 = startBroker(conf2);
 
-		// restart broker1 with tls enabled
-		conf.setTlsAllowInsecureConnection(true);
-		conf.setTlsEnabled(true);
-		conf.setTlsCertificateFilePath(TLS_SERVER_CERT_FILE_PATH);
-		conf.setTlsKeyFilePath(TLS_SERVER_KEY_FILE_PATH);
-		stopBroker();
-		startBroker();
-		pulsar.getLoadManager().get().writeLoadReportOnZookeeper();
-		pulsar2.getLoadManager().get().writeLoadReportOnZookeeper();
+        // restart broker1 with tls enabled
+        conf.setTlsAllowInsecureConnection(true);
+        conf.setTlsEnabled(true);
+        conf.setTlsCertificateFilePath(TLS_SERVER_CERT_FILE_PATH);
+        conf.setTlsKeyFilePath(TLS_SERVER_KEY_FILE_PATH);
+        stopBroker();
+        startBroker();
+        pulsar.getLoadManager().get().writeLoadReportOnZookeeper();
+        pulsar2.getLoadManager().get().writeLoadReportOnZookeeper();
 
-		LoadManager loadManager1 = spy(pulsar.getLoadManager().get());
-		LoadManager loadManager2 = spy(pulsar2.getLoadManager().get());
-		Field loadManagerField = NamespaceService.class.getDeclaredField("loadManager");
-		loadManagerField.setAccessible(true);
+        LoadManager loadManager1 = spy(pulsar.getLoadManager().get());
+        LoadManager loadManager2 = spy(pulsar2.getLoadManager().get());
+        Field loadManagerField = NamespaceService.class.getDeclaredField("loadManager");
+        loadManagerField.setAccessible(true);
 
-		// mock: redirect request to leader [2]
-		doReturn(true).when(loadManager2).isCentralized();
-		loadManagerField.set(pulsar2.getNamespaceService(), new AtomicReference<>(loadManager2));
+        // mock: redirect request to leader [2]
+        doReturn(true).when(loadManager2).isCentralized();
+        loadManagerField.set(pulsar2.getNamespaceService(), new AtomicReference<>(loadManager2));
 
-		// mock: return Broker2 as a Least-loaded broker when leader receies
-		// request [3]
-		doReturn(true).when(loadManager1).isCentralized();
-		SimpleResourceUnit resourceUnit = new SimpleResourceUnit(pulsar2.getWebServiceAddress(), null);
-		doReturn(Optional.of(resourceUnit)).when(loadManager1).getLeastLoaded(any(ServiceUnitId.class));
-		loadManagerField.set(pulsar.getNamespaceService(), new AtomicReference<>(loadManager1));
+        // mock: return Broker2 as a Least-loaded broker when leader receies
+        // request [3]
+        doReturn(true).when(loadManager1).isCentralized();
+        SimpleResourceUnit resourceUnit = new SimpleResourceUnit(pulsar2.getWebServiceAddress(), null);
+        doReturn(Optional.of(resourceUnit)).when(loadManager1).getLeastLoaded(any(ServiceUnitId.class));
+        loadManagerField.set(pulsar.getNamespaceService(), new AtomicReference<>(loadManager1));
 
-		/**** started broker-2 ****/
+        /**** started broker-2 ****/
 
-		URI brokerServiceUrl = new URI("pulsar://localhost:" + conf2.getBrokerServicePort());
-		PulsarClient pulsarClient2 = PulsarClient.create(brokerServiceUrl.toString(), new ClientConfiguration());
+        URI brokerServiceUrl = new URI("pulsar://localhost:" + conf2.getBrokerServicePort());
+        PulsarClient pulsarClient2 = PulsarClient.builder().serviceUrl(brokerServiceUrl.toString()).build();
 
-		final String lookupResourceUrl = "/lookup/v2/destination/persistent/my-property/use/my-ns/my-topic1";
+        final String lookupResourceUrl = "/lookup/v2/destination/persistent/my-property/use/my-ns/my-topic1";
 
-		// set client cert_key file
-		KeyManager[] keyManagers = null;
-		Certificate[] tlsCert = SecurityUtility.loadCertificatesFromPemFile(TLS_CLIENT_CERT_FILE_PATH);
-		PrivateKey tlsKey = SecurityUtility.loadPrivateKeyFromPemFile(TLS_CLIENT_KEY_FILE_PATH);
-		KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
-		ks.load(null, null);
-		ks.setKeyEntry("private", tlsKey, "".toCharArray(), tlsCert);
-		KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-		kmf.init(ks, "".toCharArray());
-		keyManagers = kmf.getKeyManagers();
-		TrustManager[] trustManagers = InsecureTrustManagerFactory.INSTANCE.getTrustManagers();
-		SSLContext sslCtx = SSLContext.getInstance("TLS");
-		sslCtx.init(keyManagers, trustManagers, new SecureRandom());
-		HttpsURLConnection.setDefaultSSLSocketFactory(sslCtx.getSocketFactory());
+        // set client cert_key file
+        KeyManager[] keyManagers = null;
+        Certificate[] tlsCert = SecurityUtility.loadCertificatesFromPemFile(TLS_CLIENT_CERT_FILE_PATH);
+        PrivateKey tlsKey = SecurityUtility.loadPrivateKeyFromPemFile(TLS_CLIENT_KEY_FILE_PATH);
+        KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
+        ks.load(null, null);
+        ks.setKeyEntry("private", tlsKey, "".toCharArray(), tlsCert);
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        kmf.init(ks, "".toCharArray());
+        keyManagers = kmf.getKeyManagers();
+        TrustManager[] trustManagers = InsecureTrustManagerFactory.INSTANCE.getTrustManagers();
+        SSLContext sslCtx = SSLContext.getInstance("TLS");
+        sslCtx.init(keyManagers, trustManagers, new SecureRandom());
+        HttpsURLConnection.setDefaultSSLSocketFactory(sslCtx.getSocketFactory());
 
+        // hit broker2 url
+        URLConnection con = new URL(pulsar2.getWebServiceAddressTls() + lookupResourceUrl).openConnection();
+        log.info("orignal url: {}", con.getURL());
+        con.connect();
+        log.info("connected url: {} ", con.getURL());
+        // assert connect-url: broker2-https
+        assertEquals(con.getURL().getPort(), conf2.getWebServicePortTls());
+        InputStream is = con.getInputStream();
+        // assert redirect-url: broker1-https only
+        log.info("redirected url: {}", con.getURL());
+        assertEquals(con.getURL().getPort(), conf.getWebServicePortTls());
+        is.close();
 
-		// hit broker2 url
-		URLConnection con = new URL(pulsar2.getWebServiceAddressTls() + lookupResourceUrl).openConnection();
-		log.info("orignal url: {}", con.getURL());
-		con.connect();
-		log.info("connected url: {} ", con.getURL());
-		// assert connect-url: broker2-https
-		assertEquals(con.getURL().getPort(), conf2.getWebServicePortTls());
-		InputStream is = con.getInputStream();
-		// assert redirect-url: broker1-https only
-		log.info("redirected url: {}", con.getURL());
-		assertEquals(con.getURL().getPort(), conf.getWebServicePortTls());
-		is.close();
+        pulsarClient2.close();
+        pulsar2.close();
+        loadManager1 = null;
+        loadManager2 = null;
 
-		pulsarClient2.close();
-		pulsar2.close();
-		loadManager1 = null;
-		loadManager2 = null;
-
-	}
+    }
 
     /**
-     * Discovery-Service lookup over binary-protocol
-     * 1. Start discovery service
-     * 2. start broker
-     * 3. Create Producer/Consumer: by calling Discovery service for partitionedMetadata and topic lookup
+     * Discovery-Service lookup over binary-protocol 1. Start discovery service 2. start broker 3. Create
+     * Producer/Consumer: by calling Discovery service for partitionedMetadata and topic lookup
      *
      * @throws Exception
      */
@@ -499,18 +486,18 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
 
         // (2) lookup using discovery service
         final String discoverySvcUrl = discoveryService.getServiceUrl();
-        ClientConfiguration clientConfig = new ClientConfiguration();
-        PulsarClient pulsarClient2 = PulsarClient.create(discoverySvcUrl, clientConfig);
-        Consumer consumer = pulsarClient2.subscribe("persistent://my-property2/use2/my-ns/my-topic1", "my-subscriber-name",
-                new ConsumerConfiguration());
-        Producer producer = pulsarClient2.createProducer("persistent://my-property2/use2/my-ns/my-topic1", new ProducerConfiguration());
+        PulsarClient pulsarClient2 = PulsarClient.builder().serviceUrl(discoverySvcUrl).build();
+        Consumer<byte[]> consumer = pulsarClient2.newConsumer().topic("persistent://my-property2/use2/my-ns/my-topic1")
+                .subscriptionName("my-subscriber-name").subscribe();
+        Producer<byte[]> producer = pulsarClient2.newProducer().topic("persistent://my-property2/use2/my-ns/my-topic1")
+                .create();
 
         for (int i = 0; i < 10; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
 
-        Message msg = null;
+        Message<byte[]> msg = null;
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 0; i < 10; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);
@@ -526,12 +513,12 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
 
     }
 
-
     /**
      * Verify discovery-service binary-proto lookup using tls
      *
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testDiscoveryLookupTls() throws Exception {
 
@@ -562,29 +549,26 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
 
         // (3) lookup using discovery service
         final String discoverySvcUrl = discoveryService.getServiceUrlTls();
-        ClientConfiguration clientConfig = new ClientConfiguration();
 
         Map<String, String> authParams = new HashMap<>();
         authParams.put("tlsCertFile", TLS_CLIENT_CERT_FILE_PATH);
         authParams.put("tlsKeyFile", TLS_CLIENT_KEY_FILE_PATH);
         Authentication auth = new AuthenticationTls();
         auth.configure(authParams);
-        clientConfig.setAuthentication(auth);
-        clientConfig.setUseTls(true);
-        clientConfig.setTlsAllowInsecureConnection(true);
 
-
-        PulsarClient pulsarClient2 = PulsarClient.create(discoverySvcUrl, clientConfig);
-        Consumer consumer = pulsarClient2.subscribe("persistent://my-property2/use2/my-ns/my-topic1", "my-subscriber-name",
-                new ConsumerConfiguration());
-        Producer producer = pulsarClient2.createProducer("persistent://my-property2/use2/my-ns/my-topic1", new ProducerConfiguration());
+        PulsarClient pulsarClient2 = PulsarClient.builder().serviceUrl(discoverySvcUrl).authentication(auth)
+                .enableTls(true).allowTlsInsecureConnection(true).build();
+        Consumer<byte[]> consumer = pulsarClient2.newConsumer().topic("persistent://my-property2/use2/my-ns/my-topic1")
+                .subscriptionName("my-subscriber-name").subscribe();
+        Producer<byte[]> producer = pulsarClient2.newProducer().topic("persistent://my-property2/use2/my-ns/my-topic1")
+                .create();
 
         for (int i = 0; i < 10; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
 
-        Message msg = null;
+        Message<byte[]> msg = null;
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 0; i < 10; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);
@@ -619,42 +603,45 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
 
         // (2) lookup using discovery service
         final String discoverySvcUrl = discoveryService.getServiceUrl();
-        ClientConfiguration clientConfig = new ClientConfiguration();
         // set authentication data
-        clientConfig.setAuthentication(new Authentication() {
+        Authentication auth = new Authentication() {
             private static final long serialVersionUID = 1L;
 
             @Override
             public void close() throws IOException {
             }
+
             @Override
             public String getAuthMethodName() {
                 return "auth";
             }
+
             @Override
             public AuthenticationDataProvider getAuthData() throws PulsarClientException {
                 return new AuthenticationDataProvider() {
                     private static final long serialVersionUID = 1L;
                 };
             }
+
             @Override
             public void configure(Map<String, String> authParams) {
             }
+
             @Override
             public void start() throws PulsarClientException {
             }
-        });
+        };
 
-        PulsarClient pulsarClient = PulsarClient.create(discoverySvcUrl, clientConfig);
-        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use2/my-ns/my-topic1",
-                "my-subscriber-name", new ConsumerConfiguration());
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use2/my-ns/my-topic1",
-                new ProducerConfiguration());
+        PulsarClient pulsarClient = PulsarClient.builder().serviceUrl(discoverySvcUrl).authentication(auth).build();
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/use2/my-ns/my-topic1")
+                .subscriptionName("my-subscriber-name").subscribe();
+        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use2/my-ns/my-topic1")
+                .create();
         for (int i = 0; i < 10; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
-        Message msg = null;
+        Message<byte[]> msg = null;
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 0; i < 10; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);
@@ -687,35 +674,41 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
         discoveryService.start();
         // (2) lookup using discovery service
         final String discoverySvcUrl = discoveryService.getServiceUrl();
-        ClientConfiguration clientConfig = new ClientConfiguration();
+
         // set authentication data
-        clientConfig.setAuthentication(new Authentication() {
+        Authentication auth = new Authentication() {
             private static final long serialVersionUID = 1L;
 
             @Override
             public void close() throws IOException {
             }
+
             @Override
             public String getAuthMethodName() {
                 return "auth";
             }
+
             @Override
             public AuthenticationDataProvider getAuthData() throws PulsarClientException {
                 return new AuthenticationDataProvider() {
                     private static final long serialVersionUID = 1L;
                 };
             }
+
             @Override
             public void configure(Map<String, String> authParams) {
             }
+
             @Override
             public void start() throws PulsarClientException {
             }
-        });
-        PulsarClient pulsarClient = PulsarClient.create(discoverySvcUrl, clientConfig);
+        };
+
+        @Cleanup
+        PulsarClient pulsarClient = PulsarClient.builder().serviceUrl(discoverySvcUrl).authentication(auth).build();
         try {
-            pulsarClient.subscribe("persistent://my-property/use2/my-ns/my-topic1", "my-subscriber-name",
-                    new ConsumerConfiguration());
+            pulsarClient.newConsumer().topic("persistent://my-property/use2/my-ns/my-topic1")
+                    .subscriptionName("my-subscriber-name").subscribe();
             fail("should have failed due to authentication");
         } catch (PulsarClientException e) {
             // Ok: expected
@@ -740,35 +733,41 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
         discoveryService.start();
         // (2) lookup using discovery service
         final String discoverySvcUrl = discoveryService.getServiceUrl();
-        ClientConfiguration clientConfig = new ClientConfiguration();
+
         // set authentication data
-        clientConfig.setAuthentication(new Authentication() {
+        Authentication auth = new Authentication() {
             private static final long serialVersionUID = 1L;
 
             @Override
             public void close() throws IOException {
             }
+
             @Override
             public String getAuthMethodName() {
                 return "auth";
             }
+
             @Override
             public AuthenticationDataProvider getAuthData() throws PulsarClientException {
                 return new AuthenticationDataProvider() {
                     private static final long serialVersionUID = 1L;
                 };
             }
+
             @Override
             public void configure(Map<String, String> authParams) {
             }
+
             @Override
             public void start() throws PulsarClientException {
             }
-        });
-        PulsarClient pulsarClient = PulsarClient.create(discoverySvcUrl, clientConfig);
+        };
+
+        @Cleanup
+        PulsarClient pulsarClient = PulsarClient.builder().serviceUrl(discoverySvcUrl).authentication(auth).build();
         try {
-            pulsarClient.subscribe("persistent://my-property/use2/my-ns/my-topic1", "my-subscriber-name",
-                    new ConsumerConfiguration());
+            pulsarClient.newConsumer().topic("persistent://my-property/use2/my-ns/my-topic1")
+                    .subscriptionName("my-subscriber-name").subscribe();
             fail("should have failed due to authentication");
         } catch (PulsarClientException e) {
             // Ok: expected
@@ -833,11 +832,12 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
         loadManagerField.set(pulsar.getNamespaceService(), new AtomicReference<>(loadManager1));
 
         URI broker2ServiceUrl = new URI("pulsar://localhost:" + conf2.getBrokerServicePort());
-        PulsarClient pulsarClient2 = PulsarClient.create(broker2ServiceUrl.toString(), new ClientConfiguration());
+        PulsarClient pulsarClient2 = PulsarClient.builder().serviceUrl(broker2ServiceUrl.toString()).build();
 
         // (3) Broker-2 receives topic-1 request, creates local-policies and sets the watch
         final String topic1 = "persistent://" + namespace + "/topic1";
-        Consumer consumer1 = pulsarClient2.subscribe(topic1, "my-subscriber-name", new ConsumerConfiguration());
+        Consumer<byte[]> consumer1 = pulsarClient2.newConsumer().topic(topic1).subscriptionName("my-subscriber-name")
+                .subscribe();
 
         Set<String> serviceUnits1 = pulsar.getNamespaceService().getOwnedServiceUnits().stream()
                 .map(nb -> nb.toString()).collect(Collectors.toSet());
@@ -865,10 +865,10 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
 
         // (7) Make lookup request again to Broker-2 which should succeed.
         final String topic2 = "persistent://" + namespace + "/topic2";
-        Consumer consumer2 = pulsarClient.subscribe(topic2, "my-subscriber-name", new ConsumerConfiguration());
+        Consumer<byte[]> consumer2 = pulsarClient.newConsumer().topic(topic2).subscriptionName("my-subscriber-name")
+                .subscribe();
 
-        NamespaceBundle bundleInBroker1AfterSplit = pulsar2.getNamespaceService()
-                .getBundle(TopicName.get(topic2));
+        NamespaceBundle bundleInBroker1AfterSplit = pulsar2.getNamespaceService().getBundle(TopicName.get(topic2));
         assertFalse(bundleInBroker1AfterSplit.equals(unsplitBundle));
 
         consumer1.close();
@@ -942,11 +942,12 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
             loadManagerField.set(pulsar.getNamespaceService(), new AtomicReference<>(loadManager1));
 
             URI broker2ServiceUrl = new URI("pulsar://localhost:" + conf2.getBrokerServicePort());
-            PulsarClient pulsarClient2 = PulsarClient.create(broker2ServiceUrl.toString(), new ClientConfiguration());
+            PulsarClient pulsarClient2 = PulsarClient.builder().serviceUrl(broker2ServiceUrl.toString()).build();
 
             // (3) Broker-2 receives topic-1 request, creates local-policies and sets the watch
             final String topic1 = "persistent://" + namespace + "/topic1";
-            Consumer consumer1 = pulsarClient2.subscribe(topic1, "my-subscriber-name", new ConsumerConfiguration());
+            Consumer<byte[]> consumer1 = pulsarClient2.newConsumer().topic(topic1)
+                    .subscriptionName("my-subscriber-name").subscribe();
 
             Set<String> serviceUnits1 = pulsar.getNamespaceService().getOwnedServiceUnits().stream()
                     .map(nb -> nb.toString()).collect(Collectors.toSet());
@@ -994,10 +995,10 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
 
             // (7) Make lookup request again to Broker-2 which should succeed.
             final String topic2 = "persistent://" + namespace + "/topic2";
-            Consumer consumer2 = pulsarClient.subscribe(topic2, "my-subscriber-name", new ConsumerConfiguration());
+            Consumer<byte[]> consumer2 = pulsarClient.newConsumer().topic(topic2).subscriptionName("my-subscriber-name")
+                    .subscribe();
 
-            NamespaceBundle bundleInBroker1AfterSplit = pulsar2.getNamespaceService()
-                    .getBundle(TopicName.get(topic2));
+            NamespaceBundle bundleInBroker1AfterSplit = pulsar2.getNamespaceService().getBundle(TopicName.get(topic2));
             assertFalse(bundleInBroker1AfterSplit.equals(unsplitBundle));
 
             consumer1.close();
@@ -1152,13 +1153,16 @@ public class BrokerServiceLookupTest extends ProducerConsumerBase {
         @Override
         public void close() throws IOException {
         }
+
         @Override
         public void initialize(ServiceConfiguration config) throws IOException {
         }
+
         @Override
         public String getAuthMethodName() {
             return "auth";
         }
+
         @Override
         public String authenticate(AuthenticationDataSource authData) throws AuthenticationException {
             return "appid1";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientErrorsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/ClientErrorsTest.java
@@ -30,19 +30,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.bookkeeper.test.PortManager;
-import org.apache.pulsar.client.api.ClientConfiguration;
-import org.apache.pulsar.client.api.Consumer;
-import org.apache.pulsar.client.api.ConsumerConfiguration;
-import org.apache.pulsar.client.api.Producer;
-import org.apache.pulsar.client.api.PulsarClient;
-import org.apache.pulsar.client.api.PulsarClientException;
-import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.PulsarClientException.LookupException;
 import org.apache.pulsar.client.impl.ConsumerBase;
 import org.apache.pulsar.client.impl.ProducerBase;
 import org.apache.pulsar.common.api.Commands;
-import org.apache.pulsar.common.api.proto.PulsarApi.ServerError;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandLookupTopicResponse.LookupType;
+import org.apache.pulsar.common.api.proto.PulsarApi.ServerError;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -78,13 +71,12 @@ public class ClientErrorsTest {
     public void testMockBrokerService() throws Exception {
         // test default actions of mock broker service
         try {
-            PulsarClient client = PulsarClient.create("http://127.0.0.1:" + WEB_SERVICE_PORT);
+            PulsarClient client = PulsarClient.builder().serviceUrl("http://127.0.0.1:" + WEB_SERVICE_PORT).build();
 
-            ConsumerConfiguration conf = new ConsumerConfiguration();
-            conf.setSubscriptionType(SubscriptionType.Exclusive);
-            Consumer consumer = client.subscribe("persistent://prop/use/ns/t1", "sub1", conf);
+            Consumer<byte[]> consumer = client.newConsumer().topic("persistent://prop/use/ns/t1")
+                    .subscriptionName("sub1").subscribe();
 
-            Producer producer = client.createProducer("persistent://prop/use/ns/t1");
+            Producer<byte[]> producer = client.newProducer().topic("persistent://prop/use/ns/t1").create();
             Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
             producer.send("message".getBytes());
             Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
@@ -110,7 +102,7 @@ public class ClientErrorsTest {
     }
 
     private void producerCreateFailWithoutRetry(String topic) throws Exception {
-        PulsarClient client = PulsarClient.create("http://127.0.0.1:" + WEB_SERVICE_PORT);
+        PulsarClient client = PulsarClient.builder().serviceUrl("http://127.0.0.1:" + WEB_SERVICE_PORT).build();
         final AtomicInteger counter = new AtomicInteger(0);
 
         mockBrokerService.setHandleProducer((ctx, producer) -> {
@@ -124,7 +116,7 @@ public class ClientErrorsTest {
         });
 
         try {
-            Producer producer = client.createProducer(topic);
+            client.newProducer().topic(topic).create();
         } catch (Exception e) {
             if (e.getMessage().equals(ASSERTION_ERROR)) {
                 fail("Producer create should not retry on auth error");
@@ -146,7 +138,7 @@ public class ClientErrorsTest {
     }
 
     private void producerCreateSuccessAfterRetry(String topic) throws Exception {
-        PulsarClient client = PulsarClient.create("http://127.0.0.1:" + WEB_SERVICE_PORT);
+        PulsarClient client = PulsarClient.builder().serviceUrl("http://127.0.0.1:" + WEB_SERVICE_PORT).build();
         final AtomicInteger counter = new AtomicInteger(0);
 
         mockBrokerService.setHandleProducer((ctx, producer) -> {
@@ -158,7 +150,7 @@ public class ClientErrorsTest {
         });
 
         try {
-            Producer producer = client.createProducer(topic);
+            client.newProducer().topic(topic).create();
         } catch (Exception e) {
             fail("Should not fail");
         }
@@ -178,10 +170,8 @@ public class ClientErrorsTest {
     }
 
     private void producerCreateFailAfterRetryTimeout(String topic) throws Exception {
-        ClientConfiguration conf = new ClientConfiguration();
-        conf.setOperationTimeout(1, TimeUnit.SECONDS);
-
-        PulsarClient client = PulsarClient.create("http://127.0.0.1:" + WEB_SERVICE_PORT, conf);
+        PulsarClient client = PulsarClient.builder().serviceUrl("http://127.0.0.1:" + WEB_SERVICE_PORT)
+                .operationTimeout(1, TimeUnit.SECONDS).build();
         final AtomicInteger counter = new AtomicInteger(0);
 
         mockBrokerService.setHandleProducer((ctx, producer) -> {
@@ -196,7 +186,7 @@ public class ClientErrorsTest {
         });
 
         try {
-            Producer producer = client.createProducer(topic);
+            client.newProducer().topic(topic).create();
             fail("Should have failed");
         } catch (Exception e) {
             // we fail even on the retriable error
@@ -218,7 +208,7 @@ public class ClientErrorsTest {
     }
 
     private void producerFailDoesNotFailOtherProducer(String topic1, String topic2) throws Exception {
-        PulsarClient client = PulsarClient.create("http://127.0.0.1:" + WEB_SERVICE_PORT);
+        PulsarClient client = PulsarClient.builder().serviceUrl("http://127.0.0.1:" + WEB_SERVICE_PORT).build();
         final AtomicInteger counter = new AtomicInteger(0);
 
         mockBrokerService.setHandleProducer((ctx, producer) -> {
@@ -228,14 +218,13 @@ public class ClientErrorsTest {
                 return;
             }
             ctx.writeAndFlush(Commands.newProducerSuccess(producer.getRequestId(), "default-producer"));
-
         });
 
-        ProducerBase producer1 = (ProducerBase) client.createProducer(topic1);
+        ProducerBase<byte[]> producer1 = (ProducerBase<byte[]>) client.newProducer().topic(topic1).create();
 
-        ProducerBase producer2 = null;
+        ProducerBase<byte[]> producer2 = null;
         try {
-            producer2 = (ProducerBase) client.createProducer(topic2);
+            producer2 = (ProducerBase<byte[]>) client.newProducer().topic(topic2).create();
             fail("Should have failed");
         } catch (Exception e) {
             // ok
@@ -259,7 +248,7 @@ public class ClientErrorsTest {
     }
 
     private void producerContinuousRetryAfterSendFail(String topic) throws Exception {
-        PulsarClient client = PulsarClient.create("http://127.0.0.1:" + WEB_SERVICE_PORT);
+        PulsarClient client = PulsarClient.builder().serviceUrl("http://127.0.0.1:" + WEB_SERVICE_PORT).build();
         final AtomicInteger counter = new AtomicInteger(0);
 
         mockBrokerService.setHandleProducer((ctx, producer) -> {
@@ -283,7 +272,7 @@ public class ClientErrorsTest {
         });
 
         try {
-            Producer producer = client.createProducer(topic);
+            Producer<byte[]> producer = client.newProducer().topic(topic).create();
             producer.send("message".getBytes());
         } catch (Exception e) {
             fail("Should not fail");
@@ -307,7 +296,7 @@ public class ClientErrorsTest {
     @Test
     public void testLookupWithDisconnection() throws Exception {
         final String brokerUrl = "pulsar://127.0.0.1:" + BROKER_SERVICE_PORT;
-        PulsarClient client = PulsarClient.create(brokerUrl);
+        PulsarClient client = PulsarClient.builder().serviceUrl(brokerUrl).build();
         final AtomicInteger counter = new AtomicInteger(0);
         String topic = "persistent://prop/use/ns/t1";
 
@@ -326,9 +315,7 @@ public class ClientErrorsTest {
         });
 
         try {
-            ConsumerConfiguration conf = new ConsumerConfiguration();
-            conf.setSubscriptionType(SubscriptionType.Exclusive);
-            Consumer consumer = client.subscribe(topic, "sub1", conf);
+            client.newConsumer().topic(topic).subscriptionName("sub1").subscribe();
         } catch (Exception e) {
             if (e.getMessage().equals(ASSERTION_ERROR)) {
                 fail("Subscribe should not retry on persistence error");
@@ -342,7 +329,7 @@ public class ClientErrorsTest {
     }
 
     private void subscribeFailWithoutRetry(String topic) throws Exception {
-        PulsarClient client = PulsarClient.create("http://127.0.0.1:" + WEB_SERVICE_PORT);
+        PulsarClient client = PulsarClient.builder().serviceUrl("http://127.0.0.1:" + WEB_SERVICE_PORT).build();
         final AtomicInteger counter = new AtomicInteger(0);
 
         mockBrokerService.setHandleSubscribe((ctx, subscribe) -> {
@@ -356,9 +343,7 @@ public class ClientErrorsTest {
         });
 
         try {
-            ConsumerConfiguration conf = new ConsumerConfiguration();
-            conf.setSubscriptionType(SubscriptionType.Exclusive);
-            Consumer consumer = client.subscribe(topic, "sub1", conf);
+            client.newConsumer().topic(topic).subscriptionName("sub1").subscribe();
         } catch (Exception e) {
             if (e.getMessage().equals(ASSERTION_ERROR)) {
                 fail("Subscribe should not retry on persistence error");
@@ -380,7 +365,7 @@ public class ClientErrorsTest {
     }
 
     private void subscribeSuccessAfterRetry(String topic) throws Exception {
-        PulsarClient client = PulsarClient.create("http://127.0.0.1:" + WEB_SERVICE_PORT);
+        PulsarClient client = PulsarClient.builder().serviceUrl("http://127.0.0.1:" + WEB_SERVICE_PORT).build();
         final AtomicInteger counter = new AtomicInteger(0);
 
         mockBrokerService.setHandleSubscribe((ctx, subscribe) -> {
@@ -392,9 +377,7 @@ public class ClientErrorsTest {
         });
 
         try {
-            ConsumerConfiguration conf = new ConsumerConfiguration();
-            conf.setSubscriptionType(SubscriptionType.Exclusive);
-            Consumer consumer = client.subscribe(topic, "sub1", conf);
+            client.newConsumer().topic(topic).subscriptionName("sub1").subscribe();
         } catch (Exception e) {
             fail("Should not fail");
         }
@@ -414,10 +397,8 @@ public class ClientErrorsTest {
     }
 
     private void subscribeFailAfterRetryTimeout(String topic) throws Exception {
-        ClientConfiguration conf = new ClientConfiguration();
-        conf.setOperationTimeout(200, TimeUnit.MILLISECONDS);
-
-        PulsarClient client = PulsarClient.create("http://127.0.0.1:" + WEB_SERVICE_PORT, conf);
+        PulsarClient client = PulsarClient.builder().serviceUrl("http://127.0.0.1:" + WEB_SERVICE_PORT)
+                .operationTimeout(200, TimeUnit.MILLISECONDS).build();
         final AtomicInteger counter = new AtomicInteger(0);
 
         mockBrokerService.setHandleSubscribe((ctx, subscribe) -> {
@@ -432,9 +413,7 @@ public class ClientErrorsTest {
         });
 
         try {
-            ConsumerConfiguration cConf = new ConsumerConfiguration();
-            cConf.setSubscriptionType(SubscriptionType.Exclusive);
-            client.subscribe(topic, "sub1", cConf);
+            client.newConsumer().topic(topic).subscriptionName("sub1").subscribe();
             fail("Should have failed");
         } catch (Exception e) {
             // we fail even on the retriable error
@@ -456,7 +435,7 @@ public class ClientErrorsTest {
     }
 
     private void subscribeFailDoesNotFailOtherConsumer(String topic1, String topic2) throws Exception {
-        PulsarClient client = PulsarClient.create("http://127.0.0.1:" + WEB_SERVICE_PORT);
+        PulsarClient client = PulsarClient.builder().serviceUrl("http://127.0.0.1:" + WEB_SERVICE_PORT).build();
         final AtomicInteger counter = new AtomicInteger(0);
 
         mockBrokerService.setHandleSubscribe((ctx, subscribe) -> {
@@ -469,13 +448,12 @@ public class ClientErrorsTest {
 
         });
 
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-        ConsumerBase consumer1 = (ConsumerBase) client.subscribe(topic1, "sub1", conf);
+        ConsumerBase<byte[]> consumer1 = (ConsumerBase<byte[]>) client.newConsumer().topic(topic1)
+                .subscriptionName("sub1").subscribe();
 
-        ConsumerBase consumer2 = null;
+        ConsumerBase<byte[]> consumer2 = null;
         try {
-            consumer2 = (ConsumerBase) client.subscribe(topic2, "sub1", conf);
+            consumer2 = (ConsumerBase<byte[]>) client.newConsumer().topic(topic2).subscriptionName("sub1").subscribe();
             fail("Should have failed");
         } catch (Exception e) {
             // ok
@@ -492,7 +470,7 @@ public class ClientErrorsTest {
     // other producers and fail
     @Test
     public void testOneProducerFailShouldCloseAllProducersInPartitionedProducer() throws Exception {
-        PulsarClient client = PulsarClient.create("http://127.0.0.1:" + WEB_SERVICE_PORT);
+        PulsarClient client = PulsarClient.builder().serviceUrl("http://127.0.0.1:" + WEB_SERVICE_PORT).build();
         final AtomicInteger producerCounter = new AtomicInteger(0);
         final AtomicInteger closeCounter = new AtomicInteger(0);
 
@@ -510,7 +488,7 @@ public class ClientErrorsTest {
         });
 
         try {
-            Producer producer = client.createProducer("persistent://prop/use/ns/multi-part-t1");
+            client.newProducer().topic("persistent://prop/use/ns/multi-part-t1").create();
             fail("Should have failed with an authorization error");
         } catch (Exception e) {
             assertTrue(e instanceof PulsarClientException.AuthorizationException);
@@ -527,7 +505,7 @@ public class ClientErrorsTest {
     // of other consumers and fail
     @Test
     public void testOneConsumerFailShouldCloseAllConsumersInPartitionedConsumer() throws Exception {
-        PulsarClient client = PulsarClient.create("http://127.0.0.1:" + WEB_SERVICE_PORT);
+        PulsarClient client = PulsarClient.builder().serviceUrl("http://127.0.0.1:" + WEB_SERVICE_PORT).build();
         final AtomicInteger subscribeCounter = new AtomicInteger(0);
         final AtomicInteger closeCounter = new AtomicInteger(0);
 
@@ -546,7 +524,7 @@ public class ClientErrorsTest {
         });
 
         try {
-            Consumer consumer = client.subscribe("persistent://prop/use/ns/multi-part-t1", "my-sub");
+            client.newConsumer().topic("persistent://prop/use/ns/multi-part-t1").subscriptionName("sub1").subscribe();
             fail("Should have failed with an authentication error");
         } catch (Exception e) {
             assertTrue(e instanceof PulsarClientException.AuthenticationException);
@@ -561,7 +539,7 @@ public class ClientErrorsTest {
 
     @Test
     public void testFlowSendWhenPartitionedSubscribeCompletes() throws Exception {
-        PulsarClient client = PulsarClient.create("http://127.0.0.1:" + WEB_SERVICE_PORT);
+        PulsarClient client = PulsarClient.builder().serviceUrl("http://127.0.0.1:" + WEB_SERVICE_PORT).build();
 
         AtomicInteger subscribed = new AtomicInteger();
         AtomicBoolean fail = new AtomicBoolean(false);
@@ -578,7 +556,7 @@ public class ClientErrorsTest {
             }
         });
 
-        Consumer consumer = client.subscribe("persistent://prop/use/ns/multi-part-t1", "my-sub");
+        client.newConsumer().topic("persistent://prop/use/ns/multi-part-t1").subscriptionName("sub1").subscribe();
 
         if (fail.get()) {
             fail("Flow command should have been sent after all 4 partitions subscribe successfully");
@@ -613,8 +591,8 @@ public class ClientErrorsTest {
             ctx.writeAndFlush(Commands.newSendReceipt(0, 0, 1, 1));
         });
 
-        PulsarClient client = PulsarClient.create("http://127.0.0.1:" + WEB_SERVICE_PORT);
-        Producer producer = client.createProducer("persistent://prop/use/ns/t1");
+        PulsarClient client = PulsarClient.builder().serviceUrl("http://127.0.0.1:" + WEB_SERVICE_PORT).build();
+        Producer<byte[]> producer = client.newProducer().topic("persistent://prop/use/ns/t1").create();
 
         // close the cnx after creating the producer
         channelCtx.get().channel().close().get();
@@ -651,8 +629,8 @@ public class ClientErrorsTest {
             ctx.writeAndFlush(Commands.newSuccess(subscribe.getRequestId()));
         });
 
-        PulsarClient client = PulsarClient.create("http://127.0.0.1:" + WEB_SERVICE_PORT);
-        client.subscribe("persistent://prop/use/ns/t1", "sub");
+        PulsarClient client = PulsarClient.builder().serviceUrl("http://127.0.0.1:" + WEB_SERVICE_PORT).build();
+        client.newConsumer().topic("persistent://prop/use/ns/t1").subscriptionName("sub1").subscribe();
 
         // close the cnx after creating the producer
         channelCtx.get().channel().close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MockBrokerService.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/MockBrokerService.java
@@ -244,7 +244,6 @@ public class MockBrokerService {
     EventLoopGroup workerGroup;
 
     private final int webServicePort;
-    private final int webServicePortTls;
     private final int brokerServicePort;
     private final int brokerServicePortTls;
 
@@ -268,7 +267,6 @@ public class MockBrokerService {
     public MockBrokerService(int webServicePort, int webServicePortTls, int brokerServicePort,
             int brokerServicePortTls) {
         this.webServicePort = webServicePort;
-        this.webServicePortTls = webServicePortTls;
         this.brokerServicePort = brokerServicePort;
         this.brokerServicePortTls = brokerServicePortTls;
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
@@ -479,15 +479,13 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             NonPersistentTopicStats stats;
             SubscriptionStats subStats;
 
-            TopicName dest = TopicName.get(globalTopicName);
-
             PulsarClient client1 = PulsarClient.builder().serviceUrl(replication.url1.toString()).build();
             PulsarClient client2 = PulsarClient.builder().serviceUrl(replication.url2.toString()).build();
             PulsarClient client3 = PulsarClient.builder().serviceUrl(replication.url3.toString()).build();
 
             ConsumerImpl<byte[]> consumer1 = (ConsumerImpl<byte[]>) client1.newConsumer().topic(globalTopicName)
                     .subscriptionName("subscriber-1").subscribe();
-            ConsumerImpl<byte[]> consumer2 = (ConsumerImpl<byte[]>) client2.newConsumer().topic(globalTopicName)
+            ConsumerImpl<byte[]> consumer2 = (ConsumerImpl<byte[]>) client1.newConsumer().topic(globalTopicName)
                     .subscriptionName("subscriber-2").subscribe();
 
             ConsumerImpl<byte[]> repl2Consumer = (ConsumerImpl<byte[]>) client2.newConsumer().topic(globalTopicName)
@@ -495,7 +493,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             ConsumerImpl<byte[]> repl3Consumer = (ConsumerImpl<byte[]>) client3.newConsumer().topic(globalTopicName)
                     .subscriptionName("subscriber-1").subscribe();
 
-            Producer<byte[]> producer = pulsarClient.newProducer().topic(globalTopicName).create();
+            Producer<byte[]> producer = client1.newProducer().topic(globalTopicName).create();
 
             Thread.sleep(timeWaitToSync);
 
@@ -503,7 +501,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
 
             // Replicator for r1 -> r2,r3
             NonPersistentTopic topicRef = (NonPersistentTopic) replication.pulsar1.getBrokerService()
-                    .getTopicReference(dest.toString());
+                    .getTopicReference(globalTopicName);
             NonPersistentReplicator replicatorR2 = (NonPersistentReplicator) topicRef.getPersistentReplicator("r2");
             NonPersistentReplicator replicatorR3 = (NonPersistentReplicator) topicRef.getPersistentReplicator("r3");
             assertNotNull(topicRef);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
@@ -104,14 +104,10 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
         log.info("-- Starting {} test --", methodName);
 
         final String topic = "non-persistent://my-property/use/my-ns/unacked-topic";
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(type);
+        ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(topic)
+                .subscriptionName("subscriber-1").subscriptionType(type).subscribe();
 
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-
-        ConsumerImpl consumer = (ConsumerImpl) pulsarClient.subscribe(topic, "subscriber-1", conf);
-
-        Producer producer = pulsarClient.createProducer(topic, producerConf);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).create();
 
         int totalProduceMsg = 500;
         for (int i = 0; i < totalProduceMsg; i++) {
@@ -120,7 +116,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             Thread.sleep(10);
         }
 
-        Message msg = null;
+        Message<?> msg = null;
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 0; i < totalProduceMsg; i++) {
             msg = consumer.receive(1, TimeUnit.SECONDS);
@@ -148,14 +144,10 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
 
         final String topic = "non-persistent://my-property/use/my-ns/partitioned-topic";
         admin.nonPersistentTopics().createPartitionedTopic(topic, 5);
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(type);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topic).subscriptionName("subscriber-1")
+                .subscriptionType(type).subscribe();
 
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-
-        Consumer consumer = pulsarClient.subscribe(topic, "subscriber-1", conf);
-
-        Producer producer = pulsarClient.createProducer(topic, producerConf);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).create();
 
         int totalProduceMsg = 500;
         for (int i = 0; i < totalProduceMsg; i++) {
@@ -164,7 +156,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             Thread.sleep(10);
         }
 
-        Message msg = null;
+        Message<?> msg = null;
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 0; i < totalProduceMsg; i++) {
             msg = consumer.receive(1, TimeUnit.SECONDS);
@@ -196,10 +188,10 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
 
         PulsarClient client = PulsarClient.builder().serviceUrl("pulsar://localhost:" + BROKER_PORT)
                 .statsInterval(0, TimeUnit.SECONDS).build();
-        Consumer consumer = client.newConsumer().topic(topic).subscriptionName("subscriber-1").subscriptionType(type)
-                .subscribe();
+        Consumer<byte[]> consumer = client.newConsumer().topic(topic).subscriptionName("subscriber-1")
+                .subscriptionType(type).subscribe();
 
-        Producer producer = client.newProducer().topic(topic).create();
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).create();
 
         // Ensure all partitions exist
         for (int i = 0; i < numPartitions; i++) {
@@ -214,7 +206,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             Thread.sleep(10);
         }
 
-        Message msg = null;
+        Message<?> msg = null;
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 0; i < totalProduceMsg; i++) {
             msg = consumer.receive(1, TimeUnit.SECONDS);
@@ -237,8 +229,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
     }
 
     /**
-     * It verifies that broker doesn't dispatch messages if consumer runs out of permits
-     * filled out with messages
+     * It verifies that broker doesn't dispatch messages if consumer runs out of permits filled out with messages
      */
     @Test(dataProvider = "subscriptionType")
     public void testConsumerInternalQueueMaxOut(SubscriptionType type) throws Exception {
@@ -246,15 +237,10 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
 
         final String topic = "non-persistent://my-property/use/my-ns/unacked-topic";
         final int queueSize = 10;
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(type);
-        conf.setReceiverQueueSize(queueSize);
+        ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(topic)
+                .receiverQueueSize(queueSize).subscriptionName("subscriber-1").subscriptionType(type).subscribe();
 
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-
-        ConsumerImpl consumer = (ConsumerImpl) pulsarClient.subscribe(topic, "subscriber-1", conf);
-
-        Producer producer = pulsarClient.createProducer(topic, producerConf);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).create();
 
         int totalProduceMsg = 50;
         for (int i = 0; i < totalProduceMsg; i++) {
@@ -263,7 +249,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             Thread.sleep(10);
         }
 
-        Message msg = null;
+        Message<?> msg = null;
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 0; i < totalProduceMsg; i++) {
             msg = consumer.receive(1, TimeUnit.SECONDS);
@@ -300,9 +286,9 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             // produce message concurrently
             ExecutorService executor = Executors.newFixedThreadPool(5);
             AtomicBoolean failed = new AtomicBoolean(false);
-            ProducerConfiguration producerConf = new ProducerConfiguration();
-            Consumer consumer = pulsarClient.subscribe(topic, "subscriber-1");
-            Producer producer = pulsarClient.createProducer(topic, producerConf);
+            Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topic).subscriptionName("subscriber-1")
+                    .subscribe();
+            Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).create();
             byte[] msgData = "testData".getBytes();
             final int totalProduceMessages = 10;
             CountDownLatch latch = new CountDownLatch(totalProduceMessages);
@@ -319,7 +305,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             }
             latch.await();
 
-            Message msg = null;
+            Message<?> msg = null;
             Set<String> messageSet = Sets.newHashSet();
             for (int i = 0; i < totalProduceMessages; i++) {
                 msg = consumer.receive(500, TimeUnit.MILLISECONDS);
@@ -352,19 +338,19 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
         log.info("-- Starting {} test --", methodName);
 
         final String topic = "non-persistent://my-property/use/my-ns/unacked-topic";
-        ConsumerConfiguration sharedConf = new ConsumerConfiguration();
-        sharedConf.setSubscriptionType(SubscriptionType.Shared);
-        ConsumerConfiguration excConf = new ConsumerConfiguration();
-        excConf.setSubscriptionType(SubscriptionType.Failover);
+        ConsumerImpl<byte[]> consumer1Shared = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(topic)
+                .subscriptionName("subscriber-shared").subscriptionType(SubscriptionType.Shared).subscribe();
 
-        ProducerConfiguration producerConf = new ProducerConfiguration();
+        ConsumerImpl<byte[]> consumer2Shared = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(topic)
+                .subscriptionName("subscriber-shared").subscriptionType(SubscriptionType.Shared).subscribe();
 
-        ConsumerImpl consumer1Shared = (ConsumerImpl) pulsarClient.subscribe(topic, "subscriber-shared", sharedConf);
-        ConsumerImpl consumer2Shared = (ConsumerImpl) pulsarClient.subscribe(topic, "subscriber-shared", sharedConf);
-        ConsumerImpl consumer1FailOver = (ConsumerImpl) pulsarClient.subscribe(topic, "subscriber-fo", excConf);
-        ConsumerImpl consumer2FailOver = (ConsumerImpl) pulsarClient.subscribe(topic, "subscriber-fo", excConf);
+        ConsumerImpl<byte[]> consumer1FailOver = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(topic)
+                .subscriptionName("subscriber-fo").subscriptionType(SubscriptionType.Failover).subscribe();
 
-        Producer producer = pulsarClient.createProducer(topic, producerConf);
+        ConsumerImpl<byte[]> consumer2FailOver = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(topic)
+                .subscriptionName("subscriber-fo").subscriptionType(SubscriptionType.Failover).subscribe();
+
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).create();
 
         int totalProduceMsg = 500;
         for (int i = 0; i < totalProduceMsg; i++) {
@@ -374,7 +360,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
         }
 
         // consume from shared-subscriptions
-        Message msg = null;
+        Message<?> msg = null;
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 0; i < totalProduceMsg; i++) {
             msg = consumer1Shared.receive(500, TimeUnit.MILLISECONDS);
@@ -436,9 +422,8 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
         NonPersistentTopicStats stats;
         SubscriptionStats subStats;
 
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Shared);
-        Consumer consumer = pulsarClient.subscribe(topicName, subName, conf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName)
+                .subscriptionType(SubscriptionType.Shared).subscriptionName(subName).subscribe();
         Thread.sleep(timeWaitToSync);
 
         NonPersistentTopic topicRef = (NonPersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
@@ -452,7 +437,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
         assertEquals(stats.getSubscriptions().keySet().size(), 1);
         assertEquals(subStats.consumers.size(), 1);
 
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         Thread.sleep(timeWaitToSync);
 
         int totalProducedMessages = 100;
@@ -496,19 +481,21 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
 
             TopicName dest = TopicName.get(globalTopicName);
 
-            PulsarClient client1 = PulsarClient.create(replication.url1.toString(), new ClientConfiguration());
-            PulsarClient client2 = PulsarClient.create(replication.url2.toString(), new ClientConfiguration());
-            PulsarClient client3 = PulsarClient.create(replication.url3.toString(), new ClientConfiguration());
+            PulsarClient client1 = PulsarClient.builder().serviceUrl(replication.url1.toString()).build();
+            PulsarClient client2 = PulsarClient.builder().serviceUrl(replication.url2.toString()).build();
+            PulsarClient client3 = PulsarClient.builder().serviceUrl(replication.url3.toString()).build();
 
-            ProducerConfiguration producerConf = new ProducerConfiguration();
-            ConsumerConfiguration consumerConf = new ConsumerConfiguration();
-            ConsumerImpl consumer1 = (ConsumerImpl) client1.subscribe(globalTopicName, "subscriber-1", consumerConf);
-            ConsumerImpl consumer2 = (ConsumerImpl) client1.subscribe(globalTopicName, "subscriber-2", consumerConf);
-            ConsumerImpl repl2Consumer = (ConsumerImpl) client2.subscribe(globalTopicName, "subscriber-1",
-                    consumerConf);
-            ConsumerImpl repl3Consumer = (ConsumerImpl) client3.subscribe(globalTopicName, "subscriber-1",
-                    consumerConf);
-            Producer producer = client1.createProducer(globalTopicName, producerConf);
+            ConsumerImpl<byte[]> consumer1 = (ConsumerImpl<byte[]>) client1.newConsumer().topic(globalTopicName)
+                    .subscriptionName("subscriber-1").subscribe();
+            ConsumerImpl<byte[]> consumer2 = (ConsumerImpl<byte[]>) client2.newConsumer().topic(globalTopicName)
+                    .subscriptionName("subscriber-2").subscribe();
+
+            ConsumerImpl<byte[]> repl2Consumer = (ConsumerImpl<byte[]>) client2.newConsumer().topic(globalTopicName)
+                    .subscriptionName("subscriber-1").subscribe();
+            ConsumerImpl<byte[]> repl3Consumer = (ConsumerImpl<byte[]>) client3.newConsumer().topic(globalTopicName)
+                    .subscriptionName("subscriber-1").subscribe();
+
+            Producer<byte[]> producer = pulsarClient.newProducer().topic(globalTopicName).create();
 
             Thread.sleep(timeWaitToSync);
 
@@ -540,7 +527,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             }
 
             // (1) consume by consumer1
-            Message msg = null;
+            Message<?> msg = null;
             Set<String> messageSet = Sets.newHashSet();
             for (int i = 0; i < totalProducedMessages; i++) {
                 msg = consumer1.receive(300, TimeUnit.MILLISECONDS);
@@ -623,6 +610,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
 
     /**
      * verifies load manager assigns topic only if broker started in non-persistent mode
+     *
      * <pre>
      * 1. Start broker with disable non-persistent topic mode
      * 2. Create namespace with non-persistency set
@@ -647,6 +635,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
 
             Field field = PulsarService.class.getDeclaredField("loadManager");
             field.setAccessible(true);
+            @SuppressWarnings("unchecked")
             AtomicReference<LoadManager> loadManagerRef = (AtomicReference<LoadManager>) field.get(pulsar);
             LoadManager manager = LoadManager.create(pulsar);
             manager.start();
@@ -662,9 +651,9 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             }
             assertNull(broker);
 
-            ProducerConfiguration producerConf = new ProducerConfiguration();
             try {
-                Producer producer = pulsarClient.createProducerAsync(topicName, producerConf).get(1, TimeUnit.SECONDS);
+                Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).createAsync().get(1,
+                        TimeUnit.SECONDS);
                 producer.close();
                 fail("topic loading should have failed");
             } catch (Exception e) {
@@ -697,9 +686,9 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             conf.setEnableNonPersistentTopics(false);
             stopBroker();
             startBroker();
-            ProducerConfiguration producerConf = new ProducerConfiguration();
             try {
-                Producer producer = pulsarClient.createProducerAsync(topicName, producerConf).get(1, TimeUnit.SECONDS);
+                Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).createAsync().get(1,
+                        TimeUnit.SECONDS);
                 producer.close();
                 fail("topic loading should have failed");
             } catch (Exception e) {
@@ -736,6 +725,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
 
             Field field = PulsarService.class.getDeclaredField("loadManager");
             field.setAccessible(true);
+            @SuppressWarnings("unchecked")
             AtomicReference<LoadManager> loadManagerRef = (AtomicReference<LoadManager>) field.get(pulsar);
             LoadManager manager = LoadManager.create(pulsar);
             manager.start();
@@ -751,9 +741,9 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             }
             assertNull(broker);
 
-            ProducerConfiguration producerConf = new ProducerConfiguration();
             try {
-                Producer producer = pulsarClient.createProducerAsync(topicName, producerConf).get(1, TimeUnit.SECONDS);
+                Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).createAsync().get(1,
+                        TimeUnit.SECONDS);
                 producer.close();
                 fail("topic loading should have failed");
             } catch (Exception e) {
@@ -785,15 +775,13 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             conf.setMaxConcurrentNonPersistentMessagePerConnection(1);
             stopBroker();
             startBroker();
-            ProducerConfiguration producerConf = new ProducerConfiguration();
-            ConsumerConfiguration consumerConfig1 = new ConsumerConfiguration();
-            consumerConfig1.setReceiverQueueSize(1);
-            Consumer consumer = pulsarClient.subscribe(topicName, "subscriber-1", consumerConfig1);
-            ConsumerConfiguration consumerConfig2 = new ConsumerConfiguration();
-            consumerConfig2.setReceiverQueueSize(1);
-            consumerConfig2.setSubscriptionType(SubscriptionType.Shared);
-            Consumer consumer2 = pulsarClient.subscribe(topicName, "subscriber-2", consumerConfig2);
-            ProducerImpl producer = (ProducerImpl) pulsarClient.createProducer(topicName, producerConf);
+            Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName("subscriber-1")
+                    .receiverQueueSize(1).subscribe();
+
+            Consumer<byte[]> consumer2 = pulsarClient.newConsumer().topic(topicName).subscriptionName("subscriber-2")
+                    .receiverQueueSize(1).subscriptionType(SubscriptionType.Shared).subscribe();
+
+            ProducerImpl<byte[]> producer = (ProducerImpl<byte[]>) pulsarClient.newProducer().topic(topicName).create();
             String firstTimeConnected = producer.getConnectedSince();
             ExecutorService executor = Executors.newFixedThreadPool(5);
             byte[] msgData = "testData".getBytes();
@@ -801,7 +789,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             CountDownLatch latch = new CountDownLatch(totalProduceMessages);
             for (int i = 0; i < totalProduceMessages; i++) {
                 executor.submit(() -> {
-                    producer.sendAsync(msgData).handle((msg,e)->{
+                    producer.sendAsync(msgData).handle((msg, e) -> {
                         latch.countDown();
                         return null;
                     });

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerStatTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerStatTest.java
@@ -34,14 +34,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.pulsar.client.admin.PulsarAdminException;
-import org.apache.pulsar.client.api.Consumer;
-import org.apache.pulsar.client.api.ConsumerConfiguration;
-import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.client.api.MessageId;
-import org.apache.pulsar.client.api.Producer;
-import org.apache.pulsar.client.api.ProducerConfiguration;
-import org.apache.pulsar.client.api.PulsarClientException;
-import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.ConsumerStats;
 import org.apache.pulsar.client.impl.ProducerStats;
 import org.slf4j.Logger;
@@ -84,25 +76,25 @@ public class SimpleProducerConsumerStatTest extends ProducerConsumerBase {
     @Test(dataProvider = "batch_with_timeout")
     public void testSyncProducerAndConsumer(int batchMessageDelayMs, int ackTimeoutSec) throws Exception {
         log.info("-- Starting {} test --", methodName);
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
+        ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer()
+                .topic("persistent://my-property/tp1/my-ns/my-topic1").subscriptionName("my-subscriber-name");
+
         // Cumulative Ack-counter works if ackTimeOutTimer-task is enabled
         boolean isAckTimeoutTaskEnabledForCumulativeAck = ackTimeoutSec > 0;
         if (ackTimeoutSec > 0) {
-            conf.setAckTimeout(ackTimeoutSec, TimeUnit.SECONDS);
+            consumerBuilder.ackTimeout(ackTimeoutSec, TimeUnit.SECONDS);
         }
 
-        Consumer consumer = pulsarClient.subscribe("persistent://my-property/tp1/my-ns/my-topic1", "my-subscriber-name",
-                conf);
+        Consumer<byte[]> consumer = consumerBuilder.subscribe();
 
-        ProducerConfiguration producerConf = new ProducerConfiguration();
+        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer()
+                .topic("persistent://my-property/tp1/my-ns/my-topic1");
         if (batchMessageDelayMs != 0) {
-            producerConf.setBatchingEnabled(true);
-            producerConf.setBatchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
-            producerConf.setBatchingMaxMessages(5);
+            producerBuilder.enableBatching(true).batchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS)
+                    .batchingMaxMessages(5);
         }
 
-        Producer producer = pulsarClient.createProducer("persistent://my-property/tp1/my-ns/my-topic1", producerConf);
+        Producer<byte[]> producer = producerBuilder.create();
 
         int numMessages = 11;
         for (int i = 0; i < numMessages; i++) {
@@ -110,7 +102,7 @@ public class SimpleProducerConsumerStatTest extends ProducerConsumerBase {
             producer.send(message.getBytes());
         }
 
-        Message msg = null;
+        Message<byte[]> msg = null;
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 0; i < numMessages; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);
@@ -131,23 +123,22 @@ public class SimpleProducerConsumerStatTest extends ProducerConsumerBase {
     @Test(dataProvider = "batch_with_timeout")
     public void testAsyncProducerAndAsyncAck(int batchMessageDelayMs, int ackTimeoutSec) throws Exception {
         log.info("-- Starting {} test --", methodName);
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
+        ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer()
+                .topic("persistent://my-property/tp1/my-ns/my-topic2").subscriptionName("my-subscriber-name");
         if (ackTimeoutSec > 0) {
-            conf.setAckTimeout(ackTimeoutSec, TimeUnit.SECONDS);
+            consumerBuilder.ackTimeout(ackTimeoutSec, TimeUnit.SECONDS);
         }
 
-        Consumer consumer = pulsarClient.subscribe("persistent://my-property/tp1/my-ns/my-topic2", "my-subscriber-name",
-                conf);
+        Consumer<byte[]> consumer = consumerBuilder.subscribe();
 
-        ProducerConfiguration producerConf = new ProducerConfiguration();
+        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer()
+                .topic("persistent://my-property/tp1/my-ns/my-topic2");
         if (batchMessageDelayMs != 0) {
-            producerConf.setBatchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
-            producerConf.setBatchingMaxMessages(5);
-            producerConf.setBatchingEnabled(true);
+            producerBuilder.enableBatching(true).batchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS)
+                    .batchingMaxMessages(5);
         }
 
-        Producer producer = pulsarClient.createProducer("persistent://my-property/tp1/my-ns/my-topic2", producerConf);
+        Producer<byte[]> producer = producerBuilder.create();
         List<Future<MessageId>> futures = Lists.newArrayList();
 
         int numMessages = 50;
@@ -163,7 +154,7 @@ public class SimpleProducerConsumerStatTest extends ProducerConsumerBase {
             future.get();
         }
 
-        Message msg = null;
+        Message<byte[]> msg = null;
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 0; i < numMessages; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);
@@ -187,23 +178,22 @@ public class SimpleProducerConsumerStatTest extends ProducerConsumerBase {
     public void testAsyncProducerAndReceiveAsyncAndAsyncAck(int batchMessageDelayMs, int ackTimeoutSec)
             throws Exception {
         log.info("-- Starting {} test --", methodName);
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
+        ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer()
+                .topic("persistent://my-property/tp1/my-ns/my-topic2").subscriptionName("my-subscriber-name");
         if (ackTimeoutSec > 0) {
-            conf.setAckTimeout(ackTimeoutSec, TimeUnit.SECONDS);
+            consumerBuilder.ackTimeout(ackTimeoutSec, TimeUnit.SECONDS);
         }
 
-        Consumer consumer = pulsarClient.subscribe("persistent://my-property/tp1/my-ns/my-topic2", "my-subscriber-name",
-                conf);
+        Consumer<byte[]> consumer = consumerBuilder.subscribe();
 
-        ProducerConfiguration producerConf = new ProducerConfiguration();
+        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer()
+                .topic("persistent://my-property/tp1/my-ns/my-topic2");
         if (batchMessageDelayMs != 0) {
-            producerConf.setBatchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
-            producerConf.setBatchingMaxMessages(5);
-            producerConf.setBatchingEnabled(true);
+            producerBuilder.enableBatching(true).batchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS)
+                    .batchingMaxMessages(5);
         }
 
-        Producer producer = pulsarClient.createProducer("persistent://my-property/tp1/my-ns/my-topic2", producerConf);
+        Producer<byte[]> producer = producerBuilder.create();
         List<Future<MessageId>> futures = Lists.newArrayList();
 
         int numMessages = 101;
@@ -218,8 +208,8 @@ public class SimpleProducerConsumerStatTest extends ProducerConsumerBase {
         for (Future<MessageId> future : futures) {
             future.get();
         }
-        Message msg = null;
-        CompletableFuture<Message> future_msg = null;
+        Message<byte[]> msg = null;
+        CompletableFuture<Message<byte[]>> future_msg = null;
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 0; i < numMessages; i++) {
             future_msg = consumer.receiveAsync();
@@ -245,30 +235,28 @@ public class SimpleProducerConsumerStatTest extends ProducerConsumerBase {
     @Test(dataProvider = "batch", timeOut = 100000)
     public void testMessageListener(int batchMessageDelayMs) throws Exception {
         log.info("-- Starting {} test --", methodName);
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setAckTimeout(100, TimeUnit.SECONDS);
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
 
         int numMessages = 100;
         final CountDownLatch latch = new CountDownLatch(numMessages);
 
-        conf.setMessageListener((consumer, msg) -> {
-            assertNotNull(msg, "Message cannot be null");
-            String receivedMessage = new String(msg.getData());
-            log.debug("Received message [{}] in the listener", receivedMessage);
-            consumer.acknowledgeAsync(msg);
-            latch.countDown();
-        });
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/tp1/my-ns/my-topic3")
+                .subscriptionName("my-subscriber-name").ackTimeout(100, TimeUnit.SECONDS)
+                .messageListener((consumer1, msg) -> {
+                    assertNotNull(msg, "Message cannot be null");
+                    String receivedMessage = new String(msg.getData());
+                    log.debug("Received message [{}] in the listener", receivedMessage);
+                    consumer1.acknowledgeAsync(msg);
+                    latch.countDown();
+                }).subscribe();
 
-        Consumer consumer = pulsarClient.subscribe("persistent://my-property/tp1/my-ns/my-topic3", "my-subscriber-name",
-                conf);
-        ProducerConfiguration producerConf = new ProducerConfiguration();
+        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer()
+                .topic("persistent://my-property/tp1/my-ns/my-topic3");
         if (batchMessageDelayMs != 0) {
-            producerConf.setBatchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
-            producerConf.setBatchingMaxMessages(5);
-            producerConf.setBatchingEnabled(true);
+            producerBuilder.enableBatching(true).batchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS)
+                    .batchingMaxMessages(5);
         }
-        Producer producer = pulsarClient.createProducer("persistent://my-property/tp1/my-ns/my-topic3", producerConf);
+
+        Producer<byte[]> producer = producerBuilder.create();
         List<Future<MessageId>> futures = Lists.newArrayList();
 
         // Asynchronously produce messages
@@ -295,19 +283,18 @@ public class SimpleProducerConsumerStatTest extends ProducerConsumerBase {
     public void testSendTimeout(int batchMessageDelayMs) throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        ConsumerConfiguration consumerConf = new ConsumerConfiguration();
-        consumerConf.setSubscriptionType(SubscriptionType.Exclusive);
-        Consumer consumer = pulsarClient.subscribe("persistent://my-property/tp1/my-ns/my-topic5", "my-subscriber-name",
-                consumerConf);
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-        if (batchMessageDelayMs != 0) {
-            producerConf.setBatchingMaxPublishDelay(2 * batchMessageDelayMs, TimeUnit.MILLISECONDS);
-            producerConf.setBatchingMaxMessages(5);
-            producerConf.setBatchingEnabled(true);
-        }
-        producerConf.setSendTimeout(1, TimeUnit.SECONDS);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/tp1/my-ns/my-topic5")
+                .subscriptionName("my-subscriber-name").subscribe();
 
-        Producer producer = pulsarClient.createProducer("persistent://my-property/tp1/my-ns/my-topic5", producerConf);
+        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer()
+                .topic("persistent://my-property/tp1/my-ns/my-topic5").sendTimeout(1, TimeUnit.SECONDS);
+        if (batchMessageDelayMs != 0) {
+            producerBuilder.enableBatching(true).batchingMaxPublishDelay(2 * batchMessageDelayMs, TimeUnit.MILLISECONDS)
+                    .batchingMaxMessages(5);
+        }
+
+        Producer<byte[]> producer = producerBuilder.create();
+
         final String message = "my-message";
 
         // Trigger the send timeout
@@ -325,7 +312,7 @@ public class SimpleProducerConsumerStatTest extends ProducerConsumerBase {
         startBroker();
 
         // We should not have received any message
-        Message msg = consumer.receive(3, TimeUnit.SECONDS);
+        Message<byte[]> msg = consumer.receive(3, TimeUnit.SECONDS);
         assertNull(msg);
         consumer.close();
         producer.close();
@@ -338,21 +325,16 @@ public class SimpleProducerConsumerStatTest extends ProducerConsumerBase {
         assertEquals(cStat.getTotalMsgsReceived(), cStat.getTotalAcksSent());
         log.info("-- Exiting {} test --", methodName);
     }
-    
+
     public void testBatchMessagesRateOut() throws PulsarClientException, InterruptedException, PulsarAdminException {
         log.info("-- Starting {} test --", methodName);
         String topicName = "persistent://my-property/cluster/my-ns/testBatchMessagesRateOut";
         double produceRate = 17;
         int batchSize = 5;
-        ConsumerConfiguration consumerConf = new ConsumerConfiguration();
-        consumerConf.setSubscriptionType(SubscriptionType.Exclusive);
-        Consumer<byte[]> consumer = pulsarClient.subscribe(topicName, "my-subscriber-name", consumerConf);
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-        producerConf.setBatchingMaxMessages(batchSize);
-        producerConf.setBatchingEnabled(true);
-        producerConf.setBatchingMaxPublishDelay(2, TimeUnit.SECONDS);
-
-        Producer producer = pulsarClient.createProducer(topicName, producerConf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName("my-subscriber-name")
+                .subscribe();
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).batchingMaxMessages(batchSize)
+                .enableBatching(true).batchingMaxPublishDelay(2, TimeUnit.SECONDS).create();
         AtomicBoolean runTest = new AtomicBoolean(true);
         Thread t1 = new Thread(() -> {
             RateLimiter r = RateLimiter.create(produceRate);
@@ -372,7 +354,7 @@ public class SimpleProducerConsumerStatTest extends ProducerConsumerBase {
         log.info("-- Exiting {} test --", methodName);
     }
 
-    public void validatingLogInfo(Consumer consumer, Producer producer, boolean verifyAckCount)
+    public void validatingLogInfo(Consumer<?> consumer, Producer<?> producer, boolean verifyAckCount)
             throws InterruptedException {
         // Waiting for recording last stat info
         Thread.sleep(1000);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -2255,7 +2255,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         Message<byte[]> msg = null;
         Set<String> messageSet = Sets.newHashSet();
-        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/myenc-topic1")
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/myenc-ns/myenc-topic1")
                 .subscriptionName("my-subscriber-name").subscribe();
 
         // 1. Invalid key name
@@ -2284,7 +2284,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         // 4. Set consumer config to consume even if decryption fails
         consumer.close();
-        consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/myenc-topic1")
+        consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/myenc-ns/myenc-topic1")
                 .subscriptionName("my-subscriber-name").cryptoFailureAction(ConsumerCryptoFailureAction.CONSUME)
                 .subscribe();
 
@@ -2298,13 +2298,14 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
                     + " should not match the expected message " + expectedMessage);
             consumer.acknowledgeCumulative(msg);
         } catch (Exception e) {
+            e.printStackTrace();
             Assert.fail("Failed to receive message even aftet ConsumerCryptoFailureAction.CONSUME is set.");
         }
 
         // 5. Set keyreader and failure action
         consumer.close();
         // Set keyreader
-        consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/myenc-topic1")
+        consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/myenc-ns/myenc-topic1")
                 .subscriptionName("my-subscriber-name").cryptoFailureAction(ConsumerCryptoFailureAction.FAIL)
                 .cryptoKeyReader(new EncKeyReader()).subscribe();
 
@@ -2321,7 +2322,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         // 6. Set consumer config to discard if decryption fails
         consumer.close();
-        consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/myenc-topic1")
+        consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/myenc-ns/myenc-topic1")
                 .subscriptionName("my-subscriber-name").cryptoFailureAction(ConsumerCryptoFailureAction.DISCARD)
                 .subscribe();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TlsProducerConsumerBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TlsProducerConsumerBase.java
@@ -35,8 +35,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
 public class TlsProducerConsumerBase extends ProducerConsumerBase {
-    private static final Logger log = LoggerFactory.getLogger(TlsProducerConsumerBase.class);
-
     protected final String TLS_TRUST_CERT_FILE_PATH = "./src/test/resources/authentication/tls/cacert.pem";
     protected final String TLS_SERVER_CERT_FILE_PATH = "./src/test/resources/authentication/tls/broker-cert.pem";
     protected final String TLS_SERVER_KEY_FILE_PATH = "./src/test/resources/authentication/tls/broker-key.pem";
@@ -67,11 +65,9 @@ public class TlsProducerConsumerBase extends ProducerConsumerBase {
     }
 
     protected void internalSetUpForClient() throws Exception {
-        ClientConfiguration clientConf = new ClientConfiguration();
-        clientConf.setTlsTrustCertsFilePath(TLS_TRUST_CERT_FILE_PATH);
-        clientConf.setUseTls(true);
         String lookupUrl = new URI("pulsar+ssl://localhost:" + BROKER_PORT_TLS).toString();
-        pulsarClient = PulsarClient.create(lookupUrl, clientConf);
+        pulsarClient = PulsarClient.builder().serviceUrl(lookupUrl).tlsTrustCertsFilePath(TLS_SERVER_CERT_FILE_PATH)
+                .enableTls(true).build();
     }
 
     protected void internalSetUpForNamespace() throws Exception {
@@ -79,9 +75,8 @@ public class TlsProducerConsumerBase extends ProducerConsumerBase {
         clientConf.setTlsTrustCertsFilePath(TLS_TRUST_CERT_FILE_PATH);
         clientConf.setUseTls(true);
         admin = spy(new PulsarAdmin(brokerUrlTls, clientConf));
-        admin.clusters().updateCluster(clusterName,
-                new ClusterData(brokerUrl.toString(), brokerUrlTls.toString(), "pulsar://localhost:" + BROKER_PORT,
-                        "pulsar+ssl://localhost:" + BROKER_PORT_TLS));
+        admin.clusters().updateCluster(clusterName, new ClusterData(brokerUrl.toString(), brokerUrlTls.toString(),
+                "pulsar://localhost:" + BROKER_PORT, "pulsar+ssl://localhost:" + BROKER_PORT_TLS));
         admin.properties().createProperty("my-property",
                 new PropertyAdmin(Lists.newArrayList("appid1", "appid2"), Sets.newHashSet("use")));
         admin.namespaces().createNamespace("my-property/use/my-ns");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TlsProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TlsProducerConsumerTest.java
@@ -45,21 +45,18 @@ public class TlsProducerConsumerTest extends TlsProducerConsumerBase {
         internalSetUpForClient();
         internalSetUpForNamespace();
 
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-        Consumer consumer = pulsarClient
-                .subscribe("persistent://my-property/use/my-ns/my-topic1", "my-subscriber-name", conf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/my-topic1")
+                .subscriptionName("my-subscriber-name").subscribe();
 
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic1", producerConf);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic1")
+                .create();
         for (int i = 0; i < 10; i++) {
             byte[] message = new byte[MESSAGE_SIZE];
             Arrays.fill(message, (byte) i);
             producer.send(message);
         }
 
-        Message msg = null;
+        Message<byte[]> msg = null;
         for (int i = 0; i < 10; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);
             byte[] expected = new byte[MESSAGE_SIZE];

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TopicReaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TopicReaderTest.java
@@ -60,19 +60,17 @@ public class TopicReaderTest extends ProducerConsumerBase {
 
     @Test
     public void testSimpleReader() throws Exception {
-        ReaderConfiguration conf = new ReaderConfiguration();
-        Reader reader = pulsarClient.createReader("persistent://my-property/use/my-ns/my-topic1", MessageId.earliest,
-                conf);
+        Reader<byte[]> reader = pulsarClient.newReader().topic("persistent://my-property/use/my-ns/my-topic1")
+                .startMessageId(MessageId.earliest).create();
 
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic1", producerConf);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic1")
+                .create();
         for (int i = 0; i < 10; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
 
-        Message msg = null;
+        Message<byte[]> msg = null;
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 0; i < 10; i++) {
             msg = reader.readNext(1, TimeUnit.SECONDS);
@@ -90,18 +88,17 @@ public class TopicReaderTest extends ProducerConsumerBase {
 
     @Test
     public void testReaderAfterMessagesWerePublished() throws Exception {
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic1", producerConf);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic1")
+                .create();
         for (int i = 0; i < 10; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
 
-        Reader reader = pulsarClient.createReader("persistent://my-property/use/my-ns/my-topic1", MessageId.earliest,
-                new ReaderConfiguration());
+        Reader<byte[]> reader = pulsarClient.newReader().topic("persistent://my-property/use/my-ns/my-topic1")
+                .startMessageId(MessageId.earliest).create();
 
-        Message msg = null;
+        Message<byte[]> msg = null;
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 0; i < 10; i++) {
             msg = reader.readNext(1, TimeUnit.SECONDS);
@@ -119,21 +116,20 @@ public class TopicReaderTest extends ProducerConsumerBase {
 
     @Test
     public void testMultipleReaders() throws Exception {
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic1", producerConf);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic1")
+                .create();
         for (int i = 0; i < 10; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
 
-        Reader reader1 = pulsarClient.createReader("persistent://my-property/use/my-ns/my-topic1", MessageId.earliest,
-                new ReaderConfiguration());
+        Reader<byte[]> reader1 = pulsarClient.newReader().topic("persistent://my-property/use/my-ns/my-topic1")
+                .startMessageId(MessageId.earliest).create();
 
-        Reader reader2 = pulsarClient.createReader("persistent://my-property/use/my-ns/my-topic1", MessageId.earliest,
-                new ReaderConfiguration());
+        Reader<byte[]> reader2 = pulsarClient.newReader().topic("persistent://my-property/use/my-ns/my-topic1")
+                .startMessageId(MessageId.earliest).create();
 
-        Message msg = null;
+        Message<byte[]> msg = null;
         Set<String> messageSet1 = Sets.newHashSet();
         for (int i = 0; i < 10; i++) {
             msg = reader1.readNext(1, TimeUnit.SECONDS);
@@ -163,9 +159,9 @@ public class TopicReaderTest extends ProducerConsumerBase {
     public void testTopicStats() throws Exception {
         String topicName = "persistent://my-property/use/my-ns/my-topic1";
 
-        Reader reader1 = pulsarClient.createReader(topicName, MessageId.earliest, new ReaderConfiguration());
+        Reader<byte[]> reader1 = pulsarClient.newReader().topic(topicName).startMessageId(MessageId.earliest).create();
 
-        Reader reader2 = pulsarClient.createReader(topicName, MessageId.earliest, new ReaderConfiguration());
+        Reader<byte[]> reader2 = pulsarClient.newReader().topic(topicName).startMessageId(MessageId.earliest).create();
 
         PersistentTopicStats stats = admin.persistentTopics().getStats(topicName);
         assertEquals(stats.subscriptions.size(), 2);
@@ -182,16 +178,15 @@ public class TopicReaderTest extends ProducerConsumerBase {
 
     @Test
     public void testReaderOnLastMessage() throws Exception {
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic1", producerConf);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic1")
+                .create();
         for (int i = 0; i < 10; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
 
-        Reader reader = pulsarClient.createReader("persistent://my-property/use/my-ns/my-topic1", MessageId.latest,
-                new ReaderConfiguration());
+        Reader<byte[]> reader = pulsarClient.newReader().topic("persistent://my-property/use/my-ns/my-topic1")
+                .startMessageId(MessageId.latest).create();
 
         for (int i = 10; i < 20; i++) {
             String message = "my-message-" + i;
@@ -200,7 +195,7 @@ public class TopicReaderTest extends ProducerConsumerBase {
 
         // Publish more messages and verify the readers only sees new messages
 
-        Message msg = null;
+        Message<byte[]> msg = null;
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 10; i < 20; i++) {
             msg = reader.readNext(1, TimeUnit.SECONDS);
@@ -218,20 +213,19 @@ public class TopicReaderTest extends ProducerConsumerBase {
 
     @Test
     public void testReaderOnSpecificMessage() throws Exception {
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic1", producerConf);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic1")
+                .create();
         List<MessageId> messageIds = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
             String message = "my-message-" + i;
             messageIds.add(producer.send(message.getBytes()));
         }
 
-        Reader reader = pulsarClient.createReader("persistent://my-property/use/my-ns/my-topic1", messageIds.get(4),
-                new ReaderConfiguration());
+        Reader<byte[]> reader = pulsarClient.newReader().topic("persistent://my-property/use/my-ns/my-topic1")
+                .startMessageId(messageIds.get(4)).create();
 
         // Publish more messages and verify the readers only sees messages starting from the intended message
-        Message msg = null;
+        Message<byte[]> msg = null;
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 5; i < 10; i++) {
             msg = reader.readNext(1, TimeUnit.SECONDS);
@@ -249,10 +243,9 @@ public class TopicReaderTest extends ProducerConsumerBase {
 
     @Test
     public void testReaderOnSpecificMessageWithBatches() throws Exception {
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-        producerConf.setBatchingEnabled(true);
-        producerConf.setBatchingMaxPublishDelay(100, TimeUnit.MILLISECONDS);
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/testReaderOnSpecificMessageWithBatches", producerConf);
+        Producer<byte[]> producer = pulsarClient.newProducer()
+                .topic("persistent://my-property/use/my-ns/testReaderOnSpecificMessageWithBatches").enableBatching(true)
+                .batchingMaxPublishDelay(100, TimeUnit.MILLISECONDS).create();
         for (int i = 0; i < 10; i++) {
             String message = "my-message-" + i;
             producer.sendAsync(message.getBytes());
@@ -260,13 +253,13 @@ public class TopicReaderTest extends ProducerConsumerBase {
 
         // Write one sync message to ensure everything before got persistend
         producer.send("my-message-10".getBytes());
-        Reader reader1 = pulsarClient.createReader(
-                "persistent://my-property/use/my-ns/testReaderOnSpecificMessageWithBatches", MessageId.earliest,
-                new ReaderConfiguration());
+        Reader<byte[]> reader1 = pulsarClient.newReader()
+                .topic("persistent://my-property/use/my-ns/testReaderOnSpecificMessageWithBatches")
+                .startMessageId(MessageId.earliest).create();
 
         MessageId lastMessageId = null;
         for (int i = 0; i < 5; i++) {
-            Message msg = reader1.readNext();
+            Message<byte[]> msg = reader1.readNext();
             lastMessageId = msg.getMessageId();
         }
 
@@ -274,12 +267,12 @@ public class TopicReaderTest extends ProducerConsumerBase {
 
         System.out.println("CREATING READER ON MSG ID: " + lastMessageId);
 
-        Reader reader2 = pulsarClient.createReader(
-                "persistent://my-property/use/my-ns/testReaderOnSpecificMessageWithBatches", lastMessageId,
-                new ReaderConfiguration());
+        Reader<byte[]> reader2 = pulsarClient.newReader()
+                .topic("persistent://my-property/use/my-ns/testReaderOnSpecificMessageWithBatches")
+                .startMessageId(lastMessageId).create();
 
         for (int i = 5; i < 11; i++) {
-            Message msg = reader2.readNext(1, TimeUnit.SECONDS);
+            Message<byte[]> msg = reader2.readNext(1, TimeUnit.SECONDS);
 
             String receivedMessage = new String(msg.getData());
             log.debug("Received message: [{}]", receivedMessage);
@@ -297,6 +290,7 @@ public class TopicReaderTest extends ProducerConsumerBase {
         class EncKeyReader implements CryptoKeyReader {
 
             EncryptionKeyInfo keyInfo = new EncryptionKeyInfo();
+
             @Override
             public EncryptionKeyInfo getPublicKey(String keyName, Map<String, String> keyMeta) {
                 String CERT_FILE_PATH = "./src/test/resources/certificate/public-key." + keyName;
@@ -333,22 +327,19 @@ public class TopicReaderTest extends ProducerConsumerBase {
         final int totalMsg = 10;
 
         Set<String> messageSet = Sets.newHashSet();
-        ReaderConfiguration conf = new ReaderConfiguration();
-        conf.setCryptoKeyReader(new EncKeyReader());
-        Reader reader = pulsarClient.createReader("persistent://my-property/use/my-ns/test-reader-myecdsa-topic1", MessageId.latest,
-                conf);
+        Reader<byte[]> reader = pulsarClient.newReader()
+                .topic("persistent://my-property/use/my-ns/test-reader-myecdsa-topic1").startMessageId(MessageId.latest)
+                .cryptoKeyReader(new EncKeyReader()).create();
 
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-        producerConf.addEncryptionKey("client-ecdsa.pem");
-        producerConf.setCryptoKeyReader(new EncKeyReader());
-
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/test-reader-myecdsa-topic1", producerConf);
+        Producer<byte[]> producer = pulsarClient.newProducer()
+                .topic("persistent://my-property/use/my-ns/test-reader-myecdsa-topic1")
+                .addEncryptionKey("client-ecdsa.pem").cryptoKeyReader(new EncKeyReader()).create();
         for (int i = 0; i < totalMsg; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
 
-        Message msg = null;
+        Message<byte[]> msg = null;
 
         for (int i = 0; i < totalMsg; i++) {
             msg = reader.readNext(5, TimeUnit.SECONDS);
@@ -362,14 +353,12 @@ public class TopicReaderTest extends ProducerConsumerBase {
         log.info("-- Exiting {} test --", methodName);
     }
 
-
     @Test
     public void testSimpleReaderReachEndofTopic() throws Exception {
-        ReaderConfiguration conf = new ReaderConfiguration();
-        Reader reader = pulsarClient.createReader("persistent://my-property/use/my-ns/my-topic1", MessageId.earliest,
-            conf);
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic1", producerConf);
+        Reader<byte[]> reader = pulsarClient.newReader().topic("persistent://my-property/use/my-ns/my-topic1")
+                .startMessageId(MessageId.earliest).create();
+        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic1")
+                .create();
 
         // no data write, should return false
         assertFalse(reader.hasMessageAvailable());
@@ -380,16 +369,16 @@ public class TopicReaderTest extends ProducerConsumerBase {
             producer.send(message.getBytes());
         }
 
-        MessageImpl msg = null;
+        MessageImpl<byte[]> msg = null;
         Set<String> messageSet = Sets.newHashSet();
         int index = 0;
 
         // read message till end.
         while (reader.hasMessageAvailable()) {
-            msg = (MessageImpl) reader.readNext(1, TimeUnit.SECONDS);
+            msg = (MessageImpl<byte[]>) reader.readNext(1, TimeUnit.SECONDS);
             String receivedMessage = new String(msg.getData());
             log.debug("Received message: [{}]", receivedMessage);
-            String expectedMessage = "my-message-" + (index ++);
+            String expectedMessage = "my-message-" + (index++);
             testMessageOrderAndDuplicates(messageSet, receivedMessage, expectedMessage);
         }
 
@@ -405,10 +394,10 @@ public class TopicReaderTest extends ProducerConsumerBase {
 
         // read message till end again.
         while (reader.hasMessageAvailable()) {
-            msg = (MessageImpl) reader.readNext(1, TimeUnit.SECONDS);
+            msg = (MessageImpl<byte[]>) reader.readNext(1, TimeUnit.SECONDS);
             String receivedMessage = new String(msg.getData());
             log.debug("Received message: [{}]", receivedMessage);
-            String expectedMessage = "my-message-" + (index ++);
+            String expectedMessage = "my-message-" + (index++);
             testMessageOrderAndDuplicates(messageSet, receivedMessage, expectedMessage);
         }
 
@@ -421,14 +410,13 @@ public class TopicReaderTest extends ProducerConsumerBase {
 
     @Test
     public void testReaderReachEndofTopicOnMessageWithBatches() throws Exception {
-        Reader reader = pulsarClient.createReader(
-            "persistent://my-property/use/my-ns/testReaderReachEndofTopicOnMessageWithBatches", MessageId.earliest,
-            new ReaderConfiguration());
+        Reader<byte[]> reader = pulsarClient.newReader()
+                .topic("persistent://my-property/use/my-ns/testReaderReachEndofTopicOnMessageWithBatches")
+                .startMessageId(MessageId.earliest).create();
 
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-        producerConf.setBatchingEnabled(true);
-        producerConf.setBatchingMaxPublishDelay(100, TimeUnit.MILLISECONDS);
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/testReaderReachEndofTopicOnMessageWithBatches", producerConf);
+        Producer<byte[]> producer = pulsarClient.newProducer()
+                .topic("persistent://my-property/use/my-ns/testReaderReachEndofTopicOnMessageWithBatches")
+                .enableBatching(true).batchingMaxPublishDelay(100, TimeUnit.MILLISECONDS).create();
 
         // no data write, should return false
         assertFalse(reader.hasMessageAvailable());
@@ -446,7 +434,7 @@ public class TopicReaderTest extends ProducerConsumerBase {
         assertTrue(reader.hasMessageAvailable());
 
         if (reader.hasMessageAvailable()) {
-            Message msg = reader.readNext();
+            Message<byte[]> msg = reader.readNext();
             lastMessageId = msg.getMessageId();
             assertEquals(lastMessageId.getClass(), BatchMessageIdImpl.class);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumeBaseExceptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumeBaseExceptionTest.java
@@ -19,8 +19,6 @@
 package org.apache.pulsar.client.impl;
 
 import org.apache.pulsar.client.api.Consumer;
-import org.apache.pulsar.client.api.ConsumerConfiguration;
-import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.testng.Assert;
@@ -45,8 +43,8 @@ public class ConsumeBaseExceptionTest extends ProducerConsumerBase {
 
     @Test
     public void testClosedConsumer() throws PulsarClientException {
-        Consumer consumer = null;
-        consumer = pulsarClient.subscribe("persistent://prop/cluster/ns/topicName", "my-subscription");
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://prop/cluster/ns/topicName")
+                .subscriptionName("my-subscription").subscribe();
         consumer.close();
         Assert.assertTrue(consumer.receiveAsync().isCompletedExceptionally());
 
@@ -62,11 +60,11 @@ public class ConsumeBaseExceptionTest extends ProducerConsumerBase {
 
     @Test
     public void testListener() throws PulsarClientException {
-        Consumer consumer = null;
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setMessageListener((Consumer<byte[]> c, Message<byte[]> msg) -> {
-        });
-        consumer = pulsarClient.subscribe("persistent://prop/cluster/ns/topicName", "my-subscription", conf);
+
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://prop/cluster/ns/topicName")
+                .subscriptionName("my-subscription").messageListener((consumer1, msg) -> {
+
+                }).subscribe();
         Assert.assertTrue(consumer.receiveAsync().isCompletedExceptionally());
 
         try {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerConfigurationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/ConsumerConfigurationTest.java
@@ -18,26 +18,19 @@
  */
 package org.apache.pulsar.client.impl;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
-
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
-import org.apache.pulsar.broker.service.persistent.PersistentTopic;
-import org.apache.pulsar.client.api.ConsumerConfiguration;
 import org.apache.pulsar.client.api.PulsarClientException.InvalidConfigurationException;
 import org.apache.pulsar.client.api.SubscriptionType;
-
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.PropertyAdmin;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
 public class ConsumerConfigurationTest extends MockedPulsarServiceBaseTest {
-    private static final Logger log = LoggerFactory.getLogger(ConsumerConfigurationTest.class);
     private static String persistentTopic = "persistent://my-property/use/my-ns/persist";
     private static String nonPersistentTopic = "non-persistent://my-property/use/my-ns/nopersist";
 
@@ -46,8 +39,7 @@ public class ConsumerConfigurationTest extends MockedPulsarServiceBaseTest {
     public void setup() throws Exception {
         super.internalSetup();
 
-        admin.clusters().createCluster("use",
-                new ClusterData("http://127.0.0.1:" + BROKER_WEBSERVICE_PORT));
+        admin.clusters().createCluster("use", new ClusterData("http://127.0.0.1:" + BROKER_WEBSERVICE_PORT));
         admin.properties().createProperty("my-property",
                 new PropertyAdmin(Lists.newArrayList("appid1", "appid2"), Sets.newHashSet("use")));
         admin.namespaces().createNamespace("my-property/use/my-ns");
@@ -61,29 +53,25 @@ public class ConsumerConfigurationTest extends MockedPulsarServiceBaseTest {
 
     @Test
     public void testReadCompactPersistentExclusive() throws Exception {
-        ConsumerConfiguration conf = new ConsumerConfiguration().setReadCompacted(true);
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-        pulsarClient.subscribe(persistentTopic, "sub1", conf).close();
+        pulsarClient.newConsumer().topic(persistentTopic).subscriptionName("sub1").readCompacted(true)
+                .subscriptionType(SubscriptionType.Exclusive).subscribe().close();
     }
 
     @Test
     public void testReadCompactPersistentFailover() throws Exception {
-        ConsumerConfiguration conf = new ConsumerConfiguration().setReadCompacted(true);
-        conf.setSubscriptionType(SubscriptionType.Failover);
-        pulsarClient.subscribe(persistentTopic, "sub1", conf).close();
+        pulsarClient.newConsumer().topic(persistentTopic).subscriptionName("sub1").readCompacted(true)
+                .subscriptionType(SubscriptionType.Failover).subscribe().close();
     }
 
-    @Test(expectedExceptions=InvalidConfigurationException.class)
+    @Test(expectedExceptions = InvalidConfigurationException.class)
     public void testReadCompactPersistentShared() throws Exception {
-        ConsumerConfiguration conf = new ConsumerConfiguration().setReadCompacted(true);
-        conf.setSubscriptionType(SubscriptionType.Shared);
-        pulsarClient.subscribe(persistentTopic, "sub1", conf).close();
+        pulsarClient.newConsumer().topic(persistentTopic).subscriptionName("sub1").readCompacted(true)
+                .subscriptionType(SubscriptionType.Shared).subscribe().close();
     }
 
-    @Test(expectedExceptions=InvalidConfigurationException.class)
+    @Test(expectedExceptions = InvalidConfigurationException.class)
     public void testReadCompactNonPersistentExclusive() throws Exception {
-        ConsumerConfiguration conf = new ConsumerConfiguration().setReadCompacted(true);
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-        pulsarClient.subscribe(nonPersistentTopic, "sub1", conf).close();
+        pulsarClient.newConsumer().topic(nonPersistentTopic).subscriptionName("sub1").readCompacted(true)
+                .subscriptionType(SubscriptionType.Exclusive).subscribe().close();
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageIdTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/MessageIdTest.java
@@ -42,13 +42,11 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.client.admin.PulsarAdminException;
-import org.apache.pulsar.client.api.ClientConfiguration;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageBuilder;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
-import org.apache.pulsar.client.api.ProducerConfiguration;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.ProducerImpl.OpSendMsg;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
@@ -91,14 +89,15 @@ public class MessageIdTest extends BrokerTestBase {
         final int numberOfMessages = 30;
 
         // 2. Create Producer
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
 
         // 3. Create Consumer
-        Consumer consumer = pulsarClient.subscribe(topicName, subscriptionName);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
+                .subscribe();
 
         // 4. Publish message and get message id
-        Set<MessageId> messageIds = new HashSet();
-        List<Future<MessageId>> futures = new ArrayList();
+        Set<MessageId> messageIds = new HashSet<>();
+        List<Future<MessageId>> futures = new ArrayList<>();
         for (int i = 0; i < numberOfMessages; i++) {
             String message = messagePredicate + i;
             futures.add(producer.sendAsync(message.getBytes()));
@@ -124,7 +123,7 @@ public class MessageIdTest extends BrokerTestBase {
         Assert.assertEquals(messageIds.size(), numberOfMessages, "Not all messages published successfully");
 
         for (int i = 0; i < numberOfMessages; i++) {
-            Message message = consumer.receive();
+            Message<byte[]> message = consumer.receive();
             Assert.assertEquals(new String(message.getData()), messagePredicate + i);
             MessageId messageId = message.getMessageId();
             Assert.assertTrue(messageIds.remove(messageId), "Failed to receive message");
@@ -144,13 +143,14 @@ public class MessageIdTest extends BrokerTestBase {
         final int numberOfMessages = 30;
 
         // 2. Create Producer
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
 
         // 3. Create Consumer
-        Consumer consumer = pulsarClient.subscribe(topicName, subscriptionName);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
+                .subscribe();
 
         // 4. Publish message and get message id
-        Set<MessageId> messageIds = new HashSet();
+        Set<MessageId> messageIds = new HashSet<>();
         for (int i = 0; i < numberOfMessages; i++) {
             String message = messagePredicate + i;
             messageIds.add(producer.send(message.getBytes()));
@@ -181,14 +181,15 @@ public class MessageIdTest extends BrokerTestBase {
         admin.persistentTopics().createPartitionedTopic(topicName, numberOfPartitions);
 
         // 2. Create Producer
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
 
         // 3. Create Consumer
-        Consumer consumer = pulsarClient.subscribe(topicName, subscriptionName);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
+                .subscribe();
 
         // 4. Publish message and get message id
-        Set<MessageId> messageIds = new HashSet();
-        Set<Future<MessageId>> futures = new HashSet();
+        Set<MessageId> messageIds = new HashSet<>();
+        Set<Future<MessageId>> futures = new HashSet<>();
         for (int i = 0; i < numberOfMessages; i++) {
             String message = messagePredicate + i;
             futures.add(producer.sendAsync(message.getBytes()));
@@ -228,13 +229,14 @@ public class MessageIdTest extends BrokerTestBase {
         admin.persistentTopics().createPartitionedTopic(topicName, numberOfPartitions);
 
         // 2. Create Producer
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
 
         // 3. Create Consumer
-        Consumer consumer = pulsarClient.subscribe(topicName, subscriptionName);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
+                .subscribe();
 
         // 4. Publish message and get message id
-        Set<MessageId> messageIds = new HashSet();
+        Set<MessageId> messageIds = new HashSet<>();
         for (int i = 0; i < numberOfMessages; i++) {
             String message = messagePredicate + i;
             messageIds.add(producer.send(message.getBytes()));
@@ -255,19 +257,17 @@ public class MessageIdTest extends BrokerTestBase {
     }
 
     /**
-     * Verifies: different versions of broker-deployment (one broker understands Checksum and other
-     * doesn't in that case remove checksum before sending to broker-2)
+     * Verifies: different versions of broker-deployment (one broker understands Checksum and other doesn't in that case
+     * remove checksum before sending to broker-2)
      *
-     * client first produce message with checksum and then retries to send message due to connection unavailable. But this time, if
-     * broker doesn't understand checksum: then client should remove checksum from the message before sending to broker.
+     * client first produce message with checksum and then retries to send message due to connection unavailable. But
+     * this time, if broker doesn't understand checksum: then client should remove checksum from the message before
+     * sending to broker.
      *
-     * 1. stop broker
-     * 2. client compute checksum and add into message
-     * 3. produce 2 messages and corrupt 1 message
-     * 4. start broker with lower version (which doesn't support checksum)
-     * 5. client reconnects to broker and due to incompatibility of version: removes checksum from message
-     * 6. broker doesn't do checksum validation and persist message
-     * 7. client receives ack
+     * 1. stop broker 2. client compute checksum and add into message 3. produce 2 messages and corrupt 1 message 4.
+     * start broker with lower version (which doesn't support checksum) 5. client reconnects to broker and due to
+     * incompatibility of version: removes checksum from message 6. broker doesn't do checksum validation and persist
+     * message 7. client receives ack
      *
      * @throws Exception
      */
@@ -276,15 +276,15 @@ public class MessageIdTest extends BrokerTestBase {
         final String topicName = "persistent://prop/use/ns-abc/topic1";
 
         // 1. producer connect
-        ProducerImpl prod = (ProducerImpl) pulsarClient.createProducer(topicName);
-        ProducerImpl producer = spy(prod);
+        ProducerImpl<byte[]> prod = (ProducerImpl<byte[]>) pulsarClient.newProducer().topic(topicName).create();
+        ProducerImpl<byte[]> producer = spy(prod);
         // return higher version compare to broker : so, it forces client-producer to remove checksum from payload
         doReturn(producer.brokerChecksumSupportedVersion() + 1).when(producer).brokerChecksumSupportedVersion();
         doAnswer(invocationOnMock -> prod.getState()).when(producer).getState();
         doAnswer(invocationOnMock -> prod.getClientCnx()).when(producer).getClientCnx();
         doAnswer(invocationOnMock -> prod.cnx()).when(producer).cnx();
 
-        Consumer consumer = pulsarClient.subscribe(topicName, "my-sub");
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName("my-sub").subscribe();
 
         // Stop the broker, and publishes messages. Messages are accumulated in the producer queue and they're checksums
         // would have already been computed. If we change the message content at that point, it should result in a
@@ -300,10 +300,10 @@ public class MessageIdTest extends BrokerTestBase {
         doReturn(producer.brokerChecksumSupportedVersion() - 1).when(mockClientCnx).getRemoteEndpointProtocolVersion();
         prod.setClientCnx(mockClientCnx);
 
-        Message msg1 = MessageBuilder.create().setContent("message-1".getBytes()).build();
+        Message<byte[]> msg1 = MessageBuilder.create().setContent("message-1".getBytes()).build();
         CompletableFuture<MessageId> future1 = producer.sendAsync(msg1);
 
-        Message msg2 = MessageBuilder.create().setContent("message-2".getBytes()).build();
+        Message<byte[]> msg2 = MessageBuilder.create().setContent("message-2".getBytes()).build();
         CompletableFuture<MessageId> future2 = producer.sendAsync(msg2);
 
         // corrupt the message
@@ -327,9 +327,9 @@ public class MessageIdTest extends BrokerTestBase {
             fail("Broker shouldn't verify checksum for corrupted message and it shouldn't fail");
         }
 
-        ((ConsumerImpl) consumer).grabCnx();
+        ((ConsumerImpl<byte[]>) consumer).grabCnx();
         // We should only receive msg1
-        Message msg = consumer.receive(1, TimeUnit.SECONDS);
+        Message<byte[]> msg = consumer.receive(1, TimeUnit.SECONDS);
         assertEquals(new String(msg.getData()), "message-1");
         msg = consumer.receive(1, TimeUnit.SECONDS);
         assertEquals(new String(msg.getData()), "message-3");
@@ -341,8 +341,8 @@ public class MessageIdTest extends BrokerTestBase {
         final String topicName = "persistent://prop/use/ns-abc/topic1";
 
         // 1. producer connect
-        ProducerImpl prod = (ProducerImpl) pulsarClient.createProducer(topicName);
-        ProducerImpl producer = spy(prod);
+        ProducerImpl<byte[]> prod = (ProducerImpl<byte[]>) pulsarClient.newProducer().topic(topicName).create();
+        ProducerImpl<byte[]> producer = spy(prod);
         // mock: broker-doesn't support checksum (remote_version < brokerChecksumSupportedVersion) so, it forces
         // client-producer to perform checksum-strip from msg at reconnection
         doReturn(producer.brokerChecksumSupportedVersion() + 1).when(producer).brokerChecksumSupportedVersion();
@@ -350,7 +350,7 @@ public class MessageIdTest extends BrokerTestBase {
         doAnswer(invocationOnMock -> prod.getClientCnx()).when(producer).getClientCnx();
         doAnswer(invocationOnMock -> prod.cnx()).when(producer).cnx();
 
-        Consumer consumer = pulsarClient.subscribe(topicName, "my-sub");
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName("my-sub").subscribe();
 
         stopBroker();
 
@@ -365,10 +365,10 @@ public class MessageIdTest extends BrokerTestBase {
         doReturn(producer.brokerChecksumSupportedVersion() - 1).when(mockClientCnx).getRemoteEndpointProtocolVersion();
         prod.setClientCnx(mockClientCnx);
 
-        Message msg1 = MessageBuilder.create().setContent("message-1".getBytes()).build();
+        Message<byte[]> msg1 = MessageBuilder.create().setContent("message-1".getBytes()).build();
         CompletableFuture<MessageId> future1 = producer.sendAsync(msg1);
 
-        Message msg2 = MessageBuilder.create().setContent("message-2".getBytes()).build();
+        Message<byte[]> msg2 = MessageBuilder.create().setContent("message-2".getBytes()).build();
         CompletableFuture<MessageId> future2 = producer.sendAsync(msg2);
 
         // corrupt the message
@@ -395,22 +395,19 @@ public class MessageIdTest extends BrokerTestBase {
             fail("Broker shouldn't verify checksum for corrupted message and it shouldn't fail");
         }
 
-        ((ConsumerImpl) consumer).grabCnx();
+        ((ConsumerImpl<byte[]>) consumer).grabCnx();
         // We should only receive msg1
-        Message msg = consumer.receive(1, TimeUnit.SECONDS);
+        Message<byte[]> msg = consumer.receive(1, TimeUnit.SECONDS);
         assertEquals(new String(msg.getData()), "message-1");
         msg = consumer.receive(1, TimeUnit.SECONDS);
         assertEquals(new String(msg.getData()), "message-3");
 
     }
 
-
     /**
-     * Verifies: if message is corrupted before sending to broker and if broker gives checksum error: then
-     * 1. Client-Producer recomputes checksum with modified data
-     * 2. Retry message-send again
-     * 3. Broker verifies checksum
-     * 4. client receives send-ack success
+     * Verifies: if message is corrupted before sending to broker and if broker gives checksum error: then 1.
+     * Client-Producer recomputes checksum with modified data 2. Retry message-send again 3. Broker verifies checksum 4.
+     * client receives send-ack success
      *
      * @throws Exception
      */
@@ -419,16 +416,15 @@ public class MessageIdTest extends BrokerTestBase {
 
         final String topicName = "persistent://prop/use/ns-abc/retry-topic";
 
-        ProducerConfiguration config = new ProducerConfiguration();
-        config.setSendTimeout(10, TimeUnit.MINUTES);
         // 1. producer connect
-        Producer prod = pulsarClient.createProducer(topicName, config);
-        ProducerImpl producer = spy((ProducerImpl) prod);
+        ProducerImpl<byte[]> prod = (ProducerImpl<byte[]>) pulsarClient.newProducer().topic(topicName)
+                .sendTimeout(10, TimeUnit.MINUTES).create();
+        ProducerImpl<byte[]> producer = spy(prod);
         Field producerIdField = ProducerImpl.class.getDeclaredField("producerId");
         producerIdField.setAccessible(true);
         long producerId = (long) producerIdField.get(producer);
         producer.cnx().registerProducer(producerId, producer); // registered spy ProducerImpl
-        Consumer consumer = pulsarClient.subscribe(topicName, "my-sub");
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName("my-sub").subscribe();
 
         // 2. Stop the broker, and publishes messages. Messages are accumulated in the producer queue and they're
         // checksums
@@ -437,7 +433,7 @@ public class MessageIdTest extends BrokerTestBase {
         // enable checksum at producer
         stopBroker();
 
-        Message msg = MessageBuilder.create().setContent("message-1".getBytes()).build();
+        Message<byte[]> msg = MessageBuilder.create().setContent("message-1".getBytes()).build();
         CompletableFuture<MessageId> future = producer.sendAsync(msg);
 
         // 3. corrupt the message
@@ -451,7 +447,7 @@ public class MessageIdTest extends BrokerTestBase {
             fail("send message should have failed with checksum excetion");
         } catch (Exception e) {
             if (e.getCause() instanceof PulsarClientException.ChecksumException) {
-                //ok (callback should get checksum exception as message was modified and corrupt)
+                // ok (callback should get checksum exception as message was modified and corrupt)
             } else {
                 fail("Callback should have only failed with ChecksumException", e);
             }
@@ -463,19 +459,18 @@ public class MessageIdTest extends BrokerTestBase {
         verify(producer, times(1)).recoverChecksumError(any(), anyLong());
         verify(producer, times(1)).verifyLocalBufferIsNotCorrupted(any());
 
-
         /**
-         * (5.3) verify: ProducerImpl.verifyLocalBufferIsNotCorrupted() => validates if message
-         * is corrupt
+         * (5.3) verify: ProducerImpl.verifyLocalBufferIsNotCorrupted() => validates if message is corrupt
          */
-        MessageImpl msg2 = (MessageImpl) MessageBuilder.create().setContent("message-1".getBytes()).build();
+        MessageImpl<byte[]> msg2 = (MessageImpl<byte[]>) MessageBuilder.create().setContent("message-1".getBytes())
+                .build();
         ByteBuf payload = msg2.getDataBuffer();
-        Builder metadataBuilder = ((MessageImpl) msg).getMessageBuilder();
+        Builder metadataBuilder = ((MessageImpl<byte[]>) msg).getMessageBuilder();
         MessageMetadata msgMetadata = metadataBuilder.setProducerName("test").setSequenceId(1).setPublishTime(10L)
                 .build();
         ByteBufPair cmd = Commands.newSend(producerId, 1, 1, ChecksumType.Crc32c, msgMetadata, payload);
         // (a) create OpSendMsg with message-data : "message-1"
-        OpSendMsg op = OpSendMsg.create(((MessageImpl) msg), cmd, 1, null);
+        OpSendMsg op = OpSendMsg.create(((MessageImpl<byte[]>) msg), cmd, 1, null);
         // a.verify: as message is not corrupt: no need to update checksum
         assertTrue(producer.verifyLocalBufferIsNotCorrupted(op));
         // (b) corrupt message
@@ -487,7 +482,8 @@ public class MessageIdTest extends BrokerTestBase {
 
         // [2] test-recoverChecksumError functionality
         stopBroker();
-        MessageImpl msg1 = (MessageImpl) MessageBuilder.create().setContent("message-1".getBytes()).build();
+        MessageImpl<byte[]> msg1 = (MessageImpl<byte[]>) MessageBuilder.create().setContent("message-1".getBytes())
+                .build();
         future = producer.sendAsync(msg1);
         ClientCnx cnx = spy(
                 new ClientCnx(new ClientConfigurationData(), ((PulsarClientImpl) pulsarClient).eventLoopGroup()));
@@ -497,7 +493,7 @@ public class MessageIdTest extends BrokerTestBase {
         try {
             producer.recoverChecksumError(cnx, 1);
             fail("it should call : resendMessages() => which should throw above mocked exception");
-        }catch(IllegalStateException e) {
+        } catch (IllegalStateException e) {
             assertEquals(exc, e.getMessage());
         }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PerMessageUnAcknowledgedRedeliveryTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/PerMessageUnAcknowledgedRedeliveryTest.java
@@ -24,14 +24,10 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.client.api.Consumer;
-import org.apache.pulsar.client.api.ConsumerConfiguration;
 import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.client.api.Producer;
-import org.apache.pulsar.client.api.ProducerConfiguration;
 import org.apache.pulsar.client.api.SubscriptionType;
-import org.apache.pulsar.client.api.ProducerConfiguration.MessageRoutingMode;
-import org.apache.pulsar.client.impl.ConsumerImpl;
-import org.apache.pulsar.client.impl.PartitionedConsumerImpl;
 import org.apache.pulsar.common.policies.data.PropertyAdmin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,14 +61,12 @@ public class PerMessageUnAcknowledgedRedeliveryTest extends BrokerTestBase {
         final int totalMessages = 15;
 
         // 1. producer connect
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
 
         // 2. Create consumer
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setReceiverQueueSize(50);
-        conf.setAckTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS);
-        conf.setSubscriptionType(SubscriptionType.Shared);
-        Consumer consumer = pulsarClient.subscribe(topicName, subscriptionName, conf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
+                .receiverQueueSize(50).ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS)
+                .subscriptionType(SubscriptionType.Shared).subscribe();
 
         // 3. producer publish messages
         for (int i = 0; i < totalMessages / 3; i++) {
@@ -82,13 +76,13 @@ public class PerMessageUnAcknowledgedRedeliveryTest extends BrokerTestBase {
         }
 
         // 4. Receiver receives the message, doesn't ack
-        Message message = consumer.receive();
+        Message<byte[]> message = consumer.receive();
         while (message != null) {
             String data = new String(message.getData());
             log.info("Consumer received : " + data);
             message = consumer.receive(100, TimeUnit.MILLISECONDS);
         }
-        long size = ((ConsumerImpl) consumer).getUnAckedMessageTracker().size();
+        long size = ((ConsumerImpl<byte[]>) consumer).getUnAckedMessageTracker().size();
         log.info(key + " Unacked Message Tracker size is " + size);
         assertEquals(size, 5);
 
@@ -109,13 +103,13 @@ public class PerMessageUnAcknowledgedRedeliveryTest extends BrokerTestBase {
             consumer.acknowledge(message);
             message = consumer.receive(100, TimeUnit.MILLISECONDS);
         }
-        size = ((ConsumerImpl) consumer).getUnAckedMessageTracker().size();
+        size = ((ConsumerImpl<byte[]>) consumer).getUnAckedMessageTracker().size();
         log.info(key + " Unacked Message Tracker size is " + size);
         assertEquals(size, 5);
         assertEquals(received, 5);
 
         // 7. Simulate ackTimeout
-        ((ConsumerImpl) consumer).getUnAckedMessageTracker().toggle();
+        ((ConsumerImpl<byte[]>) consumer).getUnAckedMessageTracker().toggle();
 
         // 8. producer publish more messages
         for (int i = 0; i < totalMessages / 3; i++) {
@@ -131,7 +125,7 @@ public class PerMessageUnAcknowledgedRedeliveryTest extends BrokerTestBase {
             log.info("Consumer received : " + data);
             message = consumer.receive(100, TimeUnit.MILLISECONDS);
         }
-        size = ((ConsumerImpl) consumer).getUnAckedMessageTracker().size();
+        size = ((ConsumerImpl<byte[]>) consumer).getUnAckedMessageTracker().size();
         log.info(key + " Unacked Message Tracker size is " + size);
         assertEquals(size, 10);
 
@@ -148,7 +142,7 @@ public class PerMessageUnAcknowledgedRedeliveryTest extends BrokerTestBase {
             message = consumer.receive(100, TimeUnit.MILLISECONDS);
         }
         assertEquals(redelivered, 5);
-        size = ((ConsumerImpl) consumer).getUnAckedMessageTracker().size();
+        size = ((ConsumerImpl<byte[]>) consumer).getUnAckedMessageTracker().size();
         log.info(key + " Unacked Message Tracker size is " + size);
         assertEquals(size, 5);
     }
@@ -162,14 +156,12 @@ public class PerMessageUnAcknowledgedRedeliveryTest extends BrokerTestBase {
         final int totalMessages = 15;
 
         // 1. producer connect
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
 
         // 2. Create consumer
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setReceiverQueueSize(50);
-        conf.setAckTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS);
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-        Consumer consumer = pulsarClient.subscribe(topicName, subscriptionName, conf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
+                .receiverQueueSize(50).ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS)
+                .subscriptionType(SubscriptionType.Exclusive).subscribe();
 
         // 3. producer publish messages
         for (int i = 0; i < totalMessages / 3; i++) {
@@ -179,13 +171,13 @@ public class PerMessageUnAcknowledgedRedeliveryTest extends BrokerTestBase {
         }
 
         // 4. Receiver receives the message, doesn't ack
-        Message message = consumer.receive();
+        Message<byte[]> message = consumer.receive();
         while (message != null) {
             String data = new String(message.getData());
             log.info("Consumer received : " + data);
             message = consumer.receive(100, TimeUnit.MILLISECONDS);
         }
-        long size = ((ConsumerImpl) consumer).getUnAckedMessageTracker().size();
+        long size = ((ConsumerImpl<byte[]>) consumer).getUnAckedMessageTracker().size();
         log.info(key + " Unacked Message Tracker size is " + size);
         assertEquals(size, 5);
 
@@ -206,13 +198,13 @@ public class PerMessageUnAcknowledgedRedeliveryTest extends BrokerTestBase {
             consumer.acknowledge(message);
             message = consumer.receive(100, TimeUnit.MILLISECONDS);
         }
-        size = ((ConsumerImpl) consumer).getUnAckedMessageTracker().size();
+        size = ((ConsumerImpl<byte[]>) consumer).getUnAckedMessageTracker().size();
         log.info(key + " Unacked Message Tracker size is " + size);
         assertEquals(size, 5);
         assertEquals(received, 5);
 
         // 7. Simulate ackTimeout
-        ((ConsumerImpl) consumer).getUnAckedMessageTracker().toggle();
+        ((ConsumerImpl<byte[]>) consumer).getUnAckedMessageTracker().toggle();
 
         // 8. producer publish more messages
         for (int i = 0; i < totalMessages / 3; i++) {
@@ -228,7 +220,7 @@ public class PerMessageUnAcknowledgedRedeliveryTest extends BrokerTestBase {
             log.info("Consumer received : " + data);
             message = consumer.receive(100, TimeUnit.MILLISECONDS);
         }
-        size = ((ConsumerImpl) consumer).getUnAckedMessageTracker().size();
+        size = ((ConsumerImpl<byte[]>) consumer).getUnAckedMessageTracker().size();
         log.info(key + " Unacked Message Tracker size is " + size);
         assertEquals(size, 10);
 
@@ -245,7 +237,7 @@ public class PerMessageUnAcknowledgedRedeliveryTest extends BrokerTestBase {
             message = consumer.receive(100, TimeUnit.MILLISECONDS);
         }
         assertEquals(redelivered, 10);
-        size = ((ConsumerImpl) consumer).getUnAckedMessageTracker().size();
+        size = ((ConsumerImpl<byte[]>) consumer).getUnAckedMessageTracker().size();
         log.info(key + " Unacked Message Tracker size is " + size);
         assertEquals(size, 0);
     }
@@ -259,14 +251,12 @@ public class PerMessageUnAcknowledgedRedeliveryTest extends BrokerTestBase {
         final int totalMessages = 15;
 
         // 1. producer connect
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
 
         // 2. Create consumer
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setReceiverQueueSize(50);
-        conf.setAckTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS);
-        conf.setSubscriptionType(SubscriptionType.Failover);
-        Consumer consumer = pulsarClient.subscribe(topicName, subscriptionName, conf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
+                .receiverQueueSize(50).ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS)
+                .subscriptionType(SubscriptionType.Failover).subscribe();
 
         // 3. producer publish messages
         for (int i = 0; i < totalMessages / 3; i++) {
@@ -276,13 +266,13 @@ public class PerMessageUnAcknowledgedRedeliveryTest extends BrokerTestBase {
         }
 
         // 4. Receiver receives the message, doesn't ack
-        Message message = consumer.receive();
+        Message<byte[]> message = consumer.receive();
         while (message != null) {
             String data = new String(message.getData());
             log.info("Consumer received : " + data);
             message = consumer.receive(100, TimeUnit.MILLISECONDS);
         }
-        long size = ((ConsumerImpl) consumer).getUnAckedMessageTracker().size();
+        long size = ((ConsumerImpl<byte[]>) consumer).getUnAckedMessageTracker().size();
         log.info(key + " Unacked Message Tracker size is " + size);
         assertEquals(size, 5);
 
@@ -303,13 +293,13 @@ public class PerMessageUnAcknowledgedRedeliveryTest extends BrokerTestBase {
             consumer.acknowledge(message);
             message = consumer.receive(100, TimeUnit.MILLISECONDS);
         }
-        size = ((ConsumerImpl) consumer).getUnAckedMessageTracker().size();
+        size = ((ConsumerImpl<byte[]>) consumer).getUnAckedMessageTracker().size();
         log.info(key + " Unacked Message Tracker size is " + size);
         assertEquals(size, 5);
         assertEquals(received, 5);
 
         // 7. Simulate ackTimeout
-        ((ConsumerImpl) consumer).getUnAckedMessageTracker().toggle();
+        ((ConsumerImpl<byte[]>) consumer).getUnAckedMessageTracker().toggle();
 
         // 8. producer publish more messages
         for (int i = 0; i < totalMessages / 3; i++) {
@@ -325,7 +315,7 @@ public class PerMessageUnAcknowledgedRedeliveryTest extends BrokerTestBase {
             log.info("Consumer received : " + data);
             message = consumer.receive(100, TimeUnit.MILLISECONDS);
         }
-        size = ((ConsumerImpl) consumer).getUnAckedMessageTracker().size();
+        size = ((ConsumerImpl<byte[]>) consumer).getUnAckedMessageTracker().size();
         log.info(key + " Unacked Message Tracker size is " + size);
         assertEquals(size, 10);
 
@@ -342,15 +332,15 @@ public class PerMessageUnAcknowledgedRedeliveryTest extends BrokerTestBase {
             message = consumer.receive(100, TimeUnit.MILLISECONDS);
         }
         assertEquals(redelivered, 10);
-        size = ((ConsumerImpl) consumer).getUnAckedMessageTracker().size();
+        size = ((ConsumerImpl<byte[]>) consumer).getUnAckedMessageTracker().size();
         log.info(key + " Unacked Message Tracker size is " + size);
         assertEquals(size, 0);
     }
 
     private static long getUnackedMessagesCountInPartitionedConsumer(Consumer<byte[]> c) {
-        PartitionedConsumerImpl<byte[]> pc = (PartitionedConsumerImpl) c;
-        return pc.getUnAckedMessageTracker().size() + pc.getConsumers().stream()
-                .mapToLong(consumer -> consumer.getUnAckedMessageTracker().size()).sum();
+        PartitionedConsumerImpl<byte[]> pc = (PartitionedConsumerImpl<byte[]>) c;
+        return pc.getUnAckedMessageTracker().size()
+                + pc.getConsumers().stream().mapToLong(consumer -> consumer.getUnAckedMessageTracker().size()).sum();
     }
 
     @Test(timeOut = testTimeout)
@@ -365,16 +355,13 @@ public class PerMessageUnAcknowledgedRedeliveryTest extends BrokerTestBase {
         admin.persistentTopics().createPartitionedTopic(topicName, numberOfPartitions);
 
         // 1. producer connect
-        ProducerConfiguration prodConfig = new ProducerConfiguration();
-        prodConfig.setMessageRoutingMode(MessageRoutingMode.RoundRobinPartition);
-        Producer producer = pulsarClient.createProducer(topicName, prodConfig);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName)
+                .messageRoutingMode(MessageRoutingMode.RoundRobinPartition).create();
 
         // 2. Create consumer
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setReceiverQueueSize(50);
-        conf.setAckTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS);
-        conf.setSubscriptionType(SubscriptionType.Shared);
-        Consumer<byte[]> consumer = pulsarClient.subscribe(topicName, subscriptionName, conf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
+                .receiverQueueSize(50).ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS)
+                .subscriptionType(SubscriptionType.Shared).subscribe();
 
         // 3. producer publish messages
         for (int i = 0; i < totalMessages / 3; i++) {
@@ -384,7 +371,7 @@ public class PerMessageUnAcknowledgedRedeliveryTest extends BrokerTestBase {
         }
 
         // 4. Receiver receives the message, doesn't ack
-        Message message = consumer.receive();
+        Message<byte[]> message = consumer.receive();
         while (message != null) {
             String data = new String(message.getData());
             log.info("Consumer received : " + data);
@@ -418,7 +405,7 @@ public class PerMessageUnAcknowledgedRedeliveryTest extends BrokerTestBase {
         assertEquals(received, 5);
 
         // 7. Simulate ackTimeout
-        ((PartitionedConsumerImpl) consumer).getUnAckedMessageTracker().toggle();
+        ((PartitionedConsumerImpl<byte[]>) consumer).getUnAckedMessageTracker().toggle();
         ((PartitionedConsumerImpl<byte[]>) consumer).getConsumers().forEach(c -> c.getUnAckedMessageTracker().toggle());
 
         // 8. producer publish more messages
@@ -435,7 +422,7 @@ public class PerMessageUnAcknowledgedRedeliveryTest extends BrokerTestBase {
             log.info("Consumer received : " + data);
             message = consumer.receive(100, TimeUnit.MILLISECONDS);
         }
-        size =  getUnackedMessagesCountInPartitionedConsumer(consumer);
+        size = getUnackedMessagesCountInPartitionedConsumer(consumer);
         log.info(key + " Unacked Message Tracker size is " + size);
         assertEquals(size, 10);
 
@@ -452,7 +439,7 @@ public class PerMessageUnAcknowledgedRedeliveryTest extends BrokerTestBase {
             message = consumer.receive(100, TimeUnit.MILLISECONDS);
         }
         assertEquals(redelivered, 5);
-        size =  getUnackedMessagesCountInPartitionedConsumer(consumer);
+        size = getUnackedMessagesCountInPartitionedConsumer(consumer);
         log.info(key + " Unacked Message Tracker size is " + size);
         assertEquals(size, 5);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/RawMessageSerDeserTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/RawMessageSerDeserTest.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.client.impl;
 
 
 import org.apache.pulsar.client.api.RawMessage;
-import org.apache.pulsar.common.api.ByteBufPair;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,6 +28,7 @@ import org.testng.annotations.Test;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import lombok.Cleanup;
 
 public class RawMessageSerDeserTest {
     static final Logger log = LoggerFactory.getLogger(RawMessageSerDeserTest.class);
@@ -43,6 +43,7 @@ public class RawMessageSerDeserTest {
             .setLedgerId(0xf00).setEntryId(0xbaa)
             .setPartition(10).setBatchIndex(20).build();
 
+        @Cleanup
         RawMessage m = new RawMessageImpl(id, headersAndPayload);
         ByteBuf serialized = m.serialize();
         byte[] bytes = new byte[serialized.readableBytes()];

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/UnAcknowledgedMessagesTimeoutTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/UnAcknowledgedMessagesTimeoutTest.java
@@ -25,16 +25,12 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.client.api.Consumer;
-import org.apache.pulsar.client.api.ConsumerConfiguration;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.client.api.Producer;
-import org.apache.pulsar.client.api.ProducerConfiguration;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.SubscriptionType;
-import org.apache.pulsar.client.api.ProducerConfiguration.MessageRoutingMode;
-import org.apache.pulsar.client.impl.ConsumerImpl;
-import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.policies.data.PropertyAdmin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,13 +65,11 @@ public class UnAcknowledgedMessagesTimeoutTest extends BrokerTestBase {
         final int totalMessages = 10;
 
         // 1. producer connect
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
 
         // 2. Create consumer
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setReceiverQueueSize(7);
-        conf.setAckTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS);
-        Consumer consumer = pulsarClient.subscribe(topicName, subscriptionName, conf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
+                .receiverQueueSize(7).ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS).subscribe();
 
         // 3. producer publish messages
         for (int i = 0; i < totalMessages / 2; i++) {
@@ -85,12 +79,12 @@ public class UnAcknowledgedMessagesTimeoutTest extends BrokerTestBase {
         }
 
         // 4. Receiver receives the message
-        Message message = consumer.receive();
+        Message<byte[]> message = consumer.receive();
         while (message != null) {
             log.info("Consumer received : " + new String(message.getData()));
             message = consumer.receive(500, TimeUnit.MILLISECONDS);
         }
-        long size = ((ConsumerImpl) consumer).getUnAckedMessageTracker().size();
+        long size = ((ConsumerImpl<?>) consumer).getUnAckedMessageTracker().size();
         log.info(key + " Unacked Message Tracker size is " + size);
         assertEquals(size, totalMessages / 2);
 
@@ -111,7 +105,7 @@ public class UnAcknowledgedMessagesTimeoutTest extends BrokerTestBase {
             message = consumer.receive(500, TimeUnit.MILLISECONDS);
         } while (message != null);
 
-        size = ((ConsumerImpl) consumer).getUnAckedMessageTracker().size();
+        size = ((ConsumerImpl<?>) consumer).getUnAckedMessageTracker().size();
         log.info(key + " Unacked Message Tracker size is " + size);
         assertEquals(size, 0);
         assertEquals(hSet.size(), totalMessages);
@@ -126,13 +120,11 @@ public class UnAcknowledgedMessagesTimeoutTest extends BrokerTestBase {
         final int totalMessages = 10;
 
         // 1. producer connect
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
 
         // 2. Create consumer
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setReceiverQueueSize(7);
-        conf.setAckTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS);
-        Consumer consumer = pulsarClient.subscribe(topicName, subscriptionName, conf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
+                .receiverQueueSize(7).ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS).subscribe();
 
         // 3. producer publish messages
         for (int i = 0; i < totalMessages; i++) {
@@ -142,8 +134,8 @@ public class UnAcknowledgedMessagesTimeoutTest extends BrokerTestBase {
 
         // 4. Receiver receives the message
         HashSet<String> hSet = new HashSet<>();
-        Message message = consumer.receive();
-        Message lastMessage = message;
+        Message<byte[]> message = consumer.receive();
+        Message<byte[]> lastMessage = message;
         while (message != null) {
             lastMessage = message;
             hSet.add(new String(message.getData()));
@@ -151,12 +143,12 @@ public class UnAcknowledgedMessagesTimeoutTest extends BrokerTestBase {
             log.info("Message ID details " + ((MessageIdImpl) message.getMessageId()).toString());
             message = consumer.receive(500, TimeUnit.MILLISECONDS);
         }
-        long size = ((ConsumerImpl) consumer).getUnAckedMessageTracker().size();
+        long size = ((ConsumerImpl<?>) consumer).getUnAckedMessageTracker().size();
         assertEquals(size, totalMessages);
         log.info("Comulative Ack sent for " + new String(lastMessage.getData()));
         log.info("Message ID details " + ((MessageIdImpl) lastMessage.getMessageId()).toString());
         consumer.acknowledgeCumulative(lastMessage);
-        size = ((ConsumerImpl) consumer).getUnAckedMessageTracker().size();
+        size = ((ConsumerImpl<?>) consumer).getUnAckedMessageTracker().size();
         assertEquals(size, 0);
         message = consumer.receive((int) (2 * ackTimeOutMillis), TimeUnit.MILLISECONDS);
         assertEquals(message, null);
@@ -175,19 +167,16 @@ public class UnAcknowledgedMessagesTimeoutTest extends BrokerTestBase {
         // Special step to create partitioned topic
 
         // 1. producer connect
-        ProducerConfiguration prodConfig = new ProducerConfiguration();
-        prodConfig.setMessageRoutingMode(MessageRoutingMode.RoundRobinPartition);
-        Producer producer = pulsarClient.createProducer(topicName, prodConfig);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName)
+                .messageRoutingMode(MessageRoutingMode.RoundRobinPartition).create();
 
         // 2. Create consumer
-        ConsumerConfiguration consumerConfig = new ConsumerConfiguration();
-        consumerConfig.setReceiverQueueSize(100);
-        consumerConfig.setSubscriptionType(SubscriptionType.Shared);
-        consumerConfig.setAckTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS);
-        consumerConfig.setConsumerName("Consumer-1");
-        Consumer consumer1 = pulsarClient.subscribe(topicName, subscriptionName, consumerConfig);
-        consumerConfig.setConsumerName("Consumer-2");
-        Consumer consumer2 = pulsarClient.subscribe(topicName, subscriptionName, consumerConfig);
+        Consumer<byte[]> consumer1 = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
+                .receiverQueueSize(100).subscriptionType(SubscriptionType.Shared)
+                .ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS).consumerName("Consumer-1").subscribe();
+        Consumer<byte[]> consumer2 = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
+                .receiverQueueSize(100).subscriptionType(SubscriptionType.Shared)
+                .ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS).consumerName("Consumer-2").subscribe();
 
         // 3. producer publish messages
         for (int i = 0; i < totalMessages; i++) {
@@ -235,9 +224,9 @@ public class UnAcknowledgedMessagesTimeoutTest extends BrokerTestBase {
         assertEquals(ackCount1 + ackCount2, totalMessages);
     }
 
-    private static int receiveAllMessage(Consumer consumer, boolean ackMessages) throws Exception {
+    private static int receiveAllMessage(Consumer<?> consumer, boolean ackMessages) throws Exception {
         int messagesReceived = 0;
-        Message msg = consumer.receive(1, TimeUnit.SECONDS);
+        Message<?> msg = consumer.receive(1, TimeUnit.SECONDS);
         while (msg != null) {
             ++messagesReceived;
             log.info("Consumer received {}", new String(msg.getData()));
@@ -265,19 +254,16 @@ public class UnAcknowledgedMessagesTimeoutTest extends BrokerTestBase {
         // Special step to create partitioned topic
 
         // 1. producer connect
-        ProducerConfiguration prodConfig = new ProducerConfiguration();
-        prodConfig.setMessageRoutingMode(MessageRoutingMode.RoundRobinPartition);
-        Producer producer = pulsarClient.createProducer(topicName, prodConfig);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName)
+                .messageRoutingMode(MessageRoutingMode.RoundRobinPartition).create();
 
         // 2. Create consumer
-        ConsumerConfiguration consumerConfig = new ConsumerConfiguration();
-        consumerConfig.setReceiverQueueSize(7);
-        consumerConfig.setSubscriptionType(SubscriptionType.Failover);
-        consumerConfig.setAckTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS);
-        consumerConfig.setConsumerName("Consumer-1");
-        Consumer consumer1 = pulsarClient.subscribe(topicName, subscriptionName, consumerConfig);
-        consumerConfig.setConsumerName("Consumer-2");
-        Consumer consumer2 = pulsarClient.subscribe(topicName, subscriptionName, consumerConfig);
+        Consumer<byte[]> consumer1 = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
+                .receiverQueueSize(7).subscriptionType(SubscriptionType.Shared)
+                .ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS).consumerName("Consumer-1").subscribe();
+        Consumer<byte[]> consumer2 = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
+                .receiverQueueSize(7).subscriptionType(SubscriptionType.Shared)
+                .ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS).consumerName("Consumer-2").subscribe();
 
         // 3. producer publish messages
         for (int i = 0; i < totalMessages; i++) {
@@ -287,8 +273,8 @@ public class UnAcknowledgedMessagesTimeoutTest extends BrokerTestBase {
         }
 
         // 4. Receive messages
-        Message message1 = consumer1.receive();
-        Message message2 = consumer2.receive();
+        Message<byte[]> message1 = consumer1.receive();
+        Message<byte[]> message2 = consumer2.receive();
         int messageCount1 = 0;
         int messageCount2 = 0;
         int ackCount1 = 0;
@@ -341,11 +327,8 @@ public class UnAcknowledgedMessagesTimeoutTest extends BrokerTestBase {
 
     @Test
     public void testAckTimeoutMinValue() throws PulsarClientException {
-        ConsumerConfiguration consumerConfig = new ConsumerConfiguration();
-        consumerConfig.setReceiverQueueSize(7);
-        consumerConfig.setSubscriptionType(SubscriptionType.Failover);
         try {
-            consumerConfig.setAckTimeout(999, TimeUnit.MILLISECONDS);
+            pulsarClient.newConsumer().ackTimeout(999, TimeUnit.MILLISECONDS);
             Assert.fail("Exception should have been thrown since the set timeout is less than min timeout.");
         } catch (Exception ex) {
             // Ok
@@ -361,13 +344,12 @@ public class UnAcknowledgedMessagesTimeoutTest extends BrokerTestBase {
         final int totalMessages = 3;
 
         // 1. producer connect
-        Producer producer = pulsarClient.createProducer(topicName);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
 
         // 2. Create consumer
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setReceiverQueueSize(7);
-        conf.setAckTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS);
-        ConsumerImpl consumer = (ConsumerImpl) pulsarClient.subscribe(topicName, subscriptionName, conf);
+        ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(topicName)
+                .subscriptionName(subscriptionName).receiverQueueSize(7).subscriptionType(SubscriptionType.Shared)
+                .ackTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS).subscribe();
 
         // 3. producer publish messages
         for (int i = 0; i < totalMessages; i++) {
@@ -379,13 +361,13 @@ public class UnAcknowledgedMessagesTimeoutTest extends BrokerTestBase {
         Thread.sleep((long) (ackTimeOutMillis * 1.1));
 
         for (int i = 0; i < totalMessages - 1; i++) {
-            Message msg = consumer.receive();
+            Message<byte[]> msg = consumer.receive();
             consumer.acknowledge(msg);
         }
 
         assertEquals(consumer.getUnAckedMessageTracker().size(), 1);
 
-        Message msg = consumer.receive();
+        Message<byte[]> msg = consumer.receive();
         consumer.acknowledge(msg);
         assertEquals(consumer.getUnAckedMessageTracker().size(), 0);
 
@@ -394,18 +376,4 @@ public class UnAcknowledgedMessagesTimeoutTest extends BrokerTestBase {
         assertEquals(consumer.getUnAckedMessageTracker().size(), 0);
     }
 
-    @Test()
-    public void testConfiguration() {
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setAckTimeout(10, TimeUnit.MINUTES);
-        assertEquals(conf.getAckTimeoutMillis(), 10 * 60 * 1000);
-        conf.setAckTimeout(11, TimeUnit.SECONDS);
-        assertEquals(conf.getAckTimeoutMillis(), 11 * 1000);
-        conf.setAckTimeout(15000000, TimeUnit.MICROSECONDS);
-        assertEquals(conf.getAckTimeoutMillis(), 15000);
-        conf.setAckTimeout(17000, TimeUnit.MILLISECONDS);
-        assertEquals(conf.getAckTimeoutMillis(), 17000);
-        conf.setAckTimeout(ackTimeOutMillis, TimeUnit.MILLISECONDS);
-        assertEquals(conf.getAckTimeoutMillis(), ackTimeOutMillis);
-    }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/NamespaceBundleTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/NamespaceBundleTest.java
@@ -118,6 +118,7 @@ public class NamespaceBundleTest {
         assertEquals(bundle.getNamespaceObject().toString(), "pulsar/use/ns");
     }
 
+    @SuppressWarnings("unchecked")
     private NamespaceBundleFactory getNamespaceBundleFactory() {
         PulsarService pulsar = mock(PulsarService.class);
         LocalZooKeeperCacheService localZkCache = mock(LocalZooKeeperCacheService.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/NamespaceBundlesTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/common/naming/NamespaceBundlesTest.java
@@ -123,6 +123,7 @@ public class NamespaceBundlesTest {
                 factory.getBundle(nsFld, Range.range(0x40000000l, BoundType.CLOSED, 0xffffffffl, BoundType.CLOSED)));
     }
 
+    @SuppressWarnings("unchecked")
     private NamespaceBundleFactory getNamespaceBundleFactory() {
         PulsarService pulsar = mock(PulsarService.class);
         LocalZooKeeperCacheService localZkCache = mock(LocalZooKeeperCacheService.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactedTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactedTopicTest.java
@@ -18,43 +18,40 @@
  */
 package org.apache.pulsar.compaction;
 
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.commons.lang3.tuple.Triple;
-import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
-import java.util.stream.IntStream;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.IntStream;
 
+import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.LedgerHandle;
-import org.apache.bookkeeper.client.BKException;
-import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.client.api.RawMessage;
+import org.apache.pulsar.client.impl.RawMessageImpl;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.PropertyAdmin;
-import org.apache.pulsar.client.api.RawMessage;
-import org.apache.pulsar.client.impl.RawMessageImpl;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import lombok.Cleanup;
+
 public class CompactedTopicTest extends MockedPulsarServiceBaseTest {
-    private static final Logger log = LoggerFactory.getLogger(CompactedTopicTest.class);
     private static final ByteBuf emptyBuffer = Unpooled.buffer(0);
 
     @BeforeMethod
@@ -113,6 +110,8 @@ public class CompactedTopicTest extends MockedPulsarServiceBaseTest {
                         MessageIdData id = MessageIdData.newBuilder()
                             .setLedgerId(ledgerIds.get())
                             .setEntryId(entryIds.addAndGet(delta + 1)).build();
+
+                        @Cleanup
                         RawMessage m = new RawMessageImpl(id, emptyBuffer);
 
                         CompletableFuture<Void> f = new CompletableFuture<>();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactorTest.java
@@ -20,43 +20,39 @@ package org.apache.pulsar.compaction;
 
 import static org.apache.pulsar.client.impl.RawReaderTest.extractKey;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import io.netty.buffer.ByteBuf;
-
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.LedgerEntry;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.client.api.MessageBuilder;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.RawMessage;
+import org.apache.pulsar.client.impl.RawMessageImpl;
 import org.apache.pulsar.common.api.Commands;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.PropertyAdmin;
-import org.apache.pulsar.client.api.Producer;
-import org.apache.pulsar.client.api.ProducerConfiguration;
-import org.apache.pulsar.client.api.MessageBuilder;
-import org.apache.pulsar.client.api.RawMessage;
-import org.apache.pulsar.client.impl.RawMessageImpl;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import io.netty.buffer.ByteBuf;
+
 public class CompactorTest extends MockedPulsarServiceBaseTest {
-    private static final Logger log = LoggerFactory.getLogger(CompactorTest.class);
 
     private ScheduledExecutorService compactionScheduler;
 
@@ -121,8 +117,7 @@ public class CompactorTest extends MockedPulsarServiceBaseTest {
         final int numMessages = 1000;
         final int maxKeys = 10;
 
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-        Producer producer = pulsarClient.createProducer(topic, producerConf);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).create();
 
         Map<String, byte[]> expected = new HashMap<>();
         Random r = new Random(0);
@@ -143,8 +138,7 @@ public class CompactorTest extends MockedPulsarServiceBaseTest {
     public void testCompactAddCompact() throws Exception {
         String topic = "persistent://my-property/use/my-ns/my-topic1";
 
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-        Producer producer = pulsarClient.createProducer(topic, producerConf);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).create();
 
         Map<String, byte[]> expected = new HashMap<>();
 
@@ -174,8 +168,7 @@ public class CompactorTest extends MockedPulsarServiceBaseTest {
     public void testCompactedInOrder() throws Exception {
         String topic = "persistent://my-property/use/my-ns/my-topic1";
 
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-        Producer producer = pulsarClient.createProducer(topic, producerConf);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).create();
 
         producer.send(MessageBuilder.create()
                       .setKey("c")
@@ -204,7 +197,7 @@ public class CompactorTest extends MockedPulsarServiceBaseTest {
         String topic = "persistent://my-property/use/my-ns/my-topic1";
 
         // trigger creation of topic on server side
-        pulsarClient.subscribe(topic, "sub1").close();
+        pulsarClient.newConsumer().topic(topic).subscriptionName("sub1").subscribe().close();
 
         BookKeeper bk = pulsar.getBookKeeperClientFactory().create(
                 this.conf, null);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/stats/client/PulsarBrokerStatsClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/stats/client/PulsarBrokerStatsClientTest.java
@@ -19,6 +19,8 @@
 package org.apache.pulsar.stats.client;
 
 import static org.mockito.Mockito.spy;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import java.net.URL;
 import java.util.concurrent.TimeUnit;
@@ -37,22 +39,16 @@ import org.apache.pulsar.client.admin.PulsarAdminException.ServerSideErrorExcept
 import org.apache.pulsar.client.admin.internal.BrokerStatsImpl;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.Consumer;
-import org.apache.pulsar.client.api.ConsumerConfiguration;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
-import org.apache.pulsar.client.api.ProducerConfiguration;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
-import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats.CursorStats;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.assertEquals;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
 
 public class PulsarBrokerStatsClientTest extends ProducerConsumerBase {
 
@@ -108,20 +104,16 @@ public class PulsarBrokerStatsClientTest extends ProducerConsumerBase {
 
         final String topicName = "persistent://my-property/use/my-ns/my-topic1";
         final String subscriptionName = "my-subscriber-name";
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-        Consumer consumer = pulsarClient.subscribe(topicName, subscriptionName, conf);
-
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-
-        Producer producer = pulsarClient.createProducer(topicName, producerConf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
+                .subscribe();
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         final int numberOfMsgs = 1000;
         for (int i = 0; i < numberOfMsgs; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
 
-        Message msg = null;
+        Message<byte[]> msg = null;
         int count = 0;
         for (int i = 0; i < numberOfMsgs; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);
@@ -136,7 +128,7 @@ public class PulsarBrokerStatsClientTest extends ProducerConsumerBase {
         assertEquals(cursor.numberOfEntriesSinceFirstNotAckedMessage, numberOfMsgs);
         assertTrue(cursor.totalNonContiguousDeletedMessagesRange > 0
                 && (cursor.totalNonContiguousDeletedMessagesRange) < numberOfMsgs / 2);
-        
+
         producer.close();
         consumer.close();
         log.info("-- Exiting {} test --", methodName);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/utils/StatsOutputStreamTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/utils/StatsOutputStreamTest.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.utils;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
-import java.lang.reflect.Method;
 import java.nio.charset.Charset;
 
 import org.apache.pulsar.utils.CopyOnWriteArrayList;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyAuthenticationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyAuthenticationTest.java
@@ -22,7 +22,6 @@ import static java.util.concurrent.Executors.newFixedThreadPool;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
-import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -36,7 +35,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.apache.bookkeeper.test.PortManager;
-import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
 import org.apache.pulsar.websocket.WebSocketService;
 import org.apache.pulsar.websocket.service.ProxyServer;
@@ -48,9 +46,7 @@ import org.eclipse.jetty.websocket.client.WebSocketClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyAuthorizationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/ProxyAuthorizationTest.java
@@ -28,7 +28,6 @@ import java.util.Set;
 import org.apache.bookkeeper.test.PortManager;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.broker.authorization.AuthorizationService;
-import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.ClusterData;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/SimpleProducerSocket.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/websocket/proxy/SimpleProducerSocket.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.websocket.proxy;
 
 import static org.apache.pulsar.broker.admin.AdminResource.jsonMapper;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.concurrent.CountDownLatch;
@@ -33,13 +32,13 @@ import org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketConnect;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
-import com.google.gson.Gson;
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 
 @WebSocket(maxTextMessageSize = 64 * 1024)
 public class SimpleProducerSocket {
@@ -77,7 +76,7 @@ public class SimpleProducerSocket {
         this.session = session;
         sendMessage(10);
     }
-    
+
     public void sendMessage(int totalMsgs) throws Exception {
         for (int i = 0; i < totalMsgs; i++) {
             this.session.getRemote().sendString(getTestJsonPayload(i));

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PersistentTopics.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PersistentTopics.java
@@ -784,7 +784,7 @@ public interface PersistentTopics {
      * @throws PulsarAdminException
      *             Unexpected error
      */
-    List<Message> peekMessages(String topic, String subName, int numMessages) throws PulsarAdminException;
+    List<Message<byte[]>> peekMessages(String topic, String subName, int numMessages) throws PulsarAdminException;
 
     /**
      * Peek messages from a topic subscription asynchronously
@@ -797,7 +797,7 @@ public interface PersistentTopics {
      *            Number of messages
      * @return a future that can be used to track when the messages are returned
      */
-    CompletableFuture<List<Message>> peekMessagesAsync(String topic, String subName, int numMessages);
+    CompletableFuture<List<Message<byte[]>>> peekMessagesAsync(String topic, String subName, int numMessages);
 
     /**
      * Create a new subscription on a topic

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PulsarAdmin.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PulsarAdmin.java
@@ -45,6 +45,7 @@ import org.apache.pulsar.client.api.AuthenticationFactory;
 import org.apache.pulsar.client.api.ClientConfiguration;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.auth.AuthenticationDisabled;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 import org.apache.pulsar.common.util.SecurityUtility;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
@@ -57,6 +58,7 @@ import org.slf4j.bridge.SLF4JBridgeHandler;
 /**
  * Pulsar client admin API client.
  */
+@SuppressWarnings("deprecation")
 public class PulsarAdmin implements Closeable {
     private static final Logger LOG = LoggerFactory.getLogger(PulsarAdmin.class);
 
@@ -104,6 +106,20 @@ public class PulsarAdmin implements Closeable {
      *            the ClientConfiguration object to be used to talk with Pulsar
      */
     public PulsarAdmin(URL serviceUrl, ClientConfiguration pulsarConfig) throws PulsarClientException {
+        this(serviceUrl, pulsarConfig.getConfigurationData());
+    }
+
+    /**
+     * Construct a new Pulsar Admin client object.
+     * <p>
+     * This client object can be used to perform many subsquent API calls
+     *
+     * @param serviceUrl
+     *            the Pulsar service URL (eg. "http://my-broker.example.com:8080")
+     * @param pulsarConfig
+     *            the ClientConfiguration object to be used to talk with Pulsar
+     */
+    public PulsarAdmin(URL serviceUrl, ClientConfigurationData pulsarConfig) throws PulsarClientException {
         this.auth = pulsarConfig != null ? pulsarConfig.getAuthentication() : new AuthenticationDisabled();
         LOG.debug("created: serviceUrl={}, authMethodName={}", serviceUrl,
                 auth != null ? auth.getAuthMethodName() : null);
@@ -177,6 +193,7 @@ public class PulsarAdmin implements Closeable {
      * @param auth
      *            the Authentication object to be used to talk with Pulsar
      */
+    @SuppressWarnings("deprecation")
     public PulsarAdmin(URL serviceUrl, Authentication auth) throws PulsarClientException {
         this(serviceUrl, new ClientConfiguration() {
             private static final long serialVersionUID = 1L;

--- a/pulsar-client-kafka-compat/pulsar-client-kafka-tests/src/test/java/org/apache/pulsar/client/kafka/compat/examples/ConsumerExample.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka-tests/src/test/java/org/apache/pulsar/client/kafka/compat/examples/ConsumerExample.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ConsumerExample {
+
     public static void main(String[] args) {
         String topic = "persistent://sample/standalone/ns/my-topic";
 
@@ -40,6 +41,7 @@ public class ConsumerExample {
         props.put("key.deserializer", IntegerDeserializer.class.getName());
         props.put("value.deserializer", StringDeserializer.class.getName());
 
+        @SuppressWarnings("resource")
         Consumer<Integer, String> consumer = new KafkaConsumer<>(props);
         consumer.subscribe(Arrays.asList(topic));
 

--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/test/java/org/apache/pulsar/client/kafka/compat/tests/KafkaConsumerTest.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/test/java/org/apache/pulsar/client/kafka/compat/tests/KafkaConsumerTest.java
@@ -39,8 +39,6 @@ import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageBuilder;
 import org.apache.pulsar.client.api.Producer;
-import org.apache.pulsar.client.api.ProducerConfiguration;
-import org.apache.pulsar.client.api.ProducerConfiguration.MessageRoutingMode;
 import org.apache.pulsar.common.policies.data.PropertyAdmin;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -75,11 +73,11 @@ public class KafkaConsumerTest extends BrokerTestBase {
         Consumer<String, String> consumer = new PulsarKafkaConsumer<>(props);
         consumer.subscribe(Arrays.asList(topic));
 
-        Producer pulsarProducer = pulsarClient.createProducer(topic);
+        Producer<byte[]> pulsarProducer = pulsarClient.newProducer().topic(topic).create();
 
         for (int i = 0; i < 10; i++) {
-            Message msg = MessageBuilder.create().setKey(Integer.toString(i)).setContent(("hello-" + i).getBytes())
-                    .build();
+            Message<byte[]> msg = MessageBuilder.create().setKey(Integer.toString(i))
+                    .setContent(("hello-" + i).getBytes()).build();
             pulsarProducer.send(msg);
         }
 
@@ -113,14 +111,13 @@ public class KafkaConsumerTest extends BrokerTestBase {
         Consumer<String, String> consumer = new PulsarKafkaConsumer<>(props);
         consumer.subscribe(Arrays.asList(topic));
 
-        Producer pulsarProducer = pulsarClient.createProducer(topic);
+        Producer<byte[]> pulsarProducer = pulsarClient.newProducer().topic(topic).create();
 
         for (int i = 0; i < 10; i++) {
-            Message msg = MessageBuilder.create().setKey(Integer.toString(i)).setContent(("hello-" + i).getBytes())
-                    .build();
+            Message<byte[]> msg = MessageBuilder.create().setKey(Integer.toString(i))
+                    .setContent(("hello-" + i).getBytes()).build();
             pulsarProducer.send(msg);
         }
-
 
         AtomicInteger received = new AtomicInteger();
         while (received.get() < 10) {
@@ -157,11 +154,11 @@ public class KafkaConsumerTest extends BrokerTestBase {
         Consumer<String, String> consumer = new PulsarKafkaConsumer<>(props);
         consumer.subscribe(Arrays.asList(topic));
 
-        Producer pulsarProducer = pulsarClient.createProducer(topic);
+        Producer<byte[]> pulsarProducer = pulsarClient.newProducer().topic(topic).create();
 
         for (int i = 0; i < 10; i++) {
-            Message msg = MessageBuilder.create().setKey(Integer.toString(i)).setContent(("hello-" + i).getBytes())
-                    .build();
+            Message<byte[]> msg = MessageBuilder.create().setKey(Integer.toString(i))
+                    .setContent(("hello-" + i).getBytes()).build();
             pulsarProducer.send(msg);
         }
 
@@ -207,9 +204,8 @@ public class KafkaConsumerTest extends BrokerTestBase {
         props.put("key.deserializer", StringDeserializer.class.getName());
         props.put("value.deserializer", StringDeserializer.class.getName());
 
-        ProducerConfiguration conf = new ProducerConfiguration();
-        conf.setMessageRoutingMode(MessageRoutingMode.RoundRobinPartition);
-        Producer pulsarProducer = pulsarClient.createProducer(topic);
+        Producer<byte[]> pulsarProducer = pulsarClient.newProducer().topic(topic)
+                .messageRoutingMode(org.apache.pulsar.client.api.MessageRoutingMode.RoundRobinPartition).create();
 
         // Create 2 Kakfa consumer and verify each gets half of the messages
         List<Consumer<String, String>> consumers = new ArrayList<>();
@@ -222,8 +218,8 @@ public class KafkaConsumerTest extends BrokerTestBase {
         int N = 8 * 3;
 
         for (int i = 0; i < N; i++) {
-            Message msg = MessageBuilder.create().setKey(Integer.toString(i)).setContent(("hello-" + i).getBytes())
-                    .build();
+            Message<byte[]> msg = MessageBuilder.create().setKey(Integer.toString(i))
+                    .setContent(("hello-" + i).getBytes()).build();
             pulsarProducer.send(msg);
         }
 
@@ -257,11 +253,11 @@ public class KafkaConsumerTest extends BrokerTestBase {
         Consumer<String, String> consumer = new PulsarKafkaConsumer<>(props);
         consumer.subscribe(Arrays.asList(topic));
 
-        Producer pulsarProducer = pulsarClient.createProducer(topic);
+        Producer<byte[]> pulsarProducer = pulsarClient.newProducer().topic(topic).create();
 
         for (int i = 0; i < 10; i++) {
-            Message msg = MessageBuilder.create().setKey(Integer.toString(i)).setContent(("hello-" + i).getBytes())
-                    .build();
+            Message<byte[]> msg = MessageBuilder.create().setKey(Integer.toString(i))
+                    .setContent(("hello-" + i).getBytes()).build();
             pulsarProducer.send(msg);
         }
 
@@ -313,11 +309,11 @@ public class KafkaConsumerTest extends BrokerTestBase {
         Consumer<String, String> consumer = new PulsarKafkaConsumer<>(props);
         consumer.subscribe(Arrays.asList(topic));
 
-        Producer pulsarProducer = pulsarClient.createProducer(topic);
+        Producer<byte[]> pulsarProducer = pulsarClient.newProducer().topic(topic).create();
 
         for (int i = 0; i < 10; i++) {
-            Message msg = MessageBuilder.create().setKey(Integer.toString(i)).setContent(("hello-" + i).getBytes())
-                    .build();
+            Message<byte[]> msg = MessageBuilder.create().setKey(Integer.toString(i))
+                    .setContent(("hello-" + i).getBytes()).build();
             pulsarProducer.send(msg);
         }
 

--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/test/java/org/apache/pulsar/client/kafka/compat/tests/KafkaProducerTest.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/test/java/org/apache/pulsar/client/kafka/compat/tests/KafkaProducerTest.java
@@ -55,7 +55,8 @@ public class KafkaProducerTest extends BrokerTestBase {
     public void testSimpleProducer() throws Exception {
         String topic = "persistent://sample/standalone/ns/testSimpleProducer";
 
-        Consumer pulsarConsumer = pulsarClient.subscribe(topic, "my-subscription");
+        Consumer<byte[]> pulsarConsumer = pulsarClient.newConsumer().topic(topic).subscriptionName("my-subscription")
+                .subscribe();
 
         Properties props = new Properties();
         props.put("bootstrap.servers", lookupUrl.toString());
@@ -73,7 +74,7 @@ public class KafkaProducerTest extends BrokerTestBase {
         producer.close();
 
         for (int i = 0; i < 10; i++) {
-            Message msg = pulsarConsumer.receive(1, TimeUnit.SECONDS);
+            Message<byte[]> msg = pulsarConsumer.receive(1, TimeUnit.SECONDS);
             assertEquals(new String(msg.getData()), "hello-" + i);
             pulsarConsumer.acknowledge(msg);
         }
@@ -83,7 +84,8 @@ public class KafkaProducerTest extends BrokerTestBase {
     public void testProducerCallback() throws Exception {
         String topic = "persistent://sample/standalone/ns/testProducerCallback";
 
-        Consumer pulsarConsumer = pulsarClient.subscribe(topic, "my-subscription");
+        Consumer<byte[]> pulsarConsumer = pulsarClient.newConsumer().topic(topic).subscriptionName("my-subscription")
+                .subscribe();
 
         Properties props = new Properties();
         props.put("bootstrap.servers", lookupUrl.toString());
@@ -107,7 +109,7 @@ public class KafkaProducerTest extends BrokerTestBase {
         counter.await();
 
         for (int i = 0; i < 10; i++) {
-            Message msg = pulsarConsumer.receive(1, TimeUnit.SECONDS);
+            Message<byte[]> msg = pulsarConsumer.receive(1, TimeUnit.SECONDS);
             assertEquals(new String(msg.getData()), "hello-" + i);
             pulsarConsumer.acknowledge(msg);
         }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPersistentTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdPersistentTopics.java
@@ -517,9 +517,9 @@ public class CmdPersistentTopics extends CmdBase {
         @Override
         void run() throws PulsarAdminException {
             String persistentTopic = validatePersistentTopic(params);
-            List<Message> messages = persistentTopics.peekMessages(persistentTopic, subName, numMessages);
+            List<Message<byte[]>> messages = persistentTopics.peekMessages(persistentTopic, subName, numMessages);
             int position = 0;
-            for (Message msg : messages) {
+            for (Message<byte[]> msg : messages) {
                 if (++position != 1) {
                     System.out.println("-------------------------------------------------------------------------\n");
                 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pulsar.client.cli;
 
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.io.FileInputStream;
 import java.net.MalformedURLException;
@@ -27,10 +27,9 @@ import java.util.Arrays;
 import java.util.Properties;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.pulsar.client.api.ClientConfiguration;
+import org.apache.pulsar.client.api.ClientBuilder;
+import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException.UnsupportedAuthenticationException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
@@ -39,8 +38,6 @@ import com.beust.jcommander.Parameters;
 
 @Parameters(commandDescription = "Produce or consume messages on a specified topic")
 public class PulsarClientTool {
-
-    private static final Logger LOG = LoggerFactory.getLogger(PulsarClientTool.class);
 
     @Parameter(names = { "--url" }, description = "Broker URL to which to connect.")
     String serviceURL = null;
@@ -65,7 +62,7 @@ public class PulsarClientTool {
     public PulsarClientTool(Properties properties) throws MalformedURLException {
         this.serviceURL = StringUtils.isNotBlank(properties.getProperty("brokerServiceUrl"))
                 ? properties.getProperty("brokerServiceUrl") : properties.getProperty("webServiceUrl");
-        // fallback to previous-version serviceUrl property to maintain backward-compatibility        
+        // fallback to previous-version serviceUrl property to maintain backward-compatibility
         if (StringUtils.isBlank(this.serviceURL)) {
             this.serviceURL = properties.getProperty("serviceUrl");
         }
@@ -86,16 +83,16 @@ public class PulsarClientTool {
     }
 
     private void updateConfig() throws UnsupportedAuthenticationException, MalformedURLException {
-        ClientConfiguration configuration = new ClientConfiguration();
+        ClientBuilder clientBuilder = PulsarClient.builder();
         if (isNotBlank(this.authPluginClassName)) {
-            configuration.setAuthentication(authPluginClassName, authParams);
+            clientBuilder.authentication(authPluginClassName, authParams);
         }
-        configuration.setUseTls(this.useTls);
-        configuration.setTlsAllowInsecureConnection(this.tlsAllowInsecureConnection);
-        configuration.setTlsTrustCertsFilePath(this.tlsTrustCertsFilePath);
-
-        this.produceCommand.updateConfig(this.serviceURL, configuration);
-        this.consumeCommand.updateConfig(this.serviceURL, configuration);
+        clientBuilder.enableTls(this.useTls);
+        clientBuilder.allowTlsInsecureConnection(this.tlsAllowInsecureConnection);
+        clientBuilder.tlsTrustCertsFilePath(this.tlsTrustCertsFilePath);
+        clientBuilder.serviceUrl(serviceURL);
+        this.produceCommand.updateConfig(clientBuilder);
+        this.consumeCommand.updateConfig(clientBuilder);
     }
 
     public int run(String[] args) {

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/utils/IOUtilsTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/utils/IOUtilsTest.java
@@ -54,8 +54,7 @@ public class IOUtilsTest {
         String data = "y";
         try {
             System.setIn(new ByteArrayInputStream(data.getBytes()));
-            IOUtils obj = new IOUtils();
-            Assert.assertTrue(obj.confirmPrompt("Is you name John Doe?"));
+            Assert.assertTrue(IOUtils.confirmPrompt("Is you name John Doe?"));
         } catch (IOException e) {
             Assert.fail();
         }
@@ -66,8 +65,7 @@ public class IOUtilsTest {
         String data = "yes";
         try {
             System.setIn(new ByteArrayInputStream(data.getBytes()));
-            IOUtils obj = new IOUtils();
-            Assert.assertTrue(obj.confirmPrompt("Are we there yet?"));
+            Assert.assertTrue(IOUtils.confirmPrompt("Are we there yet?"));
         } catch (IOException e) {
             Assert.fail();
         }
@@ -78,8 +76,7 @@ public class IOUtilsTest {
         String data = "n";
         try {
             System.setIn(new ByteArrayInputStream(data.getBytes()));
-            IOUtils obj = new IOUtils();
-            Assert.assertFalse(obj.confirmPrompt("Can I go home?"));
+            Assert.assertFalse(IOUtils.confirmPrompt("Can I go home?"));
         } catch (IOException e) {
             Assert.fail();
         }
@@ -90,8 +87,7 @@ public class IOUtilsTest {
         String data = "no";
         try {
             System.setIn(new ByteArrayInputStream(data.getBytes()));
-            IOUtils obj = new IOUtils();
-            Assert.assertFalse(obj.confirmPrompt("Is it Sunday?"));
+            Assert.assertFalse(IOUtils.confirmPrompt("Is it Sunday?"));
         } catch (IOException e) {
             Assert.fail();
         }
@@ -106,11 +102,11 @@ public class IOUtilsTest {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             System.setOut(new PrintStream(baos));
             System.setIn(new ByteArrayInputStream(data.getBytes()));
-            IOUtils obj = new IOUtils();
             ExecutorService executor = Executors.newSingleThreadExecutor();
+            @SuppressWarnings("unchecked")
             Future<Void> future = (Future<Void>) executor.submit(() -> {
                 try {
-                    obj.confirmPrompt("When will this week end?");
+                    IOUtils.confirmPrompt("When will this week end?");
                 } catch (IOException e) {
                     // TODO Auto-generated catch block
                     e.printStackTrace();
@@ -132,11 +128,11 @@ public class IOUtilsTest {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             System.setOut(new PrintStream(baos));
             System.setIn(new ByteArrayInputStream(data.getBytes("UTF-8")));
-            IOUtils obj = new IOUtils();
             ExecutorService executor = Executors.newSingleThreadExecutor();
+            @SuppressWarnings("unchecked")
             Future<Void> future = (Future<Void>) executor.submit(() -> {
                 try {
-                    obj.confirmPrompt("Is you name Pulsar?");
+                    IOUtils.confirmPrompt("Is you name Pulsar?");
                 } catch (IOException e) {
                     // TODO Auto-generated catch block
                     e.printStackTrace();

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/utils/NameValueParameterSplitterTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/admin/cli/utils/NameValueParameterSplitterTest.java
@@ -20,11 +20,8 @@ package org.apache.pulsar.admin.cli.utils;
 
 import java.util.Map;
 
-import org.apache.pulsar.admin.cli.utils.NameValueParameterSplitter;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import io.netty.handler.codec.http.HttpContentEncoder.Result;
 
 public class NameValueParameterSplitterTest {
     @Test(description = "Basic Test")
@@ -45,7 +42,7 @@ public class NameValueParameterSplitterTest {
     public void test3() {
         try {
             NameValueParameterSplitter splitter = new NameValueParameterSplitter();
-            Map<String, String> result = splitter.convert(" Name  Sunnyvale CA");
+            splitter.convert(" Name  Sunnyvale CA");
             // Expecting exception
             Assert.fail("' Name  Sunnyvale CA' is not a valid name value pair");
         } catch (Exception e) {

--- a/pulsar-client-tools/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
+++ b/pulsar-client-tools/src/test/java/org/apache/pulsar/client/cli/PulsarClientToolTest.java
@@ -27,7 +27,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import org.apache.pulsar.broker.service.BrokerTestBase;
-import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.cli.PulsarClientTool;
 import org.apache.pulsar.common.policies.data.PropertyAdmin;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -217,6 +217,19 @@ public interface ConsumerBuilder<T> extends Serializable, Cloneable {
     ConsumerBuilder<T> consumerName(String consumerName);
 
     /**
+     * Sets a {@link ConsumerEventListener} for the consumer.
+     *
+     * <p>
+     * The consumer group listener is used for receiving consumer state change in a consumer group for failover
+     * subscription. Application can then react to the consumer state changes.
+     *
+     * @param listener
+     *            the consumer group listener object
+     * @return consumer configuration
+     */
+    ConsumerBuilder<T> consumerEventListener(ConsumerEventListener consumerEventListener);
+
+    /**
      * If enabled, the consumer will read messages from the compacted topic rather than reading the full message backlog
      * of the topic. This means that, if the topic has been compacted, the consumer will only see the latest value for
      * each key in the topic, up until the point in the topic message backlog that has been compacted. Beyond that

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/Producer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/Producer.java
@@ -60,8 +60,8 @@ public interface Producer<T> extends Closeable {
      * <p>
      * When the producer queue is full, by default this method will complete the future with an exception {@link PulsarClientException.ProducerQueueIsFullError}
      * <p>
-     * See {@link ProducerConfiguration#setMaxPendingMessages} to configure the producer queue size and
-     * {@link ProducerConfiguration#setBlockIfQueueFull(boolean)} to change the blocking behavior.
+     * See {@link ProducerBuilder#maxPendingMessages(int)} to configure the producer queue size and
+     * {@link ProducerBuilder#blockIfQueueFull(boolean)} to change the blocking behavior.
      *
      * @param message
      *            a byte array with the payload of the message
@@ -99,8 +99,8 @@ public interface Producer<T> extends Closeable {
      * <p>
      * When the producer queue is full, by default this method will complete the future with an exception {@link PulsarClientException.ProducerQueueIsFullError}
      * <p>
-     * See {@link ProducerConfiguration#setMaxPendingMessages} to configure the producer queue size and
-     * {@link ProducerConfiguration#setBlockIfQueueFull(boolean)} to change the blocking behavior.
+     * See {@link ProducerBuilder#maxPendingMessages(int)} to configure the producer queue size and
+     * {@link ProducerBuilder#blockIfQueueFull(boolean)} to change the blocking behavior.
      *
      * @param message
      *            a message

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ProducerConfiguration.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ProducerConfiguration.java
@@ -45,10 +45,12 @@ public class ProducerConfiguration implements Serializable {
 
     private final ProducerConfigurationData conf = new ProducerConfigurationData();
 
+    @Deprecated
     public enum MessageRoutingMode {
         SinglePartition, RoundRobinPartition, CustomPartition
     }
 
+    @Deprecated
     public enum HashingScheme {
         JavaStringHash, Murmur3_32Hash
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
@@ -36,6 +36,8 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 import org.apache.pulsar.common.util.FutureUtil;
 
+import lombok.NonNull;
+
 public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
 
     private static final long serialVersionUID = 1L;
@@ -93,19 +95,25 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
     }
 
     @Override
-    public ProducerBuilder<T> producerName(String producerName) {
+    public ProducerBuilder<T> producerName(@NonNull String producerName) {
         conf.setProducerName(producerName);
         return this;
     }
 
     @Override
-    public ProducerBuilder<T> sendTimeout(int sendTimeout, TimeUnit unit) {
+    public ProducerBuilder<T> sendTimeout(int sendTimeout, @NonNull TimeUnit unit) {
+        if (sendTimeout < 0) {
+            throw new IllegalArgumentException("sendTimeout needs to be >= 0");
+        }
         conf.setSendTimeoutMs(unit.toMillis(sendTimeout));
         return this;
     }
 
     @Override
     public ProducerBuilder<T> maxPendingMessages(int maxPendingMessages) {
+        if (maxPendingMessages <= 0) {
+            throw new IllegalArgumentException("maxPendingMessages needs to be > 0");
+        }
         conf.setMaxPendingMessages(maxPendingMessages);
         return this;
     }
@@ -123,25 +131,25 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
     }
 
     @Override
-    public ProducerBuilder<T> messageRoutingMode(MessageRoutingMode messageRouteMode) {
+    public ProducerBuilder<T> messageRoutingMode(@NonNull MessageRoutingMode messageRouteMode) {
         conf.setMessageRoutingMode(messageRouteMode);
         return this;
     }
 
     @Override
-    public ProducerBuilder<T> compressionType(CompressionType compressionType) {
+    public ProducerBuilder<T> compressionType(@NonNull CompressionType compressionType) {
         conf.setCompressionType(compressionType);
         return this;
     }
 
     @Override
-    public ProducerBuilder<T> hashingScheme(HashingScheme hashingScheme) {
+    public ProducerBuilder<T> hashingScheme(@NonNull HashingScheme hashingScheme) {
         conf.setHashingScheme(hashingScheme);
         return this;
     }
 
     @Override
-    public ProducerBuilder<T> messageRouter(MessageRouter messageRouter) {
+    public ProducerBuilder<T> messageRouter(@NonNull MessageRouter messageRouter) {
         conf.setCustomMessageRouter(messageRouter);
         return this;
     }
@@ -153,25 +161,25 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
     }
 
     @Override
-    public ProducerBuilder<T> cryptoKeyReader(CryptoKeyReader cryptoKeyReader) {
+    public ProducerBuilder<T> cryptoKeyReader(@NonNull CryptoKeyReader cryptoKeyReader) {
         conf.setCryptoKeyReader(cryptoKeyReader);
         return this;
     }
 
     @Override
-    public ProducerBuilder<T> addEncryptionKey(String key) {
+    public ProducerBuilder<T> addEncryptionKey(@NonNull String key) {
         conf.getEncryptionKeys().add(key);
         return this;
     }
 
     @Override
-    public ProducerBuilder<T> cryptoFailureAction(ProducerCryptoFailureAction action) {
+    public ProducerBuilder<T> cryptoFailureAction(@NonNull ProducerCryptoFailureAction action) {
         conf.setCryptoFailureAction(action);
         return this;
     }
 
     @Override
-    public ProducerBuilder<T> batchingMaxPublishDelay(long batchDelay, TimeUnit timeUnit) {
+    public ProducerBuilder<T> batchingMaxPublishDelay(long batchDelay, @NonNull TimeUnit timeUnit) {
         conf.setBatchingMaxPublishDelayMicros(timeUnit.toMicros(batchDelay));
         return this;
     }
@@ -189,13 +197,13 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
     }
 
     @Override
-    public ProducerBuilder<T> property(String key, String value) {
+    public ProducerBuilder<T> property(@NonNull String key, @NonNull String value) {
         conf.getProperties().put(key, value);
         return this;
     }
 
     @Override
-    public ProducerBuilder<T> properties(Map<String, String> properties) {
+    public ProducerBuilder<T> properties(@NonNull Map<String, String> properties) {
         conf.getProperties().putAll(properties);
         return this;
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/SinglePartitionMessageRouterImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/SinglePartitionMessageRouterImpl.java
@@ -34,7 +34,7 @@ public class SinglePartitionMessageRouterImpl extends MessageRouterBase {
     }
 
     @Override
-    public int choosePartition(Message msg, TopicMetadata metadata) {
+    public int choosePartition(Message<?> msg, TopicMetadata metadata) {
         // If the message has a key, it supersedes the single partition routing policy
         if (msg.hasKey()) {
             return hash.makeHash(msg.getKey()) % metadata.numPartitions();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageImpl.java
@@ -23,14 +23,14 @@ import java.util.Map;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 
-public class TopicMessageImpl implements Message {
+public class TopicMessageImpl<T> implements Message<T> {
 
     private final String topicName;
-    private final Message msg;
+    private final Message<T> msg;
     private final MessageId msgId;
 
     TopicMessageImpl(String topicName,
-                     Message msg) {
+                     Message<T> msg) {
         this.topicName = topicName;
         this.msg = msg;
         this.msgId = new TopicMessageIdImpl(topicName, msg.getMessageId());
@@ -100,7 +100,7 @@ public class TopicMessageImpl implements Message {
     }
 
     @Override
-    public Object getValue() {
-        return msg.getData();
+    public T getValue() {
+        return msg.getValue();
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedMessageTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedMessageTracker.java
@@ -73,7 +73,7 @@ public class UnAckedMessageTracker implements Closeable {
         writeLock = null;
     }
 
-    public UnAckedMessageTracker(PulsarClientImpl client, ConsumerBase consumerBase, long ackTimeoutMillis) {
+    public UnAckedMessageTracker(PulsarClientImpl client, ConsumerBase<?> consumerBase, long ackTimeoutMillis) {
         currentSet = new ConcurrentOpenHashSet<MessageId>();
         oldOpenSet = new ConcurrentOpenHashSet<MessageId>();
         readWriteLock = new ReentrantReadWriteLock();
@@ -82,7 +82,7 @@ public class UnAckedMessageTracker implements Closeable {
         start(client, consumerBase, ackTimeoutMillis);
     }
 
-    public void start(PulsarClientImpl client, ConsumerBase consumerBase, long ackTimeoutMillis) {
+    public void start(PulsarClientImpl client, ConsumerBase<?> consumerBase, long ackTimeoutMillis) {
         this.stop();
         timeout = client.timer().newTimeout(new TimerTask() {
             @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedTopicMessageTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedTopicMessageTracker.java
@@ -22,7 +22,7 @@ import static com.google.common.base.Preconditions.checkState;
 
 public class UnAckedTopicMessageTracker extends UnAckedMessageTracker {
 
-    public UnAckedTopicMessageTracker(PulsarClientImpl client, ConsumerBase consumerBase, long ackTimeoutMillis) {
+    public UnAckedTopicMessageTracker(PulsarClientImpl client, ConsumerBase<?> consumerBase, long ackTimeoutMillis) {
         super(client, consumerBase, ackTimeoutMillis);
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
@@ -83,7 +83,8 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
 
     public ConsumerConfigurationData<T> clone() {
         try {
-            ConsumerConfigurationData c = (ConsumerConfigurationData) super.clone();
+            @SuppressWarnings("unchecked")
+            ConsumerConfigurationData<T> c = (ConsumerConfigurationData<T>) super.clone();
             c.topicNames = Sets.newTreeSet(this.topicNames);
             c.properties = Maps.newTreeMap(this.properties);
             return c;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ReaderConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ReaderConfigurationData.java
@@ -43,6 +43,7 @@ public class ReaderConfigurationData<T> implements Serializable, Cloneable {
     private CryptoKeyReader cryptoKeyReader = null;
     private ConsumerCryptoFailureAction cryptoFailureAction = ConsumerCryptoFailureAction.FAIL;
 
+    @SuppressWarnings("unchecked")
     public ReaderConfigurationData<T> clone() {
         try {
             return (ReaderConfigurationData<T>) super.clone();

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/api/ConsumerConfigurationTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/api/ConsumerConfigurationTest.java
@@ -37,18 +37,19 @@ public class ConsumerConfigurationTest {
 
     private static final Logger log = LoggerFactory.getLogger(ConsumerConfigurationTest.class);
 
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     @Test
     public void testJsonIgnore() throws Exception {
 
-        ConsumerConfigurationData conf = new ConsumerConfigurationData();
+        ConsumerConfigurationData<?> conf = new ConsumerConfigurationData<>();
         conf.setConsumerEventListener(new ConsumerEventListener() {
 
             @Override
-            public void becameActive(Consumer consumer, int partitionId) {
+            public void becameActive(Consumer<?> consumer, int partitionId) {
             }
 
             @Override
-            public void becameInactive(Consumer consumer, int partitionId) {
+            public void becameInactive(Consumer<?> consumer, int partitionId) {
             }
         });
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/api/MessageRouterTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/api/MessageRouterTest.java
@@ -32,11 +32,10 @@ import org.testng.annotations.Test;
  */
 public class MessageRouterTest {
 
-    @SuppressWarnings("deprecation")
     private static class TestMessageRouter implements MessageRouter {
 
         @Override
-        public int choosePartition(Message msg) {
+        public int choosePartition(Message<?> msg) {
             return 1234;
         }
     }
@@ -45,7 +44,7 @@ public class MessageRouterTest {
     @Test
     public void testChoosePartition() {
         MessageRouter router = spy(new TestMessageRouter());
-        Message mockedMsg = mock(Message.class);
+        Message<?> mockedMsg = mock(Message.class);
         TopicMetadata mockedMetadata = mock(TopicMetadata.class);
 
         assertEquals(1234, router.choosePartition(mockedMsg));

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageBuilderTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageBuilderTest.java
@@ -36,44 +36,44 @@ public class MessageBuilderTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testSetEventTimeNegative() {
-        MessageBuilder builder = MessageBuilder.create();
+        MessageBuilder<?> builder = MessageBuilder.create();
         builder.setEventTime(-1L);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testSetEventTimeZero() {
-        MessageBuilder builder = MessageBuilder.create();
+        MessageBuilder<?> builder = MessageBuilder.create();
         builder.setEventTime(0L);
     }
 
     @Test
     public void testSetEventTimePositive() {
         long eventTime = System.currentTimeMillis();
-        MessageBuilder builder = MessageBuilder.create();
+        MessageBuilder<?> builder = MessageBuilder.create();
         builder.setContent(new byte[0]);
         builder.setEventTime(eventTime);
-        Message msg = builder.build();
+        Message<?> msg = builder.build();
         assertEquals(eventTime, msg.getEventTime());
     }
 
     @Test
     public void testBuildMessageWithoutEventTime() {
-        MessageBuilder builder = MessageBuilder.create();
+        MessageBuilder<?> builder = MessageBuilder.create();
         builder.setContent(new byte[0]);
-        Message msg = builder.build();
+        Message<?> msg = builder.build();
         assertEquals(0L, msg.getEventTime());
     }
 
     @Test
     public void testSetMessageProperties() {
-        MessageBuilder builder = MessageBuilder.create();
+        MessageBuilder<?> builder = MessageBuilder.create();
         builder.setContent(new byte[0]);
         Map<String, String> map = Maps.newHashMap();
         map.put("key1", "value1");
         builder.setProperties(map);
-        Message msg = builder.build();
+        Message<?> msg = builder.build();
         assertEquals(map, msg.getProperties());
         assertEquals("value1", msg.getProperty("key1"));
     }
-    
+
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageIdCompareToTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageIdCompareToTest.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.client.impl;
 
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 import org.testng.annotations.Test;
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageImplTest.java
@@ -34,7 +34,7 @@ public class MessageImplTest {
     public void testGetSequenceIdNotAssociated() {
         MessageMetadata.Builder builder = MessageMetadata.newBuilder();
         ByteBuffer payload = ByteBuffer.wrap(new byte[0]);
-        MessageImpl msg = MessageImpl.create(builder, payload);
+        MessageImpl<?> msg = MessageImpl.create(builder, payload);
 
         assertEquals(-1, msg.getSequenceId());
     }
@@ -45,7 +45,7 @@ public class MessageImplTest {
             .setSequenceId(1234);
 
         ByteBuffer payload = ByteBuffer.wrap(new byte[0]);
-        MessageImpl msg = MessageImpl.create(builder, payload);
+        MessageImpl<?> msg = MessageImpl.create(builder, payload);
 
         assertEquals(1234, msg.getSequenceId());
     }
@@ -54,7 +54,7 @@ public class MessageImplTest {
     public void testGetProducerNameNotAssigned() {
         MessageMetadata.Builder builder = MessageMetadata.newBuilder();
         ByteBuffer payload = ByteBuffer.wrap(new byte[0]);
-        MessageImpl msg = MessageImpl.create(builder, payload);
+        MessageImpl<?> msg = MessageImpl.create(builder, payload);
 
         assertNull(msg.getProducerName());
     }
@@ -65,7 +65,7 @@ public class MessageImplTest {
             .setProducerName("test-producer");
 
         ByteBuffer payload = ByteBuffer.wrap(new byte[0]);
-        MessageImpl msg = MessageImpl.create(builder, payload);
+        MessageImpl<?> msg = MessageImpl.create(builder, payload);
 
         assertEquals("test-producer", msg.getProducerName());
     }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/RoundRobinPartitionMessageRouterImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/RoundRobinPartitionMessageRouterImplTest.java
@@ -33,7 +33,7 @@ public class RoundRobinPartitionMessageRouterImplTest {
 
     @Test
     public void testChoosePartitionWithoutKey() {
-        Message msg = mock(Message.class);
+        Message<?> msg = mock(Message.class);
         when(msg.getKey()).thenReturn(null);
 
         RoundRobinPartitionMessageRouterImpl router = new RoundRobinPartitionMessageRouterImpl(HashingScheme.JavaStringHash);
@@ -46,10 +46,10 @@ public class RoundRobinPartitionMessageRouterImplTest {
     public void testChoosePartitionWithKey() {
         String key1 = "key1";
         String key2 = "key2";
-        Message msg1 = mock(Message.class);
+        Message<?> msg1 = mock(Message.class);
         when(msg1.hasKey()).thenReturn(true);
         when(msg1.getKey()).thenReturn(key1);
-        Message msg2 = mock(Message.class);
+        Message<?> msg2 = mock(Message.class);
         when(msg2.hasKey()).thenReturn(true);
         when(msg2.getKey()).thenReturn(key2);
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/SinglePartitionMessageRouterImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/SinglePartitionMessageRouterImplTest.java
@@ -33,7 +33,7 @@ public class SinglePartitionMessageRouterImplTest {
 
     @Test
     public void testChoosePartitionWithoutKey() {
-        Message msg = mock(Message.class);
+        Message<?> msg = mock(Message.class);
         when(msg.getKey()).thenReturn(null);
 
         SinglePartitionMessageRouterImpl router = new SinglePartitionMessageRouterImpl(1234, HashingScheme.JavaStringHash);
@@ -44,10 +44,10 @@ public class SinglePartitionMessageRouterImplTest {
     public void testChoosePartitionWithKey() {
         String key1 = "key1";
         String key2 = "key2";
-        Message msg1 = mock(Message.class);
+        Message<?> msg1 = mock(Message.class);
         when(msg1.hasKey()).thenReturn(true);
         when(msg1.getKey()).thenReturn(key1);
-        Message msg2 = mock(Message.class);
+        Message<?> msg2 = mock(Message.class);
         when(msg2.hasKey()).thenReturn(true);
         when(msg2.getKey()).thenReturn(key2);
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/tutorial/ContinuousAsyncProducer.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/tutorial/ContinuousAsyncProducer.java
@@ -26,9 +26,10 @@ import org.apache.pulsar.client.api.PulsarClientException;
 
 public class ContinuousAsyncProducer {
     public static void main(String[] args) throws PulsarClientException, InterruptedException, IOException {
-        PulsarClient pulsarClient = PulsarClient.create("http://127.0.0.1:8080");
+        PulsarClient pulsarClient = PulsarClient.builder().serviceUrl("http://127.0.0.1:8080").build();
 
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic");
+        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic")
+                .blockIfQueueFull(true).create();
 
         while (true) {
             producer.sendAsync("my-message".getBytes());

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/tutorial/ContinuousProducer.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/tutorial/ContinuousProducer.java
@@ -26,9 +26,10 @@ import org.apache.pulsar.client.api.PulsarClientException;
 
 public class ContinuousProducer {
     public static void main(String[] args) throws PulsarClientException, InterruptedException, IOException {
-        PulsarClient pulsarClient = PulsarClient.create("http://127.0.0.1:8080");
+        PulsarClient pulsarClient = PulsarClient.builder().serviceUrl("http://127.0.0.1:8080").build();
 
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic");
+        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic")
+                .create();
 
         while (true) {
             try {

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/tutorial/SampleAsyncProducer.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/tutorial/SampleAsyncProducer.java
@@ -25,21 +25,20 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
-import org.apache.pulsar.client.api.ProducerConfiguration;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Lists;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public class SampleAsyncProducer {
     public static void main(String[] args) throws PulsarClientException, InterruptedException, IOException {
-        PulsarClient pulsarClient = PulsarClient.create("http://127.0.0.1:8080");
+        PulsarClient pulsarClient = PulsarClient.builder().serviceUrl("http://localhost:8080").build();
 
-        ProducerConfiguration conf = new ProducerConfiguration();
-        conf.setSendTimeout(3, TimeUnit.SECONDS);
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic", conf);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic")
+                .sendTimeout(3, TimeUnit.SECONDS).create();
 
         List<CompletableFuture<MessageId>> futures = Lists.newArrayList();
 
@@ -69,5 +68,4 @@ public class SampleAsyncProducer {
         pulsarClient.close();
     }
 
-    private static final Logger log = LoggerFactory.getLogger(SampleAsyncProducer.class);
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/tutorial/SampleConsumer.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/tutorial/SampleConsumer.java
@@ -25,10 +25,14 @@ import org.apache.pulsar.client.api.PulsarClientException;
 
 public class SampleConsumer {
     public static void main(String[] args) throws PulsarClientException, InterruptedException {
-        PulsarClient pulsarClient = PulsarClient.create("http://localhost:8080");
 
-        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic", "my-subscriber-name");
-        Message msg = null;
+        PulsarClient pulsarClient = PulsarClient.builder().serviceUrl("http://localhost:8080").build();
+
+        Consumer<byte[]> consumer = pulsarClient.newConsumer() //
+                .topic("persistent://my-property/use/my-ns/my-topic") //
+                .subscriptionName("my-subscription-name").subscribe();
+
+        Message<byte[]> msg = null;
 
         for (int i = 0; i < 100; i++) {
             msg = consumer.receive();

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/tutorial/SampleConsumerListener.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/tutorial/SampleConsumerListener.java
@@ -20,34 +20,27 @@ package org.apache.pulsar.client.tutorial;
 
 import java.io.IOException;
 
-import org.apache.pulsar.client.api.Consumer;
-import org.apache.pulsar.client.api.ConsumerConfiguration;
-import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.client.api.MessageListener;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public class SampleConsumerListener {
     public static void main(String[] args) throws PulsarClientException, InterruptedException, IOException {
-        PulsarClient pulsarClient = PulsarClient.create("http://localhost:8080");
+        PulsarClient pulsarClient = PulsarClient.builder().serviceUrl("http://localhost:8080").build();
 
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setMessageListener(new MessageListener() {
-            public void received(Consumer consumer, Message msg) {
-                log.info("Received message: {}", msg);
-                consumer.acknowledgeAsync(msg);
-            }
-        });
-
-        pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic", "my-subscriber-name", conf);
+        pulsarClient.newConsumer() //
+                .topic("persistent://my-property/use/my-ns/my-topic") //
+                .subscriptionName("my-subscription-name") //
+                .messageListener((consumer, msg) -> {
+                    log.info("Received message: {}", msg);
+                    consumer.acknowledgeAsync(msg);
+                }).subscribe();
 
         // Block main thread
         System.in.read();
 
         pulsarClient.close();
     }
-
-    private static final Logger log = LoggerFactory.getLogger(SampleConsumerListener.class);
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/tutorial/SampleProducer.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/tutorial/SampleProducer.java
@@ -28,7 +28,7 @@ public class SampleProducer {
     public static void main(String[] args) throws PulsarClientException, InterruptedException, IOException {
         PulsarClient client = PulsarClient.builder().serviceUrl("http://localhost:6650").build();
 
-        Producer producer = client.newProducer().topic("persistent://my-property/use/my-ns/my-topic").create();
+        Producer<byte[]> producer = client.newProducer().topic("persistent://my-property/use/my-ns/my-topic").create();
 
         for (int i = 0; i < 10; i++) {
             producer.send("my-message".getBytes());

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyAuthenticatedProducerConsumerTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyAuthenticatedProducerConsumerTest.java
@@ -31,13 +31,10 @@ import org.apache.pulsar.broker.authentication.AuthenticationProviderTls;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.Consumer;
-import org.apache.pulsar.client.api.ConsumerConfiguration;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
-import org.apache.pulsar.client.api.ProducerConfiguration;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
 import org.apache.pulsar.client.api.PulsarClient;
-import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.auth.AuthenticationTls;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.PropertyAdmin;
@@ -62,7 +59,7 @@ public class ProxyAuthenticatedProducerConsumerTest extends ProducerConsumerBase
     private final String TLS_CLIENT_CERT_FILE_PATH = "./src/test/resources/authentication/tls/client-cert.pem";
     private final String TLS_CLIENT_KEY_FILE_PATH = "./src/test/resources/authentication/tls/client-key.pem";
     private final String DUMMY_VALUE = "DUMMY_VALUE";
-    
+
     private ProxyService proxyService;
     private ProxyConfiguration proxyConfig = new ProxyConfiguration();
     private final String configClusterName = "use";
@@ -70,8 +67,8 @@ public class ProxyAuthenticatedProducerConsumerTest extends ProducerConsumerBase
     @BeforeMethod
     @Override
     protected void setup() throws Exception {
-        
-        // enable tls and auth&auth at broker 
+
+        // enable tls and auth&auth at broker
         conf.setAuthenticationEnabled(true);
         conf.setAuthorizationEnabled(true);
 
@@ -113,13 +110,13 @@ public class ProxyAuthenticatedProducerConsumerTest extends ProducerConsumerBase
         proxyConfig.setTlsCertificateFilePath(TLS_SERVER_CERT_FILE_PATH);
         proxyConfig.setTlsKeyFilePath(TLS_SERVER_KEY_FILE_PATH);
         proxyConfig.setTlsTrustCertsFilePath(TLS_TRUST_CERT_FILE_PATH);
-        
+
         proxyConfig.setBrokerClientAuthenticationPlugin(AuthenticationTls.class.getName());
         proxyConfig.setBrokerClientAuthenticationParameters(
                 "tlsCertFile:" + TLS_CLIENT_CERT_FILE_PATH + "," + "tlsKeyFile:" + TLS_CLIENT_KEY_FILE_PATH);
         proxyConfig.setBrokerClientTrustCertsFilePath(TLS_TRUST_CERT_FILE_PATH);
         proxyConfig.setAuthenticationProviders(providers);
-        
+
         proxyConfig.setZookeeperServers(DUMMY_VALUE);
         proxyConfig.setGlobalZookeeperServers(DUMMY_VALUE);
 
@@ -138,17 +135,18 @@ public class ProxyAuthenticatedProducerConsumerTest extends ProducerConsumerBase
     /**
      * <pre>
      * It verifies e2e tls + Authentication + Authorization (client -> proxy -> broker>
-     * 
+     *
      * 1. client connects to proxy over tls and pass auth-data
-     * 2. proxy authenticate client and retrieve client-role 
+     * 2. proxy authenticate client and retrieve client-role
      *    and send it to broker as originalPrincipal over tls
      * 3. client creates producer/consumer via proxy
      * 4. broker authorize producer/consumer create request using originalPrincipal
-     * 
+     *
      * </pre>
-     * 
+     *
      * @throws Exception
      */
+    @SuppressWarnings("deprecation")
     @Test
     public void testTlsSyncProducerAndConsumer() throws Exception {
         log.info("-- Starting {} test --", methodName);
@@ -168,21 +166,17 @@ public class ProxyAuthenticatedProducerConsumerTest extends ProducerConsumerBase
                 new PropertyAdmin(Lists.newArrayList("appid1", "appid2"), Sets.newHashSet("use")));
         admin.namespaces().createNamespace("my-property/use/my-ns");
 
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-        Consumer consumer = proxyClient.subscribe("persistent://my-property/use/my-ns/my-topic1", "my-subscriber-name",
-                conf);
-
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-
-        Producer producer = proxyClient.createProducer("persistent://my-property/use/my-ns/my-topic1", producerConf);
+        Consumer<byte[]> consumer = proxyClient.newConsumer().topic("persistent://my-property/use/my-ns/my-topic1")
+                .subscriptionName("my-subscriber-name").subscribe();
+        Producer<byte[]> producer = proxyClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic1")
+                .create();
         final int msgs = 10;
         for (int i = 0; i < msgs; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
 
-        Message msg = null;
+        Message<byte[]> msg = null;
         Set<String> messageSet = Sets.newHashSet();
         int count = 0;
         for (int i = 0; i < 10; i++) {
@@ -209,7 +203,10 @@ public class ProxyAuthenticatedProducerConsumerTest extends ProducerConsumerBase
         clientConf.setUseTls(true);
 
         admin = spy(new PulsarAdmin(brokerUrlTls, clientConf));
-        return PulsarClient.create(lookupUrl, clientConf);
+        return PulsarClient.builder().serviceUrl(lookupUrl).statsInterval(0, TimeUnit.SECONDS)
+                .tlsTrustCertsFilePath(TLS_TRUST_CERT_FILE_PATH).allowTlsInsecureConnection(true).authentication(auth)
+                .enableTls(true).build();
+
     }
 
 }

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyForwardAuthDataTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyForwardAuthDataTest.java
@@ -96,8 +96,10 @@ public class ProxyForwardAuthDataTest extends ProducerConsumerBase {
         admin.properties().createProperty("my-property",
                 new PropertyAdmin(Lists.newArrayList("appid1", "appid2"), Sets.newHashSet("use")));
         admin.namespaces().createNamespace(namespaceName);
-        admin.namespaces().grantPermissionOnNamespace(namespaceName, "proxy", Sets.newHashSet(AuthAction.consume, AuthAction.produce));
-        admin.namespaces().grantPermissionOnNamespace(namespaceName, "client", Sets.newHashSet(AuthAction.consume, AuthAction.produce));
+        admin.namespaces().grantPermissionOnNamespace(namespaceName, "proxy",
+                Sets.newHashSet(AuthAction.consume, AuthAction.produce));
+        admin.namespaces().grantPermissionOnNamespace(namespaceName, "client",
+                Sets.newHashSet(AuthAction.consume, AuthAction.produce));
 
         // Step 2: Run Pulsar Proxy without forwarding authData - expect Exception
         ProxyConfiguration proxyConfig = new ProxyConfiguration();
@@ -114,9 +116,9 @@ public class ProxyForwardAuthDataTest extends ProducerConsumerBase {
         proxyConfig.setAuthenticationProviders(providers);
 
         try (ProxyService proxyService = new ProxyService(proxyConfig);
-             PulsarClient proxyClient = createPulsarClient(proxyServiceUrl, clientAuthParams)) {
+                PulsarClient proxyClient = createPulsarClient(proxyServiceUrl, clientAuthParams)) {
             proxyService.start();
-            proxyClient.subscribe(topicName, subscriptionName);
+            proxyClient.newConsumer().topic(topicName).subscriptionName(subscriptionName).subscribe();
             Assert.fail("Shouldn't be able to subscribe, auth required");
         } catch (PulsarClientException.AuthorizationException e) {
             // expected behaviour
@@ -125,9 +127,9 @@ public class ProxyForwardAuthDataTest extends ProducerConsumerBase {
         // Step 3: Create proxy with forwardAuthData enabled
         proxyConfig.setForwardAuthorizationCredentials(true);
         try (ProxyService proxyService = new ProxyService(proxyConfig);
-             PulsarClient proxyClient = createPulsarClient(proxyServiceUrl, clientAuthParams)) {
+                PulsarClient proxyClient = createPulsarClient(proxyServiceUrl, clientAuthParams)) {
             proxyService.start();
-            proxyClient.subscribe(topicName, subscriptionName).close();
+            proxyClient.newConsumer().topic(topicName).subscriptionName(subscriptionName).subscribe().close();
         }
     }
 

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTlsTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyTlsTest.java
@@ -25,13 +25,11 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.bookkeeper.test.PortManager;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
-import org.apache.pulsar.client.api.ClientConfiguration;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.client.api.Producer;
-import org.apache.pulsar.client.api.ProducerConfiguration;
 import org.apache.pulsar.client.api.PulsarClient;
-import org.apache.pulsar.client.api.ProducerConfiguration.MessageRoutingMode;
 import org.apache.pulsar.common.policies.data.PropertyAdmin;
 import org.mockito.Mockito;
 import org.testng.annotations.AfterClass;
@@ -44,7 +42,7 @@ public class ProxyTlsTest extends MockedPulsarServiceBaseTest {
     private final String TLS_PROXY_CERT_FILE_PATH = "./src/test/resources/authentication/tls/server-cert.pem";
     private final String TLS_PROXY_KEY_FILE_PATH = "./src/test/resources/authentication/tls/server-key.pem";
     private final String DUMMY_VALUE = "DUMMY_VALUE";
-    
+
     private ProxyService proxyService;
     private ProxyConfiguration proxyConfig = new ProxyConfiguration();
 
@@ -63,7 +61,7 @@ public class ProxyTlsTest extends MockedPulsarServiceBaseTest {
         proxyConfig.setTlsKeyFilePath(TLS_PROXY_KEY_FILE_PATH);
         proxyConfig.setZookeeperServers(DUMMY_VALUE);
         proxyConfig.setGlobalZookeeperServers(DUMMY_VALUE);
-        
+
         proxyService = Mockito.spy(new ProxyService(proxyConfig));
         doReturn(mockZooKeeperClientFactory).when(proxyService).getZooKeeperClientFactory();
 
@@ -80,12 +78,10 @@ public class ProxyTlsTest extends MockedPulsarServiceBaseTest {
 
     @Test
     public void testProducer() throws Exception {
-        ClientConfiguration conf = new ClientConfiguration();
-        conf.setUseTls(true);
-        conf.setTlsAllowInsecureConnection(false);
-        conf.setTlsTrustCertsFilePath(TLS_TRUST_CERT_FILE_PATH);
-        PulsarClient client = PulsarClient.create("pulsar+ssl://localhost:" + proxyConfig.getServicePortTls(), conf);
-        Producer producer = client.createProducer("persistent://sample/test/local/topic");
+        PulsarClient client = PulsarClient.builder()
+                .serviceUrl("pulsar+ssl://localhost:" + proxyConfig.getServicePortTls()).enableTls(true)
+                .allowTlsInsecureConnection(false).tlsTrustCertsFilePath(TLS_TRUST_CERT_FILE_PATH).build();
+        Producer<byte[]> producer = client.newProducer().topic("persistent://sample/test/local/topic").create();
 
         for (int i = 0; i < 10; i++) {
             producer.send("test".getBytes());
@@ -96,28 +92,25 @@ public class ProxyTlsTest extends MockedPulsarServiceBaseTest {
 
     @Test
     public void testPartitions() throws Exception {
-        ClientConfiguration conf = new ClientConfiguration();
-        conf.setUseTls(true);
-        conf.setTlsAllowInsecureConnection(false);
-        conf.setTlsTrustCertsFilePath(TLS_TRUST_CERT_FILE_PATH);
-
-        PulsarClient client = PulsarClient.create("pulsar://localhost:" + proxyConfig.getServicePortTls(), conf);
+        PulsarClient client = PulsarClient.builder()
+                .serviceUrl("pulsar+ssl://localhost:" + proxyConfig.getServicePortTls()).enableTls(true)
+                .allowTlsInsecureConnection(false).tlsTrustCertsFilePath(TLS_TRUST_CERT_FILE_PATH).build();
         admin.properties().createProperty("sample", new PropertyAdmin());
         admin.persistentTopics().createPartitionedTopic("persistent://sample/test/local/partitioned-topic", 2);
 
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-        producerConf.setMessageRoutingMode(MessageRoutingMode.RoundRobinPartition);
-        Producer producer = client.createProducer("persistent://sample/test/local/partitioned-topic", producerConf);
+        Producer<byte[]> producer = client.newProducer().topic("persistent://sample/test/local/partitioned-topic")
+                .messageRoutingMode(MessageRoutingMode.RoundRobinPartition).create();
 
         // Create a consumer directly attached to broker
-        Consumer consumer = pulsarClient.subscribe("persistent://sample/test/local/partitioned-topic", "my-sub");
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://sample/test/local/partitioned-topic")
+                .subscriptionName("my-sub").subscribe();
 
         for (int i = 0; i < 10; i++) {
             producer.send("test".getBytes());
         }
 
         for (int i = 0; i < 10; i++) {
-            Message msg = consumer.receive(1, TimeUnit.SECONDS);
+            Message<byte[]> msg = consumer.receive(1, TimeUnit.SECONDS);
             checkNotNull(msg);
         }
 

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithoutServiceDiscoveryTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithoutServiceDiscoveryTest.java
@@ -30,19 +30,16 @@ import org.apache.pulsar.broker.authentication.AuthenticationProviderTls;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.Consumer;
-import org.apache.pulsar.client.api.ConsumerConfiguration;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
-import org.apache.pulsar.client.api.ProducerConfiguration;
 import org.apache.pulsar.client.api.ProducerConsumerBase;
 import org.apache.pulsar.client.api.PulsarClient;
-import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.auth.AuthenticationTls;
-import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.PropertyAdmin;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -50,8 +47,6 @@ import org.testng.collections.Maps;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-
-import org.testng.Assert;
 
 public class ProxyWithoutServiceDiscoveryTest extends ProducerConsumerBase {
     private static final Logger log = LoggerFactory.getLogger(ProxyWithoutServiceDiscoveryTest.class);
@@ -68,8 +63,8 @@ public class ProxyWithoutServiceDiscoveryTest extends ProducerConsumerBase {
     @BeforeMethod
     @Override
     protected void setup() throws Exception {
-        
-        // enable tls and auth&auth at broker 
+
+        // enable tls and auth&auth at broker
         conf.setAuthenticationEnabled(true);
         conf.setAuthorizationEnabled(false);
 
@@ -100,7 +95,7 @@ public class ProxyWithoutServiceDiscoveryTest extends ProducerConsumerBase {
         proxyConfig.setAuthorizationEnabled(false);
         proxyConfig.setBrokerServiceURL("pulsar://localhost:" + BROKER_PORT);
         proxyConfig.setBrokerServiceURLTLS("pulsar://localhost:" + BROKER_PORT_TLS);
-        
+
         proxyConfig.setServicePort(PortManager.nextFreePort());
         proxyConfig.setServicePortTls(PortManager.nextFreePort());
         proxyConfig.setWebServicePort(PortManager.nextFreePort());
@@ -119,7 +114,7 @@ public class ProxyWithoutServiceDiscoveryTest extends ProducerConsumerBase {
         proxyConfig.setBrokerClientTrustCertsFilePath(TLS_TRUST_CERT_FILE_PATH);
 
         proxyConfig.setAuthenticationProviders(providers);
- 
+
         proxyService = Mockito.spy(new ProxyService(proxyConfig));
 
         proxyService.start();
@@ -135,15 +130,15 @@ public class ProxyWithoutServiceDiscoveryTest extends ProducerConsumerBase {
     /**
      * <pre>
      * It verifies e2e tls + Authentication + Authorization (client -> proxy -> broker>
-     * 
+     *
      * 1. client connects to proxy over tls and pass auth-data
-     * 2. proxy authenticate client and retrieve client-role 
+     * 2. proxy authenticate client and retrieve client-role
      *    and send it to broker as originalPrincipal over tls
      * 3. client creates producer/consumer via proxy
      * 4. broker authorize producer/consumer create request using originalPrincipal
-     * 
+     *
      * </pre>
-     * 
+     *
      * @throws Exception
      */
     @Test
@@ -159,25 +154,22 @@ public class ProxyWithoutServiceDiscoveryTest extends ProducerConsumerBase {
         // create a client which connects to proxy over tls and pass authData
         PulsarClient proxyClient = createPulsarClient(authTls, proxyServiceUrl);
 
-        admin.properties().createProperty("my-property",
-                new PropertyAdmin(Lists.newArrayList("appid1", "appid2"), Sets.newHashSet("without-service-discovery")));
+        admin.properties().createProperty("my-property", new PropertyAdmin(Lists.newArrayList("appid1", "appid2"),
+                Sets.newHashSet("without-service-discovery")));
         admin.namespaces().createNamespace("my-property/without-service-discovery/my-ns");
 
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-        Consumer consumer = proxyClient.subscribe("persistent://my-property/without-service-discovery/my-ns/my-topic1", "my-subscriber-name",
-                conf);
-
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-
-        Producer producer = proxyClient.createProducer("persistent://my-property/without-service-discovery/my-ns/my-topic1", producerConf);
+        Consumer<byte[]> consumer = proxyClient.newConsumer()
+                .topic("persistent://my-property/without-service-discovery/my-ns/my-topic1")
+                .subscriptionName("my-subscriber-name").subscribe();
+        Producer<byte[]> producer = proxyClient.newProducer()
+                .topic("persistent://my-property/without-service-discovery/my-ns/my-topic1").create();
         final int msgs = 10;
         for (int i = 0; i < msgs; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
 
-        Message msg = null;
+        Message<byte[]> msg = null;
         Set<String> messageSet = Sets.newHashSet();
         int count = 0;
         for (int i = 0; i < 10; i++) {
@@ -204,7 +196,9 @@ public class ProxyWithoutServiceDiscoveryTest extends ProducerConsumerBase {
         clientConf.setUseTls(true);
 
         admin = spy(new PulsarAdmin(brokerUrlTls, clientConf));
-        return PulsarClient.create(lookupUrl, clientConf);
+        return PulsarClient.builder().serviceUrl(lookupUrl).statsInterval(0, TimeUnit.SECONDS)
+                .tlsTrustCertsFilePath(TLS_TRUST_CERT_FILE_PATH).allowTlsInsecureConnection(true).authentication(auth)
+                .enableTls(true).build();
     }
 
 }


### PR DESCRIPTION
### Motivation

Refactored all unit tests code to use new typed API. 

Left `V1_ProducerConsumerTest` test with v1 APIs to ensure we're not breaking source compatibility.