### PR TITLE
Update log size limit to 1GB

### DIFF
--- a/conf/bookkeeper.conf
+++ b/conf/bookkeeper.conf
@@ -77,7 +77,7 @@ entryLogFilePreallocationEnabled=true
 
 # Max file size of entry logger, in bytes
 # A new entry log file will be created when the old one reaches the file size limitation
-logSizeLimit=2147483648
+logSizeLimit=1073741824
 
 # Threshold of minor compaction
 # For those entry log files whose remaining size percentage reaches below


### PR DESCRIPTION

### Motivation

Apache BookKeeper enforces log size limit not to be more than 1GB since 4.4.0. 

https://issues.apache.org/jira/browse/BOOKKEEPER-833

### Modifications

Change the log size limit to 1GB

### Result

The log size limit is set to 1GB
