### PR TITLE
Fix race in PersistentTopicTest#testClosingReplicationProducerTwice

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -1205,16 +1205,15 @@ public class PersistentTopicTest {
                 "http://" + pulsar.getAdvertisedAddress() + ":" + pulsar.getConfiguration().getBrokerServicePort());
         PulsarClient client = spy(PulsarClient.builder().serviceUrl(brokerUrl.toString()).build());
         PulsarClientImpl clientImpl = (PulsarClientImpl) client;
+        doReturn(new CompletableFuture<Producer>()).when(clientImpl)
+            .createProducerAsync(any(ProducerConfigurationData.class), any(Schema.class));
 
         ManagedCursor cursor = mock(ManagedCursorImpl.class);
         doReturn(remoteCluster).when(cursor).getName();
         brokerService.getReplicationClients().put(remoteCluster, client);
         PersistentReplicator replicator = new PersistentReplicator(topic, cursor, localCluster, remoteCluster, brokerService);
 
-        doReturn(new CompletableFuture<Producer>()).when(clientImpl)
-                .createProducerAsync(any(ProducerConfigurationData.class));
-
-        replicator.startProducer();
+        // PersistentReplicator constructor calls startProducer()
         verify(clientImpl)
             .createProducerAsync(
                 any(ProducerConfigurationData.class),


### PR DESCRIPTION
A race existed where the replicator was making a startProducer call on
construction before the client was mocked. This startProducer would
fail on producer creation, which would trigger a backoff and a
retry. If this fell exactly the wrong way, it could cause
createProducerAsync to be called multiple times on the mock before the
check, which would fail the test.

This fix addresses issue #617 and it's duplicate #1145
