### PR TITLE
Timeout task for batchMessageAndSendTask is not cancelled when close

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -1053,6 +1053,11 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         long timeToWaitMs;
 
         synchronized (this) {
+            // If it's closing/closed we need to ignore this timeout and not schedule next timeout.
+            if (getState() == State.Closing || getState() == State.Closed) {
+                return;
+            }
+
             OpSendMsg firstMsg = pendingMessages.peek();
             if (firstMsg == null) {
                 // If there are no pending messages, reset the timeout to the configured value.
@@ -1078,9 +1083,9 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     timeToWaitMs = diff;
                 }
             }
-        }
 
-        sendTimeout = client.timer().newTimeout(this, timeToWaitMs, TimeUnit.MILLISECONDS);
+            sendTimeout = client.timer().newTimeout(this, timeToWaitMs, TimeUnit.MILLISECONDS);
+        }
     }
 
     /**


### PR DESCRIPTION
### Motivation

In ProducerImpl, Timeout task for batchMessageAndSendTask is not cancelled in closeAsync(), so it will throw exception, and may cause HashedWheelTimer not released well.

```
03:35:16.629 [pulsar-client-io-2-5] INFO - [persistent://benchmark/local/ns-PRVPVVU/test-3MDBQUk-0000-partition-9987] [sub-000] Closed consumer
 03:35:16.629 [pulsar-client-io-2-5] INFO - [persistent://benchmark/local/ns-PRVPVVU/test-3MDBQUk-0000] [sub-000] Closed Partitioned Consumer
 03:35:16.630 [main] INFO - Shutting down Pulsar benchmark driver
 03:35:16.630 [main] INFO - Client closing. URL: 10.0.0.250:6650
 03:35:16.635 [pulsar-timer-4-1] WARN - An exception was thrown by TimerTask.
 java.lang.IllegalStateException: cannot be started once stopped
     at io.netty.util.HashedWheelTimer.start(HashedWheelTimer.java:338) ~[io.netty-netty-all-4.1.21.Final.jar:4.1.21.Final]
     at io.netty.util.HashedWheelTimer.newTimeout(HashedWheelTimer.java:417) ~[io.netty-netty-all-4.1.21.Final.jar:4.1.21.Final]
     at org.apache.pulsar.client.impl.ProducerImpl$2.run(ProducerImpl.java:1142) ~[org.apache.pulsar-pulsar-client-original-1.22.0-incubating.jar:1.22.0-incubating]
     at io.netty.util.HashedWheelTimer$HashedWheelTimeout.expire(HashedWheelTimer.java:663) [io.netty-netty-all-4.1.21.Final.jar:4.1.21.Final]
     at io.netty.util.HashedWheelTimer$HashedWheelBucket.expireTimeouts(HashedWheelTimer.java:738) [io.netty-netty-all-4.1.21.Final.jar:4.1.21.Final]
     at io.netty.util.HashedWheelTimer$Worker.run(HashedWheelTimer.java:466) [io.netty-netty-all-4.1.21.Final.jar:4.1.21.Final]
     at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [io.netty-netty-all-4.1.21.Final.jar:4.1.21.Final]
     at java.lang.Thread.run(Thread.java:748) [?:1.8.0_161]
...
``` 
This PR is to cancel Timeout task for batchMessageAndSendTask in closeAsync().

### Modifications

- add cancel in CloseAsync
- fix potential race in batchMessageAndSendTask and SendTimeout messages task.

### Result

error should be fixed.