### PR TITLE
Publish the distribution to maven artifact

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -147,13 +147,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
### Motivation

Currently we only stage artifacts to staging repository. For pulsar functions, if people want to try it out, there is no way to access the binary unless they compile from master.

### Modifications

Since the distribution module is generating a tgz artifact for arquilian testing, we can enable maven deployment to allow snapshot job to publish this tgz to staging repository.

### Result

The distribution tgz is available in apache staging respository.
