### PR TITLE
Make close on RawMessage idempotent

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawMessageImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawMessageImpl.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.client.impl;
 
 import java.io.IOException;
+import io.netty.buffer.Unpooled;
 
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.RawMessage;
@@ -35,7 +36,7 @@ public class RawMessageImpl implements RawMessage {
     private static final Logger log = LoggerFactory.getLogger(RawMessageImpl.class);
 
     private final MessageIdData id;
-    private final ByteBuf headersAndPayload;
+    private ByteBuf headersAndPayload;
 
     public RawMessageImpl(MessageIdData id, ByteBuf headersAndPayload) {
         this.id = id;
@@ -61,6 +62,7 @@ public class RawMessageImpl implements RawMessage {
     @Override
     public void close() {
         headersAndPayload.release();
+        headersAndPayload = Unpooled.EMPTY_BUFFER;
     }
 
     @Override


### PR DESCRIPTION
Closing a raw message twice should not corrupt memory.
