### PR TITLE
Add pulsar python location to python path so that pdoc can succeed generating docs

### DIFF
--- a/site/scripts/python-doc-gen.sh
+++ b/site/scripts/python-doc-gen.sh
@@ -27,8 +27,7 @@ pip install pulsar-client
 
 INPUT=$ROOT_DIR/pulsar-client-cpp/python/pulsar.py
 DESTINATION=$ROOT_DIR/site/api/python
-
-pdoc $INPUT \
+PYTHONPATH=pulsar-client-cpp/python pdoc $INPUT \
   --html \
   --html-dir $DESTINATION
 mv $DESTINATION/pulsar.m.html $DESTINATION/index.html


### PR DESCRIPTION
### Motivation

Since pulsar functions was added post 1.22 and since there hasn't been a new release done, the pulsar-client pip module does not contain functions specific declarations. This breaks the python doc generation script. This pr tells pdoc to look at the src also to overcome this issue.

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
