### PR TITLE
Issue 1069: Provide a setting in consumer configuration to specify where to start consuming messages

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedger.java
@@ -26,6 +26,7 @@ import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCursorCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteLedgerCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.OpenCursorCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.TerminateCallback;
+import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition;
 
 /**
  * A ManagedLedger it's a superset of a BookKeeper ledger concept.
@@ -132,10 +133,27 @@ public interface ManagedLedger {
      *
      * @param name
      *            the name associated with the ManagedCursor
+     * @param initializeOnLatest
+     *            the flag tell the method wthether it should intialize the cursor at latest position or not.
      * @return the ManagedCursor
      * @throws ManagedLedgerException
      */
     ManagedCursor openCursor(String name) throws InterruptedException, ManagedLedgerException;
+
+    /**
+     * Open a ManagedCursor in this ManagedLedger.
+     * <p>
+     * If the cursors doesn't exist, a new one will be created and its position will be at the end of the ManagedLedger.
+     *
+     * @param name
+     *            the name associated with the ManagedCursor
+     * @param initialPosition
+     *            the cursor will be set at lastest position or not when first created
+     *            default is <b>true</b>
+     * @return the ManagedCursor
+     * @throws ManagedLedgerException
+     */
+    public ManagedCursor openCursor(String name, InitialPosition initialPosition) throws InterruptedException, ManagedLedgerException;
 
     /**
      * Creates a new cursor whose metadata is not backed by durable storage. A caller can treat the non-durable cursor
@@ -194,7 +212,23 @@ public interface ManagedLedger {
     void asyncOpenCursor(String name, OpenCursorCallback callback, Object ctx);
 
     /**
-     * Get a list of all the cursors reading from this ManagedLedger.
+     * Open a ManagedCursor asynchronously.
+     *
+     * @see #openCursor(String)
+     * @param name
+     *            the name associated with the ManagedCursor
+     * @param initialPosition
+     *            the cursor will be set at lastest position or not when first created
+     *            default is <b>true</b>
+     * @param callback
+     *            callback object
+     * @param ctx
+     *            opaque context
+     */
+    public void asyncOpenCursor(String name, InitialPosition initialPosition, OpenCursorCallback callback, Object ctx);
+
+    /**
+     * Get a list of all the cursors reading from this ManagedLedger
      *
      * @return a list of cursors
      */

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2051,7 +2051,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             pos = getFirstPosition();
             lastPositionAndCounter = getLastPositionAndCounter();
             count = lastPositionAndCounter.second - getNumberOfEntries(Range.openClosed(pos, lastPositionAndCounter.first));
-        } while (pos.compareTo(getFirstPosition()) != 0 && lastPositionAndCounter.first.compareTo(getLastPosition()) != 0);
+        } while (pos.compareTo(getFirstPosition()) != 0 || lastPositionAndCounter.first.compareTo(getLastPosition()) != 0);
         return Pair.create(pos, count);
     }
 

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -21,7 +21,6 @@ package org.apache.bookkeeper.mledger.impl;
 import static org.testng.Assert.*;
 
 import com.google.common.base.Charsets;
-import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
@@ -2155,11 +2154,11 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
     }
 
     @Test
