### PR TITLE
Improve sync send logic for allowing turning batching as default produce behavior

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
@@ -139,6 +139,14 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
     }
 
     @Override
+    public MessageId send(Message<T> message) throws PulsarClientException {
+        int partition = routerPolicy.choosePartition(message, topicMetadata);
+        checkArgument(partition >= 0 && partition < topicMetadata.numPartitions(),
+            "Illegal partition index chosen by the message routing policy");
+        return producers.get(partition).send(message);
+    }
+
+    @Override
     public CompletableFuture<MessageId> sendAsync(Message<T> message) {
 
         switch (getState()) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBase.java
@@ -55,23 +55,6 @@ public abstract class ProducerBase<T> extends HandlerState implements Producer<T
     }
 
     @Override
-    public MessageId send(Message<T> message) throws PulsarClientException {
-        try {
-            return sendAsync(message).get();
-        } catch (ExecutionException e) {
-            Throwable t = e.getCause();
-            if (t instanceof PulsarClientException) {
-                throw (PulsarClientException) t;
-            } else {
-                throw new PulsarClientException(t);
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new PulsarClientException(e);
-        }
-    }
-
-    @Override
     abstract public CompletableFuture<MessageId> sendAsync(Message<T> message);
 
     @Override


### PR DESCRIPTION
### Motivation

Batching is required for achieving high performance messaging. If we want to flip the default behaviour of publishers into batch publishing,
we need to improve current send logic to flush out batches after enqueuing the send requests. so batch settings won't impact sync sends.

### Modifications

- add a flush() method on single partition producer
- break the send logic on single partition producer to `enqueue-flush-wait`
- change multi-partitions producer to use single partition producer

### Result

- sync send will "kind of ignore" batch settings.