### PR TITLE
Fix Python example class name

### DIFF
--- a/site/docs/latest/functions/quickstart.md
+++ b/site/docs/latest/functions/quickstart.md
@@ -212,9 +212,9 @@ $ touch reverse.py
 In that file, add the following:
 
 ```python
-from pulsarfunction import pulsar_function
+from pulsar import Function
 
-class Reverse(pulsar_function.PulsarFunction):
+class Reverse(Function):
   def __init__(self):
     pass
 


### PR DESCRIPTION
The Python interface for Pulsar Functions has changed, and the current Pulsar Functions quick start needs to be changed to reflect this.