### PR TITLE
Allow to set BacklogQuota when RetentionSizeInMB is set to -1

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -1074,7 +1074,7 @@ public abstract class NamespacesBase extends AdminResource {
 
     private boolean checkQuotas(Policies policies, RetentionPolicies retention) {
         Map<BacklogQuota.BacklogQuotaType, BacklogQuota> backlog_quota_map = policies.backlog_quota_map;
-        if (backlog_quota_map.isEmpty() || retention.getRetentionSizeInMB() == 0) {
+        if (backlog_quota_map.isEmpty() || retention.getRetentionSizeInMB() == 0 || retention.getRetentionSizeInMB() == -1) {
             return true;
         }
         BacklogQuota quota = backlog_quota_map.get(BacklogQuotaType.destination_storage);


### PR DESCRIPTION
I think 1.22 introduced a small bug that prevent setting BacklogQuota at all when RetentionSizeInMB is set to -1, always throwing "Backlog Quota exceeds configured retention quota for namespace"

related issues:

#1135 