### PR TITLE
Allow override of redirectTestOutput from CLI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@ flexible messaging model and an intuitive client API.</description>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <redirectTestOutputToFile>true</redirectTestOutputToFile>
 
     <bookkeeper.version>4.7.0-SNAPSHOT</bookkeeper.version>
     <zookeeper.version>3.4.10</zookeeper.version>
@@ -806,7 +807,7 @@ flexible messaging model and an intuitive client API.</description>
           </argLine>
           <reuseForks>false</reuseForks>
           <forkCount>1</forkCount>
-          <redirectTestOutputToFile>true</redirectTestOutputToFile>
+          <redirectTestOutputToFile>${redirectTestOutputToFile}</redirectTestOutputToFile>
           <trimStackTrace>false</trimStackTrace>
         </configuration>
       </plugin>


### PR DESCRIPTION
If a maven option is set in the configuration, it's impossible to
override from the commandline. Sometimes, you want to be able to see
the output of a test on the commandline, such as in the case where the
test is hanging. This patch adds a property, so that the default
configuration of redirecting test output to a file can be overridden.
