### PR TITLE
Introduce pulsar-seed and pulsar-snapshot-release jenkins jobs

### DIFF
--- a/.test-infra/jenkins/common_job_properties.groovy
+++ b/.test-infra/jenkins/common_job_properties.groovy
@@ -1,0 +1,257 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+// Contains functions that help build Jenkins projects. Functions typically set
+// common properties that are shared among all Jenkins projects.
+// Code in this directory should conform to the Groovy style guide.
+//  http://groovy-lang.org/style-guide.html
+class common_job_properties {
+
+  // Sets common top-level job properties for website repository jobs.
+  static void setTopLevelWebsiteJobProperties(context,
+                                              String branch = 'master') {
+    // GitHub project.
+    context.properties {
+      githubProjectUrl('https://jenkins@github.com/apache/incubator-pulsar/')
+    }
+
+    setTopLevelJobProperties(
+            context,
+            'https://gitbox.apache.org/repos/asf/incubator-pulsar.git',
+            branch,
+            'git-websites',
+            30)
+  }
+
+  // Sets common top-level job properties for main repository jobs.
+  static void setTopLevelMainJobProperties(context,
+                                           String branch = 'master',
+                                           String jdkVersion = 'JDK 1.8 (latest)',
+                                           int timeout = 200,
+                                           String jenkinsExecutorLabel = 'ubuntu') {
+    // GitHub project.
+    context.properties {
+      githubProjectUrl('https://github.com/apache/incubator-pulsar/')
+    }
+
+
+    setTopLevelJobProperties(
+            context,
+            'https://github.com/apache/incubator-pulsar.git',
+            branch,
+            jenkinsExecutorLabel,
+            timeout)
+  }
+
+  // Sets common top-level job properties. Accessed through one of the above
+  // methods to protect jobs from internal details of param defaults.
+  private static void setTopLevelJobProperties(context,
+                                               String scmUrl,
+                                               String defaultBranch,
+                                               String jenkinsExecutorLabel,
+                                               int defaultTimeout,
+                                               String jdkVersion = 'JDK 1.8 (latest)') {
+    // Set JDK version.
+    context.jdk(jdkVersion)
+
+    // Restrict this project to run only on Jenkins executors as specified
+    context.label(jenkinsExecutorLabel)
+
+    // Discard old builds. Build records are only kept up to this number of days.
+    context.logRotator {
+      daysToKeep(14)
+    }
+
+    // Source code management.
+    context.scm {
+      git {
+        remote {
+          url(scmUrl)
+          refspec('+refs/heads/*:refs/remotes/origin/* ' +
+                  '+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*')
+        }
+        branch('${sha1}')
+        extensions {
+          cleanAfterCheckout()
+        }
+      }
+    }
+
+    context.parameters {
+      // This is a recommended setup if you want to run the job manually. The
+      // ${sha1} parameter needs to be provided, and defaults to the main branch.
+      stringParam(
+          'sha1',
+          defaultBranch,
+          'Commit id or refname (eg: origin/pr/9/head) you want to build.')
+    }
+
+    context.wrappers {
+      // Abort the build if it's stuck for more minutes than specified.
+      timeout {
+        absolute(defaultTimeout)
+        abortBuild()
+      }
+    }
+  }
+
+  // Sets the pull request build trigger. Accessed through precommit methods
+  // below to insulate callers from internal parameter defaults.
+  private static void setPullRequestBuildTrigger(context,
+                                                 String commitStatusContext,
+                                                 String successComment = '--none--',
+                                                 String prTriggerPhrase = '') {
+    context.triggers {
+      githubPullRequest {
+        admins(['asfbot'])
+        useGitHubHooks()
+        orgWhitelist(['apache'])
+        allowMembersOfWhitelistedOrgsAsAdmin()
+        permitAll()
+        // prTriggerPhrase is the argument which gets set when we want to allow
+        // post-commit builds to run against pending pull requests. This block
+        // overrides the default trigger phrase with the new one. Setting this
+        // will disable automatic invocation of this build; the phrase will be
+        // required to start it.
+        if (prTriggerPhrase) {
+          triggerPhrase(prTriggerPhrase)
+          onlyTriggerPhrase()
+        }
+
+        extensions {
+          commitStatus {
+            // This is the name that will show up in the GitHub pull request UI
+            // for this Jenkins project.
+            delegate.context("Jenkins: " + commitStatusContext)
+          }
+
+          /*
+            This section is disabled, because of jenkinsci/ghprb-plugin#417 issue.
+            For the time being, an equivalent configure section below is added.
+
+          // Comment messages after build completes.
+          buildStatus {
+            completedStatus('SUCCESS', successComment)
+            completedStatus('FAILURE', '--none--')
+            completedStatus('ERROR', '--none--')
+          }
+          */
+        }
+      }
+    }
+
+    // Comment messages after build completes.
+    context.configure {
+      def messages = it / triggers / 'org.jenkinsci.plugins.ghprb.GhprbTrigger' / extensions / 'org.jenkinsci.plugins.ghprb.extensions.comments.GhprbBuildStatus' / messages
+      messages << 'org.jenkinsci.plugins.ghprb.extensions.comments.GhprbBuildResultMessage' {
+        message(successComment)
+        result('SUCCESS')
+      }
+      messages << 'org.jenkinsci.plugins.ghprb.extensions.comments.GhprbBuildResultMessage' {
+        message('--none--')
+        result('ERROR')
+      }
+      messages << 'org.jenkinsci.plugins.ghprb.extensions.comments.GhprbBuildResultMessage' {
+        message('--none--')
+        result('FAILURE')
+      }
+    }
+  }
+
+  // Sets common config for Maven jobs.
+  static void setMavenConfig(context, mavenInstallation='Maven 3.5.0', mavenOpts='-Xmx4096m -Xms2048m') {
+    context.mavenInstallation(mavenInstallation)
+    context.mavenOpts('-Dorg.slf4j.simpleLogger.showDateTime=true')
+    context.mavenOpts('-Dorg.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd\\\'T\\\'HH:mm:ss.SSS')
+    // The -XX:+TieredCompilation -XX:TieredStopAtLevel=1 JVM options enable
+    // tiered compilation to make the JVM startup times faster during the tests.
+    context.mavenOpts('-XX:+TieredCompilation')
+    context.mavenOpts('-XX:TieredStopAtLevel=1')
+    context.mavenOpts(mavenOpts)
+    context.rootPOM('pom.xml')
+    // Use a repository local to the workspace for better isolation of jobs.
+    context.localRepository(LocalRepositoryLocation.LOCAL_TO_WORKSPACE)
+    // Disable archiving the built artifacts by default, as this is slow and flaky.
+    // We can usually recreate them easily, and we can also opt-in individual jobs
+    // to artifact archiving.
+    if (context.metaClass.respondsTo(context, 'archivingDisabled', boolean)) {
+      context.archivingDisabled(true)
+    }
+  }
+
+  // Sets common config for PreCommit jobs.
+  static void setPreCommit(context,
+                           String commitStatusName,
+                           String successComment = '--none--') {
+    // Set pull request build trigger.
+    setPullRequestBuildTrigger(context, commitStatusName, successComment)
+  }
+
+  // Enable triggering postcommit runs against pull requests. Users can comment the trigger phrase
+  // specified in the postcommit job and have the job run against their PR to run
+  // tests not in the presubmit suite for additional confidence.
+  static void enablePhraseTriggeringFromPullRequest(context,
+                                                    String commitStatusName,
+                                                    String prTriggerPhrase) {
+    setPullRequestBuildTrigger(
+      context,
+      commitStatusName,
+      '--none--',
+      prTriggerPhrase)
+  }
+
+  // Sets common config for PostCommit jobs.
+  static void setPostCommit(context,
+                            String buildSchedule = '0 */6 * * *',
+                            boolean triggerEveryPush = true,
+                            String notifyAddress = 'dev@pulsar.incubator.apache.org',
+                            boolean emailIndividuals = true) {
+    // Set build triggers
+    context.triggers {
+      // By default runs every 6 hours.
+      cron(buildSchedule)
+      if (triggerEveryPush) {
+        githubPush()
+      }
+    }
+
+    context.publishers {
+      // Notify an email address for each failed build (defaults to commits@).
+      mailer(notifyAddress, false, emailIndividuals)
+    }
+  }
+
+  // Sets common config for Website PostCommit jobs.
+  static void setWebsitePostCommit(context,
+                                   String buildSchedule = 'H 1 * * *',
+                                   String notifyAddress = 'dev@pulsar.incubator.apache.org',
+                                   boolean emailIndividuals = true) {
+    // Set build triggers
+    context.triggers {
+      // By default runs every 6 hours.
+      scm(buildSchedule)
+      githubPush()
+    }
+
+    context.publishers {
+      // Notify an email address for each failed build (defaults to commits@).
+      mailer(notifyAddress, false, emailIndividuals)
+    }
+  }
+
+}

