### PR TITLE
Fix Ruby version error

### DIFF
--- a/site/Gemfile
+++ b/site/Gemfile
@@ -18,6 +18,6 @@
 #
 
 source 'https://rubygems.org'
-ruby '>=2.3.1'
+ruby '2.3.1'
 
 gem 'jekyll', '3.7.0'

--- a/site/README.md
+++ b/site/README.md
@@ -39,7 +39,7 @@ This website is built using a wide range of tools. The most important among them
 
 > **Note**: at the moment, running the site locally *may* work on Linux but the site setup has been built with MacOS in mind. We will provide better cross-platform support in the near future.
 
-To build and run the site locally, you need to have Ruby 2.4.1 installed and set as the Ruby version here in the `site` directory. You can install and set the Ruby version using [rvm](https://rvm.io):
+To build and run the site locally, you need to have Ruby 2.3.1 installed and set as the Ruby version here in the `site` directory. You can install and set the Ruby version using [rvm](https://rvm.io):
 
 ```bash
 $ cd site


### PR DESCRIPTION
It turns out that you can't specify version ranges in `Gemfile`s. This PR fixes an error introduced in a recent PR and updates the website's `README` accordingly.