-    public void testOpenCursorOnLatestAndEarliest() throws Exception {
+    public void testConsumerSubscriptionInitializePosition() throws Exception{
         final int MAX_ENTRY_PER_LEDGER = 2;
         ManagedLedgerConfig config = new ManagedLedgerConfig().setMaxEntriesPerLedger(MAX_ENTRY_PER_LEDGER);
         ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("lastest_earliest_ledger", config);
-        // ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("lastest_earliest_ledger");
+
         final int totalInsertedEntries = 20;
         for (int i = 0; i < totalInsertedEntries; i++) {
             String content = "entry" + i; // 5 bytes
@@ -2183,5 +2182,6 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         assertEquals(earliestPositionAndCounter.second.longValue(), totalInsertedEntries - earliestCursor.getNumberOfEntriesInBacklog());
 
         ledger.close();
+
     }
 }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerTest.java
@@ -21,6 +21,7 @@ package org.apache.bookkeeper.mledger.impl;
 import static org.testng.Assert.*;
 
 import com.google.common.base.Charsets;
+import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
@@ -66,6 +67,7 @@ import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.Ledge
 import org.apache.bookkeeper.mledger.util.Pair;
 import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
 import org.apache.pulsar.common.api.ByteBufPair;
+import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
 import org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream;
 import org.apache.zookeeper.CreateMode;
@@ -2152,4 +2154,34 @@ public class ManagedLedgerTest extends MockedBookKeeperTestCase {
         return ByteBufPair.coalesce(ByteBufPair.get(headers, payload));
     }
 
+    @Test
+    public void testOpenCursorOnLatestAndEarliest() throws Exception {
+        final int MAX_ENTRY_PER_LEDGER = 2;
+        ManagedLedgerConfig config = new ManagedLedgerConfig().setMaxEntriesPerLedger(MAX_ENTRY_PER_LEDGER);
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("lastest_earliest_ledger", config);
+        // ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open("lastest_earliest_ledger");
+        final int totalInsertedEntries = 20;
+        for (int i = 0; i < totalInsertedEntries; i++) {
+            String content = "entry" + i; // 5 bytes
+            ledger.addEntry(content.getBytes());
+        }
+        // Open Cursor also adds cursor into activeCursor-container
+        ManagedCursor latestCursor = ledger.openCursor("c1", InitialPosition.Latest);
+        ManagedCursor earliestCursor = ledger.openCursor("c2", InitialPosition.Earliest);
+
+        // Since getReadPosition returns the next position, we decrease the entryId by 1
+        PositionImpl p1 = (PositionImpl) latestCursor.getReadPosition();
+        PositionImpl p2 = (PositionImpl) earliestCursor.getReadPosition();
+
+        Pair<PositionImpl, Long> latestPositionAndCounter = ledger.getLastPositionAndCounter();
+        Pair<PositionImpl, Long> earliestPositionAndCounter = ledger.getFirstPositionAndCounter();
+
+        assertEquals(latestPositionAndCounter.first.getNext(), p1);
+        assertEquals(earliestPositionAndCounter.first.getNext(), p2);
+
+        assertEquals(latestPositionAndCounter.second.longValue(), totalInsertedEntries);
+        assertEquals(earliestPositionAndCounter.second.longValue(), totalInsertedEntries - earliestCursor.getNumberOfEntriesInBacklog());
+
+        ledger.close();
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -72,6 +72,7 @@ import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.api.Commands;
 import org.apache.pulsar.common.api.proto.PulsarApi.KeyValue;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
+import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.compression.CompressionCodec;
 import org.apache.pulsar.common.compression.CompressionCodecProvider;
 import org.apache.pulsar.common.naming.TopicDomain;
@@ -818,7 +819,7 @@ public class PersistentTopicsBase extends AdminResource {
                 }
 
                 PersistentSubscription subscription = (PersistentSubscription) topic
-                        .createSubscription(subscriptionName).get();
+                        .createSubscription(subscriptionName, InitialPosition.Latest).get();
                 subscription.resetCursor(PositionImpl.get(messageId.getLedgerId(), messageId.getEntryId())).get();
                 log.info("[{}][{}] Successfully created subscription {} at message id {}", clientAppId(),
                         topicName, subscriptionName, messageId);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -37,10 +37,12 @@ import org.apache.bookkeeper.util.collections.ConcurrentLongLongPairHashMap;
 import org.apache.bookkeeper.util.collections.ConcurrentLongLongPairHashMap.LongPair;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.common.api.Commands;
 import org.apache.pulsar.common.api.proto.PulsarApi;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType;
+import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData;
 import org.apache.pulsar.common.api.proto.PulsarApi.ProtocolVersion;
@@ -68,6 +70,7 @@ public class Consumer {
     private final String appId;
     private AuthenticationDataSource authenticationData;
     private final String topicName;
+    private final InitialPosition subscriptionInitialPosition;
 
     private final long consumerId;
     private final int priorityLevel;
@@ -104,7 +107,7 @@ public class Consumer {
     public Consumer(Subscription subscription, SubType subType, String topicName, long consumerId,
                     int priorityLevel, String consumerName,
                     int maxUnackedMessages, ServerCnx cnx, String appId,
-                    Map<String, String> metadata, boolean readCompacted) throws BrokerServiceException {
+                    Map<String, String> metadata, boolean readCompacted, InitialPosition subscriptionInitialPosition) throws BrokerServiceException {
 
         this.subscription = subscription;
         this.subType = subType;
@@ -114,6 +117,7 @@ public class Consumer {
         this.readCompacted = readCompacted;
         this.consumerName = consumerName;
         this.maxUnackedMessages = maxUnackedMessages;
+        this.subscriptionInitialPosition = subscriptionInitialPosition;
         this.cnx = cnx;
         this.msgOut = new Rate();
         this.msgRedeliver = new Rate();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -76,6 +76,7 @@ import org.apache.pulsar.common.api.proto.PulsarApi.CommandRedeliverUnacknowledg
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSend;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe;
+import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandUnsubscribe;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData;
@@ -559,6 +560,7 @@ public class ServerCnx extends PulsarHandler {
         final int priorityLevel = subscribe.hasPriorityLevel() ? subscribe.getPriorityLevel() : 0;
         final boolean readCompacted = subscribe.getReadCompacted();
         final Map<String, String> metadata = CommandUtils.metadataFromCommand(subscribe);
+        final InitialPosition initialPosition = subscribe.getInitialPosition();
 
         CompletableFuture<Boolean> isProxyAuthorizedFuture;
         if (service.isAuthorizationEnabled() && originalPrincipal != null) {
@@ -622,7 +624,7 @@ public class ServerCnx extends PulsarHandler {
                         service.getTopic(topicName.toString())
                                 .thenCompose(topic -> topic.subscribe(ServerCnx.this, subscriptionName, consumerId,
                                                                       subType, priorityLevel, consumerName, isDurable,
-                                                                      startMessageId, metadata, readCompacted))
+                                                                      startMessageId, metadata, readCompacted, initialPosition))
                                 .thenAccept(consumer -> {
                                     if (consumerFuture.complete(consumer)) {
                                         log.info("[{}] Created subscription on topic {} / {}", remoteAddress, topicName,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -76,8 +76,8 @@ import org.apache.pulsar.common.api.proto.PulsarApi.CommandRedeliverUnacknowledg
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSeek;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSend;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe;
-import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
+import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandUnsubscribe;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -25,7 +25,9 @@ import org.apache.bookkeeper.mledger.Position;
 import org.apache.pulsar.broker.stats.ClusterReplicationMetrics;
 import org.apache.pulsar.broker.stats.NamespaceStats;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
+import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.policies.data.PersistentTopicStats;
@@ -80,9 +82,9 @@ public interface Topic {
 
     CompletableFuture<Consumer> subscribe(ServerCnx cnx, String subscriptionName, long consumerId, SubType subType,
             int priorityLevel, String consumerName, boolean isDurable, MessageId startMessageId,
-            Map<String, String> metadata, boolean readCompacted);
+            Map<String, String> metadata, boolean readCompacted, InitialPosition initialPosition);
 
-    CompletableFuture<Subscription> createSubscription(String subscriptionName);
+    CompletableFuture<Subscription> createSubscription(String subscriptionName, InitialPosition initialPosition);
 
     CompletableFuture<Void> unsubscribe(String subName);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Topic.java
@@ -27,7 +27,6 @@ import org.apache.pulsar.broker.stats.NamespaceStats;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
-import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.policies.data.PersistentTopicStats;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -367,7 +367,7 @@ public class NonPersistentTopic implements Topic {
 
         try {
             Consumer consumer = new Consumer(subscription, subType, topic, consumerId, priorityLevel, consumerName, 0, cnx,
-                                             cnx.getRole(), metadata, readCompacted);
+                                             cnx.getRole(), metadata, readCompacted, initialPosition);
             subscription.addConsumer(consumer);
             if (!cnx.isActive()) {
                 consumer.close();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -64,6 +64,7 @@ import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.stats.ClusterReplicationMetrics;
 import org.apache.pulsar.broker.stats.NamespaceStats;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
@@ -322,7 +323,7 @@ public class NonPersistentTopic implements Topic {
     @Override
     public CompletableFuture<Consumer> subscribe(final ServerCnx cnx, String subscriptionName, long consumerId,
             SubType subType, int priorityLevel, String consumerName, boolean isDurable, MessageId startMessageId,
-            Map<String, String> metadata, boolean readCompacted) {
+            Map<String, String> metadata, boolean readCompacted, InitialPosition initialPosition) {
 
         final CompletableFuture<Consumer> future = new CompletableFuture<>();
 
@@ -396,7 +397,7 @@ public class NonPersistentTopic implements Topic {
     }
 
     @Override
-    public CompletableFuture<Subscription> createSubscription(String subscriptionName) {
+    public CompletableFuture<Subscription> createSubscription(String subscriptionName, InitialPosition initialPosition) {
         return CompletableFuture.completedFuture(new NonPersistentSubscription(this, subscriptionName));
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -499,7 +499,7 @@ public class PersistentTopic implements Topic, AddEntryCallback {
         subscriptionFuture.thenAccept(subscription -> {
             try {
                 Consumer consumer = new Consumer(subscription, subType, topic, consumerId, priorityLevel, consumerName,
-                                                 maxUnackedMessages, cnx, cnx.getRole(), metadata, readCompacted);
+                                                 maxUnackedMessages, cnx, cnx.getRole(), metadata, readCompacted, initialPosition);
                 subscription.addConsumer(consumer);
                 if (!cnx.isActive()) {
                     consumer.close();
@@ -542,7 +542,7 @@ public class PersistentTopic implements Topic, AddEntryCallback {
                 if (log.isDebugEnabled()) {
                     log.debug("[{}][{}] Opened cursor", topic, subscriptionName);
                 }
-                
+
                 subscriptionFuture.complete(subscriptions.computeIfAbsent(subscriptionName,
                         name -> createPersistentSubscription(subscriptionName, cursor)));
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -80,6 +80,7 @@ import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.impl.BatchMessageIdImpl;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.client.impl.MessageImpl;
+import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
@@ -442,7 +443,7 @@ public class PersistentTopic implements Topic, AddEntryCallback {
     @Override
     public CompletableFuture<Consumer> subscribe(final ServerCnx cnx, String subscriptionName, long consumerId,
             SubType subType, int priorityLevel, String consumerName, boolean isDurable, MessageId startMessageId,
-            Map<String, String> metadata, boolean readCompacted) {
+            Map<String, String> metadata, boolean readCompacted, InitialPosition initialPosition) {
 
         final CompletableFuture<Consumer> future = new CompletableFuture<>();
 
@@ -490,7 +491,7 @@ public class PersistentTopic implements Topic, AddEntryCallback {
         }
 
         CompletableFuture<? extends Subscription> subscriptionFuture = isDurable ? //
-                getDurableSubscription(subscriptionName) //
+                getDurableSubscription(subscriptionName, initialPosition) //
                 : getNonDurableSubscription(subscriptionName, startMessageId);
 
         int maxUnackedMessages  = isDurable ? brokerService.pulsar().getConfiguration().getMaxUnackedMessagesPerConsumer() :0;
@@ -533,15 +534,15 @@ public class PersistentTopic implements Topic, AddEntryCallback {
         return future;
     }
 
-    private CompletableFuture<Subscription> getDurableSubscription(String subscriptionName) {
+    private CompletableFuture<Subscription> getDurableSubscription(String subscriptionName, InitialPosition initialPosition) {
         CompletableFuture<Subscription> subscriptionFuture = new CompletableFuture<>();
-        ledger.asyncOpenCursor(Codec.encode(subscriptionName), new OpenCursorCallback() {
+        ledger.asyncOpenCursor(Codec.encode(subscriptionName), initialPosition, new OpenCursorCallback() {
             @Override
             public void openCursorComplete(ManagedCursor cursor, Object ctx) {
                 if (log.isDebugEnabled()) {
                     log.debug("[{}][{}] Opened cursor", topic, subscriptionName);
                 }
-
+                
                 subscriptionFuture.complete(subscriptions.computeIfAbsent(subscriptionName,
                         name -> createPersistentSubscription(subscriptionName, cursor)));
             }
@@ -598,8 +599,8 @@ public class PersistentTopic implements Topic, AddEntryCallback {
 
     @SuppressWarnings("unchecked")
     @Override
-    public CompletableFuture<Subscription> createSubscription(String subscriptionName) {
-        return getDurableSubscription(subscriptionName);
+    public CompletableFuture<Subscription> createSubscription(String subscriptionName, InitialPosition initialPosition) {
+        return getDurableSubscription(subscriptionName, initialPosition);
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
@@ -31,6 +31,7 @@ import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.RawMessage;
 import org.apache.pulsar.client.api.RawReader;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType;
@@ -102,7 +103,7 @@ public class RawReaderImpl implements RawReader {
         RawConsumerImpl(PulsarClientImpl client, ConsumerConfigurationData conf,
                 CompletableFuture<Consumer<byte[]>> consumerFuture) {
             super(client, conf.getSingleTopic(), conf, client.externalExecutorProvider().getExecutor(), -1,
-                    consumerFuture, SubscriptionMode.Durable, MessageId.earliest, Schema.IDENTITY);
+                    consumerFuture, SubscriptionMode.Durable, MessageId.earliest, Schema.IDENTITY, SubscriptionInitialPosition.Earliest);
             incomingRawMessages = new GrowableArrayBlockingQueue<>();
             pendingRawReceives = new ConcurrentLinkedQueue<>();
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
@@ -223,10 +223,10 @@ public class PersistentDispatcherFailoverConsumerTest {
         doAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
-                ((OpenCursorCallback) invocationOnMock.getArguments()[1]).openCursorComplete(cursorMock, null);
+                ((OpenCursorCallback) invocationOnMock.getArguments()[2]).openCursorComplete(cursorMock, null);
                 return null;
             }
-        }).when(ledgerMock).asyncOpenCursor(matches(".*success.*"), any(OpenCursorCallback.class), anyObject());
+        }).when(ledgerMock).asyncOpenCursor(matches(".*success.*"), any(InitialPosition.class), any(OpenCursorCallback.class), anyObject());
 
         // call deleteLedgerComplete on ledger asyncDelete
         doAnswer(new Answer<Object>() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
@@ -70,6 +70,7 @@ import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.common.api.proto.PulsarApi.BaseCommand;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandActiveConsumerChange;
+import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 import org.apache.pulsar.common.api.proto.PulsarApi.ProtocolVersion;
 import org.apache.pulsar.common.naming.TopicName;
@@ -267,7 +268,7 @@ public class PersistentDispatcherFailoverConsumerTest {
 
         // 2. Add old consumer
         Consumer consumer1 = new Consumer(sub, SubType.Exclusive, topic.getName(), 1 /* consumer id */, 0,
-                "Cons1"/* consumer name */, 50000, serverCnxWithOldVersion, "myrole-1", Collections.emptyMap(), false);
+                "Cons1"/* consumer name */, 50000, serverCnxWithOldVersion, "myrole-1", Collections.emptyMap(), false, InitialPosition.Latest);
         pdfc.addConsumer(consumer1);
         List<Consumer> consumers = pdfc.getConsumers();
         assertTrue(consumers.get(0).consumerName() == consumer1.consumerName());
@@ -278,7 +279,7 @@ public class PersistentDispatcherFailoverConsumerTest {
 
         // 3. Add new consumer
         Consumer consumer2 = new Consumer(sub, SubType.Exclusive, topic.getName(), 2 /* consumer id */, 0,
-                "Cons2"/* consumer name */, 50000, serverCnx, "myrole-1", Collections.emptyMap(), false);
+                "Cons2"/* consumer name */, 50000, serverCnx, "myrole-1", Collections.emptyMap(), false, InitialPosition.Latest);
         pdfc.addConsumer(consumer2);
         consumers = pdfc.getConsumers();
         assertTrue(consumers.get(0).consumerName() == consumer1.consumerName());
@@ -307,7 +308,7 @@ public class PersistentDispatcherFailoverConsumerTest {
         // 2. Add consumer
         Consumer consumer1 = spy(new Consumer(sub, SubType.Exclusive, topic.getName(), 1 /* consumer id */, 0,
                 "Cons1"/* consumer name */, 50000, serverCnx, "myrole-1", Collections.emptyMap(),
-                false /* read compacted */));
+                false /* read compacted */, InitialPosition.Latest));
         pdfc.addConsumer(consumer1);
         List<Consumer> consumers = pdfc.getConsumers();
         assertTrue(consumers.get(0).consumerName() == consumer1.consumerName());
@@ -331,7 +332,7 @@ public class PersistentDispatcherFailoverConsumerTest {
 
         // 5. Add another consumer which does not change active consumer
         Consumer consumer2 = spy(new Consumer(sub, SubType.Exclusive, topic.getName(), 2 /* consumer id */, 0, "Cons2"/* consumer name */,
-                50000, serverCnx, "myrole-1", Collections.emptyMap(), false /* read compacted */));
+                50000, serverCnx, "myrole-1", Collections.emptyMap(), false /* read compacted */, InitialPosition.Latest));
         pdfc.addConsumer(consumer2);
         consumers = pdfc.getConsumers();
         assertTrue(pdfc.getActiveConsumer().consumerName() == consumer1.consumerName());
@@ -345,7 +346,7 @@ public class PersistentDispatcherFailoverConsumerTest {
         // 6. Add a consumer which changes active consumer
         Consumer consumer0 = spy(new Consumer(sub, SubType.Exclusive, topic.getName(), 0 /* consumer id */, 0,
                 "Cons0"/* consumer name */, 50000, serverCnx, "myrole-1", Collections.emptyMap(),
-                false /* read compacted */));
+                false /* read compacted */, InitialPosition.Latest));
         pdfc.addConsumer(consumer0);
         consumers = pdfc.getConsumers();
         assertTrue(pdfc.getActiveConsumer().consumerName() == consumer0.consumerName());
@@ -579,7 +580,7 @@ public class PersistentDispatcherFailoverConsumerTest {
     private Consumer createConsumer(int priority, int permit, boolean blocked, int id) throws Exception {
         Consumer consumer =
                 new Consumer(null, SubType.Shared, null, id, priority, ""+id, 5000,
-                        serverCnx, "appId", Collections.emptyMap(), false /* read compacted */);
+                        serverCnx, "appId", Collections.emptyMap(), false /* read compacted */, InitialPosition.Latest);
         try {
             consumer.flowPermits(permit);
         } catch (Exception e) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicConcurrentTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicConcurrentTest.java
@@ -48,8 +48,8 @@ import org.apache.pulsar.broker.service.Consumer;
 import org.apache.pulsar.broker.service.ServerCnx;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
-import org.apache.pulsar.broker.service.PersistentTopicTest;
 import org.apache.pulsar.common.api.proto.PulsarApi;
+import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
@@ -66,7 +66,9 @@ public class PersistentTopicConcurrentTest extends MockedBookKeeperTestCase {
     private BrokerService brokerService;
     private ManagedLedgerFactory mlFactoryMock;
     private ServerCnx serverCnx;
+    @SuppressWarnings("unused")
     private ManagedLedger ledgerMock;
+    @SuppressWarnings("unused")
     private ManagedCursor cursorMock;
 
     final String successTopicName = "persistent://prop/use/ns-abc/successTopic";
@@ -121,7 +123,7 @@ public class PersistentTopicConcurrentTest extends MockedBookKeeperTestCase {
                 .setSubType(PulsarApi.CommandSubscribe.SubType.Exclusive).build();
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
-                0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), cmd.getInitialPosition());
+                0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), InitialPosition.Latest);
         f1.get();
 
         final CyclicBarrier barrier = new CyclicBarrier(2);
@@ -179,7 +181,7 @@ public class PersistentTopicConcurrentTest extends MockedBookKeeperTestCase {
                 .setSubType(PulsarApi.CommandSubscribe.SubType.Exclusive).build();
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
-                0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), cmd.getInitialPosition());
+                0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), InitialPosition.Latest);
         f1.get();
 
         final CyclicBarrier barrier = new CyclicBarrier(2);
@@ -241,7 +243,7 @@ public class PersistentTopicConcurrentTest extends MockedBookKeeperTestCase {
                 .setSubType(PulsarApi.CommandSubscribe.SubType.Exclusive).build();
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
-                0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), cmd.getInitialPosition());
+                0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), InitialPosition.Latest);
         f1.get();
 
         final CyclicBarrier barrier = new CyclicBarrier(2);
@@ -299,7 +301,7 @@ public class PersistentTopicConcurrentTest extends MockedBookKeeperTestCase {
                 .setSubType(PulsarApi.CommandSubscribe.SubType.Exclusive).build();
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
-                0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), cmd.getInitialPosition());
+                0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), InitialPosition.Latest);
         f1.get();
 
         final CyclicBarrier barrier = new CyclicBarrier(2);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicConcurrentTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicConcurrentTest.java
@@ -48,6 +48,7 @@ import org.apache.pulsar.broker.service.Consumer;
 import org.apache.pulsar.broker.service.ServerCnx;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.broker.service.PersistentTopicTest;
 import org.apache.pulsar.common.api.proto.PulsarApi;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.naming.NamespaceBundle;
@@ -65,9 +66,7 @@ public class PersistentTopicConcurrentTest extends MockedBookKeeperTestCase {
     private BrokerService brokerService;
     private ManagedLedgerFactory mlFactoryMock;
     private ServerCnx serverCnx;
-    @SuppressWarnings("unused")
     private ManagedLedger ledgerMock;
-    @SuppressWarnings("unused")
     private ManagedCursor cursorMock;
 
     final String successTopicName = "persistent://prop/use/ns-abc/successTopic";
@@ -122,7 +121,7 @@ public class PersistentTopicConcurrentTest extends MockedBookKeeperTestCase {
                 .setSubType(PulsarApi.CommandSubscribe.SubType.Exclusive).build();
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
-                0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted());
+                0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), cmd.getInitialPosition());
         f1.get();
 
         final CyclicBarrier barrier = new CyclicBarrier(2);
@@ -180,7 +179,7 @@ public class PersistentTopicConcurrentTest extends MockedBookKeeperTestCase {
                 .setSubType(PulsarApi.CommandSubscribe.SubType.Exclusive).build();
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
-                0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted());
+                0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), cmd.getInitialPosition());
         f1.get();
 
         final CyclicBarrier barrier = new CyclicBarrier(2);
@@ -242,7 +241,7 @@ public class PersistentTopicConcurrentTest extends MockedBookKeeperTestCase {
                 .setSubType(PulsarApi.CommandSubscribe.SubType.Exclusive).build();
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
-                0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted());
+                0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), cmd.getInitialPosition());
         f1.get();
 
         final CyclicBarrier barrier = new CyclicBarrier(2);
@@ -300,7 +299,7 @@ public class PersistentTopicConcurrentTest extends MockedBookKeeperTestCase {
                 .setSubType(PulsarApi.CommandSubscribe.SubType.Exclusive).build();
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
-                0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted());
+                0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), cmd.getInitialPosition());
         f1.get();
 
         final CyclicBarrier barrier = new CyclicBarrier(2);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -86,16 +86,18 @@ import org.apache.pulsar.broker.service.persistent.PersistentReplicator;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe;
-import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition;
+import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.Policies;
+import org.apache.pulsar.common.schema.SchemaVersion;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
 import org.apache.pulsar.compaction.CompactedTopic;
 import org.apache.pulsar.compaction.Compactor;
@@ -335,7 +337,7 @@ public class PersistentTopicTest {
         String role = "appid1";
         // 1. simple add producer
         Producer producer = new Producer(topic, serverCnx, 1 /* producer id */, "prod-name",
-                role, false, null);
+                role, false, null, SchemaVersion.Latest);
         topic.addProducer(producer);
         assertEquals(topic.getProducers().size(), 1);
 
@@ -351,7 +353,7 @@ public class PersistentTopicTest {
         // 3. add producer for a different topic
         PersistentTopic failTopic = new PersistentTopic(failTopicName, ledgerMock, brokerService);
         Producer failProducer = new Producer(failTopic, serverCnx, 2 /* producer id */, "prod-name",
-                role, false, null);
+                role, false, null, SchemaVersion.Latest);
         try {
             topic.addProducer(failProducer);
             fail("should have failed");
@@ -371,18 +373,18 @@ public class PersistentTopicTest {
         PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
         String role = "appid1";
         // 1. add producer1
-        Producer producer = new Producer(topic, serverCnx, 1 /* producer id */, "prod-name1", role, false, null);
+        Producer producer = new Producer(topic, serverCnx, 1 /* producer id */, "prod-name1", role, false, null, SchemaVersion.Latest);
         topic.addProducer(producer);
         assertEquals(topic.getProducers().size(), 1);
 
         // 2. add producer2
-        Producer producer2 = new Producer(topic, serverCnx, 2 /* producer id */, "prod-name2", role, false, null);
+        Producer producer2 = new Producer(topic, serverCnx, 2 /* producer id */, "prod-name2", role, false, null, SchemaVersion.Latest);
         topic.addProducer(producer2);
         assertEquals(topic.getProducers().size(), 2);
 
         // 3. add producer3 but reached maxProducersPerTopic
         try {
-            Producer producer3 = new Producer(topic, serverCnx, 3 /* producer id */, "prod-name3", role, false, null);
+            Producer producer3 = new Producer(topic, serverCnx, 3 /* producer id */, "prod-name3", role, false, null, SchemaVersion.Latest);
             topic.addProducer(producer3);
             fail("should have failed");
         } catch (BrokerServiceException e) {
@@ -421,7 +423,7 @@ public class PersistentTopicTest {
                 .setSubscription("").setRequestId(1).setSubType(SubType.Exclusive).build();
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
-                0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), cmd.getInitialPosition());
+                0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), InitialPosition.Latest);
         try {
             f1.get();
             fail("should fail with exception");
@@ -440,12 +442,12 @@ public class PersistentTopicTest {
 
         // 1. simple subscribe
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
-                0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), cmd.getInitialPosition());
+                0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), InitialPosition.Latest);
         f1.get();
 
         // 2. duplicate subscribe
         Future<Consumer> f2 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
-                0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), cmd.getInitialPosition());
+                0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), InitialPosition.Latest);
 
         try {
             f2.get();
@@ -469,7 +471,7 @@ public class PersistentTopicTest {
 
         // 1. simple add consumer
         Consumer consumer = new Consumer(sub, SubType.Exclusive, topic.getName(), 1 /* consumer id */, 0, "Cons1"/* consumer name */,
-                50000, serverCnx, "myrole-1", Collections.emptyMap(), false /* read compacted */);
+                50000, serverCnx, "myrole-1", Collections.emptyMap(), false /* read compacted */, InitialPosition.Latest);
         sub.addConsumer(consumer);
         assertTrue(sub.getDispatcher().isConsumerConnected());
 
@@ -510,14 +512,14 @@ public class PersistentTopicTest {
         // 1. add consumer1
         Consumer consumer = new Consumer(sub, SubType.Shared, topic.getName(), 1 /* consumer id */, 0,
                 "Cons1"/* consumer name */, 50000, serverCnx, "myrole-1", Collections.emptyMap(),
-                false /* read compacted */);
+                false /* read compacted */, InitialPosition.Latest);
         sub.addConsumer(consumer);
         assertEquals(sub.getConsumers().size(), 1);
 
         // 2. add consumer2
         Consumer consumer2 = new Consumer(sub, SubType.Shared, topic.getName(), 2 /* consumer id */, 0,
                 "Cons2"/* consumer name */, 50000, serverCnx, "myrole-1", Collections.emptyMap(),
-                false /* read compacted */);
+                false /* read compacted */, InitialPosition.Latest);
         sub.addConsumer(consumer2);
         assertEquals(sub.getConsumers().size(), 2);
 
@@ -525,7 +527,7 @@ public class PersistentTopicTest {
         try {
             Consumer consumer3 = new Consumer(sub, SubType.Shared, topic.getName(), 3 /* consumer id */, 0,
                     "Cons3"/* consumer name */, 50000, serverCnx, "myrole-1", Collections.emptyMap(),
-                    false /* read compacted */);
+                    false /* read compacted */, InitialPosition.Latest);
             sub.addConsumer(consumer3);
             fail("should have failed");
         } catch (BrokerServiceException e) {
@@ -538,7 +540,7 @@ public class PersistentTopicTest {
         // 4. add consumer4 to sub2
         Consumer consumer4 = new Consumer(sub2, SubType.Shared, topic.getName(), 4 /* consumer id */, 0,
                 "Cons4"/* consumer name */, 50000, serverCnx, "myrole-1", Collections.emptyMap(),
-                false /* read compacted */);
+                false /* read compacted */, InitialPosition.Latest);
         sub2.addConsumer(consumer4);
         assertEquals(sub2.getConsumers().size(), 1);
 
@@ -549,7 +551,7 @@ public class PersistentTopicTest {
         try {
             Consumer consumer5 = new Consumer(sub2, SubType.Shared, topic.getName(), 5 /* consumer id */, 0,
                     "Cons5"/* consumer name */, 50000, serverCnx, "myrole-1", Collections.emptyMap(),
-                    false /* read compacted */);
+                    false /* read compacted */, InitialPosition.Latest);
             sub2.addConsumer(consumer5);
             fail("should have failed");
         } catch (BrokerServiceException e) {
@@ -601,14 +603,14 @@ public class PersistentTopicTest {
         // 1. add consumer1
         Consumer consumer = new Consumer(sub, SubType.Failover, topic.getName(), 1 /* consumer id */, 0,
                 "Cons1"/* consumer name */, 50000, serverCnx, "myrole-1", Collections.emptyMap(),
-                false /* read compacted */);
+                false /* read compacted */, InitialPosition.Latest);
         sub.addConsumer(consumer);
         assertEquals(sub.getConsumers().size(), 1);
 
         // 2. add consumer2
         Consumer consumer2 = new Consumer(sub, SubType.Failover, topic.getName(), 2 /* consumer id */, 0,
                 "Cons2"/* consumer name */, 50000, serverCnx, "myrole-1", Collections.emptyMap(),
-                false /* read compacted */);
+                false /* read compacted */, InitialPosition.Latest);
         sub.addConsumer(consumer2);
         assertEquals(sub.getConsumers().size(), 2);
 
@@ -616,7 +618,7 @@ public class PersistentTopicTest {
         try {
             Consumer consumer3 = new Consumer(sub, SubType.Failover, topic.getName(), 3 /* consumer id */, 0,
                     "Cons3"/* consumer name */, 50000, serverCnx, "myrole-1", Collections.emptyMap(),
-                    false /* read compacted */);
+                    false /* read compacted */, InitialPosition.Latest);
             sub.addConsumer(consumer3);
             fail("should have failed");
         } catch (BrokerServiceException e) {
@@ -629,7 +631,7 @@ public class PersistentTopicTest {
         // 4. add consumer4 to sub2
         Consumer consumer4 = new Consumer(sub2, SubType.Failover, topic.getName(), 4 /* consumer id */, 0,
                 "Cons4"/* consumer name */, 50000, serverCnx, "myrole-1", Collections.emptyMap(),
-                false /* read compacted */);
+                false /* read compacted */, InitialPosition.Latest);
         sub2.addConsumer(consumer4);
         assertEquals(sub2.getConsumers().size(), 1);
 
@@ -640,7 +642,7 @@ public class PersistentTopicTest {
         try {
             Consumer consumer5 = new Consumer(sub2, SubType.Failover, topic.getName(), 5 /* consumer id */, 0,
                     "Cons5"/* consumer name */, 50000, serverCnx, "myrole-1", Collections.emptyMap(),
-                    false /* read compacted */);
+                    false /* read compacted */, InitialPosition.Latest);
             sub2.addConsumer(consumer5);
             fail("should have failed");
         } catch (BrokerServiceException e) {
@@ -680,7 +682,7 @@ public class PersistentTopicTest {
         PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
         PersistentSubscription sub = new PersistentSubscription(topic, "sub-1", cursorMock);
         Consumer consumer1 = new Consumer(sub, SubType.Exclusive, topic.getName(), 1 /* consumer id */, 0, "Cons1"/* consumer name */,
-                50000, serverCnx, "myrole-1", Collections.emptyMap(), false /* read compacted */);
+                50000, serverCnx, "myrole-1", Collections.emptyMap(), false /* read compacted */, InitialPosition.Latest);
         sub.addConsumer(consumer1);
 
         doAnswer(new Answer<Object>() {
@@ -701,8 +703,8 @@ public class PersistentTopicTest {
 
         try {
             Thread.sleep(10); /* delay to ensure that the ubsubscribe gets executed first */
-            Consumer consumer2 = new Consumer(sub, SubType.Exclusive, topic.getName(), 2 /* consumer id */, 0, "Cons2"/* consumer name */,
-                    50000, serverCnx, "myrole-1", Collections.emptyMap(), false /* read compacted */);
+            new Consumer(sub, SubType.Exclusive, topic.getName(), 2 /* consumer id */, 0, "Cons2"/* consumer name */,
+                    50000, serverCnx, "myrole-1", Collections.emptyMap(), false /* read compacted */, InitialPosition.Latest);
         } catch (BrokerServiceException e) {
             assertTrue(e instanceof BrokerServiceException.SubscriptionFencedException);
         }
@@ -721,7 +723,7 @@ public class PersistentTopicTest {
         // 2. delete topic with producer
         topic = (PersistentTopic) brokerService.getTopic(successTopicName).get();
         Producer producer = new Producer(topic, serverCnx, 1 /* producer id */, "prod-name",
-                role, false, null);
+                role, false, null, SchemaVersion.Latest);
         topic.addProducer(producer);
 
         assertTrue(topic.delete().isCompletedExceptionally());
@@ -732,7 +734,7 @@ public class PersistentTopicTest {
                 .setSubscription(successSubName).setRequestId(1).setSubType(SubType.Exclusive).build();
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
-                0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), false /* read compacted */, cmd.getInitialPosition());
+                0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), false /* read compacted */, InitialPosition.Latest);
         f1.get();
 
         assertTrue(topic.delete().isCompletedExceptionally());
@@ -747,7 +749,7 @@ public class PersistentTopicTest {
                 .setSubscription(successSubName).setRequestId(1).setSubType(SubType.Exclusive).build();
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
-                0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), cmd.getInitialPosition());
+                0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), InitialPosition.Latest);
         f1.get();
 
         final CyclicBarrier barrier = new CyclicBarrier(2);
@@ -801,7 +803,7 @@ public class PersistentTopicTest {
                 .setSubscription(successSubName).setRequestId(1).setSubType(SubType.Exclusive).build();
 
         Future<Consumer> f1 = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
-                0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), cmd.getInitialPosition());
+                0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), InitialPosition.Latest);
         f1.get();
 
         final CyclicBarrier barrier = new CyclicBarrier(2);
@@ -877,7 +879,7 @@ public class PersistentTopicTest {
             String role = "appid1";
             Thread.sleep(10); /* delay to ensure that the delete gets executed first */
             Producer producer = new Producer(topic, serverCnx, 1 /* producer id */, "prod-name",
-                    role, false, null);
+                    role, false, null, SchemaVersion.Latest);
             topic.addProducer(producer);
             fail("Should have failed");
         } catch (BrokerServiceException e) {
@@ -888,8 +890,8 @@ public class PersistentTopicTest {
                 .setSubscription(successSubName).setRequestId(1).setSubType(SubType.Exclusive).build();
 
         Future<Consumer> f = topic.subscribe(serverCnx, cmd.getSubscription(), cmd.getConsumerId(), cmd.getSubType(),
-                0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), cmd.getInitialPosition());
-     
+                0, cmd.getConsumerName(), cmd.getDurable(), null, Collections.emptyMap(), cmd.getReadCompacted(), InitialPosition.Latest);
+
         try {
             f.get();
             fail("should have failed");
@@ -907,7 +909,7 @@ public class PersistentTopicTest {
         doReturn(new ArrayList<Object>()).when(ledgerMock).getCursors();
         doReturn("mockCursor").when(cursorMock).getName();
         // doNothing().when(cursorMock).asyncClose(new CloseCallback() {
-        doAnswer(new Answer() {
+        doAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
                 // return closeFuture.get();
@@ -963,16 +965,14 @@ public class PersistentTopicTest {
             }
         }).when(ledgerMock).asyncAddEntry(any(ByteBuf.class), any(AddEntryCallback.class), anyObject());
 
-
         // call openCursorComplete on cursor asyncOpen
         doAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
-                ((OpenCursorCallback) invocationOnMock.getArguments()[2]).openCursorComplete(cursorMock, null);
+                ((OpenCursorCallback) invocationOnMock.getArguments()[1]).openCursorComplete(cursorMock, null);
                 return null;
             }
-        }).when(ledgerMock).asyncOpenCursor(matches(".*success.*"), any(InitialPosition.class), any(OpenCursorCallback.class), anyObject());
-        
+        }).when(ledgerMock).asyncOpenCursor(matches(".*success.*"), any(OpenCursorCallback.class), anyObject());
 
         // call deleteLedgerComplete on ledger asyncDelete
         doAnswer(new Answer<Object>() {
@@ -1008,7 +1008,7 @@ public class PersistentTopicTest {
         // 1. Subscribe with non partition topic
         Future<Consumer> f1 = topic1.subscribe(serverCnx, cmd1.getSubscription(), cmd1.getConsumerId(),
                 cmd1.getSubType(), 0, cmd1.getConsumerName(), cmd1.getDurable(), null, Collections.emptyMap(),
-                cmd1.getReadCompacted(), cmd1.getInitialPosition());
+                cmd1.getReadCompacted(), InitialPosition.Latest);
         f1.get();
 
         // 2. Subscribe with partition topic
@@ -1020,7 +1020,7 @@ public class PersistentTopicTest {
 
         Future<Consumer> f2 = topic2.subscribe(serverCnx, cmd2.getSubscription(), cmd2.getConsumerId(),
                 cmd2.getSubType(), 0, cmd2.getConsumerName(), cmd2.getDurable(), null, Collections.emptyMap(),
-                cmd2.getReadCompacted(), cmd2.getInitialPosition());
+                cmd2.getReadCompacted(), InitialPosition.Latest);
         f2.get();
 
         // 3. Subscribe and create second consumer
@@ -1030,7 +1030,7 @@ public class PersistentTopicTest {
 
         Future<Consumer> f3 = topic2.subscribe(serverCnx, cmd3.getSubscription(), cmd3.getConsumerId(),
                 cmd3.getSubType(), 0, cmd3.getConsumerName(), cmd3.getDurable(), null, Collections.emptyMap(),
-                cmd3.getReadCompacted(), cmd3.getInitialPosition());
+                cmd3.getReadCompacted(), InitialPosition.Latest);
         f3.get();
 
         assertEquals(
@@ -1051,7 +1051,7 @@ public class PersistentTopicTest {
 
         Future<Consumer> f4 = topic2.subscribe(serverCnx, cmd4.getSubscription(), cmd4.getConsumerId(),
                 cmd4.getSubType(), 0, cmd4.getConsumerName(), cmd4.getDurable(), null, Collections.emptyMap(),
-                cmd4.getReadCompacted(), cmd4.getInitialPosition());
+                cmd4.getReadCompacted(), InitialPosition.Latest);
         f4.get();
 
         assertEquals(
@@ -1077,7 +1077,7 @@ public class PersistentTopicTest {
 
         Future<Consumer> f5 = topic2.subscribe(serverCnx, cmd5.getSubscription(), cmd5.getConsumerId(),
                 cmd5.getSubType(), 0, cmd5.getConsumerName(), cmd5.getDurable(), null, Collections.emptyMap(),
-                cmd5.getReadCompacted(), cmd5.getInitialPosition());
+                cmd5.getReadCompacted(), InitialPosition.Latest);
 
         try {
             f5.get();
@@ -1094,7 +1094,7 @@ public class PersistentTopicTest {
 
         Future<Consumer> f6 = topic2.subscribe(serverCnx, cmd6.getSubscription(), cmd6.getConsumerId(),
                 cmd6.getSubType(), 0, cmd6.getConsumerName(), cmd6.getDurable(), null, Collections.emptyMap(),
-                cmd6.getReadCompacted(), cmd6.getInitialPosition());
+                cmd6.getReadCompacted(), InitialPosition.Latest);
         f6.get();
 
         // 7. unsubscribe exclusive sub
@@ -1161,7 +1161,7 @@ public class PersistentTopicTest {
 
         final URL brokerUrl = new URL(
                 "http://" + pulsar.getAdvertisedAddress() + ":" + pulsar.getConfiguration().getBrokerServicePort());
-        PulsarClient client = PulsarClient.create(brokerUrl.toString());
+        PulsarClient client = PulsarClient.builder().serviceUrl(brokerUrl.toString()).build();
         ManagedCursor cursor = mock(ManagedCursorImpl.class);
         doReturn(remoteCluster).when(cursor).getName();
         brokerService.getReplicationClients().put(remoteCluster, client);
@@ -1191,6 +1191,7 @@ public class PersistentTopicTest {
         callback.deleteCursorComplete(null);
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void testClosingReplicationProducerTwice() throws Exception {
         final String globalTopicName = "persistent://prop/global/ns/testClosingReplicationProducerTwice";
@@ -1204,26 +1205,33 @@ public class PersistentTopicTest {
 
         final URL brokerUrl = new URL(
                 "http://" + pulsar.getAdvertisedAddress() + ":" + pulsar.getConfiguration().getBrokerServicePort());
-        PulsarClient client =  spy( PulsarClient.create(brokerUrl.toString()) );
+        PulsarClient client = spy(PulsarClient.builder().serviceUrl(brokerUrl.toString()).build());
         PulsarClientImpl clientImpl = (PulsarClientImpl) client;
+        doReturn(new CompletableFuture<Producer>()).when(clientImpl)
+            .createProducerAsync(any(ProducerConfigurationData.class), any(Schema.class));
 
         ManagedCursor cursor = mock(ManagedCursorImpl.class);
         doReturn(remoteCluster).when(cursor).getName();
         brokerService.getReplicationClients().put(remoteCluster, client);
         PersistentReplicator replicator = new PersistentReplicator(topic, cursor, localCluster, remoteCluster, brokerService);
 
-        doReturn(new CompletableFuture<Producer>()).when(clientImpl)
-                .createProducerAsync(any(ProducerConfigurationData.class));
-
-        replicator.startProducer();
-        verify(clientImpl).createProducerAsync(any(ProducerConfigurationData.class));
+        // PersistentReplicator constructor calls startProducer()
+        verify(clientImpl)
+            .createProducerAsync(
+                any(ProducerConfigurationData.class),
+                any(Schema.class)
+            );
 
         replicator.disconnect(false);
         replicator.disconnect(false);
 
         replicator.startProducer();
 
-        verify(clientImpl, Mockito.times(2)).createProducerAsync(any(ProducerConfigurationData.class));
+        verify(clientImpl, Mockito.times(2))
+            .createProducerAsync(
+                any(ProducerConfigurationData.class),
+                any(Schema.class)
+            );
     }
 
     @Test
@@ -1252,9 +1260,7 @@ public class PersistentTopicTest {
 
         PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
         CompactedTopic compactedTopic = mock(CompactedTopic.class);
-        PersistentSubscription sub = new CompactorSubscription(topic, compactedTopic,
-                                                               Compactor.COMPACTION_SUBSCRIPTION,
-                                                               cursorMock);
+        new CompactorSubscription(topic, compactedTopic, Compactor.COMPACTION_SUBSCRIPTION, cursorMock);
         verify(compactedTopic, Mockito.times(1)).newCompactedLedger(position, ledgerId);
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -969,10 +969,10 @@ public class PersistentTopicTest {
         doAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
-                ((OpenCursorCallback) invocationOnMock.getArguments()[1]).openCursorComplete(cursorMock, null);
+                ((OpenCursorCallback) invocationOnMock.getArguments()[2]).openCursorComplete(cursorMock, null);
                 return null;
             }
-        }).when(ledgerMock).asyncOpenCursor(matches(".*success.*"), any(OpenCursorCallback.class), anyObject());
+        }).when(ledgerMock).asyncOpenCursor(matches(".*success.*"), any(InitialPosition.class), any(OpenCursorCallback.class), anyObject());
 
         // call deleteLedgerComplete on ledger asyncDelete
         doAnswer(new Answer<Object>() {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -89,6 +89,7 @@ import org.apache.pulsar.common.api.proto.PulsarApi.CommandLookupTopicResponse;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandProducerSuccess;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSendError;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSendReceipt;
+import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSuccess;
 import org.apache.pulsar.common.api.proto.PulsarApi.EncryptionKeys;
@@ -1452,20 +1453,20 @@ public class ServerCnxTest {
             @Override
             public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
                 Thread.sleep(300);
-                ((OpenCursorCallback) invocationOnMock.getArguments()[1]).openCursorComplete(cursorMock, null);
+                ((OpenCursorCallback) invocationOnMock.getArguments()[2]).openCursorComplete(cursorMock, null);
                 return null;
             }
-        }).when(ledgerMock).asyncOpenCursor(matches(".*success.*"), any(OpenCursorCallback.class), anyObject());
+        }).when(ledgerMock).asyncOpenCursor(matches(".*success.*"), any(InitialPosition.class), any(OpenCursorCallback.class), anyObject());
 
         doAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
                 Thread.sleep(300);
-                ((OpenCursorCallback) invocationOnMock.getArguments()[1])
+                ((OpenCursorCallback) invocationOnMock.getArguments()[2])
                         .openCursorFailed(new ManagedLedgerException("Managed ledger failure"), null);
                 return null;
             }
-        }).when(ledgerMock).asyncOpenCursor(matches(".*fail.*"), any(OpenCursorCallback.class), anyObject());
+        }).when(ledgerMock).asyncOpenCursor(matches(".*fail.*"), any(InitialPosition.class), any(OpenCursorCallback.class), anyObject());
 
         doAnswer(new Answer<Object>() {
             @Override

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -32,8 +32,6 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.nio.file.Files;
-import java.nio.file.LinkOption;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
@@ -54,7 +52,7 @@ import java.util.stream.Collectors;
 import org.apache.bookkeeper.mledger.impl.EntryCacheImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
-import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.PulsarClientException.InvalidConfigurationException;
 import org.apache.pulsar.client.impl.ConsumerImpl;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.api.PulsarDecoder;
@@ -96,26 +94,25 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     public void testSyncProducerAndConsumer(int batchMessageDelayMs) throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic1", "my-subscriber-name",
-                conf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/my-topic1")
+                .subscriptionName("my-subscriber-name").subscribe();
 
-        ProducerConfiguration producerConf = new ProducerConfiguration();
+        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer()
+                .topic("persistent://my-property/use/my-ns/my-topic1");
 
         if (batchMessageDelayMs != 0) {
-            producerConf.setBatchingEnabled(true);
-            producerConf.setBatchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
-            producerConf.setBatchingMaxMessages(5);
+            producerBuilder.enableBatching(true);
+            producerBuilder.batchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
+            producerBuilder.batchingMaxMessages(5);
         }
 
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic1", producerConf);
+        Producer<byte[]> producer = producerBuilder.create();
         for (int i = 0; i < 10; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
 
-        Message msg = null;
+        Message<byte[]> msg = null;
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 0; i < 10; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);
@@ -133,17 +130,18 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     @Test(dataProvider = "batch")
     public void testAsyncProducerAndAsyncAck(int batchMessageDelayMs) throws Exception {
         log.info("-- Starting {} test --", methodName);
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic2", "my-subscriber-name",
-                conf);
-        ProducerConfiguration producerConf = new ProducerConfiguration();
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/my-topic2")
+                .subscriptionName("my-subscriber-name").subscribe();
+
+        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer()
+                .topic("persistent://my-property/use/my-ns/my-topic2");
+
         if (batchMessageDelayMs != 0) {
-            producerConf.setBatchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
-            producerConf.setBatchingMaxMessages(5);
-            producerConf.setBatchingEnabled(true);
+            producerBuilder.enableBatching(true);
+            producerBuilder.batchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
+            producerBuilder.batchingMaxMessages(5);
         }
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic2", producerConf);
+        Producer<byte[]> producer = producerBuilder.create();
         List<Future<MessageId>> futures = Lists.newArrayList();
 
         // Asynchronously produce messages
@@ -158,7 +156,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             future.get();
         }
 
-        Message msg = null;
+        Message<byte[]> msg = null;
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 0; i < 10; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);
@@ -179,28 +177,28 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     @Test(dataProvider = "batch", timeOut = 100000)
     public void testMessageListener(int batchMessageDelayMs) throws Exception {
         log.info("-- Starting {} test --", methodName);
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
 
         int numMessages = 100;
         final CountDownLatch latch = new CountDownLatch(numMessages);
 
-        conf.setMessageListener((consumer, msg) -> {
-            Assert.assertNotNull(msg, "Message cannot be null");
-            String receivedMessage = new String(msg.getData());
-            log.debug("Received message [{}] in the listener", receivedMessage);
-            consumer.acknowledgeAsync(msg);
-            latch.countDown();
-        });
-        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic3", "my-subscriber-name",
-                conf);
-        ProducerConfiguration producerConf = new ProducerConfiguration();
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/my-topic3")
+                .subscriptionName("my-subscriber-name").messageListener((c1, msg) -> {
+                    Assert.assertNotNull(msg, "Message cannot be null");
+                    String receivedMessage = new String(msg.getData());
+                    log.debug("Received message [{}] in the listener", receivedMessage);
+                    c1.acknowledgeAsync(msg);
+                    latch.countDown();
+                }).subscribe();
+
+        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer()
+                .topic("persistent://my-property/use/my-ns/my-topic3");
+
         if (batchMessageDelayMs != 0) {
-            producerConf.setBatchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
-            producerConf.setBatchingMaxMessages(5);
-            producerConf.setBatchingEnabled(true);
+            producerBuilder.enableBatching(true);
+            producerBuilder.batchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
+            producerBuilder.batchingMaxMessages(5);
         }
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic3", producerConf);
+        Producer<byte[]> producer = producerBuilder.create();
         List<Future<MessageId>> futures = Lists.newArrayList();
 
         // Asynchronously produce messages
