### PR TITLE
Build batching-awareness into round-robin message router

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
@@ -24,6 +24,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -76,7 +77,11 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
             messageRouter = customMessageRouter;
             break;
         case RoundRobinPartition:
-            messageRouter = new RoundRobinPartitionMessageRouterImpl(conf.getHashingScheme());
+            messageRouter = new RoundRobinPartitionMessageRouterImpl(
+                conf.getHashingScheme(),
+                ThreadLocalRandom.current().nextInt(topicMetadata.numPartitions()),
+                conf.isBatchingEnabled(),
+                TimeUnit.MICROSECONDS.toMillis(conf.getBatchingMaxPublishDelayMicros()));
             break;
         case SinglePartition:
         default:

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/RoundRobinPartitionMessageRouterImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/RoundRobinPartitionMessageRouterImpl.java
@@ -60,7 +60,7 @@ public class RoundRobinPartitionMessageRouterImpl extends MessageRouterBase {
         PARTITION_INDEX_UPDATER.set(this, startPtnIdx);
         this.startPtnIdx = startPtnIdx;
         this.isBatchingEnabled = isBatchingEnabled;
-        this.maxBatchingDelayMs = maxBatchingDelayMs;
+        this.maxBatchingDelayMs = Math.max(1, maxBatchingDelayMs);
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/RoundRobinPartitionMessageRouterImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/RoundRobinPartitionMessageRouterImpl.java
@@ -18,12 +18,21 @@
  */
 package org.apache.pulsar.client.impl;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import org.apache.pulsar.client.api.HashingScheme;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.TopicMetadata;
 
+/**
+ * The routing strategy here:
+ * <ul>
+ * <li>If a key is present, choose a partition based on a hash of the key.
+ * <li>If no key is present, choose a partition in a "round-robin" fashion. Batching-Awareness is built-in to improve
+ * batching locality.
+ * </ul>
+ */
 public class RoundRobinPartitionMessageRouterImpl extends MessageRouterBase {
 
     private static final long serialVersionUID = 1L;
@@ -33,9 +42,25 @@ public class RoundRobinPartitionMessageRouterImpl extends MessageRouterBase {
     @SuppressWarnings("unused")
     private volatile int partitionIndex = 0;
 
-    public RoundRobinPartitionMessageRouterImpl(HashingScheme hashingScheme) {
+    private final int startPtnIdx;
+    private final boolean isBatchingEnabled;
+    private final long maxBatchingDelayMs;
+
+    @VisibleForTesting
+    public RoundRobinPartitionMessageRouterImpl(HashingScheme hashingScheme,
+                                                int startPtnIdx) {
+        this(hashingScheme, startPtnIdx, false, 0);
+    }
+
+    public RoundRobinPartitionMessageRouterImpl(HashingScheme hashingScheme,
+                                                int startPtnIdx,
+                                                boolean isBatchingEnabled,
+                                                long maxBatchingDelayMs) {
         super(hashingScheme);
-        PARTITION_INDEX_UPDATER.set(this, 0);
+        PARTITION_INDEX_UPDATER.set(this, startPtnIdx);
+        this.startPtnIdx = startPtnIdx;
+        this.isBatchingEnabled = isBatchingEnabled;
+        this.maxBatchingDelayMs = maxBatchingDelayMs;
     }
 
     @Override
@@ -45,7 +70,12 @@ public class RoundRobinPartitionMessageRouterImpl extends MessageRouterBase {
             return hash.makeHash(msg.getKey()) % topicMetadata.numPartitions();
         }
 
-        return ((PARTITION_INDEX_UPDATER.getAndIncrement(this) & Integer.MAX_VALUE) % topicMetadata.numPartitions());
+        if (isBatchingEnabled) { // if batching is enabled, choose partition on `maxBatchingDelayMs` boundary.
+            long currentMs = System.currentTimeMillis();
+            return (((int) (currentMs / maxBatchingDelayMs)) + startPtnIdx) % topicMetadata.numPartitions();
+        } else {
+            return ((PARTITION_INDEX_UPDATER.getAndIncrement(this) & Integer.MAX_VALUE) % topicMetadata.numPartitions());
+        }
     }
 
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/RoundRobinPartitionMessageRouterImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/RoundRobinPartitionMessageRouterImplTest.java
@@ -24,19 +24,30 @@ import static org.testng.Assert.assertEquals;
 
 import org.apache.pulsar.client.api.HashingScheme;
 import org.apache.pulsar.client.api.Message;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.testng.IObjectFactory;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
 
 /**
  * Unit test of {@link RoundRobinPartitionMessageRouterImpl}.
  */
+@PrepareForTest({ RoundRobinPartitionMessageRouterImpl.class })
 public class RoundRobinPartitionMessageRouterImplTest {
+
+    @ObjectFactory
+    public IObjectFactory getObjectFactory() {
+        return new org.powermock.modules.testng.PowerMockObjectFactory();
+    }
 
     @Test
     public void testChoosePartitionWithoutKey() {
         Message<?> msg = mock(Message.class);
         when(msg.getKey()).thenReturn(null);
 
-        RoundRobinPartitionMessageRouterImpl router = new RoundRobinPartitionMessageRouterImpl(HashingScheme.JavaStringHash);
+        RoundRobinPartitionMessageRouterImpl router = new RoundRobinPartitionMessageRouterImpl(HashingScheme.JavaStringHash, 0);
         for (int i = 0; i < 10; i++) {
             assertEquals(i % 5, router.choosePartition(msg, new TopicMetadataImpl(5)));
         }
@@ -53,11 +64,35 @@ public class RoundRobinPartitionMessageRouterImplTest {
         when(msg2.hasKey()).thenReturn(true);
         when(msg2.getKey()).thenReturn(key2);
 
-        RoundRobinPartitionMessageRouterImpl router = new RoundRobinPartitionMessageRouterImpl(HashingScheme.JavaStringHash);
+        RoundRobinPartitionMessageRouterImpl router = new RoundRobinPartitionMessageRouterImpl(HashingScheme.JavaStringHash, 0);
         TopicMetadataImpl metadata = new TopicMetadataImpl(100);
 
         assertEquals(key1.hashCode() % 100, router.choosePartition(msg1, metadata));
         assertEquals(key2.hashCode() % 100, router.choosePartition(msg2, metadata));
     }
 
+    @Test
+    public void testBatchingAwareness() throws Exception {
+        Message<?> msg = mock(Message.class);
+        when(msg.getKey()).thenReturn(null);
+
+        PowerMockito.mockStatic(System.class);
+
+        RoundRobinPartitionMessageRouterImpl router = new RoundRobinPartitionMessageRouterImpl(HashingScheme.JavaStringHash, 0, true, 10);
+        TopicMetadataImpl metadata = new TopicMetadataImpl(100);
+
+        // time at `12345*` milliseconds
+        for (int i = 0; i < 10; i++) {
+            PowerMockito.when(System.currentTimeMillis()).thenReturn(123450L + i);
+
+            assertEquals(45, router.choosePartition(msg, metadata));
+        }
+
+        // time at `12346*` milliseconds
+        for (int i = 0; i < 10; i++) {
+            PowerMockito.when(System.currentTimeMillis()).thenReturn(123460L + i);
+
+            assertEquals(46, router.choosePartition(msg, metadata));
+        }
+    }
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/RoundRobinPartitionMessageRouterImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/RoundRobinPartitionMessageRouterImplTest.java
@@ -27,7 +27,6 @@ import org.apache.pulsar.client.api.Message;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.testng.IObjectFactory;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
 

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/FunctionResultRouter.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/FunctionResultRouter.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.functions.instance;
 
+import java.util.concurrent.ThreadLocalRandom;
 import org.apache.pulsar.client.api.HashingScheme;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.TopicMetadata;
@@ -31,7 +32,11 @@ public class FunctionResultRouter extends RoundRobinPartitionMessageRouterImpl {
     private static final FunctionResultRouter INSTANCE = new FunctionResultRouter();
 
     public FunctionResultRouter() {
-        super(HashingScheme.Murmur3_32Hash);
+        super(
+            HashingScheme.Murmur3_32Hash,
+            Math.abs(ThreadLocalRandom.current().nextInt()),
+            true,
+            1);
     }
 
     public static FunctionResultRouter of() {

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/FunctionResultRouter.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/FunctionResultRouter.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.functions.instance;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.pulsar.client.api.HashingScheme;
 import org.apache.pulsar.client.api.Message;
@@ -32,9 +33,14 @@ public class FunctionResultRouter extends RoundRobinPartitionMessageRouterImpl {
     private static final FunctionResultRouter INSTANCE = new FunctionResultRouter();
 
     public FunctionResultRouter() {
+        this(Math.abs(ThreadLocalRandom.current().nextInt()));
+    }
+
+    @VisibleForTesting
+    public FunctionResultRouter(int startPtnIdx) {
         super(
             HashingScheme.Murmur3_32Hash,
-            Math.abs(ThreadLocalRandom.current().nextInt()),
+            startPtnIdx,
             true,
             1);
     }

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/FunctionResultRouterTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/FunctionResultRouterTest.java
@@ -26,13 +26,24 @@ import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.TopicMetadata;
 import org.apache.pulsar.client.impl.Hash;
 import org.apache.pulsar.client.impl.Murmur3_32Hash;
+import org.apache.pulsar.client.impl.RoundRobinPartitionMessageRouterImpl;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.testng.IObjectFactory;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
 
 /**
  * Unit test of {@link FunctionResultRouter}.
  */
+@PrepareForTest({ RoundRobinPartitionMessageRouterImpl.class })
 public class FunctionResultRouterTest {
+
+    @ObjectFactory
+    public IObjectFactory getObjectFactory() {
+        return new org.powermock.modules.testng.PowerMockObjectFactory();
+    }
 
     private Hash hash;
 
@@ -50,8 +61,11 @@ public class FunctionResultRouterTest {
         TopicMetadata topicMetadata = mock(TopicMetadata.class);
         when(topicMetadata.numPartitions()).thenReturn(5);
 
-        FunctionResultRouter router = new FunctionResultRouter();
+        PowerMockito.mockStatic(System.class);
+
+        FunctionResultRouter router = new FunctionResultRouter(0);
         for (int i = 0; i < 10; i++) {
+            PowerMockito.when(System.currentTimeMillis()).thenReturn(123450L + i);
             assertEquals(i % 5, router.choosePartition(msg, topicMetadata));
         }
     }
@@ -61,7 +75,7 @@ public class FunctionResultRouterTest {
         TopicMetadata topicMetadata = mock(TopicMetadata.class);
         when(topicMetadata.numPartitions()).thenReturn(5);
 
-        FunctionResultRouter router = new FunctionResultRouter();
+        FunctionResultRouter router = new FunctionResultRouter(0);
         for (int i = 0; i < 10; i++) {
             Message msg = mock(Message.class);
             when(msg.hasKey()).thenReturn(false);
@@ -84,7 +98,7 @@ public class FunctionResultRouterTest {
         when(msg2.getKey()).thenReturn(key2);
         when(msg1.getSequenceId()).thenReturn(-1L);
 
-        FunctionResultRouter router = new FunctionResultRouter();
+        FunctionResultRouter router = new FunctionResultRouter(0);
         TopicMetadata metadata = mock(TopicMetadata.class);
         when(metadata.numPartitions()).thenReturn(100);
 
@@ -106,7 +120,7 @@ public class FunctionResultRouterTest {
         when(msg2.getKey()).thenReturn(key2);
         when(msg1.getSequenceId()).thenReturn((long) ((key2.hashCode() % 100) + 1));
 
-        FunctionResultRouter router = new FunctionResultRouter();
+        FunctionResultRouter router = new FunctionResultRouter(0);
         TopicMetadata metadata = mock(TopicMetadata.class);
         when(metadata.numPartitions()).thenReturn(100);
 


### PR DESCRIPTION

### Motivation


The default `SinglePartition` message router works well when you have more producers than the number of partitions.
Howerver partitions will become idle if you have more partitions than producers. In the case of `producers` <= `partitions`,
a round-robin message router works better. However the current round-robin messages router doesn't take `batching` into account.

### Modifications


Improve the current round-robin message router to build batching awareness into it. The round-robin messages router choose
partition based on a randomly-chosen start partition id and the current milliseconds (round-up at the `maxBatchingDelayMs` boundary).
This guarantees that at a given `maxBatchingDelayMs`, the message router is always choosing a same partition, this improves batching locality.

### Result

round-robin message router is batching aware.
