### PR TITLE
PulsarClusterMetadataSetup exits with non-zero on bad args

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
@@ -90,7 +90,7 @@ public class PulsarClusterMetadataSetup {
             }
         } catch (Exception e) {
             jcommander.usage();
-            return;
+            throw e;
         }
 
         log.info("Setting up cluster {} with zk={} global-zk={}", arguments.cluster, arguments.zookeeper,


### PR DESCRIPTION
If a user passes bad arguments to PulsarClusterMetadataSetup, it
should exit with non-zero. Otherwise, it will look like it
succeeded (if run from a script).

The fix is just to propagate the Exception after printing out the
usage message.