@@ -225,18 +223,17 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     public void testBackoffAndReconnect(int batchMessageDelayMs) throws Exception {
         log.info("-- Starting {} test --", methodName);
         // Create consumer and producer
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic4", "my-subscriber-name",
-                conf);
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-        if (batchMessageDelayMs != 0) {
-            producerConf.setBatchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
-            producerConf.setBatchingMaxMessages(5);
-            producerConf.setBatchingEnabled(true);
-        }
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic4", producerConf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/my-topic4")
+                .subscriptionName("my-subscriber-name").subscribe();
+        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer()
+                .topic("persistent://my-property/use/my-ns/my-topic4");
 
+        if (batchMessageDelayMs != 0) {
+            producerBuilder.enableBatching(true);
+            producerBuilder.batchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
+            producerBuilder.batchingMaxMessages(5);
+        }
+        Producer<byte[]> producer = producerBuilder.create();
         // Produce messages
         CompletableFuture<MessageId> lastFuture = null;
         for (int i = 0; i < 10; i++) {
@@ -248,7 +245,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         lastFuture.get();
 
-        Message msg = null;
+        Message<byte[]> msg = null;
         for (int i = 0; i < 10; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);
             log.info("Received: [{}]", new String(msg.getData()));
@@ -275,19 +272,17 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     public void testSendTimeout(int batchMessageDelayMs) throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        ConsumerConfiguration consumerConf = new ConsumerConfiguration();
-        consumerConf.setSubscriptionType(SubscriptionType.Exclusive);
-        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic5", "my-subscriber-name",
-                consumerConf);
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-        if (batchMessageDelayMs != 0) {
-            producerConf.setBatchingMaxPublishDelay(2 * batchMessageDelayMs, TimeUnit.MILLISECONDS);
-            producerConf.setBatchingMaxMessages(5);
-            producerConf.setBatchingEnabled(true);
-        }
-        producerConf.setSendTimeout(1, TimeUnit.SECONDS);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/my-topic5")
+                .subscriptionName("my-subscriber-name").subscribe();
+        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer()
+                .topic("persistent://my-property/use/my-ns/my-topic5").sendTimeout(1, TimeUnit.SECONDS);
 
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic5", producerConf);
+        if (batchMessageDelayMs != 0) {
+            producerBuilder.enableBatching(true);
+            producerBuilder.batchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
+            producerBuilder.batchingMaxMessages(5);
+        }
+        Producer<byte[]> producer = producerBuilder.create();
         final String message = "my-message";
 
         // Trigger the send timeout
@@ -305,7 +300,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         startBroker();
 
         // We should not have received any message
-        Message msg = consumer.receive(3, TimeUnit.SECONDS);
+        Message<byte[]> msg = consumer.receive(3, TimeUnit.SECONDS);
         Assert.assertNull(msg);
         consumer.close();
         log.info("-- Exiting {} test --", methodName);
@@ -315,32 +310,29 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     public void testInvalidSequence() throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        PulsarClient client1 = PulsarClient.create("http://127.0.0.1:" + BROKER_WEBSERVICE_PORT);
+        PulsarClient client1 = PulsarClient.builder().serviceUrl("http://127.0.0.1:" + BROKER_WEBSERVICE_PORT).build();
         client1.close();
 
-        ConsumerConfiguration consumerConf = new ConsumerConfiguration();
-        consumerConf.setSubscriptionType(SubscriptionType.Exclusive);
-
         try {
-            Consumer consumer = client1.subscribe("persistent://my-property/use/my-ns/my-topic6", "my-subscriber-name",
-                    consumerConf);
+            client1.newConsumer().topic("persistent://my-property/use/my-ns/my-topic6")
+                    .subscriptionName("my-subscriber-name").subscribe();
             Assert.fail("Should fail");
         } catch (PulsarClientException e) {
             Assert.assertTrue(e instanceof PulsarClientException.AlreadyClosedException);
         }
 
         try {
-            Producer producer = client1.createProducer("persistent://my-property/use/my-ns/my-topic6");
+            client1.newProducer().topic("persistent://my-property/use/my-ns/my-topic6").create();
             Assert.fail("Should fail");
         } catch (PulsarClientException e) {
             Assert.assertTrue(e instanceof PulsarClientException.AlreadyClosedException);
         }
 
-        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic6", "my-subscriber-name",
-                consumerConf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/my-topic6")
+                .subscriptionName("my-subscriber-name").subscribe();
 
         try {
-            Message msg = MessageBuilder.create().setContent("InvalidMessage".getBytes()).build();
+            Message<byte[]> msg = MessageBuilder.create().setContent("InvalidMessage".getBytes()).build();
             consumer.acknowledge(msg);
         } catch (PulsarClientException.InvalidMessageException e) {
             // ok
@@ -362,7 +354,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             // ok
         }
 
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic6");
+        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic6")
+                .create();
         producer.close();
 
         try {
@@ -377,91 +370,72 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     @Test
     public void testSillyUser() {
         try {
-            PulsarClient client1 = PulsarClient.create("invalid://url");
+            PulsarClient.builder().serviceUrl("invalid://url").build();
             Assert.fail("should fail");
         } catch (PulsarClientException e) {
             Assert.assertTrue(e instanceof PulsarClientException.InvalidServiceURL);
         }
 
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-
         try {
-            producerConf.setSendTimeout(-1, TimeUnit.SECONDS);
+            pulsarClient.newProducer().sendTimeout(-1, TimeUnit.SECONDS);
             Assert.fail("should fail");
         } catch (IllegalArgumentException e) {
             // ok
         }
 
         try {
-            producerConf.setMaxPendingMessages(0);
+            pulsarClient.newProducer().maxPendingMessages(0);
             Assert.fail("should fail");
         } catch (IllegalArgumentException e) {
             // ok
         }
 
         try {
-            Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic7", null);
-            Assert.fail("should fail");
-        } catch (PulsarClientException e) {
-            Assert.assertTrue(e instanceof PulsarClientException.InvalidConfigurationException);
-        }
-
-        try {
-            Producer producer = pulsarClient.createProducer("invalid://topic", producerConf);
+            pulsarClient.newProducer().topic("invalid://topic").create();
             Assert.fail("should fail");
         } catch (PulsarClientException e) {
             Assert.assertTrue(e instanceof PulsarClientException.InvalidTopicNameException);
         }
 
-        ConsumerConfiguration consumerConf = new ConsumerConfiguration();
-
         try {
-            consumerConf.setMessageListener(null);
+            pulsarClient.newConsumer().messageListener(null);
             Assert.fail("should fail");
         } catch (NullPointerException e) {
             // ok
         }
 
         try {
-            consumerConf.setSubscriptionType(null);
+            pulsarClient.newConsumer().subscriptionType(null);
             Assert.fail("should fail");
         } catch (NullPointerException e) {
             // ok
         }
 
         try {
-            consumerConf.setReceiverQueueSize(-1);
+            pulsarClient.newConsumer().receiverQueueSize(-1);
             Assert.fail("should fail");
         } catch (IllegalArgumentException e) {
             // ok
         }
 
         try {
-            Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic7",
-                    "my-subscriber-name", null);
+            pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/my-topic7").subscriptionName(null)
+                    .subscribe();
+            Assert.fail("Should fail");
+        } catch (PulsarClientException e) {
+            assertEquals(e.getClass(), InvalidConfigurationException.class);
+        }
+
+        try {
+            pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/my-topic7").subscriptionName("")
+                    .subscribe();
             Assert.fail("Should fail");
         } catch (PulsarClientException e) {
             Assert.assertTrue(e instanceof PulsarClientException.InvalidConfigurationException);
         }
 
         try {
-            Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic7", null,
-                    consumerConf);
-            Assert.fail("Should fail");
-        } catch (PulsarClientException e) {
-            Assert.assertTrue(e instanceof PulsarClientException.InvalidConfigurationException);
-        }
-
-        try {
-            Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic7", "",
-                    consumerConf);
-            Assert.fail("Should fail");
-        } catch (PulsarClientException e) {
-            Assert.assertTrue(e instanceof PulsarClientException.InvalidConfigurationException);
-        }
-
-        try {
-            Consumer consumer = pulsarClient.subscribe("invalid://topic7", "my-subscriber-name", consumerConf);
+            pulsarClient.newConsumer().topic("invalid://topic7").subscriptionName("my-subscriber-name").subscribe();
             Assert.fail("Should fail");
         } catch (PulsarClientException e) {
             Assert.assertTrue(e instanceof PulsarClientException.InvalidTopicNameException);
@@ -476,10 +450,10 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         final int recvQueueSize = 100;
         final int numConsumersThreads = 10;
 
-        final ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setReceiverQueueSize(recvQueueSize);
         String subName = UUID.randomUUID().toString();
-        final Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic7", subName, conf);
+        final Consumer<byte[]> consumer = pulsarClient.newConsumer()
+                .topic("persistent://my-property/use/my-ns/my-topic7").subscriptionName(subName)
+                .receiverQueueSize(recvQueueSize).subscribe();
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final CyclicBarrier barrier = new CyclicBarrier(numConsumersThreads + 1);
@@ -503,20 +477,22 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         Thread.sleep(2000);
 
         // publish 100 messages so that the consumers blocked on receive() will now get the messages
-        ProducerConfiguration producerConf = new ProducerConfiguration();
+        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer()
+                .topic("persistent://my-property/use/my-ns/my-topic7");
+
         if (batchMessageDelayMs != 0) {
-            producerConf.setBatchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
-            producerConf.setBatchingMaxMessages(5);
-            producerConf.setBatchingEnabled(true);
+            producerBuilder.batchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
+            producerBuilder.batchingMaxMessages(5);
+            producerBuilder.enableBatching(true);
         }
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic7", producerConf);
+        Producer<byte[]> producer = producerBuilder.create();
         for (int i = 0; i < recvQueueSize; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
         Thread.sleep(500);
 
-        ConsumerImpl consumerImpl = (ConsumerImpl) consumer;
+        ConsumerImpl<byte[]> consumerImpl = (ConsumerImpl<byte[]>) consumer;
         // The available permits should be 10 and num messages in the queue should be 90
         Assert.assertEquals(consumerImpl.getAvailablePermits(), numConsumersThreads);
         Assert.assertEquals(consumerImpl.numMessagesInQueue(), recvQueueSize - numConsumersThreads);
@@ -541,7 +517,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         // clear the queue
         while (true) {
-            Message msg = consumer.receive(1, TimeUnit.SECONDS);
+            Message<byte[]> msg = consumer.receive(1, TimeUnit.SECONDS);
             if (msg == null) {
                 break;
             }
@@ -584,8 +560,9 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         try {
             final String topic = "persistent://my-property/use/my-ns/bigMsg";
-            Producer producer = pulsarClient.createProducer(topic);
-            Message message = MessageBuilder.create().setContent(new byte[PulsarDecoder.MaxMessageSize + 1]).build();
+            Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).create();
+            Message<byte[]> message = MessageBuilder.create().setContent(new byte[PulsarDecoder.MaxMessageSize + 1])
+                    .build();
             producer.send(message);
             fail("Should have thrown exception");
         } catch (PulsarClientException.InvalidMessageException e) {
@@ -614,18 +591,16 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         final String topic = "persistent://my-property/use/my-ns/bigMsg";
 
         // (a) non-batch msg with compression
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-        producerConf.setCompressionType(CompressionType.LZ4);
-        Producer producer = pulsarClient.createProducer(topic, producerConf);
-        Message message = MessageBuilder.create().setContent(new byte[PulsarDecoder.MaxMessageSize + 1]).build();
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).compressionType(CompressionType.LZ4)
+                .create();
+        Message<byte[]> message = MessageBuilder.create().setContent(new byte[PulsarDecoder.MaxMessageSize + 1])
+                .build();
         producer.send(message);
         producer.close();
 
         // (b) batch-msg
-        producerConf = new ProducerConfiguration();
-        producerConf.setBatchingEnabled(true);
-        producerConf.setCompressionType(CompressionType.LZ4);
-        producer = pulsarClient.createProducer(topic, producerConf);
+        producer = pulsarClient.newProducer().topic(topic).enableBatching(true).compressionType(CompressionType.LZ4)
+                .create();
         message = MessageBuilder.create().setContent(new byte[PulsarDecoder.MaxMessageSize + 1]).build();
         try {
             producer.send(message);
@@ -636,9 +611,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         producer.close();
 
         // (c) non-batch msg without compression
-        producerConf = new ProducerConfiguration();
-        producerConf.setCompressionType(CompressionType.NONE);
-        producer = pulsarClient.createProducer(topic, producerConf);
+        producer = pulsarClient.newProducer().topic(topic).compressionType(CompressionType.NONE).create();
         message = MessageBuilder.create().setContent(new byte[PulsarDecoder.MaxMessageSize + 1]).build();
         try {
             producer.send(message);
@@ -649,10 +622,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         producer.close();
 
         // (d) non-batch msg with compression and try to consume message
-        producerConf = new ProducerConfiguration();
-        producerConf.setCompressionType(CompressionType.LZ4);
-        producer = pulsarClient.createProducer(topic, producerConf);
-        Consumer consumer = pulsarClient.subscribe(topic, "sub1");
+        producer = pulsarClient.newProducer().topic(topic).compressionType(CompressionType.LZ4).create();
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topic).subscriptionName("sub1").subscribe();
         byte[] content = new byte[PulsarDecoder.MaxMessageSize + 10];
         message = MessageBuilder.create().setContent(content).build();
         producer.send(message);
@@ -682,23 +653,21 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         final String topicName = "cache-topic";
         final String sub1 = "faster-sub1";
         final String sub2 = "slower-sub2";
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Shared);
-        conf.setReceiverQueueSize(receiverSize);
-
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-
-        if (batchMessageDelayMs != 0) {
-            producerConf.setBatchingEnabled(true);
-            producerConf.setBatchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
-            producerConf.setBatchingMaxMessages(5);
-        }
 
         /************ usecase-1: *************/
         // 1. Subscriber Faster subscriber
-        Consumer subscriber1 = pulsarClient.subscribe("persistent://my-property/use/my-ns/" + topicName, sub1, conf);
+        Consumer<byte[]> subscriber1 = pulsarClient.newConsumer()
+                .topic("persistent://my-property/use/my-ns/" + topicName).subscriptionName(sub1)
+                .subscriptionType(SubscriptionType.Shared).receiverQueueSize(receiverSize).subscribe();
         final String topic = "persistent://my-property/use/my-ns/" + topicName;
-        Producer producer = pulsarClient.createProducer(topic, producerConf);
+        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer().topic(topic);
+
+        if (batchMessageDelayMs != 0) {
+            producerBuilder.batchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
+            producerBuilder.batchingMaxMessages(5);
+            producerBuilder.enableBatching(true);
+        }
+        Producer<byte[]> producer = producerBuilder.create();
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topic);
         ManagedLedgerImpl ledger = (ManagedLedgerImpl) topicRef.getManagedLedger();
@@ -710,7 +679,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         EntryCacheImpl entryCache = spy((EntryCacheImpl) cacheField.get(ledger));
         cacheField.set(ledger, entryCache);
 
-        Message msg = null;
+        Message<byte[]> msg = null;
         // 2. Produce messages
         for (int i = 0; i < 30; i++) {
             String message = "my-message-" + i;
@@ -738,7 +707,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         /************ usecase-2: *************/
         // 1.b Subscriber slower-subscriber
-        Consumer subscriber2 = pulsarClient.subscribe("persistent://my-property/use/my-ns/" + topicName, sub2, conf);
+        Consumer<byte[]> subscriber2 = pulsarClient.newConsumer()
+                .topic("persistent://my-property/use/my-ns/" + topicName).subscriptionName(sub2).subscribe();
         // Produce messages
         final int moreMessages = 10;
         for (int i = 0; i < receiverSize + moreMessages; i++) {
@@ -764,10 +734,10 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         // 3.b Close subscriber2: which will trigger cache to clear the cache
         subscriber2.close();
-        
+
         // retry strategically until broker clean up closed subscribers and invalidate all cache entries
         retryStrategically((test) -> entryCache.getSize() == 0, 5, 100);
-        
+
         // Verify: EntryCache should be cleared
         assertTrue(entryCache.getSize() == 0);
         subscriber1.close();
@@ -784,24 +754,22 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         final String topic = "persistent://my-property/use/my-ns/" + topicName;
         final String sub1 = "faster-sub1";
         final String sub2 = "slower-sub2";
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Shared);
-        conf.setReceiverQueueSize(receiverSize);
-
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-
-        if (batchMessageDelayMs != 0) {
-            producerConf.setBatchingEnabled(true);
-            producerConf.setBatchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
-            producerConf.setBatchingMaxMessages(5);
-        }
 
         // 1. Subscriber Faster subscriber: let it consume all messages immediately
-        Consumer subscriber1 = pulsarClient.subscribe("persistent://my-property/use/my-ns/" + topicName, sub1, conf);
+        Consumer<byte[]> subscriber1 = pulsarClient.newConsumer()
+                .topic("persistent://my-property/use/my-ns/" + topicName).subscriptionName(sub1)
+                .subscriptionType(SubscriptionType.Shared).receiverQueueSize(receiverSize).subscribe();
         // 1.b. Subscriber Slow subscriber:
-        conf.setReceiverQueueSize(receiverSize);
-        Consumer subscriber2 = pulsarClient.subscribe("persistent://my-property/use/my-ns/" + topicName, sub2, conf);
-        Producer producer = pulsarClient.createProducer(topic, producerConf);
+        Consumer<byte[]> subscriber2 = pulsarClient.newConsumer()
+                .topic("persistent://my-property/use/my-ns/" + topicName).subscriptionName(sub2)
+                .subscriptionType(SubscriptionType.Shared).receiverQueueSize(receiverSize).subscribe();
+
+        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer().topic(topic);
+        if (batchMessageDelayMs != 0) {
+            producerBuilder.enableBatching(true).batchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS)
+                    .batchingMaxMessages(5);
+        }
+        Producer<byte[]> producer = producerBuilder.create();
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topic);
         ManagedLedgerImpl ledger = (ManagedLedgerImpl) topicRef.getManagedLedger();
@@ -818,7 +786,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         field.set(ledger, maxMessageCacheRetentionTimeMillis);
         final long maxActiveCursorBacklogEntries = (long) backlogThresholdField.get(ledger);
 
