### PR TITLE
Relocate service files for shading `pulsar-client-admin` module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -979,7 +979,7 @@ flexible messaging model and an intuitive client API.</description>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>2.4.2</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-enforcer-plugin</artifactId>

--- a/pulsar-client-admin-shaded/pom.xml
+++ b/pulsar-client-admin-shaded/pom.xml
@@ -185,6 +185,10 @@
                   <shadedPattern>org.apache.pulsar.admin.shade.org.reactivestreams</shadedPattern>
                 </relocation>
               </relocations>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.PluginXmlResourceTransformer" />
+              </transformers>
             </configuration>
           </execution>
         </executions>

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -160,6 +160,10 @@
                   <shadedPattern>org.apache.pulsar.shade.org.apache.http</shadedPattern>
                 </relocation>
               </relocations>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                <transformer implementation="org.apache.maven.plugins.shade.resource.PluginXmlResourceTransformer" />
+              </transformers>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
### Motivation

hk2 locator loads generator using service loaders. The service loaders are defined in the service MANIFEST files. when we are shading `pulsar-client-admin`, we only shade the classes, but we don't relocate the classes in the manifest files.

It will cause issues as below:

```
xception in thread "main" java.lang.RuntimeException: java.lang.ClassNotFoundException: Provider org.apache.pulsar.shade.org.glassfish.jersey.internal.RuntimeDelegateImpl could not be instantiated: java.lang.IllegalStateException: No generator was provided and there is no default generator registered
    at org.apache.pulsar.shade.javax.ws.rs.ext.RuntimeDelegate.findDelegate(RuntimeDelegate.java:152)
    at org.apache.pulsar.shade.javax.ws.rs.ext.RuntimeDelegate.getInstance(RuntimeDelegate.java:120)
    at org.apache.pulsar.shade.javax.ws.rs.core.UriBuilder.newInstance(UriBuilder.java:95)
    at org.apache.pulsar.shade.javax.ws.rs.core.UriBuilder.fromUri(UriBuilder.java:119)
    at org.apache.pulsar.shade.org.glassfish.jersey.client.JerseyWebTarget.<init>(JerseyWebTarget.java:71)
    at org.apache.pulsar.shade.org.glassfish.jersey.client.JerseyClient.target(JerseyClient.java:290)
    at org.apache.pulsar.shade.org.glassfish.jersey.client.JerseyClient.target(JerseyClient.java:76)
    at org.apache.pulsar.client.admin.PulsarAdmin.<init>(PulsarAdmin.java:154)
    at br.com.sticorp.tributum.accounts.CouchbaseDCPConsumer.main(CouchbaseDCPConsumer.java:43)
Caused by: java.lang.ClassNotFoundException: Provider org.apache.pulsar.shade.org.glassfish.jersey.internal.RuntimeDelegateImpl could not be instantiated: java.lang.IllegalStateException: No generator was provided and there is no default generator registered
    at org.apache.pulsar.shade.javax.ws.rs.ext.FactoryFinder.newInstance(FactoryFinder.java:122)
    at org.apache.pulsar.shade.javax.ws.rs.ext.FactoryFinder.find(FactoryFinder.java:225)
    at org.apache.pulsar.shade.javax.ws.rs.ext.RuntimeDelegate.findDelegate(RuntimeDelegate.java:135)
    ... 8 more
Caused by: java.lang.IllegalStateException: No generator was provided and there is no default generator registered
    at org.apache.pulsar.shade.org.glassfish.hk2.internal.ServiceLocatorFactoryImpl.internalCreate(ServiceLocatorFactoryImpl.java:308)
    at org.apache.pulsar.shade.org.glassfish.hk2.internal.ServiceLocatorFactoryImpl.create(ServiceLocatorFactoryImpl.java:293)
    at org.apache.pulsar.shade.org.glassfish.jersey.internal.inject.Injections._createLocator(Injections.java:138)
    at org.apache.pulsar.shade.org.glassfish.jersey.internal.inject.Injections.createLocator(Injections.java:109)
    at org.apache.pulsar.shade.org.glassfish.jersey.internal.RuntimeDelegateImpl.<init>(RuntimeDelegateImpl.java:63)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
    at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
    at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
    at java.lang.Class.newInstance(Class.java:442)
    at org.apache.pulsar.shade.javax.ws.rs.ext.FactoryFinder.newInstance(FactoryFinder.java:118)
    ... 10 more
WARN Cannot find a default implementation of the HK2 ServiceLocatorGenerator (org.apache.pulsar.shade.org.jvnet.hk2.logger:108) 

```

### Modifications

- transform services when shading 'pulsar-client-admin'
- update shade plugin to the latest version due to https://issues.apache.org/jira/browse/MSHADE-182

### Result

- services are relocated

```
META-INF/services/org.apache.pulsar.admin.shade.javax.ws.rs.ext.MessageBodyWriter
META-INF/services/org.apache.pulsar.admin.shade.com.scurrilous.circe.HashProvider
META-INF/services/org.apache.pulsar.admin.shade.org.glassfish.hk2.extension.ServiceLocatorGenerator
META-INF/services/org.apache.pulsar.admin.shade.com.fasterxml.jackson.databind.Module
META-INF/services/org.apache.pulsar.admin.shade.com.fasterxml.jackson.core.JsonFactory
META-INF/services/org.apache.pulsar.admin.shade.org.glassfish.jersey.internal.spi.AutoDiscoverable
META-INF/services/org.apache.pulsar.admin.shade.com.fasterxml.jackson.core.ObjectCodec
META-INF/services/org.apache.pulsar.admin.shade.javax.ws.rs.ext.MessageBodyReader
```

- service locator points to the right class

```
org.apache.pulsar.admin.shade.org.jvnet.hk2.external.generator.ServiceLocatorGeneratorImpl
```