--- a/.test-infra/jenkins/common_job_properties.groovy
+++ b/.test-infra/jenkins/common_job_properties.groovy
@@ -219,7 +219,7 @@ class common_job_properties {
   static void setPostCommit(context,
                             String buildSchedule = '0 */6 * * *',
                             boolean triggerEveryPush = true,
-                            String notifyAddress = 'dev@pulsar.incubator.apache.org',
+                            String notifyAddress = 'sijie@apache.org',
                             boolean emailIndividuals = true) {
     // Set build triggers
     context.triggers {
@@ -239,7 +239,7 @@ class common_job_properties {
   // Sets common config for Website PostCommit jobs.
   static void setWebsitePostCommit(context,
                                    String buildSchedule = 'H 1 * * *',
-                                   String notifyAddress = 'dev@pulsar.incubator.apache.org',
+                                   String notifyAddress = 'sijie@apache.org',
                                    boolean emailIndividuals = true) {
     // Set build triggers
     context.triggers {

--- a/.test-infra/jenkins/common_job_properties.groovy
+++ b/.test-infra/jenkins/common_job_properties.groovy
@@ -219,7 +219,7 @@ class common_job_properties {
   static void setPostCommit(context,
                             String buildSchedule = '0 */6 * * *',
                             boolean triggerEveryPush = true,
-                            String notifyAddress = 'sijie@apache.org',
+                            String notifyAddress = 'dev@pulsar.incubator.apache.org',
                             boolean emailIndividuals = true) {
     // Set build triggers
     context.triggers {
@@ -239,7 +239,7 @@ class common_job_properties {
   // Sets common config for Website PostCommit jobs.
   static void setWebsitePostCommit(context,
                                    String buildSchedule = 'H 1 * * *',
-                                   String notifyAddress = 'sijie@apache.org',
+                                   String notifyAddress = 'dev@pulsar.incubator.apache.org',
                                    boolean emailIndividuals = true) {
     // Set build triggers
     context.triggers {

--- a/.test-infra/jenkins/job_pulsar_release_nightly_snapshot.groovy
+++ b/.test-infra/jenkins/job_pulsar_release_nightly_snapshot.groovy
@@ -41,5 +41,5 @@ mavenJob('pulsar_release_nightly_snapshot') {
   common_job_properties.setMavenConfig(delegate)
 
   // Maven build project.
-  goals('clean package deploy')
+  goals('clean package deploy -DskipTests')
 }

--- a/.test-infra/jenkins/job_pulsar_release_nightly_snapshot.groovy
+++ b/.test-infra/jenkins/job_pulsar_release_nightly_snapshot.groovy
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import common_job_properties
+
+// This job deploys a snapshot of latest master to artifactory nightly
+mavenJob('pulsar_release_nightly_snapshot') {
+  description('runs a `mvn clean deploy` of the nightly snapshot for pulsar.')
+
+  // Set common parameters.
+  common_job_properties.setTopLevelMainJobProperties(delegate)
+
+  // Sets that this is a PostCommit job.
+  common_job_properties.setPostCommit(
+      delegate,
+      'H 12 * * *',
+      false)
+
+  // Allows triggering this build against pull requests.
+  common_job_properties.enablePhraseTriggeringFromPullRequest(
+      delegate,
+      'Release Snapshot',
+      '/release-snapshot')
+
+  // Set maven parameters.
+  common_job_properties.setMavenConfig(delegate)
+
+  // Maven build project.
+  goals('clean package deploy')
+}

--- a/.test-infra/jenkins/job_pulsar_release_nightly_snapshot.groovy
+++ b/.test-infra/jenkins/job_pulsar_release_nightly_snapshot.groovy
@@ -41,5 +41,5 @@ mavenJob('pulsar_release_nightly_snapshot') {
   common_job_properties.setMavenConfig(delegate)
 
   // Maven build project.
-  goals('clean package deploy -Papache-release -DskipTests')
+  goals('clean package deploy -DskipTests')
 }

--- a/.test-infra/jenkins/job_pulsar_release_nightly_snapshot.groovy
+++ b/.test-infra/jenkins/job_pulsar_release_nightly_snapshot.groovy
@@ -41,5 +41,5 @@ mavenJob('pulsar_release_nightly_snapshot') {
   common_job_properties.setMavenConfig(delegate)
 
   // Maven build project.
-  goals('clean package deploy -DskipTests')
+  goals('clean package deploy -Papache-release -DskipTests')
 }

--- a/.test-infra/jenkins/job_seed.groovy
+++ b/.test-infra/jenkins/job_seed.groovy
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import common_job_properties
+
+// Defines the seed job, which creates or updates all other Jenkins projects.
+job('pulsar-seed') {
+  description('Automatically configures all Apache BookKeeper Jenkins projects based' +
+              ' on Jenkins DSL groovy files checked into the code repository.')
+
+  // Set common parameters.
+  common_job_properties.setTopLevelMainJobProperties(delegate)
+
+  // This is a post-commit job that runs once per day, not for every push.
+  common_job_properties.setPostCommit(
+      delegate,
+      'H 6 * * *',
+      false,
+      'dev@pulsar.incubator.apache.org')
+
+  // Allows triggering this build against pull requests.
+  common_job_properties.enablePhraseTriggeringFromPullRequest(
+    delegate,
+    'Seed Job',
+    '/seed')
+
+  steps {
+    dsl {
+      // A list or a glob of other groovy files to process.
+      external('.test-infra/jenkins/job_*.groovy')
+
+      // If a job is removed from the script, delete it
+      removeAction('DELETE')
+    }
+  }
+}

--- a/.test-infra/jenkins/job_seed.groovy
+++ b/.test-infra/jenkins/job_seed.groovy
@@ -31,7 +31,7 @@ job('pulsar-seed') {
       delegate,
       'H 6 * * *',
       false,
-      'dev@pulsar.incubator.apache.org')
+      'sijie@apache.org')
 
   // Allows triggering this build against pull requests.
   common_job_properties.enablePhraseTriggeringFromPullRequest(

--- a/.test-infra/jenkins/job_seed.groovy
+++ b/.test-infra/jenkins/job_seed.groovy
@@ -31,7 +31,7 @@ job('pulsar-seed') {
       delegate,
       'H 6 * * *',
       false,
-      'sijie@apache.org')
+      'dev@pulsar.incubator.apache.org')
 
   // Allows triggering this build against pull requests.
   common_job_properties.enablePhraseTriggeringFromPullRequest(

--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -22,6 +22,12 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <parent>
+    <groupId>org.apache</groupId>
+    <artifactId>apache</artifactId>
+    <version>18</version>
+  </parent>
+
   <groupId>org.apache.pulsar</groupId>
   <artifactId>buildtools</artifactId>
   <version>2.0.0-incubating-SNAPSHOT</version>


### PR DESCRIPTION
### Motivation

It is nice to have a snapshot release task that publishes snapshot to apache snapshot repo. so user can try out new pulsar features as the change gets into master.

### Modifications

- introduce jenkins dsl to define and manage jenkins jobs
- add a job-seed jenkins job to bootstrap all pulsar jenkins job 
- add a release snapshot jenkins job to publish snapshot
- let buildtools module inherit from apache profile, so we can publish to apache repo

(the jenkins dsls are borrowed from bookkeeper)

### Result

we will have a snapshot version in the snapshot repository - https://repository.apache.org/content/repositories/snapshots/org/apache/pulsar/
