### PR TITLE
Increase timeout on ReplicatorTest#testCloseReplicatorStartProducer

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -789,7 +789,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
      *
      * @throws Exception
      */
-    @Test(timeOut = 5000)
+    @Test(timeOut = 15000)
     public void testCloseReplicatorStartProducer() throws Exception {
 
         TopicName dest = TopicName.get("persistent://pulsar/global/ns1/closeCursor");


### PR DESCRIPTION
A good run takes around 3.5 seconds, so it doesn't take much to push
it past 5 seconds. Increased timeout to 15 seconds.