-        Message msg = null;
+        Message<byte[]> msg = null;
         final int totalMsgs = (int) maxActiveCursorBacklogEntries + receiverSize + 1;
         // 2. Produce messages
         for (int i = 0; i < totalMsgs; i++) {
@@ -866,15 +834,13 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         final int totalMsg = 100;
         final Set<String> produceMsgs = Sets.newHashSet();
         final Set<String> consumeMsgs = Sets.newHashSet();
-        final ProducerConfiguration producerConf = new ProducerConfiguration();
-        final ConsumerConfiguration conf = new ConsumerConfiguration();
 
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic1", "my-subscriber-name",
-                conf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/my-topic1")
+                .subscriptionName("my-subscriber-name").subscribe();
 
         // produce message
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic1", producerConf);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic1")
+                .create();
         for (int i = 0; i < totalMsg; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
@@ -907,15 +873,13 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         final int totalMsg = 100;
         final Set<String> produceMsgs = Sets.newHashSet();
         final Set<String> consumeMsgs = Sets.newHashSet();
-        final ProducerConfiguration producerConf = new ProducerConfiguration();
-        final ConsumerConfiguration conf = new ConsumerConfiguration();
-
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic1", "my-subscriber-name",
-                conf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/my-topic1")
+                .subscriptionName("my-subscriber-name").subscribe();
+        ;
 
         // produce message
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic1", producerConf);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic1")
+                .create();
         for (int i = 0; i < totalMsg; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
@@ -946,11 +910,11 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         log.info("-- Starting {} test --", methodName);
 
         final int totalMsg = 100;
-        final ProducerConfiguration producerConf = new ProducerConfiguration();
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic1", producerConf);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic1")
+                .create();
         for (int i = 0; i < totalMsg; i++) {
             final String message = "my-message-" + i;
-            Message msg = MessageBuilder.create().setContent(message.getBytes()).build();
+            Message<byte[]> msg = MessageBuilder.create().setContent(message.getBytes()).build();
             final AtomicInteger msgLength = new AtomicInteger();
             CompletableFuture<MessageId> future = producer.sendAsync(msg).handle((r, ex) -> {
                 if (ex != null) {
@@ -975,25 +939,22 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     public void testSharedConsumerAckDifferentConsumer() throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setReceiverQueueSize(1);
-        conf.setSubscriptionType(SubscriptionType.Shared);
-        Consumer consumer1 = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic1", "my-subscriber-name",
-                conf);
-        Consumer consumer2 = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic1", "my-subscriber-name",
-                conf);
+        ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer()
+                .topic("persistent://my-property/use/my-ns/my-topic1").subscriptionName("my-subscriber-name")
+                .receiverQueueSize(1).subscriptionType(SubscriptionType.Shared);
+        Consumer<byte[]> consumer1 = consumerBuilder.subscribe();
+        Consumer<byte[]> consumer2 = consumerBuilder.subscribe();
 
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic1", producerConf);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic1")
+                .create();
         for (int i = 0; i < 10; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
 
-        Message msg = null;
-        Set<Message> consumerMsgSet1 = Sets.newHashSet();
-        Set<Message> consumerMsgSet2 = Sets.newHashSet();
+        Message<byte[]> msg = null;
+        Set<Message<byte[]>> consumerMsgSet1 = Sets.newHashSet();
+        Set<Message<byte[]>> consumerMsgSet2 = Sets.newHashSet();
         for (int i = 0; i < 5; i++) {
             msg = consumer1.receive();
             consumerMsgSet1.add(msg);
@@ -1033,10 +994,10 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         log.info("-- Exiting {} test --", methodName);
     }
 
-    private void receiveAsync(Consumer consumer, int totalMessage, int currentMessage, CountDownLatch latch,
+    private void receiveAsync(Consumer<byte[]> consumer, int totalMessage, int currentMessage, CountDownLatch latch,
             final Set<String> consumeMsg, ExecutorService executor) throws PulsarClientException {
         if (currentMessage < totalMessage) {
-            CompletableFuture<Message> future = consumer.receiveAsync();
+            CompletableFuture<Message<byte[]>> future = consumer.receiveAsync();
             future.handle((msg, exception) -> {
                 if (exception == null) {
                     // add message to consumer-queue to verify with produced messages
@@ -1062,13 +1023,11 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     }
 
     /**
-     * Verify: Consumer stops receiving msg when reach unack-msg limit and
-     * starts receiving once acks messages
-     * 1. Produce X (600) messages
-     * 2. Consumer has receive size (10) and receive message without acknowledging
-     * 3. Consumer will stop receiving message after unAckThreshold = 500
-     * 4. Consumer acks messages and starts consuming remanining messages
-     * This testcase enables checksum sending while producing message and broker verifies the checksum for the message.
+     * Verify: Consumer stops receiving msg when reach unack-msg limit and starts receiving once acks messages 1.
+     * Produce X (600) messages 2. Consumer has receive size (10) and receive message without acknowledging 3. Consumer
+     * will stop receiving message after unAckThreshold = 500 4. Consumer acks messages and starts consuming remanining
+     * messages This testcase enables checksum sending while producing message and broker verifies the checksum for the
+     * message.
      *
      * @throws Exception
      */
@@ -1083,16 +1042,12 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             final int totalProducedMsgs = 600;
 
             pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(unAckedMessagesBufferSize);
-            ConsumerConfiguration conf = new ConsumerConfiguration();
-            conf.setReceiverQueueSize(receiverQueueSize);
-            conf.setSubscriptionType(SubscriptionType.Shared);
-            Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/unacked-topic",
-                    "subscriber-1", conf);
+            Consumer<byte[]> consumer = pulsarClient.newConsumer()
+                    .topic("persistent://my-property/use/my-ns/unacked-topic").subscriptionName("subscriber-1")
+                    .receiverQueueSize(receiverQueueSize).subscriptionType(SubscriptionType.Shared).subscribe();
 
-            ProducerConfiguration producerConf = new ProducerConfiguration();
-
-            Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/unacked-topic",
-                    producerConf);
+            Producer<byte[]> producer = pulsarClient.newProducer()
+                    .topic("persistent://my-property/use/my-ns/unacked-topic").create();
 
             // (1) Produced Messages
             for (int i = 0; i < totalProducedMsgs; i++) {
@@ -1101,8 +1056,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             }
 
             // (2) try to consume messages: but will be able to consume number of messages = unAckedMessagesBufferSize
-            Message msg = null;
-            List<Message> messages = Lists.newArrayList();
+            Message<byte[]> msg = null;
+            List<Message<byte[]>> messages = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
                 msg = consumer.receive(1, TimeUnit.SECONDS);
                 if (msg != null) {
@@ -1147,18 +1102,11 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     }
 
     /**
-     * Verify: iteration of
-     * a. message receive w/o acking
-     * b. stop receiving msg
-     * c. ack msgs
-     * d. started receiving msgs
+     * Verify: iteration of a. message receive w/o acking b. stop receiving msg c. ack msgs d. started receiving msgs
      *
-     * 1. Produce total X (1500) messages
-     * 2. Consumer consumes messages without acking until stop receiving
-     * from broker due to reaching ack-threshold (500)
-     * 3. Consumer acks messages after stop getting messages
-     * 4. Consumer again tries to consume messages
-     * 5. Consumer should be able to complete consuming all 1500 messages in 3 iteration (1500/500)
+     * 1. Produce total X (1500) messages 2. Consumer consumes messages without acking until stop receiving from broker
+     * due to reaching ack-threshold (500) 3. Consumer acks messages after stop getting messages 4. Consumer again tries
+     * to consume messages 5. Consumer should be able to complete consuming all 1500 messages in 3 iteration (1500/500)
      *
      * @throws Exception
      */
@@ -1175,16 +1123,12 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             // receiver consumes messages in iteration after acknowledging broker
             final int totalReceiveIteration = totalProducedMsgs / unAckedMessagesBufferSize;
             pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(unAckedMessagesBufferSize);
-            ConsumerConfiguration conf = new ConsumerConfiguration();
-            conf.setReceiverQueueSize(receiverQueueSize);
-            conf.setSubscriptionType(SubscriptionType.Shared);
-            Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/unacked-topic",
-                    "subscriber-1", conf);
+            Consumer<byte[]> consumer = pulsarClient.newConsumer()
+                    .topic("persistent://my-property/use/my-ns/unacked-topic").subscriptionName("subscriber-1")
+                    .receiverQueueSize(receiverQueueSize).subscriptionType(SubscriptionType.Shared).subscribe();
 
-            ProducerConfiguration producerConf = new ProducerConfiguration();
-
-            Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/unacked-topic",
-                    producerConf);
+            Producer<byte[]> producer = pulsarClient.newProducer()
+                    .topic("persistent://my-property/use/my-ns/unacked-topic").create();
 
             // (1) Produced Messages
             for (int i = 0; i < totalProducedMsgs; i++) {
@@ -1196,8 +1140,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             // (2) Receive Messages
             for (int j = 0; j < totalReceiveIteration; j++) {
 
-                Message msg = null;
-                List<Message> messages = Lists.newArrayList();
+                Message<byte[]> msg = null;
+                List<Message<byte[]>> messages = Lists.newArrayList();
                 for (int i = 0; i < totalProducedMsgs; i++) {
                     msg = consumer.receive(1, TimeUnit.SECONDS);
                     if (msg != null) {
@@ -1233,7 +1177,6 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         }
     }
 
-
     /**
      * Verify: Consumer1 which doesn't send ack will not impact Consumer2 which sends ack for consumed message.
      *
@@ -1253,18 +1196,13 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             int totalReceiveMessages = 0;
 
             pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(maxUnackedMessages);
-            ConsumerConfiguration conf = new ConsumerConfiguration();
-            conf.setReceiverQueueSize(receiverQueueSize);
-            conf.setSubscriptionType(SubscriptionType.Shared);
-            Consumer consumer1 = pulsarClient.subscribe("persistent://my-property/use/my-ns/unacked-topic",
-                    "subscriber-1", conf);
-            Consumer consumer2 = pulsarClient.subscribe("persistent://my-property/use/my-ns/unacked-topic",
-                    "subscriber-1", conf);
-
-            ProducerConfiguration producerConf = new ProducerConfiguration();
-
-            Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/unacked-topic",
-                    producerConf);
+            ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer()
+                    .topic("persistent://my-property/use/my-ns/unacked-topic").subscriptionName("subscriber-1")
+                    .receiverQueueSize(receiverQueueSize).subscriptionType(SubscriptionType.Shared);
+            Consumer<byte[]> consumer1 = consumerBuilder.subscribe();
+            Consumer<byte[]> consumer2 = consumerBuilder.subscribe();
+            Producer<byte[]> producer = pulsarClient.newProducer()
+                    .topic("persistent://my-property/use/my-ns/unacked-topic").create();
 
             // (1) Produced Messages
             for (int i = 0; i < totalProducedMsgs; i++) {
@@ -1272,11 +1210,10 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
                 producer.send(message.getBytes());
             }
 
-
             // (2) Consumer1: consume without ack:
             // try to consume messages: but will be able to consume number of messages = maxUnackedMessages
-            Message msg = null;
-            List<Message> messages = Lists.newArrayList();
+            Message<byte[]> msg = null;
+            List<Message<byte[]>> messages = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
                 msg = consumer1.receive(1, TimeUnit.SECONDS);
                 if (msg != null) {
@@ -1349,17 +1286,13 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             final int receiverQueueSize = 20;
             final int totalProducedMsgs = 100;
 
-            ConsumerConfiguration conf = new ConsumerConfiguration();
-            conf.setReceiverQueueSize(receiverQueueSize);
-            conf.setAckTimeout(1, TimeUnit.SECONDS);
-            conf.setSubscriptionType(SubscriptionType.Shared);
-            ConsumerImpl consumer = (ConsumerImpl) pulsarClient
-                    .subscribe("persistent://my-property/use/my-ns/unacked-topic", "subscriber-1", conf);
+            ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer()
+                    .topic("persistent://my-property/use/my-ns/unacked-topic").subscriptionName("subscriber-1")
+                    .receiverQueueSize(receiverQueueSize).ackTimeout(1, TimeUnit.SECONDS)
+                    .subscriptionType(SubscriptionType.Shared).subscribe();
 
-            ProducerConfiguration producerConf = new ProducerConfiguration();
-
-            Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/unacked-topic",
-                    producerConf);
+            Producer<byte[]> producer = pulsarClient.newProducer()
+                    .topic("persistent://my-property/use/my-ns/unacked-topic").create();
 
             // (1) Produced Messages
             for (int i = 0; i < totalProducedMsgs; i++) {
@@ -1376,7 +1309,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             assertEquals(consumer.numMessagesInQueue(), receiverQueueSize);
 
             for (int i = 0; i < totalProducedMsgs; i++) {
-                Message msg = consumer.receive(1, TimeUnit.SECONDS);
+                Message<byte[]> msg = consumer.receive(1, TimeUnit.SECONDS);
                 if (msg != null) {
                     consumer.acknowledge(msg);
                     totalReceiveMsg++;
@@ -1410,16 +1343,12 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             final int totalProducedMsgs = 100;
 
             pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(unAckedMessagesBufferSize);
-            ConsumerConfiguration conf = new ConsumerConfiguration();
-            conf.setReceiverQueueSize(receiverQueueSize);
-            conf.setSubscriptionType(SubscriptionType.Shared);
-            ConsumerImpl consumer = (ConsumerImpl) pulsarClient
-                    .subscribe("persistent://my-property/use/my-ns/unacked-topic", "subscriber-1", conf);
+            ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer()
+                    .topic("persistent://my-property/use/my-ns/unacked-topic").subscriptionName("subscriber-1")
+                    .receiverQueueSize(receiverQueueSize).subscriptionType(SubscriptionType.Shared).subscribe();
 
-            ProducerConfiguration producerConf = new ProducerConfiguration();
-
-            Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/unacked-topic",
-                    producerConf);
+            Producer<byte[]> producer = pulsarClient.newProducer()
+                    .topic("persistent://my-property/use/my-ns/unacked-topic").create();
 
             // (1) Produced Messages
             for (int i = 0; i < totalProducedMsgs; i++) {
@@ -1428,8 +1357,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             }
 
             // (2) try to consume messages: but will be able to consume number of messages = unAckedMessagesBufferSize
-            Message msg = null;
-            List<Message> messages = Lists.newArrayList();
+            Message<byte[]> msg = null;
+            List<Message<byte[]>> messages = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
                 msg = consumer.receive(1, TimeUnit.SECONDS);
                 if (msg != null) {
@@ -1481,22 +1410,20 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             int totalReceiveMessages = 0;
 
             pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(maxUnackedMessages);
-            ConsumerConfiguration conf = new ConsumerConfiguration();
-            conf.setReceiverQueueSize(receiverQueueSize);
-            conf.setSubscriptionType(SubscriptionType.Shared);
-            Consumer consumer1 = pulsarClient.subscribe("persistent://my-property/use/my-ns/unacked-topic",
-                    "subscriber-1", conf);
+            Consumer<byte[]> consumer1 = pulsarClient.newConsumer()
+                    .topic("persistent://my-property/use/my-ns/unacked-topic").subscriptionName("subscriber-1")
+                    .receiverQueueSize(receiverQueueSize).subscriptionType(SubscriptionType.Shared).subscribe();
 
-            ProducerConfiguration producerConf = new ProducerConfiguration();
+            ProducerBuilder<byte[]> producerBuidler = pulsarClient.newProducer()
+                    .topic("persistent://my-property/use/my-ns/unacked-topic");
 
             if (batchMessageDelayMs != 0) {
-                producerConf.setBatchingEnabled(true);
-                producerConf.setBatchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
-                producerConf.setBatchingMaxMessages(5);
+                producerBuidler.enableBatching(true);
+                producerBuidler.batchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
+                producerBuidler.batchingMaxMessages(5);
             }
 
-            Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/unacked-topic",
-                    producerConf);
+            Producer<byte[]> producer = producerBuidler.create();
 
             List<CompletableFuture<MessageId>> futures = Lists.newArrayList();
             // (1) Produced Messages
@@ -1509,8 +1436,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
             // (2) Consumer1: consume without ack:
             // try to consume messages: but will be able to consume number of messages = maxUnackedMessages
-            Message msg = null;
-            List<Message> messages = Lists.newArrayList();
+            Message<byte[]> msg = null;
+            List<Message<byte[]>> messages = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
                 msg = consumer1.receive(1, TimeUnit.SECONDS);
                 if (msg != null) {
@@ -1576,18 +1503,14 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             int totalReceiveMessages = 0;
 
             pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(maxUnackedMessages);
-            ConsumerConfiguration conf = new ConsumerConfiguration();
-            conf.setReceiverQueueSize(receiverQueueSize);
-            conf.setSubscriptionType(SubscriptionType.Shared);
-            Consumer consumer1 = pulsarClient.subscribe("persistent://my-property/use/my-ns/unacked-topic",
-                    "subscriber-1", conf);
-            Consumer consumer2 = pulsarClient.subscribe("persistent://my-property/use/my-ns/unacked-topic",
-                    "subscriber-1", conf);
+            ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer()
+                    .topic("persistent://my-property/use/my-ns/unacked-topic").subscriptionName("subscriber-1")
+                    .receiverQueueSize(receiverQueueSize).subscriptionType(SubscriptionType.Shared);
+            Consumer<byte[]> consumer1 = consumerBuilder.subscribe();
+            Consumer<byte[]> consumer2 = consumerBuilder.subscribe();
 
-            ProducerConfiguration producerConf = new ProducerConfiguration();
-
-            Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/unacked-topic",
-                    producerConf);
+            Producer<byte[]> producer = pulsarClient.newProducer()
+                    .topic("persistent://my-property/use/my-ns/unacked-topic").create();
 
             // (1) Produced Messages
             for (int i = 0; i < totalProducedMsgs; i++) {
@@ -1595,11 +1518,10 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
                 producer.send(message.getBytes());
             }
 
-
             // (2) Consumer1: consume without ack:
             // try to consume messages: but will be able to consume number of messages = maxUnackedMessages
-            Message msg = null;
-            List<Message> messages = Lists.newArrayList();
+            Message<byte[]> msg = null;
+            List<Message<byte[]>> messages = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
                 msg = consumer1.receive(1, TimeUnit.SECONDS);
                 if (msg != null) {
@@ -1611,7 +1533,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
                 }
             }
 
-            assertEquals(messages.size(), maxUnackedMessages); //consumer1
+            assertEquals(messages.size(), maxUnackedMessages); // consumer1
 
             // (3) ack for all UnackedMessages from consumer2
             messages.forEach(m -> {
@@ -1662,26 +1584,24 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         log.info("-- Starting {} test --", methodName);
 
         final int totalMsg = 10;
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic1", "my-subscriber-name",
-                conf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/my-topic1")
+                .subscriptionName("my-subscriber-name").subscribe();
 
-        ProducerConfiguration producerConf = new ProducerConfiguration();
+        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer()
+                .topic("persistent://my-property/use/my-ns/my-topic1");
         final int batchMessageDelayMs = 300;
         if (batchMessageDelayMs != 0) {
-            producerConf.setBatchingEnabled(true);
-            producerConf.setBatchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
-            producerConf.setBatchingMaxMessages(5);
+            producerBuilder.enableBatching(true).batchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS)
+                    .batchingMaxMessages(5);
         }
 
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic1", producerConf);
+        Producer<byte[]> producer = producerBuilder.create();
         for (int i = 0; i < totalMsg; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
 
-        Message msg = null;
+        Message<byte[]> msg = null;
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 0; i < totalMsg; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);
@@ -1715,16 +1635,12 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             final int totalProducedMsgs = 20;
 
             pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(unAckedMessagesBufferSize);
-            ConsumerConfiguration conf = new ConsumerConfiguration();
-            conf.setReceiverQueueSize(receiverQueueSize);
-            conf.setSubscriptionType(SubscriptionType.Shared);
-            ConsumerImpl consumer = (ConsumerImpl) pulsarClient
-                    .subscribe("persistent://my-property/use/my-ns/unacked-topic", "subscriber-1", conf);
+            ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer()
+                    .topic("persistent://my-property/use/my-ns/unacked-topic").subscriptionName("subscriber-1")
+                    .receiverQueueSize(receiverQueueSize).subscriptionType(SubscriptionType.Shared).subscribe();
 
-            ProducerConfiguration producerConf = new ProducerConfiguration();
-
-            Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/unacked-topic",
-                    producerConf);
+            Producer<byte[]> producer = pulsarClient.newProducer()
+                    .topic("persistent://my-property/use/my-ns/unacked-topic").create();
 
             // (1) Produced Messages
             for (int i = 0; i < totalProducedMsgs; i++) {
@@ -1734,8 +1650,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             }
 
             // (2) try to consume messages: but will be able to consume number of messages = unAckedMessagesBufferSize
-            Message msg = null;
-            List<Message> messages1 = Lists.newArrayList();
+            Message<byte[]> msg = null;
+            List<Message<byte[]>> messages1 = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
                 msg = consumer.receive(1, TimeUnit.SECONDS);
                 if (msg != null) {
@@ -1785,8 +1701,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
      * It verifies that redelivery-of-specific messages: that redelivers all those messages even when consumer gets
      * blocked due to unacked messsages
      *
-     * Usecase: Consumer starts consuming only after all messages have been produced.
-     * So, consumer consumes total receiver-queue-size number messages => ask for redelivery and receives all messages again.
+     * Usecase: Consumer starts consuming only after all messages have been produced. So, consumer consumes total
+     * receiver-queue-size number messages => ask for redelivery and receives all messages again.
      *
      * @throws Exception
      */
@@ -1801,18 +1717,14 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             final int totalProducedMsgs = 50;
 
             pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(unAckedMessagesBufferSize);
-            ConsumerConfiguration conf = new ConsumerConfiguration();
-            conf.setReceiverQueueSize(receiverQueueSize);
-            conf.setSubscriptionType(SubscriptionType.Shared);
             // Only subscribe consumer
-            ConsumerImpl consumer = (ConsumerImpl) pulsarClient
-                    .subscribe("persistent://my-property/use/my-ns/unacked-topic", "subscriber-1", conf);
+            ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer()
+                    .topic("persistent://my-property/use/my-ns/unacked-topic").subscriptionName("subscriber-1")
+                    .receiverQueueSize(receiverQueueSize).subscriptionType(SubscriptionType.Shared).subscribe();
             consumer.close();
 
-            ProducerConfiguration producerConf = new ProducerConfiguration();
-
-            Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/unacked-topic",
-                    producerConf);
+            Producer<byte[]> producer = pulsarClient.newProducer()
+                    .topic("persistent://my-property/use/my-ns/unacked-topic").create();
 
             // (1) Produced Messages
             for (int i = 0; i < totalProducedMsgs; i++) {
@@ -1822,12 +1734,13 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             }
 
             // (1.a) start consumer again
-            consumer = (ConsumerImpl) pulsarClient.subscribe("persistent://my-property/use/my-ns/unacked-topic",
-                    "subscriber-1", conf);
+            consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer()
+                    .topic("persistent://my-property/use/my-ns/unacked-topic").subscriptionName("subscriber-1")
+                    .receiverQueueSize(receiverQueueSize).subscriptionType(SubscriptionType.Shared).subscribe();
 
             // (2) try to consume messages: but will be able to consume number of messages = unAckedMessagesBufferSize
-            Message msg = null;
-            List<Message> messages1 = Lists.newArrayList();
+            Message<byte[]> msg = null;
+            List<Message<byte[]>> messages1 = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
                 msg = consumer.receive(1, TimeUnit.SECONDS);
                 if (msg != null) {
@@ -1876,24 +1789,16 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     @Test
     public void testPriorityConsumer() throws Exception {
         log.info("-- Starting {} test --", methodName);
-        ConsumerConfiguration conf1 = new ConsumerConfiguration();
-        conf1.setSubscriptionType(SubscriptionType.Shared);
-        conf1.setPriorityLevel(1);
-        conf1.setReceiverQueueSize(5);
-        ConsumerConfiguration conf4 = new ConsumerConfiguration();
-        conf4.setSubscriptionType(SubscriptionType.Shared);
-        conf4.setPriorityLevel(2);
-        conf4.setReceiverQueueSize(5);
-        Consumer consumer1 = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic2", "my-subscriber-name",
-                conf1);
-        Consumer consumer2 = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic2", "my-subscriber-name",
-                conf1);
-        Consumer consumer3 = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic2", "my-subscriber-name",
-                conf1);
-        Consumer consumer4 = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic2", "my-subscriber-name",
-                conf4);
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic2", producerConf);
+        ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer()
+                .topic("persistent://my-property/use/my-ns/my-topic2").subscriptionName("my-subscriber-name")
+                .subscriptionType(SubscriptionType.Shared).receiverQueueSize(5).priorityLevel(1);
+
+        Consumer<byte[]> consumer1 = consumerBuilder.subscribe();
+        Consumer<byte[]> consumer2 = consumerBuilder.subscribe();
+        Consumer<byte[]> consumer3 = consumerBuilder.subscribe();
+        Consumer<byte[]> consumer4 = consumerBuilder.clone().priorityLevel(2).subscribe();
+        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic2")
+                .create();
         List<Future<MessageId>> futures = Lists.newArrayList();
 
         // Asynchronously produce messages
@@ -1914,9 +1819,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         }
 
         /**
-         * a. consumer1 and consumer2 now has more permits (as received and sent more permits)
-         * b. try to produce more messages: which will again distribute among consumer1 and consumer2
-         * and should not dispatch to consumer4
+         * a. consumer1 and consumer2 now has more permits (as received and sent more permits) b. try to produce more
+         * messages: which will again distribute among consumer1 and consumer2 and should not dispatch to consumer4
          *
          */
         for (int i = 0; i < 5; i++) {
@@ -1948,21 +1852,20 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
      *
      * @throws Exception
      */
-    @Test(timeOut=5000)
+    @Test(timeOut = 5000)
     public void testSharedSamePriorityConsumer() throws Exception {
         log.info("-- Starting {} test --", methodName);
-        ConsumerConfiguration conf1 = new ConsumerConfiguration();
-        conf1.setSubscriptionType(SubscriptionType.Shared);
         final int queueSize = 5;
-        conf1.setReceiverQueueSize(queueSize);
         int maxUnAckMsgs = pulsar.getConfiguration().getMaxConcurrentLookupRequest();
         pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(queueSize);
-        Consumer c1 = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic2", "my-subscriber-name",
-                conf1);
-        Consumer c2 = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic2", "my-subscriber-name",
-                conf1);
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic2", producerConf);
+
+        ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer()
+                .topic("persistent://my-property/use/my-ns/my-topic2").subscriptionName("my-subscriber-name")
+                .subscriptionType(SubscriptionType.Shared).receiverQueueSize(queueSize);
+        Consumer<byte[]> c1 = consumerBuilder.subscribe();
+        Consumer<byte[]> c2 = consumerBuilder.subscribe();
+        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic2")
+                .create();
         List<Future<MessageId>> futures = Lists.newArrayList();
 
         // Asynchronously produce messages
@@ -1978,11 +1881,11 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             future.get();
         }
 
