### PR TITLE
Ignore log4j coming from bookkeeper-server:tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -746,6 +746,14 @@ flexible messaging model and an intuitive client API.</description>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
         </exclusion>
+        <exclusion>
+          <artifactId>log4j</artifactId>
+            <groupId>log4j</groupId>
+        </exclusion>
+          <exclusion>
+            <groupId>org.jboss.netty</groupId>
+            <artifactId>netty</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
   </dependencies>


### PR DESCRIPTION
### Motivation

`bookkeeper-server:tests` is pulling in the log4j-1.2.x version together with the 2.x we're already using (and has a different groupId).