### PR TITLE
Copy only needed files for building Python Instance

### DIFF
--- a/pulsar-functions/runtime/pom.xml
+++ b/pulsar-functions/runtime/pom.xml
@@ -71,7 +71,9 @@
                 <echo>building python instance</echo>
                 <mkdir dir="${basedir}/target/python-instance"/>
                 <copydir src="${basedir}/../instance/src/main/python" dest="${basedir}/target/python-instance"/>
-                <copydir src="${basedir}/../../pulsar-client-cpp/python" dest="${basedir}/target/python-instance"/>
+                <copy file="${basedir}/../../pulsar-client-cpp/python/pulsar.py" tofile="${basedir}/target/python-instance/pulsar.py"/>
+                <mkdir dir="${basedir}/target/python-instance/functions"/>
+                <copydir src="${basedir}/../../pulsar-client-cpp/python/functions" dest="${basedir}/target/python-instance/functions"/>
               </tasks>
             </configuration>
           </execution>


### PR DESCRIPTION
### Motivation

Currently we copy a lot of unneeded files(like test classes, cpp/.h files etc) in the python instance directory. All that we really need is pulsar and functions definitions. This will help lower the .tar.gz footprint.

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