-        List<Message> messages = Lists.newArrayList();
+        List<Message<byte[]>> messages = Lists.newArrayList();
 
         // let consumer1 and consumer2 cosume messages up to the queue will be full
         for (int i = 0; i < totalPublishMessages; i++) {
-            Message msg = c1.receive(500, TimeUnit.MILLISECONDS);
+            Message<byte[]> msg = c1.receive(500, TimeUnit.MILLISECONDS);
             if (msg != null) {
                 messages.add(msg);
             } else {
@@ -1990,7 +1893,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             }
         }
         for (int i = 0; i < totalPublishMessages; i++) {
-            Message msg = c2.receive(500, TimeUnit.MILLISECONDS);
+            Message<byte[]> msg = c2.receive(500, TimeUnit.MILLISECONDS);
             if (msg != null) {
                 messages.add(msg);
             } else {
@@ -2001,17 +1904,14 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         Assert.assertEquals(queueSize * 2, messages.size());
 
         // create new consumers with the same priority
-        Consumer c3 = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic2", "my-subscriber-name",
-                conf1);
-        Consumer c4 = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic2", "my-subscriber-name",
-                conf1);
-        Consumer c5 = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic2", "my-subscriber-name",
-                conf1);
+        Consumer<byte[]> c3 = consumerBuilder.subscribe();
+        Consumer<byte[]> c4 = consumerBuilder.subscribe();
+        Consumer<byte[]> c5 = consumerBuilder.subscribe();
 
         // c1 and c2 are blocked: so, let c3, c4 and c5 consume rest of the messages
 
         for (int i = 0; i < totalPublishMessages; i++) {
-            Message msg = c4.receive(500, TimeUnit.MILLISECONDS);
+            Message<byte[]> msg = c4.receive(500, TimeUnit.MILLISECONDS);
             if (msg != null) {
                 messages.add(msg);
             } else {
@@ -2020,7 +1920,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         }
 
         for (int i = 0; i < totalPublishMessages; i++) {
-            Message msg = c5.receive(500, TimeUnit.MILLISECONDS);
+            Message<byte[]> msg = c5.receive(500, TimeUnit.MILLISECONDS);
             if (msg != null) {
                 messages.add(msg);
             } else {
@@ -2029,7 +1929,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         }
 
         for (int i = 0; i < totalPublishMessages; i++) {
-            Message msg = c3.receive(500, TimeUnit.MILLISECONDS);
+            Message<byte[]> msg = c3.receive(500, TimeUnit.MILLISECONDS);
             if (msg != null) {
                 messages.add(msg);
                 c3.acknowledge(msg);
@@ -2058,17 +1958,13 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         final int receiverQueueSize = 10;
 
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setReceiverQueueSize(receiverQueueSize);
-        conf.setSubscriptionType(SubscriptionType.Failover);
         // Only subscribe consumer
-        ConsumerImpl consumer = (ConsumerImpl) pulsarClient
-                .subscribe("persistent://my-property/use/my-ns/unacked-topic", "subscriber-1", conf);
+        ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer()
+                .topic("persistent://my-property/use/my-ns/unacked-topic").subscriptionName("subscriber-1")
+                .receiverQueueSize(receiverQueueSize).subscriptionType(SubscriptionType.Failover).subscribe();
 
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/unacked-topic",
-                producerConf);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/unacked-topic")
+                .create();
 
         // (1) First round to produce-consume messages
         int consumeMsgInParts = 4;
@@ -2078,8 +1974,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             Thread.sleep(10);
         }
         // (1.a) consume first consumeMsgInParts msgs and trigger redeliver
-        Message msg = null;
-        List<Message> messages1 = Lists.newArrayList();
+        Message<byte[]> msg = null;
+        List<Message<byte[]>> messages1 = Lists.newArrayList();
         for (int i = 0; i < consumeMsgInParts; i++) {
             msg = consumer.receive(1, TimeUnit.SECONDS);
             if (msg != null) {
@@ -2140,8 +2036,9 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         log.info("-- Starting {} test --", methodName);
 
         // (1) simple consumers
-        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/failAsyncReceive",
-                "my-subscriber-name", new ConsumerConfiguration());
+        Consumer<byte[]> consumer = pulsarClient.newConsumer()
+                .topic("persistent://my-property/use/my-ns/failAsyncReceive").subscriptionName("my-subscriber-name")
+                .subscribe();
         consumer.close();
         // receive messages
         try {
@@ -2155,8 +2052,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         int numPartitions = 4;
         TopicName topicName = TopicName.get("persistent://my-property/use/my-ns/failAsyncReceive");
         admin.persistentTopics().createPartitionedTopic(topicName.toString(), numPartitions);
-        Consumer partitionedConsumer = pulsarClient.subscribe(topicName.toString(), "my-partitioned-subscriber",
-                new ConsumerConfiguration());
+        Consumer<byte[]> partitionedConsumer = pulsarClient.newConsumer().topic(topicName.toString())
+                .subscriptionName("my-partitioned-subscriber").subscribe();
         partitionedConsumer.close();
         // receive messages
         try {
@@ -2176,6 +2073,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         class EncKeyReader implements CryptoKeyReader {
 
             EncryptionKeyInfo keyInfo = new EncryptionKeyInfo();
+
             @Override
             public EncryptionKeyInfo getPublicKey(String keyName, Map<String, String> keyMeta) {
                 String CERT_FILE_PATH = "./src/test/resources/certificate/public-key." + keyName;
@@ -2212,23 +2110,20 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         final int totalMsg = 10;
 
         Set<String> messageSet = Sets.newHashSet();
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-        conf.setCryptoKeyReader(new EncKeyReader());
-        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/myecdsa-topic1", "my-subscriber-name",
-                conf);
 
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-        producerConf.addEncryptionKey("client-ecdsa.pem");
-        producerConf.setCryptoKeyReader(new EncKeyReader());
+        Consumer<byte[]> consumer = pulsarClient.newConsumer()
+                .topic("persistent://my-property/use/my-ns/myecdsa-topic1").subscriptionName("my-subscriber-name")
+                .cryptoKeyReader(new EncKeyReader()).subscribe();
 
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/myecdsa-topic1", producerConf);
+        Producer<byte[]> producer = pulsarClient.newProducer()
+                .topic("persistent://my-property/use/my-ns/myecdsa-topic1").addEncryptionKey("client-ecdsa.pem")
+                .cryptoKeyReader(new EncKeyReader()).create();
         for (int i = 0; i < totalMsg; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
 
-        Message msg = null;
+        Message<byte[]> msg = null;
 
         for (int i = 0; i < totalMsg; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);
@@ -2250,6 +2145,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         class EncKeyReader implements CryptoKeyReader {
 
             EncryptionKeyInfo keyInfo = new EncryptionKeyInfo();
+
             @Override
             public EncryptionKeyInfo getPublicKey(String keyName, Map<String, String> keyMeta) {
                 String CERT_FILE_PATH = "./src/test/resources/certificate/public-key." + keyName;
@@ -2286,30 +2182,26 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         final int totalMsg = 10;
 
         Set<String> messageSet = Sets.newHashSet();
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-        conf.setCryptoKeyReader(new EncKeyReader());
-        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/myrsa-topic1", "my-subscriber-name",
-                conf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/myrsa-topic1")
+                .subscriptionName("my-subscriber-name").cryptoKeyReader(new EncKeyReader()).subscribe();
 
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-        producerConf.addEncryptionKey("client-rsa.pem");
-        producerConf.setCryptoKeyReader(new EncKeyReader());
+        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/myrsa-topic1")
+                .addEncryptionKey("client-rsa.pem").cryptoKeyReader(new EncKeyReader()).create();
+        Producer<byte[]> producer2 = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/myrsa-topic1")
+                .addEncryptionKey("client-rsa.pem").cryptoKeyReader(new EncKeyReader()).create();
 
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/myrsa-topic1", producerConf);
-        Producer producer2 = pulsarClient.createProducer("persistent://my-property/use/my-ns/myrsa-topic1", producerConf);
         for (int i = 0; i < totalMsg; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
-        for (int i = totalMsg; i < totalMsg*2; i++) {
+        for (int i = totalMsg; i < totalMsg * 2; i++) {
             String message = "my-message-" + i;
             producer2.send(message.getBytes());
         }
 
-        Message msg = null;
+        Message<byte[]> msg = null;
 
-        for (int i = 0; i < totalMsg*2; i++) {
+        for (int i = 0; i < totalMsg * 2; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);
             String receivedMessage = new String(msg.getData());
             log.debug("Received message: [{}]", receivedMessage);
@@ -2329,6 +2221,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         class EncKeyReader implements CryptoKeyReader {
 
             EncryptionKeyInfo keyInfo = new EncryptionKeyInfo();
+
             @Override
             public EncryptionKeyInfo getPublicKey(String keyName, Map<String, String> keyMeta) {
                 String CERT_FILE_PATH = "./src/test/resources/certificate/public-key." + keyName;
@@ -2360,32 +2253,25 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         final int totalMsg = 10;
 
-        ProducerConfiguration producerConf = new ProducerConfiguration();
-        
-        Message msg = null;
+        Message<byte[]> msg = null;
         Set<String> messageSet = Sets.newHashSet();
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        conf.setSubscriptionType(SubscriptionType.Exclusive);
-        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/myenc-topic1", "my-subscriber-name",
-                conf);
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/myenc-ns/myenc-topic1")
+                .subscriptionName("my-subscriber-name").subscribe();
 
         // 1. Invalid key name
-        producerConf.addEncryptionKey("client-non-existant-rsa.pem");
-        producerConf.setCryptoKeyReader(new EncKeyReader());
-
         try {
-            Producer producer = pulsarClient.createProducer("persistent://my-property/use/myenc-ns/myenc-topic1", producerConf);
+            pulsarClient.newProducer().topic("persistent://my-property/use/myenc-ns/myenc-topic1")
+                    .addEncryptionKey("client-non-existant-rsa.pem").cryptoKeyReader(new EncKeyReader()).create();
             Assert.fail("Producer creation should not suceed if failing to read key");
         } catch (Exception e) {
             // ok
         }
 
         // 2. Producer with valid key name
-        producerConf = new ProducerConfiguration();
-        producerConf.setCryptoKeyReader(new EncKeyReader());
-        producerConf.addEncryptionKey("client-rsa.pem");
-        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/myenc-topic1", producerConf);
-        
+        Producer<byte[]> producer = pulsarClient.newProducer()
+                .topic("persistent://my-property/use/myenc-ns/myenc-topic1").addEncryptionKey("client-rsa.pem")
+                .cryptoKeyReader(new EncKeyReader()).create();
+
         for (int i = 0; i < totalMsg; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
@@ -2397,33 +2283,33 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         Assert.assertNull(msg, "Receive should have failed with no keyreader");
 
         // 4. Set consumer config to consume even if decryption fails
-        conf.setCryptoFailureAction(ConsumerCryptoFailureAction.CONSUME);
         consumer.close();
-        consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/myenc-topic1", "my-subscriber-name",
-                conf);
-        
+        consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/myenc-ns/myenc-topic1")
+                .subscriptionName("my-subscriber-name").cryptoFailureAction(ConsumerCryptoFailureAction.CONSUME)
+                .subscribe();
+
         int msgNum = 0;
         try {
             // Receive should proceed and deliver encrypted message
             msg = consumer.receive(5, TimeUnit.SECONDS);
             String receivedMessage = new String(msg.getData());
             String expectedMessage = "my-message-" + msgNum++;
-            Assert.assertNotEquals(receivedMessage, expectedMessage,
-                    "Received encrypted message " + receivedMessage + " should not match the expected message " + expectedMessage);
+            Assert.assertNotEquals(receivedMessage, expectedMessage, "Received encrypted message " + receivedMessage
+                    + " should not match the expected message " + expectedMessage);
             consumer.acknowledgeCumulative(msg);
         } catch (Exception e) {
+            e.printStackTrace();
             Assert.fail("Failed to receive message even aftet ConsumerCryptoFailureAction.CONSUME is set.");
         }
 
         // 5. Set keyreader and failure action
-        conf.setCryptoFailureAction(ConsumerCryptoFailureAction.FAIL);
         consumer.close();
         // Set keyreader
-        conf.setCryptoKeyReader(new EncKeyReader());
-        consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/myenc-topic1", "my-subscriber-name",
-                conf);
+        consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/myenc-ns/myenc-topic1")
+                .subscriptionName("my-subscriber-name").cryptoFailureAction(ConsumerCryptoFailureAction.FAIL)
+                .cryptoKeyReader(new EncKeyReader()).subscribe();
 
-        for (int i = msgNum; i < totalMsg-1; i++) {
+        for (int i = msgNum; i < totalMsg - 1; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);
             String receivedMessage = new String(msg.getData());
             log.debug("Received message: [{}]", receivedMessage);
@@ -2434,12 +2320,11 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         consumer.acknowledgeCumulative(msg);
         consumer.close();
 
-         //6. Set consumer config to discard if decryption fails
+        // 6. Set consumer config to discard if decryption fails
         consumer.close();
-        ConsumerConfiguration conf2 = new ConsumerConfiguration();
-        conf2.setSubscriptionType(SubscriptionType.Exclusive);
-        conf2.setCryptoFailureAction(ConsumerCryptoFailureAction.DISCARD);
-        consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/myenc-topic1", "my-subscriber-name", conf2);
+        consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/myenc-ns/myenc-topic1")
+                .subscriptionName("my-subscriber-name").cryptoFailureAction(ConsumerCryptoFailureAction.DISCARD)
+                .subscribe();
 
         // Receive should proceed and discard encrypted messages
         msg = consumer.receive(5, TimeUnit.SECONDS);
@@ -2448,40 +2333,4 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         log.info("-- Exiting {} test --", methodName);
     }
 
-    @Test
-    public void testConsumerSubscriptionInitialize() throws Exception {
-        log.info("-- Starting {} test --", methodName);
-        String topic = "persistent://my-property/use/my-ns/my-topic-test-subscription-initialize";
-        
-        Producer producer = pulsarClient.createProducer(topic);
-
-        // first produce 5 messages
-        for (int i = 0; i < 5; i++) {
-            final String message = "my-message-" + i;
-            producer.send(message.getBytes());
-        }
-
-        // second create consumers
-        ConsumerConfiguration conf = new ConsumerConfiguration();
-        Consumer defaultConsumer = pulsarClient.subscribe(topic, "test-subscription-default");
-        conf.setSubscriptionInitialPosition(SubscriptionInitialPosition.Latest);
-        Consumer latestConsumer = pulsarClient.subscribe(topic, "test-subscription-latest", conf);
-        conf.setSubscriptionInitialPosition(SubscriptionInitialPosition.Earliest);
-        Consumer earlistConsumer = pulsarClient.subscribe(topic, "test-subscription-earliest", conf);
-
-        // third produce 5 messages
-        for (int i = 5; i < 10; i++) {
-            final String message = "my-message-" + i;
-            producer.send(message.getBytes());
-        }
-
-        assertEquals(defaultConsumer.receive().getData(), "my-message-5".getBytes());
-        assertEquals(latestConsumer.receive().getData(), "my-message-5".getBytes());
-        assertEquals(earlistConsumer.receive().getData(), "my-message-0".getBytes());
-
-        defaultConsumer.close();
-        latestConsumer.close();
-        earlistConsumer.close();
-        log.info("-- Exiting {} test --", methodName);
-    }    
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -32,6 +32,8 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
@@ -52,7 +54,7 @@ import java.util.stream.Collectors;
 import org.apache.bookkeeper.mledger.impl.EntryCacheImpl;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
-import org.apache.pulsar.client.api.PulsarClientException.InvalidConfigurationException;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.impl.ConsumerImpl;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.api.PulsarDecoder;
@@ -94,25 +96,26 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     public void testSyncProducerAndConsumer(int batchMessageDelayMs) throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/my-topic1")
-                .subscriptionName("my-subscriber-name").subscribe();
+        ConsumerConfiguration conf = new ConsumerConfiguration();
+        conf.setSubscriptionType(SubscriptionType.Exclusive);
+        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic1", "my-subscriber-name",
+                conf);
 
-        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer()
-                .topic("persistent://my-property/use/my-ns/my-topic1");
+        ProducerConfiguration producerConf = new ProducerConfiguration();
 
         if (batchMessageDelayMs != 0) {
-            producerBuilder.enableBatching(true);
-            producerBuilder.batchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
-            producerBuilder.batchingMaxMessages(5);
+            producerConf.setBatchingEnabled(true);
+            producerConf.setBatchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
+            producerConf.setBatchingMaxMessages(5);
         }
 
-        Producer<byte[]> producer = producerBuilder.create();
+        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic1", producerConf);
         for (int i = 0; i < 10; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
 
-        Message<byte[]> msg = null;
+        Message msg = null;
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 0; i < 10; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);
@@ -130,18 +133,17 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     @Test(dataProvider = "batch")
     public void testAsyncProducerAndAsyncAck(int batchMessageDelayMs) throws Exception {
         log.info("-- Starting {} test --", methodName);
-        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/my-topic2")
-                .subscriptionName("my-subscriber-name").subscribe();
-
-        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer()
-                .topic("persistent://my-property/use/my-ns/my-topic2");
-
+        ConsumerConfiguration conf = new ConsumerConfiguration();
+        conf.setSubscriptionType(SubscriptionType.Exclusive);
+        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic2", "my-subscriber-name",
+                conf);
+        ProducerConfiguration producerConf = new ProducerConfiguration();
         if (batchMessageDelayMs != 0) {
-            producerBuilder.enableBatching(true);
-            producerBuilder.batchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
-            producerBuilder.batchingMaxMessages(5);
+            producerConf.setBatchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
+            producerConf.setBatchingMaxMessages(5);
+            producerConf.setBatchingEnabled(true);
         }
-        Producer<byte[]> producer = producerBuilder.create();
+        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic2", producerConf);
         List<Future<MessageId>> futures = Lists.newArrayList();
 
         // Asynchronously produce messages
@@ -156,7 +158,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             future.get();
         }
 
-        Message<byte[]> msg = null;
+        Message msg = null;
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 0; i < 10; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);
@@ -177,28 +179,28 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     @Test(dataProvider = "batch", timeOut = 100000)
     public void testMessageListener(int batchMessageDelayMs) throws Exception {
         log.info("-- Starting {} test --", methodName);
+        ConsumerConfiguration conf = new ConsumerConfiguration();
+        conf.setSubscriptionType(SubscriptionType.Exclusive);
 
         int numMessages = 100;
         final CountDownLatch latch = new CountDownLatch(numMessages);
 
-        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/my-topic3")
-                .subscriptionName("my-subscriber-name").messageListener((c1, msg) -> {
-                    Assert.assertNotNull(msg, "Message cannot be null");
-                    String receivedMessage = new String(msg.getData());
-                    log.debug("Received message [{}] in the listener", receivedMessage);
-                    c1.acknowledgeAsync(msg);
-                    latch.countDown();
-                }).subscribe();
-
-        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer()
-                .topic("persistent://my-property/use/my-ns/my-topic3");
-
+        conf.setMessageListener((consumer, msg) -> {
+            Assert.assertNotNull(msg, "Message cannot be null");
+            String receivedMessage = new String(msg.getData());
+            log.debug("Received message [{}] in the listener", receivedMessage);
+            consumer.acknowledgeAsync(msg);
+            latch.countDown();
+        });
+        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic3", "my-subscriber-name",
+                conf);
+        ProducerConfiguration producerConf = new ProducerConfiguration();
         if (batchMessageDelayMs != 0) {
-            producerBuilder.enableBatching(true);
-            producerBuilder.batchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
-            producerBuilder.batchingMaxMessages(5);
+            producerConf.setBatchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
+            producerConf.setBatchingMaxMessages(5);
+            producerConf.setBatchingEnabled(true);
         }
-        Producer<byte[]> producer = producerBuilder.create();
+        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic3", producerConf);
         List<Future<MessageId>> futures = Lists.newArrayList();
 
         // Asynchronously produce messages
@@ -223,17 +225,18 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     public void testBackoffAndReconnect(int batchMessageDelayMs) throws Exception {
         log.info("-- Starting {} test --", methodName);
         // Create consumer and producer
-        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/my-topic4")
-                .subscriptionName("my-subscriber-name").subscribe();
-        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer()
-                .topic("persistent://my-property/use/my-ns/my-topic4");
-
+        ConsumerConfiguration conf = new ConsumerConfiguration();
+        conf.setSubscriptionType(SubscriptionType.Exclusive);
+        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic4", "my-subscriber-name",
+                conf);
+        ProducerConfiguration producerConf = new ProducerConfiguration();
         if (batchMessageDelayMs != 0) {
-            producerBuilder.enableBatching(true);
-            producerBuilder.batchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
-            producerBuilder.batchingMaxMessages(5);
+            producerConf.setBatchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
+            producerConf.setBatchingMaxMessages(5);
+            producerConf.setBatchingEnabled(true);
         }
-        Producer<byte[]> producer = producerBuilder.create();
+        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic4", producerConf);
+
         // Produce messages
         CompletableFuture<MessageId> lastFuture = null;
         for (int i = 0; i < 10; i++) {
@@ -245,7 +248,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         lastFuture.get();
 
-        Message<byte[]> msg = null;
+        Message msg = null;
         for (int i = 0; i < 10; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);
             log.info("Received: [{}]", new String(msg.getData()));
@@ -272,17 +275,19 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     public void testSendTimeout(int batchMessageDelayMs) throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/my-topic5")
-                .subscriptionName("my-subscriber-name").subscribe();
-        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer()
-                .topic("persistent://my-property/use/my-ns/my-topic5").sendTimeout(1, TimeUnit.SECONDS);
-
+        ConsumerConfiguration consumerConf = new ConsumerConfiguration();
+        consumerConf.setSubscriptionType(SubscriptionType.Exclusive);
+        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic5", "my-subscriber-name",
+                consumerConf);
+        ProducerConfiguration producerConf = new ProducerConfiguration();
         if (batchMessageDelayMs != 0) {
-            producerBuilder.enableBatching(true);
-            producerBuilder.batchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
-            producerBuilder.batchingMaxMessages(5);
+            producerConf.setBatchingMaxPublishDelay(2 * batchMessageDelayMs, TimeUnit.MILLISECONDS);
+            producerConf.setBatchingMaxMessages(5);
+            producerConf.setBatchingEnabled(true);
         }
-        Producer<byte[]> producer = producerBuilder.create();
+        producerConf.setSendTimeout(1, TimeUnit.SECONDS);
+
+        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic5", producerConf);
         final String message = "my-message";
 
         // Trigger the send timeout
@@ -300,7 +305,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         startBroker();
 
         // We should not have received any message
-        Message<byte[]> msg = consumer.receive(3, TimeUnit.SECONDS);
+        Message msg = consumer.receive(3, TimeUnit.SECONDS);
         Assert.assertNull(msg);
         consumer.close();
         log.info("-- Exiting {} test --", methodName);
@@ -310,29 +315,32 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     public void testInvalidSequence() throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        PulsarClient client1 = PulsarClient.builder().serviceUrl("http://127.0.0.1:" + BROKER_WEBSERVICE_PORT).build();
+        PulsarClient client1 = PulsarClient.create("http://127.0.0.1:" + BROKER_WEBSERVICE_PORT);
         client1.close();
 
+        ConsumerConfiguration consumerConf = new ConsumerConfiguration();
+        consumerConf.setSubscriptionType(SubscriptionType.Exclusive);
+
         try {
-            client1.newConsumer().topic("persistent://my-property/use/my-ns/my-topic6")
-                    .subscriptionName("my-subscriber-name").subscribe();
+            Consumer consumer = client1.subscribe("persistent://my-property/use/my-ns/my-topic6", "my-subscriber-name",
+                    consumerConf);
             Assert.fail("Should fail");
         } catch (PulsarClientException e) {
             Assert.assertTrue(e instanceof PulsarClientException.AlreadyClosedException);
         }
 
         try {
-            client1.newProducer().topic("persistent://my-property/use/my-ns/my-topic6").create();
+            Producer producer = client1.createProducer("persistent://my-property/use/my-ns/my-topic6");
             Assert.fail("Should fail");
         } catch (PulsarClientException e) {
             Assert.assertTrue(e instanceof PulsarClientException.AlreadyClosedException);
         }
 
-        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/my-topic6")
-                .subscriptionName("my-subscriber-name").subscribe();
+        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic6", "my-subscriber-name",
+                consumerConf);
 
         try {
-            Message<byte[]> msg = MessageBuilder.create().setContent("InvalidMessage".getBytes()).build();
+            Message msg = MessageBuilder.create().setContent("InvalidMessage".getBytes()).build();
             consumer.acknowledge(msg);
         } catch (PulsarClientException.InvalidMessageException e) {
             // ok
@@ -354,8 +362,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             // ok
         }
 
-        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic6")
-                .create();
+        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic6");
         producer.close();
 
         try {
@@ -370,72 +377,91 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     @Test
     public void testSillyUser() {
         try {
-            PulsarClient.builder().serviceUrl("invalid://url").build();
+            PulsarClient client1 = PulsarClient.create("invalid://url");
             Assert.fail("should fail");
         } catch (PulsarClientException e) {
             Assert.assertTrue(e instanceof PulsarClientException.InvalidServiceURL);
         }
 
+        ProducerConfiguration producerConf = new ProducerConfiguration();
+
         try {
-            pulsarClient.newProducer().sendTimeout(-1, TimeUnit.SECONDS);
+            producerConf.setSendTimeout(-1, TimeUnit.SECONDS);
             Assert.fail("should fail");
         } catch (IllegalArgumentException e) {
             // ok
         }
 
         try {
-            pulsarClient.newProducer().maxPendingMessages(0);
+            producerConf.setMaxPendingMessages(0);
             Assert.fail("should fail");
         } catch (IllegalArgumentException e) {
             // ok
         }
 
         try {
-            pulsarClient.newProducer().topic("invalid://topic").create();
+            Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic7", null);
+            Assert.fail("should fail");
+        } catch (PulsarClientException e) {
+            Assert.assertTrue(e instanceof PulsarClientException.InvalidConfigurationException);
+        }
+
+        try {
+            Producer producer = pulsarClient.createProducer("invalid://topic", producerConf);
             Assert.fail("should fail");
         } catch (PulsarClientException e) {
             Assert.assertTrue(e instanceof PulsarClientException.InvalidTopicNameException);
         }
 
+        ConsumerConfiguration consumerConf = new ConsumerConfiguration();
+
         try {
-            pulsarClient.newConsumer().messageListener(null);
+            consumerConf.setMessageListener(null);
             Assert.fail("should fail");
         } catch (NullPointerException e) {
             // ok
         }
 
         try {
-            pulsarClient.newConsumer().subscriptionType(null);
+            consumerConf.setSubscriptionType(null);
             Assert.fail("should fail");
         } catch (NullPointerException e) {
             // ok
         }
 
         try {
-            pulsarClient.newConsumer().receiverQueueSize(-1);
+            consumerConf.setReceiverQueueSize(-1);
             Assert.fail("should fail");
         } catch (IllegalArgumentException e) {
             // ok
         }
 
         try {
-            pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/my-topic7").subscriptionName(null)
-                    .subscribe();
-            Assert.fail("Should fail");
-        } catch (PulsarClientException e) {
-            assertEquals(e.getClass(), InvalidConfigurationException.class);
-        }
-
-        try {
-            pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/my-topic7").subscriptionName("")
-                    .subscribe();
+            Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic7",
+                    "my-subscriber-name", null);
             Assert.fail("Should fail");
         } catch (PulsarClientException e) {
             Assert.assertTrue(e instanceof PulsarClientException.InvalidConfigurationException);
         }
 
         try {
-            pulsarClient.newConsumer().topic("invalid://topic7").subscriptionName("my-subscriber-name").subscribe();
+            Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic7", null,
+                    consumerConf);
+            Assert.fail("Should fail");
+        } catch (PulsarClientException e) {
+            Assert.assertTrue(e instanceof PulsarClientException.InvalidConfigurationException);
+        }
+
+        try {
+            Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic7", "",
+                    consumerConf);
+            Assert.fail("Should fail");
+        } catch (PulsarClientException e) {
+            Assert.assertTrue(e instanceof PulsarClientException.InvalidConfigurationException);
+        }
+
+        try {
+            Consumer consumer = pulsarClient.subscribe("invalid://topic7", "my-subscriber-name", consumerConf);
             Assert.fail("Should fail");
         } catch (PulsarClientException e) {
             Assert.assertTrue(e instanceof PulsarClientException.InvalidTopicNameException);
@@ -450,10 +476,10 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         final int recvQueueSize = 100;
         final int numConsumersThreads = 10;
 
+        final ConsumerConfiguration conf = new ConsumerConfiguration();
+        conf.setReceiverQueueSize(recvQueueSize);
         String subName = UUID.randomUUID().toString();
-        final Consumer<byte[]> consumer = pulsarClient.newConsumer()
-                .topic("persistent://my-property/use/my-ns/my-topic7").subscriptionName(subName)
-                .receiverQueueSize(recvQueueSize).subscribe();
+        final Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic7", subName, conf);
         ExecutorService executor = Executors.newCachedThreadPool();
 
         final CyclicBarrier barrier = new CyclicBarrier(numConsumersThreads + 1);
@@ -477,22 +503,20 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         Thread.sleep(2000);
 
         // publish 100 messages so that the consumers blocked on receive() will now get the messages
-        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer()
-                .topic("persistent://my-property/use/my-ns/my-topic7");
-
+        ProducerConfiguration producerConf = new ProducerConfiguration();
         if (batchMessageDelayMs != 0) {
-            producerBuilder.batchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
-            producerBuilder.batchingMaxMessages(5);
-            producerBuilder.enableBatching(true);
+            producerConf.setBatchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
+            producerConf.setBatchingMaxMessages(5);
+            producerConf.setBatchingEnabled(true);
         }
-        Producer<byte[]> producer = producerBuilder.create();
+        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic7", producerConf);
         for (int i = 0; i < recvQueueSize; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
         Thread.sleep(500);
 
-        ConsumerImpl<byte[]> consumerImpl = (ConsumerImpl<byte[]>) consumer;
+        ConsumerImpl consumerImpl = (ConsumerImpl) consumer;
         // The available permits should be 10 and num messages in the queue should be 90
         Assert.assertEquals(consumerImpl.getAvailablePermits(), numConsumersThreads);
         Assert.assertEquals(consumerImpl.numMessagesInQueue(), recvQueueSize - numConsumersThreads);
@@ -517,7 +541,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         // clear the queue
         while (true) {
-            Message<byte[]> msg = consumer.receive(1, TimeUnit.SECONDS);
+            Message msg = consumer.receive(1, TimeUnit.SECONDS);
             if (msg == null) {
                 break;
             }
@@ -560,9 +584,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         try {
             final String topic = "persistent://my-property/use/my-ns/bigMsg";
-            Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).create();
-            Message<byte[]> message = MessageBuilder.create().setContent(new byte[PulsarDecoder.MaxMessageSize + 1])
-                    .build();
+            Producer producer = pulsarClient.createProducer(topic);
+            Message message = MessageBuilder.create().setContent(new byte[PulsarDecoder.MaxMessageSize + 1]).build();
             producer.send(message);
             fail("Should have thrown exception");
         } catch (PulsarClientException.InvalidMessageException e) {
@@ -591,16 +614,18 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         final String topic = "persistent://my-property/use/my-ns/bigMsg";
 
         // (a) non-batch msg with compression
-        Producer<byte[]> producer = pulsarClient.newProducer().topic(topic).compressionType(CompressionType.LZ4)
-                .create();
-        Message<byte[]> message = MessageBuilder.create().setContent(new byte[PulsarDecoder.MaxMessageSize + 1])
-                .build();
+        ProducerConfiguration producerConf = new ProducerConfiguration();
+        producerConf.setCompressionType(CompressionType.LZ4);
+        Producer producer = pulsarClient.createProducer(topic, producerConf);
+        Message message = MessageBuilder.create().setContent(new byte[PulsarDecoder.MaxMessageSize + 1]).build();
         producer.send(message);
         producer.close();
 
         // (b) batch-msg
-        producer = pulsarClient.newProducer().topic(topic).enableBatching(true).compressionType(CompressionType.LZ4)
-                .create();
+        producerConf = new ProducerConfiguration();
+        producerConf.setBatchingEnabled(true);
+        producerConf.setCompressionType(CompressionType.LZ4);
+        producer = pulsarClient.createProducer(topic, producerConf);
         message = MessageBuilder.create().setContent(new byte[PulsarDecoder.MaxMessageSize + 1]).build();
         try {
             producer.send(message);
@@ -611,7 +636,9 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         producer.close();
 
         // (c) non-batch msg without compression
-        producer = pulsarClient.newProducer().topic(topic).compressionType(CompressionType.NONE).create();
+        producerConf = new ProducerConfiguration();
+        producerConf.setCompressionType(CompressionType.NONE);
+        producer = pulsarClient.createProducer(topic, producerConf);
         message = MessageBuilder.create().setContent(new byte[PulsarDecoder.MaxMessageSize + 1]).build();
         try {
             producer.send(message);
@@ -622,8 +649,10 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         producer.close();
 
         // (d) non-batch msg with compression and try to consume message
-        producer = pulsarClient.newProducer().topic(topic).compressionType(CompressionType.LZ4).create();
-        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topic).subscriptionName("sub1").subscribe();
+        producerConf = new ProducerConfiguration();
+        producerConf.setCompressionType(CompressionType.LZ4);
+        producer = pulsarClient.createProducer(topic, producerConf);
+        Consumer consumer = pulsarClient.subscribe(topic, "sub1");
         byte[] content = new byte[PulsarDecoder.MaxMessageSize + 10];
         message = MessageBuilder.create().setContent(content).build();
         producer.send(message);
@@ -653,21 +682,23 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         final String topicName = "cache-topic";
         final String sub1 = "faster-sub1";
         final String sub2 = "slower-sub2";
+        ConsumerConfiguration conf = new ConsumerConfiguration();
+        conf.setSubscriptionType(SubscriptionType.Shared);
+        conf.setReceiverQueueSize(receiverSize);
+
+        ProducerConfiguration producerConf = new ProducerConfiguration();
+
+        if (batchMessageDelayMs != 0) {
+            producerConf.setBatchingEnabled(true);
+            producerConf.setBatchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
+            producerConf.setBatchingMaxMessages(5);
+        }
 
         /************ usecase-1: *************/
         // 1. Subscriber Faster subscriber
-        Consumer<byte[]> subscriber1 = pulsarClient.newConsumer()
-                .topic("persistent://my-property/use/my-ns/" + topicName).subscriptionName(sub1)
-                .subscriptionType(SubscriptionType.Shared).receiverQueueSize(receiverSize).subscribe();
+        Consumer subscriber1 = pulsarClient.subscribe("persistent://my-property/use/my-ns/" + topicName, sub1, conf);
         final String topic = "persistent://my-property/use/my-ns/" + topicName;
-        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer().topic(topic);
-
-        if (batchMessageDelayMs != 0) {
-            producerBuilder.batchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
-            producerBuilder.batchingMaxMessages(5);
-            producerBuilder.enableBatching(true);
-        }
-        Producer<byte[]> producer = producerBuilder.create();
+        Producer producer = pulsarClient.createProducer(topic, producerConf);
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topic);
         ManagedLedgerImpl ledger = (ManagedLedgerImpl) topicRef.getManagedLedger();
@@ -679,7 +710,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         EntryCacheImpl entryCache = spy((EntryCacheImpl) cacheField.get(ledger));
         cacheField.set(ledger, entryCache);
 
-        Message<byte[]> msg = null;
+        Message msg = null;
         // 2. Produce messages
         for (int i = 0; i < 30; i++) {
             String message = "my-message-" + i;
@@ -707,8 +738,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         /************ usecase-2: *************/
         // 1.b Subscriber slower-subscriber
-        Consumer<byte[]> subscriber2 = pulsarClient.newConsumer()
-                .topic("persistent://my-property/use/my-ns/" + topicName).subscriptionName(sub2).subscribe();
+        Consumer subscriber2 = pulsarClient.subscribe("persistent://my-property/use/my-ns/" + topicName, sub2, conf);
         // Produce messages
         final int moreMessages = 10;
         for (int i = 0; i < receiverSize + moreMessages; i++) {
@@ -734,10 +764,10 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         // 3.b Close subscriber2: which will trigger cache to clear the cache
         subscriber2.close();
-
+        
         // retry strategically until broker clean up closed subscribers and invalidate all cache entries
         retryStrategically((test) -> entryCache.getSize() == 0, 5, 100);
-
+        
         // Verify: EntryCache should be cleared
         assertTrue(entryCache.getSize() == 0);
         subscriber1.close();
@@ -754,22 +784,24 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         final String topic = "persistent://my-property/use/my-ns/" + topicName;
         final String sub1 = "faster-sub1";
         final String sub2 = "slower-sub2";
+        ConsumerConfiguration conf = new ConsumerConfiguration();
+        conf.setSubscriptionType(SubscriptionType.Shared);
+        conf.setReceiverQueueSize(receiverSize);
+
+        ProducerConfiguration producerConf = new ProducerConfiguration();
+
+        if (batchMessageDelayMs != 0) {
+            producerConf.setBatchingEnabled(true);
+            producerConf.setBatchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
+            producerConf.setBatchingMaxMessages(5);
+        }
 
         // 1. Subscriber Faster subscriber: let it consume all messages immediately
-        Consumer<byte[]> subscriber1 = pulsarClient.newConsumer()
-                .topic("persistent://my-property/use/my-ns/" + topicName).subscriptionName(sub1)
-                .subscriptionType(SubscriptionType.Shared).receiverQueueSize(receiverSize).subscribe();
+        Consumer subscriber1 = pulsarClient.subscribe("persistent://my-property/use/my-ns/" + topicName, sub1, conf);
         // 1.b. Subscriber Slow subscriber:
-        Consumer<byte[]> subscriber2 = pulsarClient.newConsumer()
-                .topic("persistent://my-property/use/my-ns/" + topicName).subscriptionName(sub2)
-                .subscriptionType(SubscriptionType.Shared).receiverQueueSize(receiverSize).subscribe();
-
-        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer().topic(topic);
-        if (batchMessageDelayMs != 0) {
-            producerBuilder.enableBatching(true).batchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS)
-                    .batchingMaxMessages(5);
-        }
-        Producer<byte[]> producer = producerBuilder.create();
+        conf.setReceiverQueueSize(receiverSize);
+        Consumer subscriber2 = pulsarClient.subscribe("persistent://my-property/use/my-ns/" + topicName, sub2, conf);
+        Producer producer = pulsarClient.createProducer(topic, producerConf);
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topic);
         ManagedLedgerImpl ledger = (ManagedLedgerImpl) topicRef.getManagedLedger();
@@ -786,7 +818,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         field.set(ledger, maxMessageCacheRetentionTimeMillis);
         final long maxActiveCursorBacklogEntries = (long) backlogThresholdField.get(ledger);
 
-        Message<byte[]> msg = null;
+        Message msg = null;
         final int totalMsgs = (int) maxActiveCursorBacklogEntries + receiverSize + 1;
         // 2. Produce messages
         for (int i = 0; i < totalMsgs; i++) {
@@ -834,13 +866,15 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         final int totalMsg = 100;
         final Set<String> produceMsgs = Sets.newHashSet();
         final Set<String> consumeMsgs = Sets.newHashSet();
+        final ProducerConfiguration producerConf = new ProducerConfiguration();
+        final ConsumerConfiguration conf = new ConsumerConfiguration();
 
-        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/my-topic1")
-                .subscriptionName("my-subscriber-name").subscribe();
+        conf.setSubscriptionType(SubscriptionType.Exclusive);
+        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic1", "my-subscriber-name",
+                conf);
 
         // produce message
-        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic1")
-                .create();
+        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic1", producerConf);
         for (int i = 0; i < totalMsg; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
@@ -873,13 +907,15 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         final int totalMsg = 100;
         final Set<String> produceMsgs = Sets.newHashSet();
         final Set<String> consumeMsgs = Sets.newHashSet();
-        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/my-topic1")
-                .subscriptionName("my-subscriber-name").subscribe();
-        ;
+        final ProducerConfiguration producerConf = new ProducerConfiguration();
+        final ConsumerConfiguration conf = new ConsumerConfiguration();
+
+        conf.setSubscriptionType(SubscriptionType.Exclusive);
+        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic1", "my-subscriber-name",
+                conf);
 
         // produce message
-        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic1")
-                .create();
+        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic1", producerConf);
         for (int i = 0; i < totalMsg; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
@@ -910,11 +946,11 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         log.info("-- Starting {} test --", methodName);
 
         final int totalMsg = 100;
-        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic1")
-                .create();
+        final ProducerConfiguration producerConf = new ProducerConfiguration();
+        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic1", producerConf);
         for (int i = 0; i < totalMsg; i++) {
             final String message = "my-message-" + i;
-            Message<byte[]> msg = MessageBuilder.create().setContent(message.getBytes()).build();
+            Message msg = MessageBuilder.create().setContent(message.getBytes()).build();
             final AtomicInteger msgLength = new AtomicInteger();
             CompletableFuture<MessageId> future = producer.sendAsync(msg).handle((r, ex) -> {
                 if (ex != null) {
@@ -939,22 +975,25 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     public void testSharedConsumerAckDifferentConsumer() throws Exception {
         log.info("-- Starting {} test --", methodName);
 
-        ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer()
-                .topic("persistent://my-property/use/my-ns/my-topic1").subscriptionName("my-subscriber-name")
-                .receiverQueueSize(1).subscriptionType(SubscriptionType.Shared);
-        Consumer<byte[]> consumer1 = consumerBuilder.subscribe();
-        Consumer<byte[]> consumer2 = consumerBuilder.subscribe();
+        ConsumerConfiguration conf = new ConsumerConfiguration();
+        conf.setReceiverQueueSize(1);
+        conf.setSubscriptionType(SubscriptionType.Shared);
+        Consumer consumer1 = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic1", "my-subscriber-name",
+                conf);
+        Consumer consumer2 = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic1", "my-subscriber-name",
+                conf);
 
-        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic1")
-                .create();
+        ProducerConfiguration producerConf = new ProducerConfiguration();
+
+        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic1", producerConf);
         for (int i = 0; i < 10; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
 
-        Message<byte[]> msg = null;
-        Set<Message<byte[]>> consumerMsgSet1 = Sets.newHashSet();
-        Set<Message<byte[]>> consumerMsgSet2 = Sets.newHashSet();
+        Message msg = null;
+        Set<Message> consumerMsgSet1 = Sets.newHashSet();
+        Set<Message> consumerMsgSet2 = Sets.newHashSet();
         for (int i = 0; i < 5; i++) {
             msg = consumer1.receive();
             consumerMsgSet1.add(msg);
@@ -994,10 +1033,10 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         log.info("-- Exiting {} test --", methodName);
     }
 
-    private void receiveAsync(Consumer<byte[]> consumer, int totalMessage, int currentMessage, CountDownLatch latch,
+    private void receiveAsync(Consumer consumer, int totalMessage, int currentMessage, CountDownLatch latch,
             final Set<String> consumeMsg, ExecutorService executor) throws PulsarClientException {
         if (currentMessage < totalMessage) {
-            CompletableFuture<Message<byte[]>> future = consumer.receiveAsync();
+            CompletableFuture<Message> future = consumer.receiveAsync();
             future.handle((msg, exception) -> {
                 if (exception == null) {
                     // add message to consumer-queue to verify with produced messages
@@ -1023,11 +1062,13 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     }
 
     /**
-     * Verify: Consumer stops receiving msg when reach unack-msg limit and starts receiving once acks messages 1.
-     * Produce X (600) messages 2. Consumer has receive size (10) and receive message without acknowledging 3. Consumer
-     * will stop receiving message after unAckThreshold = 500 4. Consumer acks messages and starts consuming remanining
-     * messages This testcase enables checksum sending while producing message and broker verifies the checksum for the
-     * message.
+     * Verify: Consumer stops receiving msg when reach unack-msg limit and
+     * starts receiving once acks messages
+     * 1. Produce X (600) messages
+     * 2. Consumer has receive size (10) and receive message without acknowledging
+     * 3. Consumer will stop receiving message after unAckThreshold = 500
+     * 4. Consumer acks messages and starts consuming remanining messages
+     * This testcase enables checksum sending while producing message and broker verifies the checksum for the message.
      *
      * @throws Exception
      */
@@ -1042,12 +1083,16 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             final int totalProducedMsgs = 600;
 
             pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(unAckedMessagesBufferSize);
-            Consumer<byte[]> consumer = pulsarClient.newConsumer()
-                    .topic("persistent://my-property/use/my-ns/unacked-topic").subscriptionName("subscriber-1")
-                    .receiverQueueSize(receiverQueueSize).subscriptionType(SubscriptionType.Shared).subscribe();
+            ConsumerConfiguration conf = new ConsumerConfiguration();
+            conf.setReceiverQueueSize(receiverQueueSize);
+            conf.setSubscriptionType(SubscriptionType.Shared);
+            Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/unacked-topic",
+                    "subscriber-1", conf);
 
-            Producer<byte[]> producer = pulsarClient.newProducer()
-                    .topic("persistent://my-property/use/my-ns/unacked-topic").create();
+            ProducerConfiguration producerConf = new ProducerConfiguration();
+
+            Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/unacked-topic",
+                    producerConf);
 
             // (1) Produced Messages
             for (int i = 0; i < totalProducedMsgs; i++) {
@@ -1056,8 +1101,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             }
 
             // (2) try to consume messages: but will be able to consume number of messages = unAckedMessagesBufferSize
-            Message<byte[]> msg = null;
-            List<Message<byte[]>> messages = Lists.newArrayList();
+            Message msg = null;
+            List<Message> messages = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
                 msg = consumer.receive(1, TimeUnit.SECONDS);
                 if (msg != null) {
@@ -1102,11 +1147,18 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     }
 
     /**
-     * Verify: iteration of a. message receive w/o acking b. stop receiving msg c. ack msgs d. started receiving msgs
+     * Verify: iteration of
+     * a. message receive w/o acking
+     * b. stop receiving msg
+     * c. ack msgs
+     * d. started receiving msgs
      *
-     * 1. Produce total X (1500) messages 2. Consumer consumes messages without acking until stop receiving from broker
-     * due to reaching ack-threshold (500) 3. Consumer acks messages after stop getting messages 4. Consumer again tries
-     * to consume messages 5. Consumer should be able to complete consuming all 1500 messages in 3 iteration (1500/500)
+     * 1. Produce total X (1500) messages
+     * 2. Consumer consumes messages without acking until stop receiving
+     * from broker due to reaching ack-threshold (500)
+     * 3. Consumer acks messages after stop getting messages
+     * 4. Consumer again tries to consume messages
+     * 5. Consumer should be able to complete consuming all 1500 messages in 3 iteration (1500/500)
      *
      * @throws Exception
      */
@@ -1123,12 +1175,16 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             // receiver consumes messages in iteration after acknowledging broker
             final int totalReceiveIteration = totalProducedMsgs / unAckedMessagesBufferSize;
             pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(unAckedMessagesBufferSize);
-            Consumer<byte[]> consumer = pulsarClient.newConsumer()
-                    .topic("persistent://my-property/use/my-ns/unacked-topic").subscriptionName("subscriber-1")
-                    .receiverQueueSize(receiverQueueSize).subscriptionType(SubscriptionType.Shared).subscribe();
+            ConsumerConfiguration conf = new ConsumerConfiguration();
+            conf.setReceiverQueueSize(receiverQueueSize);
+            conf.setSubscriptionType(SubscriptionType.Shared);
+            Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/unacked-topic",
+                    "subscriber-1", conf);
 
-            Producer<byte[]> producer = pulsarClient.newProducer()
-                    .topic("persistent://my-property/use/my-ns/unacked-topic").create();
+            ProducerConfiguration producerConf = new ProducerConfiguration();
+
+            Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/unacked-topic",
+                    producerConf);
 
             // (1) Produced Messages
             for (int i = 0; i < totalProducedMsgs; i++) {
@@ -1140,8 +1196,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             // (2) Receive Messages
             for (int j = 0; j < totalReceiveIteration; j++) {
 
-                Message<byte[]> msg = null;
-                List<Message<byte[]>> messages = Lists.newArrayList();
+                Message msg = null;
+                List<Message> messages = Lists.newArrayList();
                 for (int i = 0; i < totalProducedMsgs; i++) {
                     msg = consumer.receive(1, TimeUnit.SECONDS);
                     if (msg != null) {
@@ -1177,6 +1233,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         }
     }
 
+
     /**
      * Verify: Consumer1 which doesn't send ack will not impact Consumer2 which sends ack for consumed message.
      *
@@ -1196,13 +1253,18 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             int totalReceiveMessages = 0;
 
             pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(maxUnackedMessages);
-            ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer()
-                    .topic("persistent://my-property/use/my-ns/unacked-topic").subscriptionName("subscriber-1")
-                    .receiverQueueSize(receiverQueueSize).subscriptionType(SubscriptionType.Shared);
-            Consumer<byte[]> consumer1 = consumerBuilder.subscribe();
-            Consumer<byte[]> consumer2 = consumerBuilder.subscribe();
-            Producer<byte[]> producer = pulsarClient.newProducer()
-                    .topic("persistent://my-property/use/my-ns/unacked-topic").create();
+            ConsumerConfiguration conf = new ConsumerConfiguration();
+            conf.setReceiverQueueSize(receiverQueueSize);
+            conf.setSubscriptionType(SubscriptionType.Shared);
+            Consumer consumer1 = pulsarClient.subscribe("persistent://my-property/use/my-ns/unacked-topic",
+                    "subscriber-1", conf);
+            Consumer consumer2 = pulsarClient.subscribe("persistent://my-property/use/my-ns/unacked-topic",
+                    "subscriber-1", conf);
+
+            ProducerConfiguration producerConf = new ProducerConfiguration();
+
+            Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/unacked-topic",
+                    producerConf);
 
             // (1) Produced Messages
             for (int i = 0; i < totalProducedMsgs; i++) {
@@ -1210,10 +1272,11 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
                 producer.send(message.getBytes());
             }
 
+
             // (2) Consumer1: consume without ack:
             // try to consume messages: but will be able to consume number of messages = maxUnackedMessages
-            Message<byte[]> msg = null;
-            List<Message<byte[]>> messages = Lists.newArrayList();
+            Message msg = null;
+            List<Message> messages = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
                 msg = consumer1.receive(1, TimeUnit.SECONDS);
                 if (msg != null) {
@@ -1286,13 +1349,17 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             final int receiverQueueSize = 20;
             final int totalProducedMsgs = 100;
 
-            ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer()
-                    .topic("persistent://my-property/use/my-ns/unacked-topic").subscriptionName("subscriber-1")
-                    .receiverQueueSize(receiverQueueSize).ackTimeout(1, TimeUnit.SECONDS)
-                    .subscriptionType(SubscriptionType.Shared).subscribe();
+            ConsumerConfiguration conf = new ConsumerConfiguration();
+            conf.setReceiverQueueSize(receiverQueueSize);
+            conf.setAckTimeout(1, TimeUnit.SECONDS);
+            conf.setSubscriptionType(SubscriptionType.Shared);
+            ConsumerImpl consumer = (ConsumerImpl) pulsarClient
+                    .subscribe("persistent://my-property/use/my-ns/unacked-topic", "subscriber-1", conf);
 
-            Producer<byte[]> producer = pulsarClient.newProducer()
-                    .topic("persistent://my-property/use/my-ns/unacked-topic").create();
+            ProducerConfiguration producerConf = new ProducerConfiguration();
+
+            Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/unacked-topic",
+                    producerConf);
 
             // (1) Produced Messages
             for (int i = 0; i < totalProducedMsgs; i++) {
@@ -1309,7 +1376,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             assertEquals(consumer.numMessagesInQueue(), receiverQueueSize);
 
             for (int i = 0; i < totalProducedMsgs; i++) {
-                Message<byte[]> msg = consumer.receive(1, TimeUnit.SECONDS);
+                Message msg = consumer.receive(1, TimeUnit.SECONDS);
                 if (msg != null) {
                     consumer.acknowledge(msg);
                     totalReceiveMsg++;
@@ -1343,12 +1410,16 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             final int totalProducedMsgs = 100;
 
             pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(unAckedMessagesBufferSize);
-            ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer()
-                    .topic("persistent://my-property/use/my-ns/unacked-topic").subscriptionName("subscriber-1")
-                    .receiverQueueSize(receiverQueueSize).subscriptionType(SubscriptionType.Shared).subscribe();
+            ConsumerConfiguration conf = new ConsumerConfiguration();
+            conf.setReceiverQueueSize(receiverQueueSize);
+            conf.setSubscriptionType(SubscriptionType.Shared);
+            ConsumerImpl consumer = (ConsumerImpl) pulsarClient
+                    .subscribe("persistent://my-property/use/my-ns/unacked-topic", "subscriber-1", conf);
 
-            Producer<byte[]> producer = pulsarClient.newProducer()
-                    .topic("persistent://my-property/use/my-ns/unacked-topic").create();
+            ProducerConfiguration producerConf = new ProducerConfiguration();
+
+            Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/unacked-topic",
+                    producerConf);
 
             // (1) Produced Messages
             for (int i = 0; i < totalProducedMsgs; i++) {
@@ -1357,8 +1428,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             }
 
             // (2) try to consume messages: but will be able to consume number of messages = unAckedMessagesBufferSize
-            Message<byte[]> msg = null;
-            List<Message<byte[]>> messages = Lists.newArrayList();
+            Message msg = null;
+            List<Message> messages = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
                 msg = consumer.receive(1, TimeUnit.SECONDS);
                 if (msg != null) {
@@ -1410,20 +1481,22 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             int totalReceiveMessages = 0;
 
             pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(maxUnackedMessages);
-            Consumer<byte[]> consumer1 = pulsarClient.newConsumer()
-                    .topic("persistent://my-property/use/my-ns/unacked-topic").subscriptionName("subscriber-1")
-                    .receiverQueueSize(receiverQueueSize).subscriptionType(SubscriptionType.Shared).subscribe();
+            ConsumerConfiguration conf = new ConsumerConfiguration();
+            conf.setReceiverQueueSize(receiverQueueSize);
+            conf.setSubscriptionType(SubscriptionType.Shared);
+            Consumer consumer1 = pulsarClient.subscribe("persistent://my-property/use/my-ns/unacked-topic",
+                    "subscriber-1", conf);
 
-            ProducerBuilder<byte[]> producerBuidler = pulsarClient.newProducer()
-                    .topic("persistent://my-property/use/my-ns/unacked-topic");
+            ProducerConfiguration producerConf = new ProducerConfiguration();
 
             if (batchMessageDelayMs != 0) {
-                producerBuidler.enableBatching(true);
-                producerBuidler.batchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
-                producerBuidler.batchingMaxMessages(5);
+                producerConf.setBatchingEnabled(true);
+                producerConf.setBatchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
+                producerConf.setBatchingMaxMessages(5);
             }
 
-            Producer<byte[]> producer = producerBuidler.create();
+            Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/unacked-topic",
+                    producerConf);
 
             List<CompletableFuture<MessageId>> futures = Lists.newArrayList();
             // (1) Produced Messages
@@ -1436,8 +1509,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
             // (2) Consumer1: consume without ack:
             // try to consume messages: but will be able to consume number of messages = maxUnackedMessages
-            Message<byte[]> msg = null;
-            List<Message<byte[]>> messages = Lists.newArrayList();
+            Message msg = null;
+            List<Message> messages = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
                 msg = consumer1.receive(1, TimeUnit.SECONDS);
                 if (msg != null) {
@@ -1503,14 +1576,18 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             int totalReceiveMessages = 0;
 
             pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(maxUnackedMessages);
-            ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer()
-                    .topic("persistent://my-property/use/my-ns/unacked-topic").subscriptionName("subscriber-1")
-                    .receiverQueueSize(receiverQueueSize).subscriptionType(SubscriptionType.Shared);
-            Consumer<byte[]> consumer1 = consumerBuilder.subscribe();
-            Consumer<byte[]> consumer2 = consumerBuilder.subscribe();
+            ConsumerConfiguration conf = new ConsumerConfiguration();
+            conf.setReceiverQueueSize(receiverQueueSize);
+            conf.setSubscriptionType(SubscriptionType.Shared);
+            Consumer consumer1 = pulsarClient.subscribe("persistent://my-property/use/my-ns/unacked-topic",
+                    "subscriber-1", conf);
+            Consumer consumer2 = pulsarClient.subscribe("persistent://my-property/use/my-ns/unacked-topic",
+                    "subscriber-1", conf);
 
-            Producer<byte[]> producer = pulsarClient.newProducer()
-                    .topic("persistent://my-property/use/my-ns/unacked-topic").create();
+            ProducerConfiguration producerConf = new ProducerConfiguration();
+
+            Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/unacked-topic",
+                    producerConf);
 
             // (1) Produced Messages
             for (int i = 0; i < totalProducedMsgs; i++) {
@@ -1518,10 +1595,11 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
                 producer.send(message.getBytes());
             }
 
+
             // (2) Consumer1: consume without ack:
             // try to consume messages: but will be able to consume number of messages = maxUnackedMessages
-            Message<byte[]> msg = null;
-            List<Message<byte[]>> messages = Lists.newArrayList();
+            Message msg = null;
+            List<Message> messages = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
                 msg = consumer1.receive(1, TimeUnit.SECONDS);
                 if (msg != null) {
@@ -1533,7 +1611,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
                 }
             }
 
-            assertEquals(messages.size(), maxUnackedMessages); // consumer1
+            assertEquals(messages.size(), maxUnackedMessages); //consumer1
 
             // (3) ack for all UnackedMessages from consumer2
             messages.forEach(m -> {
@@ -1584,24 +1662,26 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         log.info("-- Starting {} test --", methodName);
 
         final int totalMsg = 10;
-        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/my-topic1")
-                .subscriptionName("my-subscriber-name").subscribe();
+        ConsumerConfiguration conf = new ConsumerConfiguration();
+        conf.setSubscriptionType(SubscriptionType.Exclusive);
+        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic1", "my-subscriber-name",
+                conf);
 
-        ProducerBuilder<byte[]> producerBuilder = pulsarClient.newProducer()
-                .topic("persistent://my-property/use/my-ns/my-topic1");
+        ProducerConfiguration producerConf = new ProducerConfiguration();
         final int batchMessageDelayMs = 300;
         if (batchMessageDelayMs != 0) {
-            producerBuilder.enableBatching(true).batchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS)
-                    .batchingMaxMessages(5);
+            producerConf.setBatchingEnabled(true);
+            producerConf.setBatchingMaxPublishDelay(batchMessageDelayMs, TimeUnit.MILLISECONDS);
+            producerConf.setBatchingMaxMessages(5);
         }
 
-        Producer<byte[]> producer = producerBuilder.create();
+        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic1", producerConf);
         for (int i = 0; i < totalMsg; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
 
-        Message<byte[]> msg = null;
+        Message msg = null;
         Set<String> messageSet = Sets.newHashSet();
         for (int i = 0; i < totalMsg; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);
@@ -1635,12 +1715,16 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             final int totalProducedMsgs = 20;
 
             pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(unAckedMessagesBufferSize);
-            ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer()
-                    .topic("persistent://my-property/use/my-ns/unacked-topic").subscriptionName("subscriber-1")
-                    .receiverQueueSize(receiverQueueSize).subscriptionType(SubscriptionType.Shared).subscribe();
+            ConsumerConfiguration conf = new ConsumerConfiguration();
+            conf.setReceiverQueueSize(receiverQueueSize);
+            conf.setSubscriptionType(SubscriptionType.Shared);
+            ConsumerImpl consumer = (ConsumerImpl) pulsarClient
+                    .subscribe("persistent://my-property/use/my-ns/unacked-topic", "subscriber-1", conf);
 
-            Producer<byte[]> producer = pulsarClient.newProducer()
-                    .topic("persistent://my-property/use/my-ns/unacked-topic").create();
+            ProducerConfiguration producerConf = new ProducerConfiguration();
+
+            Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/unacked-topic",
+                    producerConf);
 
             // (1) Produced Messages
             for (int i = 0; i < totalProducedMsgs; i++) {
@@ -1650,8 +1734,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             }
 
             // (2) try to consume messages: but will be able to consume number of messages = unAckedMessagesBufferSize
-            Message<byte[]> msg = null;
-            List<Message<byte[]>> messages1 = Lists.newArrayList();
+            Message msg = null;
+            List<Message> messages1 = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
                 msg = consumer.receive(1, TimeUnit.SECONDS);
                 if (msg != null) {
@@ -1701,8 +1785,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
      * It verifies that redelivery-of-specific messages: that redelivers all those messages even when consumer gets
      * blocked due to unacked messsages
      *
-     * Usecase: Consumer starts consuming only after all messages have been produced. So, consumer consumes total
-     * receiver-queue-size number messages => ask for redelivery and receives all messages again.
+     * Usecase: Consumer starts consuming only after all messages have been produced.
+     * So, consumer consumes total receiver-queue-size number messages => ask for redelivery and receives all messages again.
      *
      * @throws Exception
      */
@@ -1717,14 +1801,18 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             final int totalProducedMsgs = 50;
 
             pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(unAckedMessagesBufferSize);
+            ConsumerConfiguration conf = new ConsumerConfiguration();
+            conf.setReceiverQueueSize(receiverQueueSize);
+            conf.setSubscriptionType(SubscriptionType.Shared);
             // Only subscribe consumer
-            ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer()
-                    .topic("persistent://my-property/use/my-ns/unacked-topic").subscriptionName("subscriber-1")
-                    .receiverQueueSize(receiverQueueSize).subscriptionType(SubscriptionType.Shared).subscribe();
+            ConsumerImpl consumer = (ConsumerImpl) pulsarClient
+                    .subscribe("persistent://my-property/use/my-ns/unacked-topic", "subscriber-1", conf);
             consumer.close();
 
-            Producer<byte[]> producer = pulsarClient.newProducer()
-                    .topic("persistent://my-property/use/my-ns/unacked-topic").create();
+            ProducerConfiguration producerConf = new ProducerConfiguration();
+
+            Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/unacked-topic",
+                    producerConf);
 
             // (1) Produced Messages
             for (int i = 0; i < totalProducedMsgs; i++) {
@@ -1734,13 +1822,12 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             }
 
             // (1.a) start consumer again
-            consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer()
-                    .topic("persistent://my-property/use/my-ns/unacked-topic").subscriptionName("subscriber-1")
-                    .receiverQueueSize(receiverQueueSize).subscriptionType(SubscriptionType.Shared).subscribe();
+            consumer = (ConsumerImpl) pulsarClient.subscribe("persistent://my-property/use/my-ns/unacked-topic",
+                    "subscriber-1", conf);
 
             // (2) try to consume messages: but will be able to consume number of messages = unAckedMessagesBufferSize
-            Message<byte[]> msg = null;
-            List<Message<byte[]>> messages1 = Lists.newArrayList();
+            Message msg = null;
+            List<Message> messages1 = Lists.newArrayList();
             for (int i = 0; i < totalProducedMsgs; i++) {
                 msg = consumer.receive(1, TimeUnit.SECONDS);
                 if (msg != null) {
@@ -1789,16 +1876,24 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     @Test
     public void testPriorityConsumer() throws Exception {
         log.info("-- Starting {} test --", methodName);
-        ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer()
-                .topic("persistent://my-property/use/my-ns/my-topic2").subscriptionName("my-subscriber-name")
-                .subscriptionType(SubscriptionType.Shared).receiverQueueSize(5).priorityLevel(1);
-
-        Consumer<byte[]> consumer1 = consumerBuilder.subscribe();
-        Consumer<byte[]> consumer2 = consumerBuilder.subscribe();
-        Consumer<byte[]> consumer3 = consumerBuilder.subscribe();
-        Consumer<byte[]> consumer4 = consumerBuilder.clone().priorityLevel(2).subscribe();
-        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic2")
-                .create();
+        ConsumerConfiguration conf1 = new ConsumerConfiguration();
+        conf1.setSubscriptionType(SubscriptionType.Shared);
+        conf1.setPriorityLevel(1);
+        conf1.setReceiverQueueSize(5);
+        ConsumerConfiguration conf4 = new ConsumerConfiguration();
+        conf4.setSubscriptionType(SubscriptionType.Shared);
+        conf4.setPriorityLevel(2);
+        conf4.setReceiverQueueSize(5);
+        Consumer consumer1 = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic2", "my-subscriber-name",
+                conf1);
+        Consumer consumer2 = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic2", "my-subscriber-name",
+                conf1);
+        Consumer consumer3 = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic2", "my-subscriber-name",
+                conf1);
+        Consumer consumer4 = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic2", "my-subscriber-name",
+                conf4);
+        ProducerConfiguration producerConf = new ProducerConfiguration();
+        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic2", producerConf);
         List<Future<MessageId>> futures = Lists.newArrayList();
 
         // Asynchronously produce messages
@@ -1819,8 +1914,9 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         }
 
         /**
-         * a. consumer1 and consumer2 now has more permits (as received and sent more permits) b. try to produce more
-         * messages: which will again distribute among consumer1 and consumer2 and should not dispatch to consumer4
+         * a. consumer1 and consumer2 now has more permits (as received and sent more permits)
+         * b. try to produce more messages: which will again distribute among consumer1 and consumer2
+         * and should not dispatch to consumer4
          *
          */
         for (int i = 0; i < 5; i++) {
@@ -1852,20 +1948,21 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
      *
      * @throws Exception
      */
-    @Test(timeOut = 5000)
+    @Test(timeOut=5000)
     public void testSharedSamePriorityConsumer() throws Exception {
         log.info("-- Starting {} test --", methodName);
+        ConsumerConfiguration conf1 = new ConsumerConfiguration();
+        conf1.setSubscriptionType(SubscriptionType.Shared);
         final int queueSize = 5;
+        conf1.setReceiverQueueSize(queueSize);
         int maxUnAckMsgs = pulsar.getConfiguration().getMaxConcurrentLookupRequest();
         pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(queueSize);
-
-        ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer()
-                .topic("persistent://my-property/use/my-ns/my-topic2").subscriptionName("my-subscriber-name")
-                .subscriptionType(SubscriptionType.Shared).receiverQueueSize(queueSize);
-        Consumer<byte[]> c1 = consumerBuilder.subscribe();
-        Consumer<byte[]> c2 = consumerBuilder.subscribe();
-        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic2")
-                .create();
+        Consumer c1 = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic2", "my-subscriber-name",
+                conf1);
+        Consumer c2 = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic2", "my-subscriber-name",
+                conf1);
+        ProducerConfiguration producerConf = new ProducerConfiguration();
+        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/my-topic2", producerConf);
         List<Future<MessageId>> futures = Lists.newArrayList();
 
         // Asynchronously produce messages
@@ -1881,11 +1978,11 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             future.get();
         }
 
-        List<Message<byte[]>> messages = Lists.newArrayList();
+        List<Message> messages = Lists.newArrayList();
 
         // let consumer1 and consumer2 cosume messages up to the queue will be full
         for (int i = 0; i < totalPublishMessages; i++) {
-            Message<byte[]> msg = c1.receive(500, TimeUnit.MILLISECONDS);
+            Message msg = c1.receive(500, TimeUnit.MILLISECONDS);
             if (msg != null) {
                 messages.add(msg);
             } else {
@@ -1893,7 +1990,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             }
         }
         for (int i = 0; i < totalPublishMessages; i++) {
-            Message<byte[]> msg = c2.receive(500, TimeUnit.MILLISECONDS);
+            Message msg = c2.receive(500, TimeUnit.MILLISECONDS);
             if (msg != null) {
                 messages.add(msg);
             } else {
@@ -1904,14 +2001,17 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         Assert.assertEquals(queueSize * 2, messages.size());
 
         // create new consumers with the same priority
-        Consumer<byte[]> c3 = consumerBuilder.subscribe();
-        Consumer<byte[]> c4 = consumerBuilder.subscribe();
-        Consumer<byte[]> c5 = consumerBuilder.subscribe();
+        Consumer c3 = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic2", "my-subscriber-name",
+                conf1);
+        Consumer c4 = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic2", "my-subscriber-name",
+                conf1);
+        Consumer c5 = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic2", "my-subscriber-name",
+                conf1);
 
         // c1 and c2 are blocked: so, let c3, c4 and c5 consume rest of the messages
 
         for (int i = 0; i < totalPublishMessages; i++) {
-            Message<byte[]> msg = c4.receive(500, TimeUnit.MILLISECONDS);
+            Message msg = c4.receive(500, TimeUnit.MILLISECONDS);
             if (msg != null) {
                 messages.add(msg);
             } else {
@@ -1920,7 +2020,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         }
 
         for (int i = 0; i < totalPublishMessages; i++) {
-            Message<byte[]> msg = c5.receive(500, TimeUnit.MILLISECONDS);
+            Message msg = c5.receive(500, TimeUnit.MILLISECONDS);
             if (msg != null) {
                 messages.add(msg);
             } else {
@@ -1929,7 +2029,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         }
 
         for (int i = 0; i < totalPublishMessages; i++) {
-            Message<byte[]> msg = c3.receive(500, TimeUnit.MILLISECONDS);
+            Message msg = c3.receive(500, TimeUnit.MILLISECONDS);
             if (msg != null) {
                 messages.add(msg);
                 c3.acknowledge(msg);
@@ -1958,13 +2058,17 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         final int receiverQueueSize = 10;
 
+        ConsumerConfiguration conf = new ConsumerConfiguration();
+        conf.setReceiverQueueSize(receiverQueueSize);
+        conf.setSubscriptionType(SubscriptionType.Failover);
         // Only subscribe consumer
-        ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer()
-                .topic("persistent://my-property/use/my-ns/unacked-topic").subscriptionName("subscriber-1")
-                .receiverQueueSize(receiverQueueSize).subscriptionType(SubscriptionType.Failover).subscribe();
+        ConsumerImpl consumer = (ConsumerImpl) pulsarClient
+                .subscribe("persistent://my-property/use/my-ns/unacked-topic", "subscriber-1", conf);
 
-        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/unacked-topic")
-                .create();
+        ProducerConfiguration producerConf = new ProducerConfiguration();
+
+        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/unacked-topic",
+                producerConf);
 
         // (1) First round to produce-consume messages
         int consumeMsgInParts = 4;
@@ -1974,8 +2078,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             Thread.sleep(10);
         }
         // (1.a) consume first consumeMsgInParts msgs and trigger redeliver
-        Message<byte[]> msg = null;
-        List<Message<byte[]>> messages1 = Lists.newArrayList();
+        Message msg = null;
+        List<Message> messages1 = Lists.newArrayList();
         for (int i = 0; i < consumeMsgInParts; i++) {
             msg = consumer.receive(1, TimeUnit.SECONDS);
             if (msg != null) {
@@ -2036,9 +2140,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         log.info("-- Starting {} test --", methodName);
 
         // (1) simple consumers
-        Consumer<byte[]> consumer = pulsarClient.newConsumer()
-                .topic("persistent://my-property/use/my-ns/failAsyncReceive").subscriptionName("my-subscriber-name")
-                .subscribe();
+        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/failAsyncReceive",
+                "my-subscriber-name", new ConsumerConfiguration());
         consumer.close();
         // receive messages
         try {
@@ -2052,8 +2155,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         int numPartitions = 4;
         TopicName topicName = TopicName.get("persistent://my-property/use/my-ns/failAsyncReceive");
         admin.persistentTopics().createPartitionedTopic(topicName.toString(), numPartitions);
-        Consumer<byte[]> partitionedConsumer = pulsarClient.newConsumer().topic(topicName.toString())
-                .subscriptionName("my-partitioned-subscriber").subscribe();
+        Consumer partitionedConsumer = pulsarClient.subscribe(topicName.toString(), "my-partitioned-subscriber",
+                new ConsumerConfiguration());
         partitionedConsumer.close();
         // receive messages
         try {
@@ -2073,7 +2176,6 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         class EncKeyReader implements CryptoKeyReader {
 
             EncryptionKeyInfo keyInfo = new EncryptionKeyInfo();
-
             @Override
             public EncryptionKeyInfo getPublicKey(String keyName, Map<String, String> keyMeta) {
                 String CERT_FILE_PATH = "./src/test/resources/certificate/public-key." + keyName;
@@ -2110,20 +2212,23 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         final int totalMsg = 10;
 
         Set<String> messageSet = Sets.newHashSet();
+        ConsumerConfiguration conf = new ConsumerConfiguration();
+        conf.setSubscriptionType(SubscriptionType.Exclusive);
+        conf.setCryptoKeyReader(new EncKeyReader());
+        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/myecdsa-topic1", "my-subscriber-name",
+                conf);
 
-        Consumer<byte[]> consumer = pulsarClient.newConsumer()
-                .topic("persistent://my-property/use/my-ns/myecdsa-topic1").subscriptionName("my-subscriber-name")
-                .cryptoKeyReader(new EncKeyReader()).subscribe();
+        ProducerConfiguration producerConf = new ProducerConfiguration();
+        producerConf.addEncryptionKey("client-ecdsa.pem");
+        producerConf.setCryptoKeyReader(new EncKeyReader());
 
-        Producer<byte[]> producer = pulsarClient.newProducer()
-                .topic("persistent://my-property/use/my-ns/myecdsa-topic1").addEncryptionKey("client-ecdsa.pem")
-                .cryptoKeyReader(new EncKeyReader()).create();
+        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/myecdsa-topic1", producerConf);
         for (int i = 0; i < totalMsg; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
 
-        Message<byte[]> msg = null;
+        Message msg = null;
 
         for (int i = 0; i < totalMsg; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);
@@ -2145,7 +2250,6 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         class EncKeyReader implements CryptoKeyReader {
 
             EncryptionKeyInfo keyInfo = new EncryptionKeyInfo();
-
             @Override
             public EncryptionKeyInfo getPublicKey(String keyName, Map<String, String> keyMeta) {
                 String CERT_FILE_PATH = "./src/test/resources/certificate/public-key." + keyName;
@@ -2182,26 +2286,30 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         final int totalMsg = 10;
 
         Set<String> messageSet = Sets.newHashSet();
-        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/myrsa-topic1")
-                .subscriptionName("my-subscriber-name").cryptoKeyReader(new EncKeyReader()).subscribe();
+        ConsumerConfiguration conf = new ConsumerConfiguration();
+        conf.setSubscriptionType(SubscriptionType.Exclusive);
+        conf.setCryptoKeyReader(new EncKeyReader());
+        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/myrsa-topic1", "my-subscriber-name",
+                conf);
 
-        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/myrsa-topic1")
-                .addEncryptionKey("client-rsa.pem").cryptoKeyReader(new EncKeyReader()).create();
-        Producer<byte[]> producer2 = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/myrsa-topic1")
-                .addEncryptionKey("client-rsa.pem").cryptoKeyReader(new EncKeyReader()).create();
+        ProducerConfiguration producerConf = new ProducerConfiguration();
+        producerConf.addEncryptionKey("client-rsa.pem");
+        producerConf.setCryptoKeyReader(new EncKeyReader());
 
+        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/myrsa-topic1", producerConf);
+        Producer producer2 = pulsarClient.createProducer("persistent://my-property/use/my-ns/myrsa-topic1", producerConf);
         for (int i = 0; i < totalMsg; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
         }
-        for (int i = totalMsg; i < totalMsg * 2; i++) {
+        for (int i = totalMsg; i < totalMsg*2; i++) {
             String message = "my-message-" + i;
             producer2.send(message.getBytes());
         }
 
-        Message<byte[]> msg = null;
+        Message msg = null;
 
-        for (int i = 0; i < totalMsg * 2; i++) {
+        for (int i = 0; i < totalMsg*2; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);
             String receivedMessage = new String(msg.getData());
             log.debug("Received message: [{}]", receivedMessage);
@@ -2221,7 +2329,6 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         class EncKeyReader implements CryptoKeyReader {
 
             EncryptionKeyInfo keyInfo = new EncryptionKeyInfo();
-
             @Override
             public EncryptionKeyInfo getPublicKey(String keyName, Map<String, String> keyMeta) {
                 String CERT_FILE_PATH = "./src/test/resources/certificate/public-key." + keyName;
@@ -2253,25 +2360,32 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         final int totalMsg = 10;
 
-        Message<byte[]> msg = null;
+        ProducerConfiguration producerConf = new ProducerConfiguration();
+        
+        Message msg = null;
         Set<String> messageSet = Sets.newHashSet();
-        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/myenc-ns/myenc-topic1")
-                .subscriptionName("my-subscriber-name").subscribe();
+        ConsumerConfiguration conf = new ConsumerConfiguration();
+        conf.setSubscriptionType(SubscriptionType.Exclusive);
+        Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/myenc-topic1", "my-subscriber-name",
+                conf);
 
         // 1. Invalid key name
+        producerConf.addEncryptionKey("client-non-existant-rsa.pem");
+        producerConf.setCryptoKeyReader(new EncKeyReader());
+
         try {
-            pulsarClient.newProducer().topic("persistent://my-property/use/myenc-ns/myenc-topic1")
-                    .addEncryptionKey("client-non-existant-rsa.pem").cryptoKeyReader(new EncKeyReader()).create();
+            Producer producer = pulsarClient.createProducer("persistent://my-property/use/myenc-ns/myenc-topic1", producerConf);
             Assert.fail("Producer creation should not suceed if failing to read key");
         } catch (Exception e) {
             // ok
         }
 
         // 2. Producer with valid key name
-        Producer<byte[]> producer = pulsarClient.newProducer()
-                .topic("persistent://my-property/use/myenc-ns/myenc-topic1").addEncryptionKey("client-rsa.pem")
-                .cryptoKeyReader(new EncKeyReader()).create();
-
+        producerConf = new ProducerConfiguration();
+        producerConf.setCryptoKeyReader(new EncKeyReader());
+        producerConf.addEncryptionKey("client-rsa.pem");
+        Producer producer = pulsarClient.createProducer("persistent://my-property/use/my-ns/myenc-topic1", producerConf);
+        
         for (int i = 0; i < totalMsg; i++) {
             String message = "my-message-" + i;
             producer.send(message.getBytes());
@@ -2283,33 +2397,33 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         Assert.assertNull(msg, "Receive should have failed with no keyreader");
 
         // 4. Set consumer config to consume even if decryption fails
+        conf.setCryptoFailureAction(ConsumerCryptoFailureAction.CONSUME);
         consumer.close();
-        consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/myenc-ns/myenc-topic1")
-                .subscriptionName("my-subscriber-name").cryptoFailureAction(ConsumerCryptoFailureAction.CONSUME)
-                .subscribe();
-
+        consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/myenc-topic1", "my-subscriber-name",
+                conf);
+        
         int msgNum = 0;
         try {
             // Receive should proceed and deliver encrypted message
             msg = consumer.receive(5, TimeUnit.SECONDS);
             String receivedMessage = new String(msg.getData());
             String expectedMessage = "my-message-" + msgNum++;
-            Assert.assertNotEquals(receivedMessage, expectedMessage, "Received encrypted message " + receivedMessage
-                    + " should not match the expected message " + expectedMessage);
+            Assert.assertNotEquals(receivedMessage, expectedMessage,
+                    "Received encrypted message " + receivedMessage + " should not match the expected message " + expectedMessage);
             consumer.acknowledgeCumulative(msg);
         } catch (Exception e) {
-            e.printStackTrace();
             Assert.fail("Failed to receive message even aftet ConsumerCryptoFailureAction.CONSUME is set.");
         }
 
         // 5. Set keyreader and failure action
+        conf.setCryptoFailureAction(ConsumerCryptoFailureAction.FAIL);
         consumer.close();
         // Set keyreader
-        consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/myenc-ns/myenc-topic1")
-                .subscriptionName("my-subscriber-name").cryptoFailureAction(ConsumerCryptoFailureAction.FAIL)
-                .cryptoKeyReader(new EncKeyReader()).subscribe();
+        conf.setCryptoKeyReader(new EncKeyReader());
+        consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/myenc-topic1", "my-subscriber-name",
+                conf);
 
-        for (int i = msgNum; i < totalMsg - 1; i++) {
+        for (int i = msgNum; i < totalMsg-1; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);
             String receivedMessage = new String(msg.getData());
             log.debug("Received message: [{}]", receivedMessage);
@@ -2320,11 +2434,12 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         consumer.acknowledgeCumulative(msg);
         consumer.close();
 
-        // 6. Set consumer config to discard if decryption fails
+         //6. Set consumer config to discard if decryption fails
         consumer.close();
-        consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/myenc-ns/myenc-topic1")
-                .subscriptionName("my-subscriber-name").cryptoFailureAction(ConsumerCryptoFailureAction.DISCARD)
-                .subscribe();
+        ConsumerConfiguration conf2 = new ConsumerConfiguration();
+        conf2.setSubscriptionType(SubscriptionType.Exclusive);
+        conf2.setCryptoFailureAction(ConsumerCryptoFailureAction.DISCARD);
+        consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/myenc-topic1", "my-subscriber-name", conf2);
 
         // Receive should proceed and discard encrypted messages
         msg = consumer.receive(5, TimeUnit.SECONDS);
@@ -2333,4 +2448,40 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         log.info("-- Exiting {} test --", methodName);
     }
 
+    @Test
+    public void testConsumerSubscriptionInitialize() throws Exception {
+        log.info("-- Starting {} test --", methodName);
+        String topic = "persistent://my-property/use/my-ns/my-topic-test-subscription-initialize";
+        
+        Producer producer = pulsarClient.createProducer(topic);
+
+        // first produce 5 messages
+        for (int i = 0; i < 5; i++) {
+            final String message = "my-message-" + i;
+            producer.send(message.getBytes());
+        }
+
+        // second create consumers
+        ConsumerConfiguration conf = new ConsumerConfiguration();
+        Consumer defaultConsumer = pulsarClient.subscribe(topic, "test-subscription-default");
+        conf.setSubscriptionInitialPosition(SubscriptionInitialPosition.Latest);
+        Consumer latestConsumer = pulsarClient.subscribe(topic, "test-subscription-latest", conf);
+        conf.setSubscriptionInitialPosition(SubscriptionInitialPosition.Earliest);
+        Consumer earlistConsumer = pulsarClient.subscribe(topic, "test-subscription-earliest", conf);
+
+        // third produce 5 messages
+        for (int i = 5; i < 10; i++) {
+            final String message = "my-message-" + i;
+            producer.send(message.getBytes());
+        }
+
+        assertEquals(defaultConsumer.receive().getData(), "my-message-5".getBytes());
+        assertEquals(latestConsumer.receive().getData(), "my-message-5".getBytes());
+        assertEquals(earlistConsumer.receive().getData(), "my-message-0".getBytes());
+
+        defaultConsumer.close();
+        latestConsumer.close();
+        earlistConsumer.close();
+        log.info("-- Exiting {} test --", methodName);
+    }    
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -292,4 +292,8 @@ public interface ConsumerBuilder<T> extends Serializable, Cloneable {
      */
     ConsumerBuilder<T> properties(Map<String, String> properties);
 
+    /**
+     * Set subscriptionInitialPosition for the consumer
+    */
+    ConsumerBuilder<T> subscriptionInitialPosition(SubscriptionInitialPosition subscriptionInitialPosition);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerConfiguration.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerConfiguration.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
-
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 /**
  * Class specifying the configuration of a consumer. In Exclusive subscription, only a single consumer is allowed to
  * attach to the subscription. Other consumers will get an error message. In Shared subscription, multiple consumers
@@ -46,6 +46,7 @@ public class ConsumerConfiguration implements Serializable {
 
     private final ConsumerConfigurationData<byte[]> conf = new ConsumerConfigurationData<>();
 
+    private boolean initializeSubscriptionOnLatest = true;
     /**
      * @return the configured timeout in milliseconds for unacked messages.
      */
@@ -339,4 +340,21 @@ public class ConsumerConfiguration implements Serializable {
     public ConsumerConfigurationData<byte[]> getConfigurationData() {
         return conf;
     }
+    
+     /** 
+     * @param subscriptionInitialPosition the initial position at which to set
+     * set cursor  when subscribing to the topic first time
+     * Default is {@value InitialPosition.Latest}
+     */
+    public ConsumerConfiguration setSubscriptionInitialPosition(SubscriptionInitialPosition subscriptionInitialPosition) {
+        conf.setSubscriptionInitialPosition(subscriptionInitialPosition);
+        return this;
+    }   
+
+    /** 
+     * @return the configured {@link subscriptionInitailPosition} for the consumer
+     */
+    public SubscriptionInitialPosition getSubscriptionInitialPosition(){
+        return conf.getSubscriptionInitialPosition();
+    }   
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/SubscriptionInitialPosition.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/SubscriptionInitialPosition.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+/**
+ * intial position at which the cursor will be set when subscribe
+ *
+ *
+ */
+public enum SubscriptionInitialPosition {
+    /**
+     * the latest position which means the start consuming position will be the last message
+     */
+    Latest,
+
+    /**
+     * the earliest position which means the start consuming position will be the first message
+     */
+    Earliest,
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -37,6 +37,7 @@ import org.apache.pulsar.client.api.MessageListener;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.PulsarClientException.InvalidConfigurationException;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
 import org.apache.pulsar.common.util.FutureUtil;
@@ -222,4 +223,10 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
         conf.setPatternAutoDiscoveryPeriod(periodInMinutes);
         return this;
     }
+
+	@Override
+	public ConsumerBuilder<T> subscriptionInitialPosition(SubscriptionInitialPosition subscriptionInitialPosition) {
+        conf.setSubscriptionInitialPosition(subscriptionInitialPosition);
+		return this;
+	}
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
@@ -32,6 +32,7 @@ import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Reader;
 import org.apache.pulsar.client.api.ReaderListener;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.ConsumerImpl.SubscriptionMode;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
@@ -82,7 +83,7 @@ public class ReaderImpl<T> implements Reader<T> {
         }
 
         consumer = new ConsumerImpl<>(client, readerConfiguration.getTopicName(), consumerConfiguration, listenerExecutor,
-                -1, consumerFuture, SubscriptionMode.NonDurable, readerConfiguration.getStartMessageId(), schema);
+                -1, consumerFuture, SubscriptionMode.NonDurable, readerConfiguration.getStartMessageId(), schema, SubscriptionInitialPosition.Latest);
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
@@ -35,6 +35,7 @@ import org.apache.pulsar.client.api.ConsumerEventListener;
 import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.MessageListener;
 import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 
 @Data
 public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
@@ -72,6 +73,8 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
     private SortedMap<String, String> properties = new TreeMap<>();
 
     private boolean readCompacted = false;
+
+    private SubscriptionInitialPosition subscriptionInitialPosition = SubscriptionInitialPosition.Latest;
 
     private int patternAutoDiscoveryPeriod = 1;
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
@@ -6741,6 +6741,10 @@ public final class PulsarApi {
     // optional .pulsar.proto.Schema schema = 12;
     boolean hasSchema();
     org.apache.pulsar.common.api.proto.PulsarApi.Schema getSchema();
+    
+    // optional .pulsar.proto.CommandSubscribe.InitialPosition initialPosition = 13 [default = Latest];
+    boolean hasInitialPosition();
+    org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition getInitialPosition();
   }
   public static final class CommandSubscribe extends
       com.google.protobuf.GeneratedMessageLite
@@ -6820,6 +6824,47 @@ public final class PulsarApi {
       }
       
       // @@protoc_insertion_point(enum_scope:pulsar.proto.CommandSubscribe.SubType)
+    }
+    
+    public enum InitialPosition
+        implements com.google.protobuf.Internal.EnumLite {
+      Latest(0, 0),
+      Earliest(1, 1),
+      ;
+      
+      public static final int Latest_VALUE = 0;
+      public static final int Earliest_VALUE = 1;
+      
+      
+      public final int getNumber() { return value; }
+      
+      public static InitialPosition valueOf(int value) {
+        switch (value) {
+          case 0: return Latest;
+          case 1: return Earliest;
+          default: return null;
+        }
+      }
+      
+      public static com.google.protobuf.Internal.EnumLiteMap<InitialPosition>
+          internalGetValueMap() {
+        return internalValueMap;
+      }
+      private static com.google.protobuf.Internal.EnumLiteMap<InitialPosition>
+          internalValueMap =
+            new com.google.protobuf.Internal.EnumLiteMap<InitialPosition>() {
+              public InitialPosition findValueByNumber(int number) {
+                return InitialPosition.valueOf(number);
+              }
+            };
+      
+      private final int value;
+      
+      private InitialPosition(int index, int value) {
+        this.value = value;
+      }
+      
+      // @@protoc_insertion_point(enum_scope:pulsar.proto.CommandSubscribe.InitialPosition)
     }
     
     private int bitField0_;
@@ -7020,6 +7065,16 @@ public final class PulsarApi {
       return schema_;
     }
     
+    // optional .pulsar.proto.CommandSubscribe.InitialPosition initialPosition = 13 [default = Latest];
+    public static final int INITIALPOSITION_FIELD_NUMBER = 13;
+    private org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition initialPosition_;
+    public boolean hasInitialPosition() {
+      return ((bitField0_ & 0x00000800) == 0x00000800);
+    }
+    public org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition getInitialPosition() {
+      return initialPosition_;
+    }
+    
     private void initFields() {
       topic_ = "";
       subscription_ = "";
@@ -7033,6 +7088,7 @@ public final class PulsarApi {
       metadata_ = java.util.Collections.emptyList();
       readCompacted_ = false;
       schema_ = org.apache.pulsar.common.api.proto.PulsarApi.Schema.getDefaultInstance();
+      initialPosition_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition.Latest;
     }
     private byte memoizedIsInitialized = -1;
     public final boolean isInitialized() {
@@ -7125,6 +7181,9 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00000400) == 0x00000400)) {
         output.writeMessage(12, schema_);
       }
+      if (((bitField0_ & 0x00000800) == 0x00000800)) {
+        output.writeEnum(13, initialPosition_.getNumber());
+      }
     }
     
     private int memoizedSerializedSize = -1;
@@ -7180,6 +7239,10 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00000400) == 0x00000400)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(12, schema_);
+      }
+      if (((bitField0_ & 0x00000800) == 0x00000800)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeEnumSize(13, initialPosition_.getNumber());
       }
       memoizedSerializedSize = size;
       return size;
@@ -7318,6 +7381,8 @@ public final class PulsarApi {
         bitField0_ = (bitField0_ & ~0x00000400);
         schema_ = org.apache.pulsar.common.api.proto.PulsarApi.Schema.getDefaultInstance();
         bitField0_ = (bitField0_ & ~0x00000800);
+        initialPosition_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition.Latest;
+        bitField0_ = (bitField0_ & ~0x00001000);
         return this;
       }
       
@@ -7400,6 +7465,10 @@ public final class PulsarApi {
           to_bitField0_ |= 0x00000400;
         }
         result.schema_ = schema_;
+        if (((from_bitField0_ & 0x00001000) == 0x00001000)) {
+          to_bitField0_ |= 0x00000800;
+        }
+        result.initialPosition_ = initialPosition_;
         result.bitField0_ = to_bitField0_;
         return result;
       }
@@ -7448,6 +7517,9 @@ public final class PulsarApi {
         }
         if (other.hasSchema()) {
           mergeSchema(other.getSchema());
+        }
+        if (other.hasInitialPosition()) {
+          setInitialPosition(other.getInitialPosition());
         }
         return this;
       }
@@ -7589,6 +7661,15 @@ public final class PulsarApi {
               input.readMessage(subBuilder, extensionRegistry);
               setSchema(subBuilder.buildPartial());
               subBuilder.recycle();
+              break;
+            }
+            case 104: {
+              int rawValue = input.readEnum();
+              org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition value = org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition.valueOf(rawValue);
+              if (value != null) {
+                bitField0_ |= 0x00001000;
+                initialPosition_ = value;
+              }
               break;
             }
           }
@@ -8006,6 +8087,30 @@ public final class PulsarApi {
         schema_ = org.apache.pulsar.common.api.proto.PulsarApi.Schema.getDefaultInstance();
         
         bitField0_ = (bitField0_ & ~0x00000800);
+        return this;
+      }
+      
+      // optional .pulsar.proto.CommandSubscribe.InitialPosition initialPosition = 13 [default = Latest];
+      private org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition initialPosition_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition.Latest;
+      public boolean hasInitialPosition() {
+        return ((bitField0_ & 0x00001000) == 0x00001000);
+      }
+      public org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition getInitialPosition() {
+        return initialPosition_;
+      }
+      public Builder setInitialPosition(org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        bitField0_ |= 0x00001000;
+        initialPosition_ = value;
+        
+        return this;
+      }
+      public Builder clearInitialPosition() {
+        bitField0_ = (bitField0_ & ~0x00001000);
+        initialPosition_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.InitialPosition.Latest;
+        
         return this;
       }
       

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -216,6 +216,13 @@ message CommandSubscribe {
     optional bool read_compacted = 11;
 
 	optional Schema schema = 12;
+	enum InitialPosition {
+		Latest   = 0;
+		Earliest = 1;
+	}
+	// Signal wthether the subscription will initialize on latest
+	// or not -- earliest
+	optional InitialPosition initialPosition = 13 [default = Latest];
 }
 
 message CommandPartitionedTopicMetadata {


### PR DESCRIPTION
### Motivation

This is an alternative to PR 1219 because there are too many changes to understand works.

### Modifications

1. add configuration option initializeSubscriptionOnLatest to class ConsumerConfiguration
2. add an overloaded method for asyncOpenCursor in ManageLedger to implement different 3. the initial position of the cursor created.

### Result

When a user subscribes a topic the first time, the broker will initialize the cursor the subscription on latest or earliest, which depends on the configuration option "subscriptionInitialPosition" in class ConsumerConfiguration.
