### PR TITLE
Enforce timeout on all TestNG tests, thread dump on timeout

### DIFF
--- a/buildtools/src/main/java/org/apache/pulsar/tests/AnnotationListener.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/AnnotationListener.java
@@ -27,9 +27,19 @@ import org.testng.annotations.ITestAnnotation;
 @SuppressWarnings("rawtypes")
 public class AnnotationListener implements IAnnotationTransformer {
 
+    private static final int DEFAULT_TEST_TIMEOUT_MILLIS = 30000;
+
+    public AnnotationListener() {
+        System.out.println("Created annotation listener");
+    }
+
     @Override
     public void transform(ITestAnnotation annotation, Class testClass, Constructor testConstructor, Method testMethod) {
         annotation.setRetryAnalyzer(RetryAnalyzer.class);
-    }
 
+        // Enforce default test timeout
+        if (annotation.getTimeOut() == 0) {
+            annotation.setTimeOut(DEFAULT_TEST_TIMEOUT_MILLIS);
+        }
+    }
 }

--- a/buildtools/src/main/java/org/apache/pulsar/tests/AnnotationListener.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/AnnotationListener.java
@@ -27,7 +27,7 @@ import org.testng.annotations.ITestAnnotation;
 @SuppressWarnings("rawtypes")
 public class AnnotationListener implements IAnnotationTransformer {
 
-    private static final int DEFAULT_TEST_TIMEOUT_MILLIS = 30000;
+    private static final int DEFAULT_TEST_TIMEOUT_MILLIS = 120000;
 
     public AnnotationListener() {
         System.out.println("Created annotation listener");

--- a/buildtools/src/main/java/org/apache/pulsar/tests/PulsarTestListener.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/PulsarTestListener.java
@@ -20,8 +20,6 @@ package org.apache.pulsar.tests;
 
 import java.util.Arrays;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.ITestContext;
 import org.testng.ITestListener;
 import org.testng.ITestResult;
@@ -31,31 +29,30 @@ public class PulsarTestListener implements ITestListener {
 
     @Override
     public void onTestStart(ITestResult result) {
-        log.info("------- Starting test {}.{}({})-------", result.getTestClass(), result.getTestName(),
+        System.out.format("------- Starting test %s.%s(%s)-------\n", result.getTestClass(), result.getTestName(),
                 Arrays.toString(result.getParameters()));
     }
 
     @Override
     public void onTestSuccess(ITestResult result) {
-        log.info("------- SUCCESS -- {}.{}({})-------", result.getTestClass(), result.getTestName(),
+        System.out.format("------- SUCCESS -- %s.%s(%s)-------", result.getTestClass(), result.getTestName(),
                 Arrays.toString(result.getParameters()));
     }
 
     @Override
     public void onTestFailure(ITestResult result) {
-        log.info("!!!!!!!!! FAILURE-- {}.{}({})-------", result.getTestClass(), result.getTestName(),
+        System.out.format("!!!!!!!!! FAILURE-- %s.%s(%s)-------\n", result.getTestClass(), result.getTestName(),
                 Arrays.toString(result.getParameters()));
-        log.info("!!!!!!!!! FAILURE -- ", result.getThrowable());
 
         if (result.getThrowable() instanceof ThreadTimeoutException) {
-            log.info("====== THREAD DUMPS ======");
+            System.out.println("====== THREAD DUMPS ======");
             System.out.println(ThreadDumpUtil.buildThreadDiagnosticString());
         }
     }
 
     @Override
     public void onTestSkipped(ITestResult result) {
-        log.info("~~~~~~~~~ SKIPPED -- {}.{}({})-------", result.getTestClass(), result.getTestName(),
+        System.out.format("~~~~~~~~~ SKIPPED -- %s.%s(%s)-------", result.getTestClass(), result.getTestName(),
                 Arrays.toString(result.getParameters()));
     }
 
@@ -73,6 +70,4 @@ public class PulsarTestListener implements ITestListener {
     public void onFinish(ITestContext context) {
 
     }
-
-    private static final Logger log = LoggerFactory.getLogger(PulsarTestListener.class);
 }

--- a/buildtools/src/main/java/org/apache/pulsar/tests/PulsarTestListener.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/PulsarTestListener.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests;
+
+import java.util.Arrays;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.ITestContext;
+import org.testng.ITestListener;
+import org.testng.ITestResult;
+import org.testng.internal.thread.ThreadTimeoutException;
+
+public class PulsarTestListener implements ITestListener {
+
+    @Override
+    public void onTestStart(ITestResult result) {
+        log.info("------- Starting test {}.{}({})-------", result.getTestClass(), result.getTestName(),
+                Arrays.toString(result.getParameters()));
+    }
+
+    @Override
+    public void onTestSuccess(ITestResult result) {
+        log.info("------- SUCCESS -- {}.{}({})-------", result.getTestClass(), result.getTestName(),
+                Arrays.toString(result.getParameters()));
+    }
+
+    @Override
+    public void onTestFailure(ITestResult result) {
+        log.info("!!!!!!!!! FAILURE-- {}.{}({})-------", result.getTestClass(), result.getTestName(),
+                Arrays.toString(result.getParameters()));
+        log.info("!!!!!!!!! FAILURE -- ", result.getThrowable());
+
+        if (result.getThrowable() instanceof ThreadTimeoutException) {
+            log.info("====== THREAD DUMPS ======");
+            System.out.println(ThreadDumpUtil.buildThreadDiagnosticString());
+        }
+    }
+
+    @Override
+    public void onTestSkipped(ITestResult result) {
+        log.info("~~~~~~~~~ SKIPPED -- {}.{}({})-------", result.getTestClass(), result.getTestName(),
+                Arrays.toString(result.getParameters()));
+    }
+
+    @Override
+    public void onTestFailedButWithinSuccessPercentage(ITestResult result) {
+
+    }
+
+    @Override
+    public void onStart(ITestContext context) {
+
+    }
+
+    @Override
+    public void onFinish(ITestContext context) {
+
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(PulsarTestListener.class);
+}

--- a/buildtools/src/main/java/org/apache/pulsar/tests/ThreadDumpUtil.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/ThreadDumpUtil.java
@@ -1,0 +1,148 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.management.LockInfo;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MonitorInfo;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Map;
+
+/**
+ * Adapted from Hadoop TimedOutTestsListener
+ *
+ * https://raw.githubusercontent.com/apache/hadoop/master/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/test/TimedOutTestsListener.java
+ */
+public class ThreadDumpUtil {
+    static final String TEST_TIMED_OUT_PREFIX = "test timed out after";
+
+    private static String INDENT = "    ";
+
+    public static String buildThreadDiagnosticString() {
+        StringWriter sw = new StringWriter();
+        PrintWriter output = new PrintWriter(sw);
+
+        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss,SSS");
+        output.println(String.format("Timestamp: %s", dateFormat.format(new Date())));
+        output.println();
+        output.println(buildThreadDump());
+
+        String deadlocksInfo = buildDeadlockInfo();
+        if (deadlocksInfo != null) {
+            output.println("====> DEADLOCKS DETECTED <====");
+            output.println();
+            output.println(deadlocksInfo);
+        }
+
+        return sw.toString();
+    }
+
+    static String buildThreadDump() {
+        StringBuilder dump = new StringBuilder();
+        Map<Thread, StackTraceElement[]> stackTraces = Thread.getAllStackTraces();
+        for (Map.Entry<Thread, StackTraceElement[]> e : stackTraces.entrySet()) {
+            Thread thread = e.getKey();
+            dump.append('\n');
+            dump.append(String.format("\"%s\" %s prio=%d tid=%d %s\njava.lang.Thread.State: %s", thread.getName(),
+                    (thread.isDaemon() ? "daemon" : ""), thread.getPriority(), thread.getId(),
+                    Thread.State.WAITING.equals(thread.getState()) ? "in Object.wait()" : thread.getState().name(),
+                    Thread.State.WAITING.equals(thread.getState()) ? "WAITING (on object monitor)"
+                            : thread.getState()));
+            for (StackTraceElement stackTraceElement : e.getValue()) {
+                dump.append("\n        at ");
+                dump.append(stackTraceElement);
+            }
+            dump.append("\n");
+        }
+        return dump.toString();
+    }
+
+    static String buildDeadlockInfo() {
+        ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
+        long[] threadIds = threadBean.findMonitorDeadlockedThreads();
+        if (threadIds != null && threadIds.length > 0) {
+            StringWriter stringWriter = new StringWriter();
+            PrintWriter out = new PrintWriter(stringWriter);
+
+            ThreadInfo[] infos = threadBean.getThreadInfo(threadIds, true, true);
+            for (ThreadInfo ti : infos) {
+                printThreadInfo(ti, out);
+                printLockInfo(ti.getLockedSynchronizers(), out);
+                out.println();
+            }
+
+            out.close();
+            return stringWriter.toString();
+        } else {
+            return null;
+        }
+    }
+
+    private static void printThreadInfo(ThreadInfo ti, PrintWriter out) {
+        // print thread information
+        printThread(ti, out);
+
+        // print stack trace with locks
+        StackTraceElement[] stacktrace = ti.getStackTrace();
+        MonitorInfo[] monitors = ti.getLockedMonitors();
+        for (int i = 0; i < stacktrace.length; i++) {
+            StackTraceElement ste = stacktrace[i];
+            out.println(INDENT + "at " + ste.toString());
+            for (MonitorInfo mi : monitors) {
+                if (mi.getLockedStackDepth() == i) {
+                    out.println(INDENT + "  - locked " + mi);
+                }
+            }
+        }
+        out.println();
+    }
+
+    private static void printThread(ThreadInfo ti, PrintWriter out) {
+        out.println();
+        out.print("\"" + ti.getThreadName() + "\"" + " Id=" + ti.getThreadId() + " in " + ti.getThreadState());
+        if (ti.getLockName() != null) {
+            out.print(" on lock=" + ti.getLockName());
+        }
+        if (ti.isSuspended()) {
+            out.print(" (suspended)");
+        }
+        if (ti.isInNative()) {
+            out.print(" (running in native)");
+        }
+        out.println();
+        if (ti.getLockOwnerName() != null) {
+            out.println(INDENT + " owned by " + ti.getLockOwnerName() + " Id=" + ti.getLockOwnerId());
+        }
+    }
+
+    private static void printLockInfo(LockInfo[] locks, PrintWriter out) {
+        out.println(INDENT + "Locked synchronizers: count = " + locks.length);
+        for (LockInfo li : locks) {
+            out.println(INDENT + "  - " + li);
+        }
+        out.println();
+    }
+
+}

--- a/managed-ledger/pom.xml
+++ b/managed-ledger/pom.xml
@@ -96,18 +96,6 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <properties>
-            <property>
-              <name>listener</name>
-              <value>org.apache.pulsar.tests.AnnotationListener</value>
-            </property>
-          </properties>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -809,6 +809,12 @@ flexible messaging model and an intuitive client API.</description>
           <forkCount>1</forkCount>
           <redirectTestOutputToFile>${redirectTestOutputToFile}</redirectTestOutputToFile>
           <trimStackTrace>false</trimStackTrace>
+          <properties>
+            <property>
+              <name>listener</name>
+              <value>org.apache.pulsar.tests.PulsarTestListener,org.apache.pulsar.tests.AnnotationListener</value>
+            </property>
+          </properties>
         </configuration>
       </plugin>
 
@@ -962,7 +968,7 @@ flexible messaging model and an intuitive client API.</description>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.20</version>
+          <version>2.21.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -269,18 +269,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <properties>
-            <property>
-              <name>listener</name>
-              <value>org.apache.pulsar.tests.AnnotationListener</value>
-            </property>
-          </properties>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>1.10</version>

--- a/pulsar-discovery-service/pom.xml
+++ b/pulsar-discovery-service/pom.xml
@@ -142,21 +142,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <properties>
-            <property>
-              <name>listener</name>
-              <value>org.apache.pulsar.tests.AnnotationListener</value>
-            </property>
-          </properties>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>


### PR DESCRIPTION
### Motivation

 * We have many tests which don't have a `timeOut=xxx` parameter on the `@Test` annotation
 * When a timeout happens, we have the stack trace of the main thread, but this thread may be just waiting for other background threads which are deadlocked.

### Modification
 * Enforce 30sec timeout on tests where timeout is not defined
 * Print all threads stack traces when a test timeout happens.