### PR TITLE
NPE in PersistentReplicator in Debug mode since messageId is not set …

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentReplicator.java
@@ -232,9 +232,8 @@ public class PersistentReplicator extends AbstractReplicator implements Replicat
 
                 if (msg.hasReplicateTo() && !msg.getReplicateTo().contains(remoteCluster)) {
                     if (log.isDebugEnabled()) {
-                        log.debug("[{}][{} -> {}] Skipping message at {} / msg-id: {}: replicateTo {}", topicName,
-                                localCluster, remoteCluster, entry.getPosition(), msg.getMessageId(),
-                                msg.getReplicateTo());
+                        log.debug("[{}][{} -> {}] Skipping message at position {}, replicateTo {}", topicName,
+                                localCluster, remoteCluster, entry.getPosition(), msg.getReplicateTo());
                     }
                     cursor.asyncDelete(entry.getPosition(), this, entry.getPosition());
                     entry.release();
@@ -245,8 +244,8 @@ public class PersistentReplicator extends AbstractReplicator implements Replicat
                 if (msg.isExpired(messageTTLInSeconds)) {
                     msgExpired.recordEvent(0 /* no value stat */);
                     if (log.isDebugEnabled()) {
-                        log.debug("[{}][{} -> {}] Discarding expired message at {} / msg-id: {}", topicName,
-                                localCluster, remoteCluster, entry.getPosition(), msg.getMessageId());
+                        log.debug("[{}][{} -> {}] Discarding expired message at position {}, replicateTo {}", topicName,
+                                localCluster, remoteCluster, entry.getPosition(), msg.getReplicateTo());
                     }
                     cursor.asyncDelete(entry.getPosition(), this, entry.getPosition());
                     entry.release();


### PR DESCRIPTION
…during MessageImpl.deserialize

The message is constructed in PersistentReplicator.java:216, this message has messageId as null.

When Debug mode is enabled and getMessageId is called you get an exception

```
19:15:20.938 [bookkeeper-ml-workers-41-1] ERROR o.a.p.b.s.p.PersistentReplicator     - [persistent://XXXXX][X -> Y] Unexpected exception: Cannot get the message id of a mess
age that was not received
java.lang.NullPointerException: Cannot get the message id of a message that was not received
        at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:209) ~[guava-15.0.jar:na]
        at org.apache.pulsar.client.impl.MessageImpl.getMessageId(MessageImpl.java:192) ~[pulsar-client-1.20.6-incubating-yahoo.jar:1.20.6-incubating-yahoo]
        at org.apache.pulsar.broker.service.persistent.PersistentReplicator.readEntriesComplete(PersistentReplicator.java:235) ~[pulsar-broker-1.20.6-incubating-yahoo.jar:1.20.6-incubating-yahoo]
        at org.apache.bookkeeper.mledger.impl.OpReadEntry.lambda$checkReadCompletion$2(OpReadEntry.java:131) [managed-ledger-1.20.6-incubating-yahoo.jar:1.20.6-incubating-yahoo]
        at org.apache.bookkeeper.mledger.util.SafeRun$1.safeRun(SafeRun.java:30) ~[managed-ledger-1.20.6-incubating-yahoo.jar:1.20.6-incubating-yahoo]
        at org.apache.bookkeeper.util.SafeRunnable.run(SafeRunnable.java:31) ~[bookkeeper-server-4.3.1.74-yahoo.jar:4.3.1.74-yahoo]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[na:1.8.0_131]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[na:1.8.0_131]
        at io.netty.util.concurrent.DefaultThreadFactory$DefaultRunnableDecorator.run(DefaultThreadFactory.java:144) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_131]
```
