### PR TITLE
Refactored PulsarAdmin to use builder for configuration

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
@@ -208,8 +208,8 @@ public class PulsarStandaloneStarter {
                 String.format("http://%s:%d", config.getAdvertisedAddress(), config.getWebServicePort()));
         final String brokerServiceUrl = String.format("pulsar://%s:%d", config.getAdvertisedAddress(),
                 config.getBrokerServicePort());
-        admin = new PulsarAdmin(webServiceUrl, config.getBrokerClientAuthenticationPlugin(),
-                config.getBrokerClientAuthenticationParameters());
+        admin = PulsarAdmin.builder().serviceHttpUrl(webServiceUrl.toString()).authentication(
+                config.getBrokerClientAuthenticationPlugin(), config.getBrokerClientAuthenticationParameters()).build();
         final String property = "sample";
         final String cluster = config.getClusterName();
         final String globalCluster = "global";

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -635,9 +635,11 @@ public class PulsarService implements AutoCloseable {
         if (this.adminClient == null) {
             try {
                 String adminApiUrl = webAddress(config);
-                this.adminClient = new PulsarAdmin(new URL(adminApiUrl),
-                        this.getConfiguration().getBrokerClientAuthenticationPlugin(),
-                        this.getConfiguration().getBrokerClientAuthenticationParameters());
+                this.adminClient = PulsarAdmin.builder().serviceHttpUrl(adminApiUrl) //
+                        .authentication( //
+                                this.getConfiguration().getBrokerClientAuthenticationPlugin(), //
+                                this.getConfiguration().getBrokerClientAuthenticationParameters()) //
+                        .build();
                 LOG.info("Admin api url: " + adminApiUrl);
             } catch (Exception e) {
                 throw new PulsarServerException(e);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/SLAMonitoringTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/SLAMonitoringTest.java
@@ -36,14 +36,10 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.bookkeeper.test.PortManager;
-import org.apache.pulsar.broker.PulsarServerException;
-import org.apache.pulsar.broker.PulsarService;
-import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.LoadBalancerTest;
 import org.apache.pulsar.broker.namespace.NamespaceService;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
-import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.NamespaceOwnershipStatus;
@@ -100,7 +96,7 @@ public class SLAMonitoringTest {
             pulsarServices[i].start();
 
             brokerUrls[i] = new URL("http://127.0.0.1" + ":" + brokerWebServicePorts[i]);
-            pulsarAdmins[i] = new PulsarAdmin(brokerUrls[i], (Authentication) null);
+            pulsarAdmins[i] = PulsarAdmin.builder().serviceHttpUrl(brokerUrls[i].toString()).build();
         }
 
         Thread.sleep(100);
@@ -116,7 +112,7 @@ public class SLAMonitoringTest {
     private void createProperty(PulsarAdmin pulsarAdmin)
             throws PulsarClientException, MalformedURLException, PulsarAdminException {
         ClusterData clusterData = new ClusterData();
-        clusterData.setServiceUrl(pulsarAdmin.getServiceUrl().toString());
+        clusterData.setServiceUrl(pulsarAdmin.getServiceUrl());
         pulsarAdmins[0].clusters().createCluster("my-cluster", clusterData);
         Set<String> allowedClusters = new HashSet<>();
         allowedClusters.add("my-cluster");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -140,10 +140,8 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
 
         bundleFactory = new NamespaceBundleFactory(pulsar, Hashing.crc32());
 
-        ClientConfiguration clientConf = new ClientConfiguration();
-        clientConf.setUseTls(true);
-        clientConf.setTlsTrustCertsFilePath(TLS_SERVER_CERT_FILE_PATH);
-        adminTls = spy(new PulsarAdmin(brokerUrlTls, clientConf));
+        adminTls = spy(PulsarAdmin.builder().tlsTrustCertsFilePath(TLS_SERVER_CERT_FILE_PATH)
+                .serviceHttpUrl(brokerUrlTls.toString()).build());
 
         // create otherbroker to test redirect on calls that need
         // namespace ownership

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -131,7 +131,7 @@ public abstract class MockedPulsarServiceBaseTest {
         brokerUrl = new URL("http://" + pulsar.getAdvertisedAddress() + ":" + BROKER_WEBSERVICE_PORT);
         brokerUrlTls = new URL("https://" + pulsar.getAdvertisedAddress() + ":" + BROKER_WEBSERVICE_PORT_TLS);
 
-        admin = spy(new PulsarAdmin(brokerUrl, (Authentication) null));
+        admin = spy(PulsarAdmin.builder().serviceHttpUrl(brokerUrl.toString()).build());
     }
 
     protected final void internalCleanup() throws Exception {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/AntiAffinityNamespaceGroupTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/AntiAffinityNamespaceGroupTest.java
@@ -132,7 +132,7 @@ public class AntiAffinityNamespaceGroupTest {
 
         primaryHost = String.format("%s:%d", "localhost", PRIMARY_BROKER_WEBSERVICE_PORT);
         url1 = new URL("http://127.0.0.1" + ":" + PRIMARY_BROKER_WEBSERVICE_PORT);
-        admin1 = new PulsarAdmin(url1, (Authentication) null);
+        admin1 = PulsarAdmin.builder().serviceHttpUrl(url1.toString()).build();
 
         // Start broker 2
         ServiceConfiguration config2 = new ServiceConfiguration();
@@ -149,7 +149,7 @@ public class AntiAffinityNamespaceGroupTest {
         pulsar2.start();
 
         url2 = new URL("http://127.0.0.1" + ":" + SECONDARY_BROKER_WEBSERVICE_PORT);
-        admin2 = new PulsarAdmin(url2, (Authentication) null);
+        admin2 = PulsarAdmin.builder().serviceHttpUrl(url2.toString()).build();
 
         primaryLoadManager = (ModularLoadManagerImpl) getField(pulsar1.getLoadManager().get(), "loadManager");
         secondaryLoadManager = (ModularLoadManagerImpl) getField(pulsar2.getLoadManager().get(), "loadManager");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadBalancerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/LoadBalancerTest.java
@@ -56,9 +56,8 @@ import org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl;
 import org.apache.pulsar.broker.loadbalance.impl.SimpleResourceUnit;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.internal.NamespacesImpl;
-import org.apache.pulsar.client.api.Authentication;
-import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.AutoFailoverPolicyData;
 import org.apache.pulsar.common.policies.data.AutoFailoverPolicyType;
 import org.apache.pulsar.common.policies.data.BundlesData;
@@ -150,7 +149,7 @@ public class LoadBalancerTest {
 
             brokerUrls[i] = new URL("http://127.0.0.1" + ":" + brokerWebServicePorts[i]);
             lookupAddresses[i] = pulsarServices[i].getAdvertisedAddress() + ":" + config.getWebServicePort();
-            pulsarAdmins[i] = new PulsarAdmin(brokerUrls[i], (Authentication) null);
+            pulsarAdmins[i] = PulsarAdmin.builder().serviceHttpUrl(brokerUrls[i].toString()).build();
         }
 
         createNamespacePolicies(pulsarServices[0]);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/ModularLoadManagerImplTest.java
@@ -56,7 +56,6 @@ import org.apache.pulsar.broker.loadbalance.impl.ModularLoadManagerWrapper;
 import org.apache.pulsar.broker.loadbalance.impl.SimpleResourceAllocationPolicies;
 import org.apache.pulsar.client.admin.Namespaces;
 import org.apache.pulsar.client.admin.PulsarAdmin;
-import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.NamespaceBundleFactory;
 import org.apache.pulsar.common.naming.NamespaceBundles;
@@ -164,7 +163,7 @@ public class ModularLoadManagerImplTest {
 
         primaryHost = String.format("%s:%d", InetAddress.getLocalHost().getHostName(), PRIMARY_BROKER_WEBSERVICE_PORT);
         url1 = new URL("http://127.0.0.1" + ":" + PRIMARY_BROKER_WEBSERVICE_PORT);
-        admin1 = new PulsarAdmin(url1, (Authentication) null);
+        admin1 = PulsarAdmin.builder().serviceHttpUrl(url1.toString()).build();
 
         // Start broker 2
         ServiceConfiguration config2 = new ServiceConfiguration();
@@ -180,7 +179,7 @@ public class ModularLoadManagerImplTest {
         pulsar2.start();
 
         url2 = new URL("http://127.0.0.1" + ":" + SECONDARY_BROKER_WEBSERVICE_PORT);
-        admin2 = new PulsarAdmin(url2, (Authentication) null);
+        admin2 = PulsarAdmin.builder().serviceHttpUrl(url2.toString()).build();
 
         primaryLoadManager = (ModularLoadManagerImpl) getField(pulsar1.getLoadManager().get(), "loadManager");
         secondaryLoadManager = (ModularLoadManagerImpl) getField(pulsar2.getLoadManager().get(), "loadManager");

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/SimpleLoadManagerImplTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/loadbalance/SimpleLoadManagerImplTest.java
@@ -61,7 +61,6 @@ import org.apache.pulsar.broker.loadbalance.impl.SimpleLoadManagerImpl;
 import org.apache.pulsar.broker.loadbalance.impl.SimpleResourceUnit;
 import org.apache.pulsar.client.admin.BrokerStats;
 import org.apache.pulsar.client.admin.PulsarAdmin;
-import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.policies.data.AutoFailoverPolicyData;
@@ -143,7 +142,7 @@ public class SimpleLoadManagerImplTest {
         pulsar1.start();
 
         url1 = new URL("http://127.0.0.1" + ":" + PRIMARY_BROKER_WEBSERVICE_PORT);
-        admin1 = new PulsarAdmin(url1, (Authentication) null);
+        admin1 = PulsarAdmin.builder().serviceHttpUrl(url1.toString()).build();
         brokerStatsClient1 = admin1.brokerStats();
         primaryHost = String.format("http://%s:%d", InetAddress.getLocalHost().getHostName(),
                 PRIMARY_BROKER_WEBSERVICE_PORT);
@@ -160,7 +159,7 @@ public class SimpleLoadManagerImplTest {
         pulsar2.start();
 
         url2 = new URL("http://127.0.0.1" + ":" + SECONDARY_BROKER_WEBSERVICE_PORT);
-        admin2 = new PulsarAdmin(url2, (Authentication) null);
+        admin2 = PulsarAdmin.builder().serviceHttpUrl(url2.toString()).build();
         brokerStatsClient2 = admin2.brokerStats();
         secondaryHost = String.format("http://%s:%d", InetAddress.getLocalHost().getHostName(),
                 SECONDARY_BROKER_WEBSERVICE_PORT);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BacklogQuotaManagerTest.java
@@ -30,7 +30,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.client.admin.PulsarAdmin;
-import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
@@ -92,7 +91,7 @@ public class BacklogQuotaManagerTest {
             pulsar.start();
 
             adminUrl = new URL("http://127.0.0.1" + ":" + BROKER_WEBSERVICE_PORT);
-            admin = new PulsarAdmin(adminUrl, (Authentication) null);
+            admin = PulsarAdmin.builder().serviceHttpUrl(adminUrl.toString()).build();;
 
             admin.clusters().createCluster("usc", new ClusterData(adminUrl.toString()));
             admin.properties().createProperty("prop",

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBkEnsemblesTests.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBkEnsemblesTests.java
@@ -39,7 +39,6 @@ import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.PulsarAdmin;
-import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Producer;
@@ -97,7 +96,7 @@ public class BrokerBkEnsemblesTests {
             pulsar.start();
 
             adminUrl = new URL("http://127.0.0.1" + ":" + BROKER_WEBSERVICE_PORT);
-            admin = new PulsarAdmin(adminUrl, (Authentication) null);
+            admin = PulsarAdmin.builder().serviceHttpUrl(adminUrl.toString()).build();
 
             admin.clusters().createCluster("usc", new ClusterData(adminUrl.toString()));
             admin.properties().createProperty("prop",

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTestBase.java
@@ -33,7 +33,6 @@ import org.apache.bookkeeper.test.PortManager;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.client.admin.PulsarAdmin;
-import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageBuilder;
@@ -137,7 +136,7 @@ public class ReplicatorTestBase {
 
         url1 = new URL("http://localhost:" + webServicePort1);
         urlTls1 = new URL("https://localhost:" + webServicePortTls1);
-        admin1 = new PulsarAdmin(url1, (Authentication) null);
+        admin1 = PulsarAdmin.builder().serviceHttpUrl(url1.toString()).build();
 
         // Start region 2
 
@@ -171,7 +170,7 @@ public class ReplicatorTestBase {
 
         url2 = new URL("http://localhost:" + webServicePort2);
         urlTls2 = new URL("https://localhost:" + webServicePortTls2);
-        admin2 = new PulsarAdmin(url2, (Authentication) null);
+        admin2 = PulsarAdmin.builder().serviceHttpUrl(url2.toString()).build();
 
         // Start region 3
 
@@ -204,7 +203,7 @@ public class ReplicatorTestBase {
 
         url3 = new URL("http://localhost:" + webServicePort3);
         urlTls3 = new URL("https://localhost:" + webServicePortTls3);
-        admin3 = new PulsarAdmin(url3, (Authentication) null);
+        admin3 = PulsarAdmin.builder().serviceHttpUrl(url3.toString()).build();
 
         // Provision the global namespace
         admin1.clusters().createCluster("r1", new ClusterData(url1.toString(), urlTls1.toString(),

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthenticatedProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthenticatedProducerConsumerTest.java
@@ -94,14 +94,9 @@ public class AuthenticatedProducerConsumerTest extends ProducerConsumerBase {
     }
 
     protected final void internalSetup(Authentication auth) throws Exception {
-        org.apache.pulsar.client.api.ClientConfiguration clientConf = new org.apache.pulsar.client.api.ClientConfiguration();
-        clientConf.setStatsInterval(0, TimeUnit.SECONDS);
-        clientConf.setTlsTrustCertsFilePath(TLS_TRUST_CERT_FILE_PATH);
-        clientConf.setTlsAllowInsecureConnection(true);
-        clientConf.setAuthentication(auth);
-        clientConf.setUseTls(true);
-
-        admin = spy(new PulsarAdmin(brokerUrlTls, clientConf));
+        admin = spy(PulsarAdmin.builder().serviceHttpUrl(brokerUrlTls.toString())
+                .tlsTrustCertsFilePath(TLS_TRUST_CERT_FILE_PATH).allowTlsInsecureConnection(true).authentication(auth)
+                .build());
         String lookupUrl;
         // For http basic authentication test
         if (methodName.equals("testBasicCryptSyncProducerAndConsumer")) {
@@ -227,9 +222,7 @@ public class AuthenticatedProducerConsumerTest extends ProducerConsumerBase {
 
         // make a PulsarAdmin instance as "anonymousUser" for http request
         admin.close();
-        ClientConfiguration clientConf = new ClientConfiguration();
-        clientConf.setOperationTimeout(1, TimeUnit.SECONDS);
-        admin = spy(new PulsarAdmin(brokerUrl, clientConf));
+        admin = spy(PulsarAdmin.builder().serviceHttpUrl(brokerUrl.toString()).build());
         admin.namespaces().createNamespace("my-property/use/my-ns");
         admin.persistentTopics().grantPermission("persistent://my-property/use/my-ns/my-topic", "anonymousUser",
                 EnumSet.allOf(AuthAction.class));

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthenticationTlsHostnameVerificationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthenticationTlsHostnameVerificationTest.java
@@ -107,15 +107,9 @@ public class AuthenticationTlsHostnameVerificationTest extends ProducerConsumerB
         Authentication authTls = new AuthenticationTls();
         authTls.configure(authParams);
 
-        org.apache.pulsar.client.api.ClientConfiguration clientConf = new org.apache.pulsar.client.api.ClientConfiguration();
-        clientConf.setStatsInterval(0, TimeUnit.SECONDS);
-        clientConf.setTlsTrustCertsFilePath(TLS_MIM_TRUST_CERT_FILE_PATH);
-        clientConf.setTlsAllowInsecureConnection(true);
-        clientConf.setAuthentication(authTls);
-        clientConf.setUseTls(true);
-        clientConf.setTlsHostnameVerificationEnable(hostnameVerificationEnabled);
-
-        admin = spy(new PulsarAdmin(brokerUrlTls, clientConf));
+        admin = spy(PulsarAdmin.builder().serviceHttpUrl(brokerUrlTls.toString())
+                .tlsTrustCertsFilePath(TLS_MIM_TRUST_CERT_FILE_PATH).allowTlsInsecureConnection(true)
+                .authentication(authTls).build());
         String lookupUrl;
         lookupUrl = new URI("pulsar+ssl://" + brokerHostName + ":" + BROKER_PORT_TLS).toString();
         pulsarClient = PulsarClient.builder().serviceUrl(lookupUrl).statsInterval(0, TimeUnit.SECONDS)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/AuthorizationProducerConsumerTest.java
@@ -102,10 +102,9 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
         conf.setAuthorizationProvider(TestAuthorizationProvider.class.getName());
         setup();
 
-        ClientConfiguration adminConf = new ClientConfiguration();
         Authentication adminAuthentication = new ClientAuthentication("superUser");
-        adminConf.setAuthentication(adminAuthentication);
-        admin = spy(new PulsarAdmin(brokerUrl, adminConf));
+        admin = spy(
+                PulsarAdmin.builder().serviceHttpUrl(brokerUrl.toString()).authentication(adminAuthentication).build());
 
         String lookupUrl;
         lookupUrl = new URI("pulsar://localhost:" + BROKER_PORT).toString();
@@ -155,10 +154,9 @@ public class AuthorizationProducerConsumerTest extends ProducerConsumerBase {
         conf.setAuthorizationProvider(TestAuthorizationProviderWithSubscriptionPrefix.class.getName());
         setup();
 
-        ClientConfiguration adminConf = new ClientConfiguration();
         Authentication adminAuthentication = new ClientAuthentication("superUser");
-        adminConf.setAuthentication(adminAuthentication);
-        admin = spy(new PulsarAdmin(brokerUrl, adminConf));
+        admin = spy(
+                PulsarAdmin.builder().serviceHttpUrl(brokerUrl.toString()).authentication(adminAuthentication).build());
 
         String lookupUrl;
         lookupUrl = new URI("pulsar://localhost:" + BROKER_PORT).toString();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
@@ -887,7 +887,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             ns1 = pulsar1.getBrokerService();
 
             url1 = new URL("http://127.0.0.1:" + webServicePort1);
-            admin1 = new PulsarAdmin(url1, (Authentication) null);
+            admin1 = PulsarAdmin.builder().serviceHttpUrl(url1.toString()).build();
 
             // Start region 2
 
@@ -913,7 +913,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             ns2 = pulsar2.getBrokerService();
 
             url2 = new URL("http://127.0.0.1:" + webServicePort2);
-            admin2 = new PulsarAdmin(url2, (Authentication) null);
+            admin2 = PulsarAdmin.builder().serviceHttpUrl(url2.toString()).build();
 
             // Start region 3
 
@@ -938,7 +938,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             ns3 = pulsar3.getBrokerService();
 
             url3 = new URL("http://127.0.0.1:" + webServicePort3);
-            admin3 = new PulsarAdmin(url3, (Authentication) null);
+            admin3 = PulsarAdmin.builder().serviceHttpUrl(url3.toString()).build();
 
             // Provision the global namespace
             admin1.clusters().createCluster("r1", new ClusterData(url1.toString(), null, pulsar1.getBrokerServiceUrl(),

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TlsProducerConsumerBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TlsProducerConsumerBase.java
@@ -20,7 +20,9 @@ package org.apache.pulsar.client.api;
 
 import static org.mockito.Mockito.spy;
 
-import java.net.URI;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -29,15 +31,8 @@ import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.impl.auth.AuthenticationTls;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.PropertyAdmin;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
-
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
-
-import io.netty.handler.ssl.ClientAuth;
 
 public class TlsProducerConsumerBase extends ProducerConsumerBase {
     protected final String TLS_TRUST_CERT_FILE_PATH = "./src/test/resources/authentication/tls/cacert.pem";
@@ -76,29 +71,24 @@ public class TlsProducerConsumerBase extends ProducerConsumerBase {
     }
 
     protected void internalSetUpForClient(boolean addCertificates, String lookupUrl) throws Exception {
-        ClientConfiguration clientConf = new ClientConfiguration();
-        clientConf.setTlsTrustCertsFilePath(TLS_TRUST_CERT_FILE_PATH);
-        clientConf.setUseTls(true);
-        clientConf.setTlsAllowInsecureConnection(false);
+        ClientBuilder clientBuilder = PulsarClient.builder().serviceUrl(lookupUrl)
+                .tlsTrustCertsFilePath(TLS_TRUST_CERT_FILE_PATH).enableTls(true).allowTlsInsecureConnection(false);
         if (addCertificates) {
             Map<String, String> authParams = new HashMap<>();
             authParams.put("tlsCertFile", TLS_CLIENT_CERT_FILE_PATH);
             authParams.put("tlsKeyFile", TLS_CLIENT_KEY_FILE_PATH);
-            clientConf.setAuthentication(AuthenticationTls.class.getName(), authParams);
+            clientBuilder.authentication(AuthenticationTls.class.getName(), authParams);
         }
-        pulsarClient = PulsarClient.create(lookupUrl, clientConf);
+        pulsarClient = clientBuilder.build();
     }
 
     protected void internalSetUpForNamespace() throws Exception {
-        ClientConfiguration clientConf = new ClientConfiguration();
-        clientConf.setTlsTrustCertsFilePath(TLS_TRUST_CERT_FILE_PATH);
-        clientConf.setUseTls(true);
-        clientConf.setTlsAllowInsecureConnection(false);
         Map<String, String> authParams = new HashMap<>();
         authParams.put("tlsCertFile", TLS_CLIENT_CERT_FILE_PATH);
         authParams.put("tlsKeyFile", TLS_CLIENT_KEY_FILE_PATH);
-        clientConf.setAuthentication(AuthenticationTls.class.getName(), authParams);
-        admin = spy(new PulsarAdmin(brokerUrlTls, clientConf));
+        admin = spy(PulsarAdmin.builder().serviceHttpUrl(brokerUrlTls.toString())
+                .tlsTrustCertsFilePath(TLS_TRUST_CERT_FILE_PATH).allowTlsInsecureConnection(false)
+                .authentication(AuthenticationTls.class.getName(), authParams).build());
         admin.clusters().createCluster(clusterName, new ClusterData(brokerUrl.toString(), brokerUrlTls.toString(),
                 "pulsar://localhost:" + BROKER_PORT, "pulsar+ssl://localhost:" + BROKER_PORT_TLS));
         admin.properties().createProperty("my-property",

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/BrokerClientIntegrationTest.java
@@ -440,7 +440,7 @@ public class BrokerClientIntegrationTest extends ProducerConsumerBase {
         received.clear();
 
         log.info("reset cursor to " + timestamp + " for topic " + topicName.toString() + " for subs " + subsId);
-        log.info("issuing admin operation on " + admin.getServiceUrl().toString());
+        log.info("issuing admin operation on " + admin.getServiceUrl());
         List<String> subList = admin.persistentTopics().getSubscriptions(topicName.toString());
         for (String subs : subList) {
             log.info("got sub " + subs);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/stats/client/PulsarBrokerStatsClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/stats/client/PulsarBrokerStatsClientTest.java
@@ -68,7 +68,7 @@ public class PulsarBrokerStatsClientTest extends ProducerConsumerBase {
     @Test
     public void testServiceException() throws Exception {
         URL url = new URL("http://localhost:15000");
-        PulsarAdmin admin = new PulsarAdmin(url, (Authentication) null);
+        PulsarAdmin admin = PulsarAdmin.builder().serviceHttpUrl(url.toString()).build();
         BrokerStatsImpl client = (BrokerStatsImpl) spy(admin.brokerStats());
         try {
             client.getLoadReport();

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PulsarAdminBuilder.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PulsarAdminBuilder.java
@@ -1,0 +1,162 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.admin;
+
+import java.util.Map;
+
+import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.PulsarClientException.UnsupportedAuthenticationException;
+
+/**
+ * Builder class for a {@link PulsarAdmin} instance.
+ *
+ */
+public interface PulsarAdminBuilder {
+
+    /**
+     * @return the new {@link PulsarAdmin} instance
+     */
+    PulsarAdmin build() throws PulsarClientException;
+
+    /**
+     * Create a copy of the current client builder.
+     * <p>
+     * Cloning the builder can be used to share an incomplete configuration and specialize it multiple times. For
+     * example:
+     *
+     * <pre>
+     * PulsarAdminBuilder builder = PulsarAdmin.builder().allowTlsInsecureConnection(false);
+     *
+     * PulsarAdmin client1 = builder.clone().serviceHttpUrl(URL_1).build();
+     * PulsarAdmin client2 = builder.clone().serviceHttpUrl(URL_2).build();
+     * </pre>
+     */
+    PulsarAdminBuilder clone();
+
+    /**
+     * Set the Pulsar service HTTP URL for the admin endpoint (eg. "http://my-broker.example.com:8080", or
+     * "https://my-broker.example.com:8443" for TLS)
+     */
+    PulsarAdminBuilder serviceHttpUrl(String serviceHttpUrl);
+
+    /**
+     * Set the authentication provider to use in the Pulsar client instance.
+     * <p>
+     * Example:
+     * <p>
+     *
+     * <pre>
+     * <code>
+     * String AUTH_CLASS = "org.apache.pulsar.client.impl.auth.AuthenticationTls";
+     * String AUTH_PARAMS = "tlsCertFile:/my/cert/file,tlsKeyFile:/my/key/file";
+     *
+     * PulsarAdmin client = PulsarAdmin.builder()
+     *          .serviceHttpUrl(SERVICE_HTTP_URL)
+     *          .authentication(AUTH_CLASS, AUTH_PARAMS)
+     *          .build();
+     * ....
+     * </code>
+     * </pre>
+     *
+     * @param authPluginClassName
+     *            name of the Authentication-Plugin you want to use
+     * @param authParamsString
+     *            string which represents parameters for the Authentication-Plugin, e.g., "key1:val1,key2:val2"
+     * @throws UnsupportedAuthenticationException
+     *             failed to instantiate specified Authentication-Plugin
+     */
+    PulsarAdminBuilder authentication(String authPluginClassName, String authParamsString)
+            throws UnsupportedAuthenticationException;
+
+    /**
+     * Set the authentication provider to use in the Pulsar client instance.
+     * <p>
+     * Example:
+     * <p>
+     *
+     * <pre>
+     * <code>
+     * String AUTH_CLASS = "org.apache.pulsar.client.impl.auth.AuthenticationTls";
+     *
+     * Map<String, String> conf = new TreeMap<>();
+     * conf.put("tlsCertFile", "/my/cert/file");
+     * conf.put("tlsKeyFile", "/my/key/file");
+     *
+     * PulsarAdmin client = PulsarAdmin.builder()
+     *          .serviceHttpUrl(SERVICE_HTTP_URL)
+     *          .authentication(AUTH_CLASS, conf)
+     *          .build();
+     * ....
+     * </code>
+     *
+     * @param authPluginClassName
+     *            name of the Authentication-Plugin you want to use
+     * @param authParams
+     *            map which represents parameters for the Authentication-Plugin
+     * @throws UnsupportedAuthenticationException
+     *             failed to instantiate specified Authentication-Plugin
+     */
+    PulsarAdminBuilder authentication(String authPluginClassName, Map<String, String> authParams)
+            throws UnsupportedAuthenticationException;
+
+    /**
+     * Set the authentication provider to use in the Pulsar admin instance.
+     * <p>
+     * Example:
+     * <p>
+     *
+     * <pre>
+     * <code>
+     * String AUTH_CLASS = "org.apache.pulsar.client.impl.auth.AuthenticationTls";
+     *
+     * Map<String, String> conf = new TreeMap<>();
+     * conf.put("tlsCertFile", "/my/cert/file");
+     * conf.put("tlsKeyFile", "/my/key/file");
+     *
+     * Authentication auth = AuthenticationFactor.create(AUTH_CLASS, conf);
+     *
+     * PulsarAdmin admin = PulsarAdmin.builder()
+     *          .serviceHttpUrl(SERVICE_URL)
+     *          .authentication(auth)
+     *          .build();
+     * ....
+     * </code>
+     * </pre>
+     *
+     * @param authentication
+     *            an instance of the {@link Authentication} provider already constructed
+     */
+    PulsarAdminBuilder authentication(Authentication authentication);
+
+    /**
+     * Set the path to the trusted TLS certificate file
+     *
+     * @param tlsTrustCertsFilePath
+     */
+    PulsarAdminBuilder tlsTrustCertsFilePath(String tlsTrustCertsFilePath);
+
+    /**
+     * Configure whether the Pulsar admin client accept untrusted TLS certificate from broker <i>(default: false)</i>
+     *
+     * @param allowTlsInsecureConnection
+     */
+    PulsarAdminBuilder allowTlsInsecureConnection(boolean allowTlsInsecureConnection);
+
+}

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImpl.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.admin.internal;
+
+import java.util.Map;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminBuilder;
+import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.client.api.AuthenticationFactory;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.PulsarClientException.UnsupportedAuthenticationException;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+
+public class PulsarAdminBuilderImpl implements PulsarAdminBuilder {
+
+    protected final ClientConfigurationData conf;
+
+    @Override
+    public PulsarAdmin build() throws PulsarClientException {
+        return new PulsarAdmin(conf.getServiceUrl(), conf);
+    }
+
+    public PulsarAdminBuilderImpl() {
+        this.conf = new ClientConfigurationData();
+    }
+
+    private PulsarAdminBuilderImpl(ClientConfigurationData conf) {
+        this.conf = conf;
+    }
+
+    @Override
+    public PulsarAdminBuilder clone() {
+        return new PulsarAdminBuilderImpl(conf.clone());
+    }
+
+    @Override
+    public PulsarAdminBuilder serviceHttpUrl(String serviceHttpUrl) {
+        conf.setServiceUrl(serviceHttpUrl);
+        return this;
+    }
+
+    @Override
+    public PulsarAdminBuilder authentication(Authentication authentication) {
+        conf.setAuthentication(authentication);
+        return this;
+    }
+
+    @Override
+    public PulsarAdminBuilder authentication(String authPluginClassName, Map<String, String> authParams)
+            throws UnsupportedAuthenticationException {
+        conf.setAuthentication(AuthenticationFactory.create(authPluginClassName, authParams));
+        return this;
+    }
+
+    @Override
+    public PulsarAdminBuilder authentication(String authPluginClassName, String authParamsString)
+            throws UnsupportedAuthenticationException {
+        conf.setAuthentication(AuthenticationFactory.create(authPluginClassName, authParamsString));
+        return this;
+    }
+
+    @Override
+    public PulsarAdminBuilder tlsTrustCertsFilePath(String tlsTrustCertsFilePath) {
+        conf.setTlsTrustCertsFilePath(tlsTrustCertsFilePath);
+        return this;
+    }
+
+    @Override
+    public PulsarAdminBuilder allowTlsInsecureConnection(boolean allowTlsInsecureConnection) {
+        conf.setTlsAllowInsecureConnection(allowTlsInsecureConnection);
+        return this;
+    }
+}

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/CmdFunctionsTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/CmdFunctionsTest.java
@@ -103,7 +103,7 @@ public class CmdFunctionsTest {
         this.admin = mock(PulsarAdminWithFunctions.class);
         this.functions = mock(Functions.class);
         when(admin.functions()).thenReturn(functions);
-        when(admin.getServiceUrl()).thenReturn(URI.create("http://localhost:1234").toURL());
+        when(admin.getServiceUrl()).thenReturn("http://localhost:1234");
         when(admin.getClientConf()).thenReturn(new ClientConfigurationData());
         this.cmd = new CmdFunctions(admin);
 

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -22,7 +22,9 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertEquals;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 import java.util.EnumSet;
 
@@ -50,9 +52,6 @@ import org.mockito.ArgumentMatcher;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 
 @Test
 public class PulsarAdminToolTest {
@@ -534,18 +533,6 @@ public class PulsarAdminToolTest {
         topics.run(split("list-in-bundle myprop/clust/ns1 --bundle 0x23d70a30_0x26666658"));
         verify(mockTopics).getListInBundle("myprop/clust/ns1", "0x23d70a30_0x26666658");
 
-    }
-
-    @Test
-    void tool() throws Exception {
-        java.util.Properties properties = new java.util.Properties();
-        properties.setProperty("serviceUrl", "http://api.messaging.use.example.com:8080");
-        PulsarAdminTool tool = new PulsarAdminTool(properties);
-
-        assertEquals(tool.run(new String[0]), false);
-        assertEquals(tool.run(split("clusters list")), false);
-        assertEquals(tool.run(split("invalid")), false);
-        assertEquals(tool.run(split("--help")), false);
     }
 
     String[] split(String s) {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/admin/PulsarAdminWithFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/admin/PulsarAdminWithFunctions.java
@@ -19,35 +19,27 @@
 package org.apache.pulsar.client.admin;
 
 import org.apache.pulsar.client.admin.internal.FunctionsImpl;
-import org.apache.pulsar.client.api.*;
-
+import org.apache.pulsar.client.admin.internal.PulsarAdminBuilderImpl;
+import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.net.URL;
 
 
 /**
  * Pulsar client admin client with functions support.
  */
 public class PulsarAdminWithFunctions extends PulsarAdmin {
-    private static final Logger LOG = LoggerFactory.getLogger(PulsarAdminWithFunctions.class);
 
     private final Functions functions;
     private final ClientConfigurationData clientConf;
 
     /**
-     * Construct a new Pulsar Admin client object.
-     * <p>
-     * This client object can be used to perform many subsquent API calls
-     *
-     * @param serviceUrl
-     *            the Pulsar service URL (eg. "http://my-broker.example.com:8080")
-     * @param pulsarConfig
-     *            the ClientConfiguration object to be used to talk with Pulsar
+     * Creates a builder to construct an instance of {@link PulsarAdminWithFunctions}.
      */
-    public PulsarAdminWithFunctions(URL serviceUrl, ClientConfigurationData pulsarConfig) throws PulsarClientException {
+    public static PulsarAdminBuilder builder() {
+        return new PulsarAdminBuilderImpl();
+    }
+
+    PulsarAdminWithFunctions(String serviceUrl, ClientConfigurationData pulsarConfig) throws PulsarClientException {
         super(serviceUrl, pulsarConfig);
         this.functions = new FunctionsImpl(root, auth);
         this.clientConf = pulsarConfig;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/admin/PulsarAdminWithFunctionsBuilderImpl.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/admin/PulsarAdminWithFunctionsBuilderImpl.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.admin;
+
+import org.apache.pulsar.client.admin.internal.PulsarAdminBuilderImpl;
+import org.apache.pulsar.client.api.PulsarClientException;
+
+public class PulsarAdminWithFunctionsBuilderImpl extends PulsarAdminBuilderImpl {
+    @Override
+    public PulsarAdmin build() throws PulsarClientException {
+        return new PulsarAdminWithFunctions(conf.getServiceUrl(), conf);
+    }
+}

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/Utils.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/Utils.java
@@ -176,22 +176,12 @@ public final class Utils {
     }
 
     public static PulsarAdmin getPulsarAdminClient(String pulsarWebServiceUrl) {
-        URL url = null;
         try {
-            url = new URL(pulsarWebServiceUrl);
-        } catch (MalformedURLException e) {
-            log.error("Error when parsing pulsar web service url", e);
-            throw new RuntimeException(e);
-        }
-
-        PulsarAdmin admin = null;
-        try {
-            admin = new PulsarAdmin(url, new org.apache.pulsar.client.api.ClientConfiguration());
+            return PulsarAdmin.builder().serviceHttpUrl(pulsarWebServiceUrl).build();
         } catch (PulsarClientException e) {
             log.error("Error creating pulsar admin client", e);
             throw new RuntimeException(e);
         }
-        return admin;
     }
 
     public static String getFullyQualifiedInstanceId(Function.Instance instance) {

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyAuthenticatedProducerConsumerTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyAuthenticatedProducerConsumerTest.java
@@ -195,14 +195,8 @@ public class ProxyAuthenticatedProducerConsumerTest extends ProducerConsumerBase
     }
 
     protected final PulsarClient createPulsarClient(Authentication auth, String lookupUrl) throws Exception {
-        org.apache.pulsar.client.api.ClientConfiguration clientConf = new org.apache.pulsar.client.api.ClientConfiguration();
-        clientConf.setStatsInterval(0, TimeUnit.SECONDS);
-        clientConf.setTlsTrustCertsFilePath(TLS_TRUST_CERT_FILE_PATH);
-        clientConf.setTlsAllowInsecureConnection(true);
-        clientConf.setAuthentication(auth);
-        clientConf.setUseTls(true);
-
-        admin = spy(new PulsarAdmin(brokerUrlTls, clientConf));
+        admin = spy(PulsarAdmin.builder().serviceHttpUrl(brokerUrlTls.toString()).tlsTrustCertsFilePath(TLS_TRUST_CERT_FILE_PATH)
+                .allowTlsInsecureConnection(true).authentication(auth).build());
         return PulsarClient.builder().serviceUrl(lookupUrl).statsInterval(0, TimeUnit.SECONDS)
                 .tlsTrustCertsFilePath(TLS_TRUST_CERT_FILE_PATH).allowTlsInsecureConnection(true).authentication(auth)
                 .enableTls(true).build();

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyForwardAuthDataTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyForwardAuthDataTest.java
@@ -135,10 +135,8 @@ public class ProxyForwardAuthDataTest extends ProducerConsumerBase {
 
     private void createAdminClient() throws PulsarClientException {
         String adminAuthParams = "authParam:admin";
-        org.apache.pulsar.client.api.ClientConfiguration clientConf = new org.apache.pulsar.client.api.ClientConfiguration();
-        clientConf.setAuthentication(BasicAuthentication.class.getName(), adminAuthParams);
-
-        admin = spy(new PulsarAdmin(brokerUrl, clientConf));
+        admin = spy(PulsarAdmin.builder().serviceHttpUrl(brokerUrl.toString())
+                .authentication(BasicAuthentication.class.getName(), adminAuthParams).build());
     }
 
     private PulsarClient createPulsarClient(String proxyServiceUrl, String authParams) throws PulsarClientException {

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyRolesEnforcementTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyRolesEnforcementTest.java
@@ -42,6 +42,7 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.PropertyAdmin;
+import org.apache.pulsar.proxy.server.ProxyRolesEnforcementTest.BasicAuthentication;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -246,10 +247,8 @@ public class ProxyRolesEnforcementTest extends ProducerConsumerBase {
 
     private void createAdminClient() throws PulsarClientException {
         String adminAuthParams = "authParam:admin";
-        org.apache.pulsar.client.api.ClientConfiguration clientConf = new org.apache.pulsar.client.api.ClientConfiguration();
-        clientConf.setAuthentication(BasicAuthentication.class.getName(), adminAuthParams);
-
-        admin = spy(new PulsarAdmin(brokerUrl, clientConf));
+        admin = spy(PulsarAdmin.builder().serviceHttpUrl(brokerUrl.toString())
+                .authentication(BasicAuthentication.class.getName(), adminAuthParams).build());
     }
 
     private PulsarClient createPulsarClient(String proxyServiceUrl, String authParams) throws PulsarClientException {

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithAuthorizationNegTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithAuthorizationNegTest.java
@@ -220,16 +220,10 @@ public class ProxyWithAuthorizationNegTest extends ProducerConsumerBase {
         Map<String, String> authParams = Maps.newHashMap();
         authParams.put("tlsCertFile", TLS_SUPERUSER_CLIENT_CERT_FILE_PATH);
         authParams.put("tlsKeyFile", TLS_SUPERUSER_CLIENT_KEY_FILE_PATH);
-        Authentication authTls = new AuthenticationTls();
-        authTls.configure(authParams);
-        org.apache.pulsar.client.api.ClientConfiguration clientConf = new org.apache.pulsar.client.api.ClientConfiguration();
-        clientConf.setStatsInterval(0, TimeUnit.SECONDS);
-        clientConf.setTlsTrustCertsFilePath(TLS_BROKER_TRUST_CERT_FILE_PATH);
-        clientConf.setTlsAllowInsecureConnection(true);
-        clientConf.setAuthentication(authTls);
-        clientConf.setUseTls(true);
 
-        admin = spy(new PulsarAdmin(brokerUrlTls, clientConf));
+        admin = spy(PulsarAdmin.builder().serviceHttpUrl(brokerUrlTls.toString())
+                .tlsTrustCertsFilePath(TLS_BROKER_TRUST_CERT_FILE_PATH).allowTlsInsecureConnection(true)
+                .authentication(AuthenticationTls.class.getName(), authParams).build());
     }
 
     @SuppressWarnings("deprecation")

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithAuthorizationTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithAuthorizationTest.java
@@ -436,16 +436,10 @@ public class ProxyWithAuthorizationTest extends ProducerConsumerBase {
         Map<String, String> authParams = Maps.newHashMap();
         authParams.put("tlsCertFile", TLS_SUPERUSER_CLIENT_CERT_FILE_PATH);
         authParams.put("tlsKeyFile", TLS_SUPERUSER_CLIENT_KEY_FILE_PATH);
-        Authentication authTls = new AuthenticationTls();
-        authTls.configure(authParams);
-        org.apache.pulsar.client.api.ClientConfiguration clientConf = new org.apache.pulsar.client.api.ClientConfiguration();
-        clientConf.setStatsInterval(0, TimeUnit.SECONDS);
-        clientConf.setTlsTrustCertsFilePath(TLS_PROXY_TRUST_CERT_FILE_PATH);
-        clientConf.setTlsAllowInsecureConnection(true);
-        clientConf.setAuthentication(authTls);
-        clientConf.setUseTls(true);
 
-        admin = spy(new PulsarAdmin(brokerUrlTls, clientConf));
+        admin = spy(PulsarAdmin.builder().serviceHttpUrl(brokerUrlTls.toString())
+                .tlsTrustCertsFilePath(TLS_PROXY_TRUST_CERT_FILE_PATH).allowTlsInsecureConnection(true)
+                .authentication(AuthenticationTls.class.getName(), authParams).build());
     }
 
     @SuppressWarnings("deprecation")

--- a/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithoutServiceDiscoveryTest.java
+++ b/pulsar-proxy/src/test/java/org/apache/pulsar/proxy/server/ProxyWithoutServiceDiscoveryTest.java
@@ -188,14 +188,8 @@ public class ProxyWithoutServiceDiscoveryTest extends ProducerConsumerBase {
     }
 
     protected final PulsarClient createPulsarClient(Authentication auth, String lookupUrl) throws Exception {
-        org.apache.pulsar.client.api.ClientConfiguration clientConf = new org.apache.pulsar.client.api.ClientConfiguration();
-        clientConf.setStatsInterval(0, TimeUnit.SECONDS);
-        clientConf.setTlsTrustCertsFilePath(TLS_TRUST_CERT_FILE_PATH);
-        clientConf.setTlsAllowInsecureConnection(true);
-        clientConf.setAuthentication(auth);
-        clientConf.setUseTls(true);
-
-        admin = spy(new PulsarAdmin(brokerUrlTls, clientConf));
+        admin = spy(PulsarAdmin.builder().serviceHttpUrl(brokerUrlTls.toString()).tlsTrustCertsFilePath(TLS_TRUST_CERT_FILE_PATH)
+                .allowTlsInsecureConnection(true).authentication(auth).build());
         return PulsarClient.builder().serviceUrl(lookupUrl).statsInterval(0, TimeUnit.SECONDS)
                 .tlsTrustCertsFilePath(TLS_TRUST_CERT_FILE_PATH).allowTlsInsecureConnection(true).authentication(auth)
                 .enableTls(true).build();


### PR DESCRIPTION
### Motivation

`PulsarAdmin` was taking a `ClientConfiguration`  object from `pulsar-client`. The `ClientConfiguration` class has been now deprecated and in any case it was not really appropriate for the `PulsarAdmin` since it just needs to get the configuration for the authentication plugin

### Modifications

 * Deprecated current constructors for `PulsarAdmin`
 * Added builder to configure and construct `PulsarAdmin` instance, consistent with `PulsarClient` API.
 * Updated all usages to new API