### PR TITLE
Rename pulsar function api from V1 to V2

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/Resources.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/Resources.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.functions.worker.rest;
 
-import org.apache.pulsar.functions.worker.rest.api.v1.FunctionApiV1Resource;
+import org.apache.pulsar.functions.worker.rest.api.v2.FunctionApiV2Resource;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 
 import java.util.Arrays;
@@ -38,7 +38,7 @@ public final class Resources {
     private static List<Class<?>> getClasses() {
         return Arrays.asList(
                 ConfigurationResource.class,
-                FunctionApiV1Resource.class,
+                FunctionApiV2Resource.class,
                 MultiPartFeature.class
         );
     }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2Resource.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2Resource.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.functions.worker.rest.api.v1;
+package org.apache.pulsar.functions.worker.rest.api.v2;
 
 import com.google.gson.Gson;
 import javax.ws.rs.core.Response.Status;
@@ -38,7 +38,6 @@ import org.apache.pulsar.functions.worker.MembershipManager;
 import org.apache.pulsar.functions.worker.Utils;
 import org.apache.pulsar.functions.worker.request.RequestResult;
 import org.apache.pulsar.functions.worker.rest.FunctionApiResource;
-import org.apache.pulsar.functions.worker.WorkerConfig;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 
@@ -62,8 +61,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 @Slf4j
-@Path("/admin/functions")
-public class FunctionApiV1Resource extends FunctionApiResource {
+@Path("/functions")
+public class FunctionApiV2Resource extends FunctionApiResource {
 
     @POST
     @Path("/{tenant}/{namespace}/{functionName}")

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2ResourceTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.functions.worker.rest.api.v1;
+package org.apache.pulsar.functions.worker.rest.api.v2;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -67,11 +67,11 @@ import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
 
 /**
- * Unit test of {@link FunctionApiV1Resource}.
+ * Unit test of {@link FunctionApiV2Resource}.
  */
 @PrepareForTest(Utils.class)
 @PowerMockIgnore({ "javax.management.*", "javax.ws.*", "org.apache.logging.log4j.*" })
-public class FunctionApiV1ResourceTest {
+public class FunctionApiV2ResourceTest {
 
     @ObjectFactory
     public IObjectFactory getObjectFactory() {
@@ -98,13 +98,13 @@ public class FunctionApiV1ResourceTest {
     private WorkerService mockedWorkerService;
     private FunctionMetaDataManager mockedManager;
     private Namespace mockedNamespace;
-    private FunctionApiV1Resource resource;
+    private FunctionApiV2Resource resource;
     private InputStream mockedInputStream;
     private FormDataContentDisposition mockedFormData;
 
     @BeforeMethod
     public void setup() {
-        this.resource = spy(new FunctionApiV1Resource());
+        this.resource = spy(new FunctionApiV2Resource());
         this.mockedManager = mock(FunctionMetaDataManager.class);
         this.mockedInputStream = mock(InputStream.class);
         this.mockedFormData = mock(FormDataContentDisposition.class);


### PR DESCRIPTION
- rename the V1 to V2
- change the way how the rest api was organized to allow it merged back to pulsar webservice and cli
