### PR TITLE
Fix partitioned topic update for admin v2 api.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -20,11 +20,11 @@ package org.apache.pulsar.broker.admin;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES;
-import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES_ROOT;
 
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
@@ -451,6 +451,19 @@ public abstract class AdminResource extends PulsarWebResource {
             throw re;
         } catch (Exception e) {
             log.error("[{}] Failed to get namespace policies {}/{}/{}", clientAppId(), property, cluster, namespace, e);
+            throw new RestException(e);
+        }
+    }
+
+    protected boolean isNamespaceReplicated(NamespaceName namespaceName) {
+        try {
+            final Policies policies = policiesCache().get(ZkAdminPaths.namespacePoliciesPath(namespaceName))
+                    .orElseThrow(() -> new RestException(Status.NOT_FOUND, "Namespace does not exist"));
+            return policies.replication_clusters.size() > 1;
+        } catch (RestException re) {
+            throw re;
+        } catch (Exception e) {
+            log.error("[{}] Failed to get namespace policies {}", clientAppId(), namespaceName, e);
             throw new RestException(e);
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/ZkAdminPaths.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/ZkAdminPaths.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.admin;
+
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.TopicName;
+
+public class ZkAdminPaths {
+
+    public static final String POLICIES = "policies";
+    public static final String PARTITIONED_TOPIC_PATH_ZNODE = "partitioned-topics";
+
+    public static String partitionedTopicPath(TopicName name) {
+        return adminPath(PARTITIONED_TOPIC_PATH_ZNODE,
+                name.getNamespace(), name.getDomain().value(), name.getEncodedLocalName());
+    }
+
+    public static String namespacePoliciesPath(NamespaceName name) {
+        return adminPath(POLICIES, name.toString());
+    }
+
+    private static String adminPath(String... parts) {
+        return "/admin/" + String.join("/", parts);
+    }
+
+    private ZkAdminPaths() {}
+}


### PR DESCRIPTION
Fix partitioned topic update for the admin rest api v2. This also adds a helper class to create zk paths for pulsar objects.
