### PR TITLE
Make admin client namepsaces work with v2 rest endpoints.

### DIFF
--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Namespaces.java
@@ -87,6 +87,7 @@ public interface Namespaces {
      * @throws PulsarAdminException
      *             Unexpected error
      */
+    @Deprecated
     List<String> getNamespaces(String property, String cluster) throws PulsarAdminException;
 
     /**


### PR DESCRIPTION
Make the admin client namespace methods compatible with the new v2 endpoints.
