### PR TITLE
Allow site to be built on debian/ubuntu

### DIFF
--- a/site/Gemfile
+++ b/site/Gemfile
@@ -18,6 +18,6 @@
 #
 
 source 'https://rubygems.org'
-ruby '2.4.1'
+ruby '>=2.3.1'
 
 gem 'jekyll', '3.7.0'

--- a/site/Makefile
+++ b/site/Makefile
@@ -41,7 +41,7 @@ clean_local:
 	rm -rf generated
 
 ruby_setup:
-	gem install bundler \
+	gem install --user-install bundler \
 		--no-rdoc \
 		--no-ri
 	NOKOGIRI_USE_SYSTEM_LIBRARIES=true $(BUNDLE) install \


### PR DESCRIPTION
The current scripts need root and a version of ruby newer than what
Debian and Ubuntu ship.

This patch removes the need for root and makes any ruby newer than
or equal to 2.3.1 acceptable.
