### PR TITLE
Fixed BK PrometheusProvider package name

### DIFF
--- a/conf/bookkeeper.conf
+++ b/conf/bookkeeper.conf
@@ -311,7 +311,7 @@ writeBufferSizeBytes=65536
 useHostNameAsBookieID=false
 
 # Stats Provider Class
-statsProviderClass=org.apache.bookkeeper.stats.PrometheusMetricsProvider
+statsProviderClass=org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
 # Default port for Prometheus metrics exporter
 prometheusStatsHttpPort=8000
 


### PR DESCRIPTION
### Motivation

`PrometheusProvider` package name was changed in BookKeeper 4.7. We need to adjust the default in config file.