### PR TITLE
Make it possible to get namespaces owned by broker when TLS is enabled

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -276,7 +276,9 @@ public abstract class AdminResource extends PulsarWebResource {
      */
     protected void validateBrokerName(String broker) throws MalformedURLException {
         String brokerUrl = String.format("http://%s", broker);
-        if (!pulsar().getWebServiceAddress().equals(brokerUrl)) {
+        String brokerUrlTls = String.format("https://%s", broker);
+        if (!pulsar().getWebServiceAddress().equals(brokerUrl)
+                && !pulsar().getWebServiceAddressTls().equals(brokerUrlTls)) {
             String[] parts = broker.split(":");
             checkArgument(parts.length == 2, "Invalid broker url %s", broker);
             String host = parts[0];


### PR DESCRIPTION
### Motivation

If TLS is enabled, `pulsar-admin brokers namespaces` command does not work properly.
```sh
# port 8080 is used by http
$ sudo pulsar-admin brokers namespaces --url broker1.example.com:8080 cluster1

null

Reason: javax.ws.rs.ProcessingException: javax.net.ssl.SSLException: Unrecognized SSL message, plaintext connection?

# port 8443 is used by https
$ sudo pulsar-admin brokers namespaces --url broker1.example.com:8443 cluster1

null

Reason: javax.ws.rs.ProcessingException: java.net.ProtocolException: Server redirected too many  times (20)
```

When specifying a broker name whose port is 8080 using `--url` option, the redirection URL whose scheme is https and whose port is http is returned. Therefore, SSLException seems to occur.

> Location: https://broker1.example.com:8080/admin/brokers/cluster1/broker1.example.com:8080/ownedNamespaces

On the other hand, when specifying a broker name whose port is 8443, `broker1.example.com` does not process that request. As a consequence, a redirection loop occurs.

### Modifications

Fixed `AdminResource#validateBrokerName()` not to redirect the request if the specified broker name is equal to either `webServiceAddress` or `webServiceAddressTls`.

### Result

Even if TLS is enabled, the command will work properly.