### PR TITLE
Issue #1117: handle race in concurrent bundle split

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/cache/LocalZooKeeperCacheService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/cache/LocalZooKeeperCacheService.java
@@ -81,35 +81,6 @@ public class LocalZooKeeperCacheService {
             }
 
             @Override
-            public CompletableFuture<Optional<LocalPolicies>> getAsync(String path) {
-                CompletableFuture<Optional<LocalPolicies>> future = new CompletableFuture<>();
-
-                // First check in local-zk cache
-                super.getAsync(path).thenAccept(localPolicies -> {
-                    if (localPolicies.isPresent()) {
-                        future.complete(localPolicies);
-                    } else {
-                        // create new policies node under Local ZK by coping it from Global ZK
-                        createPolicies(path, true).thenAccept(p -> {
-                            LOG.info("Successfully created local policies for {} -- {}", path, p);
-                            // local-policies have been created but it's not part of policiesCache. so, call
-                            // super.getAsync() which will load it and set the watch on local-policies path
-                            super.getAsync(path);
-                            future.complete(p);
-                        }).exceptionally(ex -> {
-                            future.completeExceptionally(ex);
-                            return null;
-                        });
-                    }
-                }).exceptionally(ex -> {
-                    future.completeExceptionally(ex);
-                    return null;
-                });
-
-                return future;
-            }
-
-            @Override
             public CompletableFuture<Optional<Entry<LocalPolicies, Stat>>> getWithStatAsync(String path) {
                 CompletableFuture<Optional<Entry<LocalPolicies, Stat>>> future = new CompletableFuture<>();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/cache/LocalZooKeeperCacheService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/cache/LocalZooKeeperCacheService.java
@@ -81,6 +81,11 @@ public class LocalZooKeeperCacheService {
             }
 
             @Override
+            public CompletableFuture<Optional<LocalPolicies>> getAsync(String path) {
+                return getWithStatAsync(path).thenApply(entry -> entry.map(e -> e.getKey()));
+            }
+
+            @Override
             public CompletableFuture<Optional<Entry<LocalPolicies, Stat>>> getWithStatAsync(String path) {
                 CompletableFuture<Optional<Entry<LocalPolicies, Stat>>> future = new CompletableFuture<>();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/cache/LocalZooKeeperCacheService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/cache/LocalZooKeeperCacheService.java
@@ -22,6 +22,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.pulsar.broker.cache.ConfigurationCacheService.POLICIES_ROOT;
 import static org.apache.pulsar.broker.web.PulsarWebResource.joinPath;
 
+import com.google.common.collect.Maps;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -38,6 +40,7 @@ import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooDefs.Ids;
 import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -93,6 +96,38 @@ public class LocalZooKeeperCacheService {
                             // super.getAsync() which will load it and set the watch on local-policies path
                             super.getAsync(path);
                             future.complete(p);
+                        }).exceptionally(ex -> {
+                            future.completeExceptionally(ex);
+                            return null;
+                        });
+                    }
+                }).exceptionally(ex -> {
+                    future.completeExceptionally(ex);
+                    return null;
+                });
+
+                return future;
+            }
+
+            @Override
+            public CompletableFuture<Optional<Entry<LocalPolicies, Stat>>> getWithStatAsync(String path) {
+                CompletableFuture<Optional<Entry<LocalPolicies, Stat>>> future = new CompletableFuture<>();
+
+                // First check in local-zk cache
+                super.getWithStatAsync(path).thenAccept(result -> {
+                    Optional<LocalPolicies> localPolicies = result.map(Entry::getKey);
+                    if (localPolicies.isPresent()) {
+                        future.complete(result);
+                    } else {
+                        // create new policies node under Local ZK by coping it from Global ZK
+                        createPolicies(path, true).thenAccept(p -> {
+                            LOG.info("Successfully created local policies for {} -- {}", path, p);
+                            // local-policies have been created but it's not part of policiesCache. so, call
+                            // super.getAsync() which will load it and set the watch on local-policies path
+                            super.getWithStatAsync(path);
+                            Stat stat = new Stat();
+                            stat.setVersion(-1);
+                            future.complete(Optional.of(Maps.immutableEntry(p.orElse(null), stat)));
                         }).exceptionally(ex -> {
                             future.completeExceptionally(ex);
                             return null;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1022,7 +1022,18 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
     }
 
     public List<Topic> getAllTopicsFromNamespaceBundle(String namespace, String bundle) {
-        return multiLayerTopicsMap.get(namespace).get(bundle).values();
+        if (multiLayerTopicsMap.get(namespace) == null) {
+            return Lists.newArrayList();
+        }
+
+        if (multiLayerTopicsMap.get(namespace).get(bundle) == null) {
+            return Lists.newArrayList();
+        }
+
+        return multiLayerTopicsMap
+            .get(namespace)
+            .get(bundle)
+            .values();
     }
 
     public ZooKeeperDataCache<Map<String, String>> getDynamicConfigurationCache() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import java.net.URI;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -1022,18 +1023,17 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
     }
 
     public List<Topic> getAllTopicsFromNamespaceBundle(String namespace, String bundle) {
-        if (multiLayerTopicsMap.get(namespace) == null) {
-            return Lists.newArrayList();
+        ConcurrentOpenHashMap<String, ConcurrentOpenHashMap<String, Topic>> map1 = multiLayerTopicsMap.get(namespace);
+        if (map1 == null) {
+            return Collections.emptyList();
         }
 
-        if (multiLayerTopicsMap.get(namespace).get(bundle) == null) {
-            return Lists.newArrayList();
+        ConcurrentOpenHashMap<String, Topic> map2 = map1.get(bundle);
+        if (map2 == null) {
+            return Collections.emptyList();
         }
 
-        return multiLayerTopicsMap
-            .get(namespace)
-            .get(bundle)
-            .values();
+        return map2.values();
     }
 
     public ZooKeeperDataCache<Map<String, String>> getDynamicConfigurationCache() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleFactory.java
@@ -28,6 +28,8 @@ import static org.apache.pulsar.common.policies.data.Policies.LAST_BOUNDARY;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.SortedSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -78,10 +80,19 @@ public class NamespaceBundleFactory implements ZooKeeperCacheListener<LocalPolic
 
             CompletableFuture<NamespaceBundles> future = new CompletableFuture<>();
             // Read the static bundle data from the policies
-            pulsar.getLocalZkCacheService().policiesCache().getAsync(path).thenAccept(policies -> {
+            pulsar.getLocalZkCacheService().policiesCache().getWithStatAsync(path).thenAccept(result -> {
                 // If no policies defined for namespace, assume 1 single bundle
-                BundlesData bundlesData = policies.map(p -> p.bundles).orElse(null);
-                NamespaceBundles namespaceBundles = getBundles(namespace, bundlesData);
+                BundlesData bundlesData = result.map(Entry::getKey).map(p -> p.bundles).orElse(null);
+                NamespaceBundles namespaceBundles = getBundles(
+                    namespace, bundlesData, result.map(Entry::getValue).map(s -> s.getVersion()).orElse(-1));
+
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("[{}] Get bundles from getLocalZkCacheService: path: {},  bundles: {}, version: {}",
+                        namespace, path,
+                        (bundlesData != null && bundlesData.boundaries != null) ? bundlesData.toString() : "null",
+                        namespaceBundles.getVersion());
+                }
+
                 future.complete(namespaceBundles);
             }).exceptionally(ex -> {
                 future.completeExceptionally(ex);
@@ -111,7 +122,6 @@ public class NamespaceBundleFactory implements ZooKeeperCacheListener<LocalPolic
         final NamespaceName namespace = NamespaceName.get(getNamespaceFromPoliciesPath(path));
 
         try {
-            LOG.info("Policy updated for namespace {}, refreshing the bundle cache.", namespace);
             // invalidate the bundle cache to fetch new bundle data from the policies
             bundlesCache.synchronous().invalidate(namespace);
         } catch (Exception e) {
@@ -157,7 +167,7 @@ public class NamespaceBundleFactory implements ZooKeeperCacheListener<LocalPolic
                 (upperEndpoint.equals(NamespaceBundles.FULL_UPPER_BOUND)) ? BoundType.CLOSED : BoundType.OPEN);
         return getBundle(NamespaceName.get(namespace), hashRange);
     }
-    
+
     public NamespaceBundle getFullBundle(NamespaceName fqnn) throws Exception {
         return bundlesCache.synchronous().get(fqnn).getFullBundle();
     }
@@ -167,6 +177,10 @@ public class NamespaceBundleFactory implements ZooKeeperCacheListener<LocalPolic
     }
 
     public NamespaceBundles getBundles(NamespaceName nsname, BundlesData bundleData) {
+        return getBundles(nsname, bundleData, -1);
+    }
+
+    public NamespaceBundles getBundles(NamespaceName nsname, BundlesData bundleData, long version) {
         long[] partitions;
         if (bundleData == null) {
             partitions = new long[] { Long.decode(FIRST_BOUNDARY), Long.decode(LAST_BOUNDARY) };
@@ -176,7 +190,7 @@ public class NamespaceBundleFactory implements ZooKeeperCacheListener<LocalPolic
                 partitions[i] = Long.decode(bundleData.boundaries.get(i));
             }
         }
-        return new NamespaceBundles(nsname, partitions, this);
+        return new NamespaceBundles(nsname, partitions, this, version);
     }
 
     public static BundlesData getBundlesData(NamespaceBundles bundles) throws Exception {
@@ -199,10 +213,8 @@ public class NamespaceBundleFactory implements ZooKeeperCacheListener<LocalPolic
      *            split into numBundles
      * @return List of split {@link NamespaceBundle} and {@link NamespaceBundles} that contains final bundles including
      *         split bundles for a given namespace
-     * @throws Exception
      */
-    public Pair<NamespaceBundles, List<NamespaceBundle>> splitBundles(NamespaceBundle targetBundle, int numBundles)
-            throws Exception {
+    public Pair<NamespaceBundles, List<NamespaceBundle>> splitBundles(NamespaceBundle targetBundle, int numBundles) {
         checkArgument(canSplitBundle(targetBundle), "%s bundle can't be split further", targetBundle);
         checkNotNull(targetBundle, "can't split null bundle");
         checkNotNull(targetBundle.getNamespaceObject(), "namespace must be present");
@@ -234,7 +246,8 @@ public class NamespaceBundleFactory implements ZooKeeperCacheListener<LocalPolic
         }
         partitions[pos] = sourceBundle.partitions[lastIndex];
         if (splitPartition != -1) {
-            NamespaceBundles splittedNsBundles = new NamespaceBundles(nsname, partitions, this);
+            // keep version of sourceBundle
+            NamespaceBundles splittedNsBundles = new NamespaceBundles(nsname, partitions, this, sourceBundle.getVersion());
             List<NamespaceBundle> splittedBundles = splittedNsBundles.getBundles().subList(splitPartition,
                     (splitPartition + numBundles));
             return new ImmutablePair<NamespaceBundles, List<NamespaceBundle>>(splittedNsBundles, splittedBundles);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleFactory.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundleFactory.java
@@ -122,6 +122,7 @@ public class NamespaceBundleFactory implements ZooKeeperCacheListener<LocalPolic
         final NamespaceName namespace = NamespaceName.get(getNamespaceFromPoliciesPath(path));
 
         try {
+            LOG.info("Policy updated for namespace {}, refreshing the bundle cache.", namespace);
             // invalidate the bundle cache to fetch new bundle data from the policies
             bundlesCache.synchronous().invalidate(namespace);
         } catch (Exception e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundles.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/common/naming/NamespaceBundles.java
@@ -26,9 +26,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.SortedSet;
 
-import org.apache.pulsar.common.naming.TopicName;
-import org.apache.pulsar.common.naming.NamespaceName;
-
 import com.google.common.base.Objects;
 import com.google.common.collect.BoundType;
 import com.google.common.collect.Lists;
@@ -38,6 +35,8 @@ public class NamespaceBundles {
     private final NamespaceName nsname;
     private final ArrayList<NamespaceBundle> bundles;
     private final NamespaceBundleFactory factory;
+    private final long version;
+
     protected final long[] partitions;
 
     public static final Long FULL_LOWER_BOUND = 0x00000000L;
@@ -49,16 +48,17 @@ public class NamespaceBundles {
         this(nsname, convertPartitions(partitionsSet), factory);
     }
 
-    public NamespaceBundles(NamespaceName nsname, long[] partitions, NamespaceBundleFactory factory) {
+    public NamespaceBundles(NamespaceName nsname, long[] partitions, NamespaceBundleFactory factory, long version) {
         // check input arguments
         this.nsname = checkNotNull(nsname);
         this.factory = checkNotNull(factory);
+        this.version = version;
         checkArgument(partitions.length > 0, "Can't create bundles w/o partition boundaries");
 
         // calculate bundles based on partition boundaries
         this.bundles = Lists.newArrayList();
         fullBundle = new NamespaceBundle(nsname,
-                Range.range(FULL_LOWER_BOUND, BoundType.CLOSED, FULL_UPPER_BOUND, BoundType.CLOSED), factory);
+            Range.range(FULL_LOWER_BOUND, BoundType.CLOSED, FULL_UPPER_BOUND, BoundType.CLOSED), factory);
 
         if (partitions.length > 0) {
             if (partitions.length == 1) {
@@ -84,6 +84,10 @@ public class NamespaceBundles {
             this.partitions = new long[] { 0l };
             bundles.add(fullBundle);
         }
+    }
+
+    public NamespaceBundles(NamespaceName nsname, long[] partitions, NamespaceBundleFactory factory) {
+        this(nsname, partitions, factory, -1);
     }
 
     public NamespaceBundle findBundle(TopicName topicName) {
@@ -139,5 +143,9 @@ public class NamespaceBundles {
             return (Objects.equal(this.nsname, other.nsname) && Objects.equal(this.bundles, other.bundles));
         }
         return false;
+    }
+
+    public long getVersion() {
+        return version;
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -28,18 +28,23 @@ import static org.testng.Assert.fail;
 import java.lang.reflect.Field;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import javax.ws.rs.client.InvocationCallback;
 import javax.ws.rs.client.WebTarget;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
@@ -106,6 +111,7 @@ import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.google.common.hash.Hashing;
 
+@Slf4j
 public class AdminApiTest extends MockedPulsarServiceBaseTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(AdminApiTest.class);
@@ -927,6 +933,115 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
         String[] splitRange = { namespace + "/0x00000000_0x7fffffff", namespace + "/0x7fffffff_0xffffffff" };
         for (int i = 0; i < bundles.getBundles().size(); i++) {
             assertEquals(bundles.getBundles().get(i).toString(), splitRange[i]);
+        }
+
+        producer.close();
+    }
+
+    @Test
+    public void testNamespaceSplitBundleC() throws Exception {
+        // Force to create a topic
+        final String namespace = "prop-xyz/use/ns1";
+        final String topicName = (new StringBuilder("persistent://")).append(namespace).append("/ds2").toString();
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
+        producer.send("message".getBytes());
+        publishMessagesOnPersistentTopic(topicName, 0);
+        assertEquals(admin.persistentTopics().getList(namespace), Lists.newArrayList(topicName));
+
+        try {
+            admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0xffffffff", false);
+        } catch (Exception e) {
+            fail("split bundle shouldn't have thrown exception");
+        }
+
+        // bundle-factory cache must have updated split bundles
+        NamespaceBundles bundles = bundleFactory.getBundles(NamespaceName.get(namespace));
+        String[] splitRange = {namespace + "/0x00000000_0x7fffffff", namespace + "/0x7fffffff_0xffffffff"};
+        for (int i = 0; i < bundles.getBundles().size(); i++) {
+            assertEquals(bundles.getBundles().get(i).toString(), splitRange[i]);
+        }
+
+        ExecutorService executorService = Executors.newCachedThreadPool();
+
+
+        try {
+            executorService.invokeAll(
+                Arrays.asList(
+                    () ->
+                    {
+                        log.info("split 2 bundles at the same time. spilt: 0x00000000_0x7fffffff ");
+                        admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0x7fffffff", false);
+                        return null;
+                    },
+                    () ->
+                    {
+                        log.info("split 2 bundles at the same time. spilt: 0x7fffffff_0xffffffff ");
+                        admin.namespaces().splitNamespaceBundle(namespace, "0x7fffffff_0xffffffff", false);
+                        return null;
+                    }
+                )
+            );
+        } catch (Exception e) {
+            fail("split bundle shouldn't have thrown exception");
+        }
+
+        String[] splitRange4 = {
+            namespace + "/0x00000000_0x3fffffff",
+            namespace + "/0x3fffffff_0x7fffffff",
+            namespace + "/0x7fffffff_0xbfffffff",
+            namespace + "/0xbfffffff_0xffffffff"};
+        bundles = bundleFactory.getBundles(NamespaceName.get(namespace));
+        assertEquals(bundles.getBundles().size(), 4);
+        for (int i = 0; i < bundles.getBundles().size(); i++) {
+            assertEquals(bundles.getBundles().get(i).toString(), splitRange4[i]);
+        }
+
+        try {
+            executorService.invokeAll(
+                Arrays.asList(
+                    () ->
+                    {
+                        log.info("split 4 bundles at the same time. spilt: 0x00000000_0x3fffffff ");
+                        admin.namespaces().splitNamespaceBundle(namespace, "0x00000000_0x3fffffff", false);
+                        return null;
+                    },
+                    () ->
+                    {
+                        log.info("split 4 bundles at the same time. spilt: 0x3fffffff_0x7fffffff ");
+                        admin.namespaces().splitNamespaceBundle(namespace, "0x3fffffff_0x7fffffff", false);
+                        return null;
+                    },
+                    () ->
+                    {
+                        log.info("split 4 bundles at the same time. spilt: 0x7fffffff_0xbfffffff ");
+                        admin.namespaces().splitNamespaceBundle(namespace, "0x7fffffff_0xbfffffff", false);
+                        return null;
+                    },
+                    () ->
+                    {
+                        log.info("split 4 bundles at the same time. spilt: 0xbfffffff_0xffffffff ");
+                        admin.namespaces().splitNamespaceBundle(namespace, "0xbfffffff_0xffffffff", false);
+                        return null;
+                    }
+                )
+            );
+        } catch (Exception e) {
+            fail("split bundle shouldn't have thrown exception");
+        }
+
+        String[] splitRange8 = {
+            namespace + "/0x00000000_0x1fffffff",
+            namespace + "/0x1fffffff_0x3fffffff",
+            namespace + "/0x3fffffff_0x5fffffff",
+            namespace + "/0x5fffffff_0x7fffffff",
+            namespace + "/0x7fffffff_0x9fffffff",
+            namespace + "/0x9fffffff_0xbfffffff",
+            namespace + "/0xbfffffff_0xdfffffff",
+            namespace + "/0xdfffffff_0xffffffff"};
+        bundles = bundleFactory.getBundles(NamespaceName.get(namespace));
+        assertEquals(bundles.getBundles().size(), 8);
+        for (int i = 0; i < bundles.getBundles().size(); i++) {
+            assertEquals(bundles.getBundles().get(i).toString(), splitRange8[i]);
         }
 
         producer.close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -939,7 +939,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
     }
 
     @Test
-    public void testNamespaceSplitBundleC() throws Exception {
+    public void testNamespaceSplitBundleConcurrent() throws Exception {
         // Force to create a topic
         final String namespace = "prop-xyz/use/ns1";
         final String topicName = (new StringBuilder("persistent://")).append(namespace).append("/ds2").toString();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
@@ -196,13 +196,9 @@ public class NamespaceServiceTest extends BrokerTestBase {
             fail("split bundle faild", e);
         }
 
-        try {
-            // old bundle should be removed from status-map
-            list = this.pulsar.getBrokerService().getAllTopicsFromNamespaceBundle(nspace, originalBundle.toString());
-            fail();
-        } catch (NullPointerException ne) {
-            // OK
-        }
+        // old bundle should be removed from status-map
+        list = this.pulsar.getBrokerService().getAllTopicsFromNamespaceBundle(nspace, originalBundle.toString());
+        assertTrue(list.isEmpty());
 
         // status-map should be updated with new split bundles
         NamespaceBundle splitBundle = pulsar.getNamespaceService().getBundle(topicName);

--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZooKeeperDataCache.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZooKeeperDataCache.java
@@ -74,16 +74,11 @@ public abstract class ZooKeeperDataCache<T> implements Deserializer<T>, CacheUpd
     }
 
     public CompletableFuture<Optional<Entry<T, Stat>>> getWithStatAsync(String path) {
-        CompletableFuture<Optional<Entry<T, Stat>>> future = new CompletableFuture<>();
-        cache.getDataAsync(path, this, this).thenAccept(entry -> {
-            future.complete(entry);
-        }).exceptionally(ex -> {
-            cache.asyncInvalidate(path);
-            future.completeExceptionally(ex);
-            return null;
+        return cache.getDataAsync(path, this, this).whenComplete((entry, ex) -> {
+            if (ex != null) {
+                cache.asyncInvalidate(path);
+            }
         });
-
-        return future;
     }
 
     /**

--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZooKeeperDataCache.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZooKeeperDataCache.java
@@ -73,6 +73,19 @@ public abstract class ZooKeeperDataCache<T> implements Deserializer<T>, CacheUpd
         return future;
     }
 
+    public CompletableFuture<Optional<Entry<T, Stat>>> getWithStatAsync(String path) {
+        CompletableFuture<Optional<Entry<T, Stat>>> future = new CompletableFuture<>();
+        cache.getDataAsync(path, this, this).thenAccept(entry -> {
+            future.complete(entry);
+        }).exceptionally(ex -> {
+            cache.asyncInvalidate(path);
+            future.completeExceptionally(ex);
+            return null;
+        });
+
+        return future;
+    }
+
     /**
      * Return an item from the cache
      *


### PR DESCRIPTION
### Motivation

in `NamespaceService.splitAndOwnBundle()`. 
The concurrent update of Policies of same namespace will cause some override to bundles value that kept in Zookeeper. And this involves at least 2 rounds of split. 
e.g.
1. At beginning, we have 2 bundles, with partitions:[0x00000000, 0x7fffffff, 0xffffffff],
2. First round of split: We will split the 2 bundles at the same time. In first bundle split, the `NamespaceBundles` value that returned by `NamespaceBundleFactory.splitBundles()` would be: 
[0x00000000, **0x3fffffff**, 0x7fffffff, 0xffffffff]; 
while at the same time, the `NamespaceBundles` value for second bundle split would be:
 [0x00000000, 0x7fffffff, **0xbfffffff**, 0xffffffff]
3. Then the 2 split operations, whoever success `updateNamespaceBundles` last, will override the former one. 
Here if second split finally success,  it will override the former success value [0x00000000, **0x3fffffff**, 0x7fffffff, 0xffffffff], and the final bundles partitions would be:  [0x00000000, 0x7fffffff, **0xbfffffff**, 0xffffffff];  But we thought it should be [0x00000000, **0x3fffffff**, 0x7fffffff, **0xbfffffff**,  0xffffffff]; 
4. Second round split:  e.g. try to split to range [0x00000000, 0x3fffffff], it will not find upper boundary 0x3fffffff in actual [0x00000000, 0x7fffffff, 0xbfffffff, 0xffffffff].
And  this will cause the error: 
`
java.lang.IllegalArgumentException: Invalid upper boundary for bundle
    at com.google.common.base.Preconditions.checkArgument(Preconditions.java:122)
 `
### Modifications

- Add version in NamespaceBundles,  when update the zookeeper z-node, verify the version, and do read-modify-write retry when there are simultaneous write to the z-node.
- Add test for it.

### Result

No user behavior will change. This concurrent bug fixed. 

Fixes #1117