### PR TITLE
Handle null redirection url with error-message at broker

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookup.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.broker.lookup;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.pulsar.common.api.Commands.newLookupErrorResponse;
 import static org.apache.pulsar.common.api.Commands.newLookupResponse;
 
@@ -56,6 +57,7 @@ import org.apache.pulsar.common.util.Codec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import dlshade.org.apache.commons.lang3.StringUtils;
 import io.netty.buffer.ByteBuf;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
@@ -123,9 +125,10 @@ public class TopicLookup extends PulsarWebResource {
                 try {
                     String redirectUrl = isRequestHttps() ? result.getLookupData().getHttpUrlTls()
                             : result.getLookupData().getHttpUrl();
+                    checkNotNull(redirectUrl, "Redirected cluster's service url is not configured");
                     redirect = new URI(String.format("%s%s%s?authoritative=%s", redirectUrl, "/lookup/v2/destination/",
                             topic.getLookupName(), newAuthoritative));
-                } catch (URISyntaxException e) {
+                } catch (URISyntaxException | NullPointerException e) {
                     log.error("Error in preparing redirect url for {}: {}", topic, e.getMessage(), e);
                     completeLookupResponseExceptionally(asyncResponse, e);
                     return;
@@ -239,6 +242,12 @@ public class TopicLookup extends PulsarWebResource {
                             }
                             // if peer-cluster-data is present it means namespace is owned by that peer-cluster and
                             // request should be redirect to the peer-cluster
+                            if (StringUtils.isBlank(peerClusterData.getBrokerServiceUrl())
+                                    && StringUtils.isBlank(peerClusterData.getBrokerServiceUrl())) {
+                                validationFuture.complete(
+                                        newLookupErrorResponse(ServerError.MetadataError, "Redirected cluster's brokerService url is not configured", requestId));
+                                return;
+                            }
                             validationFuture.complete(newLookupResponse(peerClusterData.getBrokerServiceUrl(),
                                     peerClusterData.getBrokerServiceUrlTls(), true, LookupType.Redirect, requestId,
                                     false));


### PR DESCRIPTION
### Motivation

Right now, if cluster's serviceUrl/brokerServiceUrl is not configured then broker returns null in redirection lookup result which throws below NPE at client side. therefore, broker should handle null value of redirection url properly so, client can get better error message.

```
00:10:16.241 [pulsar-client-io-1-1] WARN  o.a.p.c.i.BinaryProtoLookupService - [persistent://pulsar/global/peer-test/test] failed to send lookup request : org.apache.pulsar.client.api.PulsarClientException$BrokerMetadataException: java.lang.NullPointerException
java.util.concurrent.CompletionException: org.apache.pulsar.client.api.PulsarClientException$BrokerMetadataException: java.lang.NullPointerException
        at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:292) ~[na:1.8.0_131]
        at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:308) ~[na:1.8.0_131]
        at java.util.concurrent.CompletableFuture.uniAccept(CompletableFuture.java:647) ~[na:1.8.0_131]
        at java.util.concurrent.CompletableFuture$UniAccept.tryFire(CompletableFuture.java:632) ~[na:1.8.0_131]
        at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:474) ~[na:1.8.0_131]
        at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:1977) ~[na:1.8.0_131]
        at org.apache.pulsar.client.impl.ClientCnx.handleLookupResponse(ClientCnx.java:253) ~[pulsar-client-1.20.6-incubating-yahoo.jar:1.20.6-incubating-yahoo]
        at org.apache.pulsar.common.api.PulsarDecoder.channelRead(PulsarDecoder.java:111) ~[pulsar-common-1.20.6-incubating-yahoo.jar:1.20.6-incubating-yahoo]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:356) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:342) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:335) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:295) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:269) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:356) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:342) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:335) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1294) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:356) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:342) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:911) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:934) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:397) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:302) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:131) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at io.netty.util.concurrent.DefaultThreadFactory$DefaultRunnableDecorator.run(DefaultThreadFactory.java:144) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_131]
```

### Modifications

Return error message instead null redirection url.

### Result

Client will not see NPE instead client will get proper error-message if cluster url is not configured.
