### PR TITLE
Add compactedOut flag for batched messages

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/CompactedOutBatchMessageTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/CompactedOutBatchMessageTest.java
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import static org.testng.Assert.assertEquals;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+import java.io.IOException;
+
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.ProducerConsumerBase;
+import org.apache.pulsar.client.impl.BatchMessageIdImpl;
+import org.apache.pulsar.common.api.Commands;
+import org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData;
+import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
+import org.apache.pulsar.common.api.proto.PulsarApi.SingleMessageMetadata;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class CompactedOutBatchMessageTest extends ProducerConsumerBase {
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        producerBaseSetup();
+    }
+
+    @AfterMethod
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testCompactedOutMessages() throws Exception {
+        final String ns1 = "my-property/use/con-ns1";
+        admin.namespaces().createNamespace(ns1);
+        final String topic1 = "persistent://" + ns1 + "/my-topic";
+
+        MessageMetadata metadata = MessageMetadata.newBuilder().setProducerName("foobar")
+            .setSequenceId(1).setPublishTime(1).setNumMessagesInBatch(3).build();
+
+        // build a buffer with 4 messages, first and last compacted out
+        ByteBuf batchBuffer = Unpooled.buffer(1000);
+        Commands.serializeSingleMessageInBatchWithPayload(
+                SingleMessageMetadata.newBuilder().setCompactedOut(true).setPartitionKey("key1"),
+                Unpooled.EMPTY_BUFFER, batchBuffer);
+        Commands.serializeSingleMessageInBatchWithPayload(
+                SingleMessageMetadata.newBuilder().setCompactedOut(true).setPartitionKey("key2"),
+                Unpooled.EMPTY_BUFFER, batchBuffer);
+        Commands.serializeSingleMessageInBatchWithPayload(
+                SingleMessageMetadata.newBuilder().setCompactedOut(false).setPartitionKey("key3"),
+                Unpooled.EMPTY_BUFFER, batchBuffer);
+        Commands.serializeSingleMessageInBatchWithPayload(
+                SingleMessageMetadata.newBuilder().setCompactedOut(true).setPartitionKey("key4"),
+                Unpooled.EMPTY_BUFFER, batchBuffer);
+
+        try (ConsumerImpl<byte[]> consumer
+             = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(topic1)
+                .subscriptionName("my-subscriber-name").subscribe()) {
+            // shove it in the sideways
+            consumer.receiveIndividualMessagesFromBatch(metadata, batchBuffer,
+                                                        MessageIdData.newBuilder().setLedgerId(1234)
+                                                        .setEntryId(567).build(), consumer.cnx());
+            Message m = consumer.receive();
+            assertEquals(((BatchMessageIdImpl)m.getMessageId()).getLedgerId(), 1234);
+            assertEquals(((BatchMessageIdImpl)m.getMessageId()).getEntryId(), 567);
+            assertEquals(((BatchMessageIdImpl)m.getMessageId()).getBatchIndex(), 2);
+            assertEquals(m.getKey(), "key3");
+
+            assertEquals(consumer.numMessagesInQueue(), 0);
+        }
+    }
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -947,6 +947,14 @@ public class ConsumerImpl<T> extends ConsumerBase<T> {
                     ++skippedMessages;
                     continue;
                 }
+                if (singleMessageMetadataBuilder.getCompactedOut()) {
+                    // message has been compacted out, so don't send to the user
+                    singleMessagePayload.release();
+                    singleMessageMetadataBuilder.recycle();
+
+                    ++skippedMessages;
+                    continue;
+                }
 
                 BatchMessageIdImpl batchMessageIdImpl = new BatchMessageIdImpl(messageId.getLedgerId(),
                         messageId.getEntryId(), getPartitionIndex(), i);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/Commands.java
@@ -830,6 +830,26 @@ public class Commands {
         return builder.getSequenceId();
     }
 
+    public static ByteBuf serializeSingleMessageInBatchWithPayload(
+            PulsarApi.SingleMessageMetadata.Builder singleMessageMetadataBuilder,
+            ByteBuf payload, ByteBuf batchBuffer) {
+        int payLoadSize = payload.readableBytes();
+        PulsarApi.SingleMessageMetadata singleMessageMetadata = singleMessageMetadataBuilder.setPayloadSize(payLoadSize)
+                .build();
+        // serialize meta-data size, meta-data and payload for single message in batch
+        int singleMsgMetadataSize = singleMessageMetadata.getSerializedSize();
+        try {
+            batchBuffer.writeInt(singleMsgMetadataSize);
+            ByteBufCodedOutputStream outStream = ByteBufCodedOutputStream.get(batchBuffer);
+            singleMessageMetadata.writeTo(outStream);
+            singleMessageMetadata.recycle();
+            outStream.recycle();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return batchBuffer.writeBytes(payload);
+    }
+
     public static ByteBuf serializeSingleMessageInBatchWithPayload(PulsarApi.MessageMetadata.Builder msgBuilder,
             ByteBuf payload, ByteBuf batchBuffer) {
 
@@ -843,23 +863,11 @@ public class Commands {
             singleMessageMetadataBuilder = singleMessageMetadataBuilder
                     .addAllProperties(msgBuilder.getPropertiesList());
         }
-        int payLoadSize = payload.readableBytes();
-        PulsarApi.SingleMessageMetadata singleMessageMetadata = singleMessageMetadataBuilder.setPayloadSize(payLoadSize)
-                .build();
-        singleMessageMetadataBuilder.recycle();
-
-        // serialize meta-data size, meta-data and payload for single message in batch
-        int singleMsgMetadataSize = singleMessageMetadata.getSerializedSize();
         try {
-            batchBuffer.writeInt(singleMsgMetadataSize);
-            ByteBufCodedOutputStream outStream = ByteBufCodedOutputStream.get(batchBuffer);
-            singleMessageMetadata.writeTo(outStream);
-            singleMessageMetadata.recycle();
-            outStream.recycle();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+            return serializeSingleMessageInBatchWithPayload(singleMessageMetadataBuilder, payload, batchBuffer);
+        } finally {
+            singleMessageMetadataBuilder.recycle();
         }
-        return batchBuffer.writeBytes(payload);
     }
 
     public static ByteBuf deSerializeSingleMessageInBatch(ByteBuf uncompressedPayload,

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
@@ -4623,6 +4623,10 @@ public final class PulsarApi {
     // required int32 payload_size = 3;
     boolean hasPayloadSize();
     int getPayloadSize();
+    
+    // optional bool compacted_out = 4 [default = false];
+    boolean hasCompactedOut();
+    boolean getCompactedOut();
   }
   public static final class SingleMessageMetadata extends
       com.google.protobuf.GeneratedMessageLite
@@ -4724,10 +4728,21 @@ public final class PulsarApi {
       return payloadSize_;
     }
     
+    // optional bool compacted_out = 4 [default = false];
+    public static final int COMPACTED_OUT_FIELD_NUMBER = 4;
+    private boolean compactedOut_;
+    public boolean hasCompactedOut() {
+      return ((bitField0_ & 0x00000004) == 0x00000004);
+    }
+    public boolean getCompactedOut() {
+      return compactedOut_;
+    }
+    
     private void initFields() {
       properties_ = java.util.Collections.emptyList();
       partitionKey_ = "";
       payloadSize_ = 0;
+      compactedOut_ = false;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -4765,6 +4780,9 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         output.writeInt32(3, payloadSize_);
       }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        output.writeBool(4, compactedOut_);
+      }
     }
     
     private int memoizedSerializedSize = -1;
@@ -4784,6 +4802,10 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
           .computeInt32Size(3, payloadSize_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(4, compactedOut_);
       }
       memoizedSerializedSize = size;
       return size;
@@ -4904,6 +4926,8 @@ public final class PulsarApi {
         bitField0_ = (bitField0_ & ~0x00000002);
         payloadSize_ = 0;
         bitField0_ = (bitField0_ & ~0x00000004);
+        compactedOut_ = false;
+        bitField0_ = (bitField0_ & ~0x00000008);
         return this;
       }
       
@@ -4950,6 +4974,10 @@ public final class PulsarApi {
           to_bitField0_ |= 0x00000002;
         }
         result.payloadSize_ = payloadSize_;
+        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        result.compactedOut_ = compactedOut_;
         result.bitField0_ = to_bitField0_;
         return result;
       }
@@ -4971,6 +4999,9 @@ public final class PulsarApi {
         }
         if (other.hasPayloadSize()) {
           setPayloadSize(other.getPayloadSize());
+        }
+        if (other.hasCompactedOut()) {
+          setCompactedOut(other.getCompactedOut());
         }
         return this;
       }
@@ -5025,6 +5056,11 @@ public final class PulsarApi {
             case 24: {
               bitField0_ |= 0x00000004;
               payloadSize_ = input.readInt32();
+              break;
+            }
+            case 32: {
+              bitField0_ |= 0x00000008;
+              compactedOut_ = input.readBool();
               break;
             }
           }
@@ -5175,6 +5211,27 @@ public final class PulsarApi {
       public Builder clearPayloadSize() {
         bitField0_ = (bitField0_ & ~0x00000004);
         payloadSize_ = 0;
+        
+        return this;
+      }
+      
+      // optional bool compacted_out = 4 [default = false];
+      private boolean compactedOut_ ;
+      public boolean hasCompactedOut() {
+        return ((bitField0_ & 0x00000008) == 0x00000008);
+      }
+      public boolean getCompactedOut() {
+        return compactedOut_;
+      }
+      public Builder setCompactedOut(boolean value) {
+        bitField0_ |= 0x00000008;
+        compactedOut_ = value;
+        
+        return this;
+      }
+      public Builder clearCompactedOut() {
+        bitField0_ = (bitField0_ & ~0x00000008);
+        compactedOut_ = false;
         
         return this;
       }

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -104,6 +104,7 @@ message SingleMessageMetadata {
 	repeated KeyValue properties    = 1;
 	optional string partition_key   = 2;
 	required int32 payload_size	= 3;
+        optional bool compacted_out     = 4 [default = false];
 }
 
 enum ServerError {


### PR DESCRIPTION
If batched messages are to be compactable without changing their
message ids, we need to be able to pad out the batch with empty
messages, so that the batch index does not change.

For this purpose, this patch introduces a flag, compactedOut. If a
message in the batch has this flag, it will not be passed to the
consumer.
