### PR TITLE
Update user config interface for Java Pulsar Functions SDK

### DIFF
--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/Context.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/Context.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.functions.api;
 import org.slf4j.Logger;
 
 import java.util.Collection;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -112,11 +113,19 @@ public interface Context {
     void incrCounter(String key, long amount);
 
     /**
-     * Get Any user defined key/value
+     * Get any user-defined key/value
      * @param key The key
-     * @return The value specified by the user for that key. null if no such key
+     * @return The Optional value specified by the user for that key.
      */
-    String getUserConfigValue(String key);
+    Optional<String> getUserConfigValue(String key);
+
+    /**
+     * Get any user-defined key/value or a default value if none is present
+     * @param key
+     * @param defaultValue
+     * @return Either the user config value associated with a given key or a supplied default value
+     */
+    String getUserConfigValueOrDefault(String key, String defaultValue);
 
     /**
      * Record a user defined metric

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -174,12 +175,13 @@ class ContextImpl implements Context {
     }
 
     @Override
-    public String getUserConfigValue(String key) {
-        if (config.getFunctionConfig().containsUserConfig(key)) {
-            return config.getFunctionConfig().getUserConfigOrDefault(key, null);
-        } else {
-            return null;
-        }
+    public Optional<String> getUserConfigValue(String key) {
+        return Optional.ofNullable(config.getFunctionConfig().getUserConfigOrDefault(key, null));
+    }
+
+    @Override
+    public String getUserConfigValueOrDefault(String key, String defaultValue) {
+        return getUserConfigValue(key).orElse(defaultValue);
     }
 
     @Override

--- a/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/PublishFunction.java
+++ b/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/PublishFunction.java
@@ -25,7 +25,9 @@ import org.apache.pulsar.functions.api.utils.DefaultSerDe;
 public class PublishFunction implements Function<String, Void> {
     @Override
     public Void process(String input, Context context) {
-        context.publish(context.getUserConfigValue("PublishTopic"), input + "!", DefaultSerDe.class.getName());
+        String publishTopic = context.getUserConfigValueOrDefault("publish-topic", "persistent://sample/standalone/ns1/publish");
+        String output = String.format("%s!", input);
+        context.publish(publishTopic, output, DefaultSerDe.class.getName());
         return null;
     }
 }

--- a/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/UserConfigFunction.java
+++ b/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/UserConfigFunction.java
@@ -37,5 +37,7 @@ public class UserConfigFunction implements Function<String, Void> {
         } else {
             LOG.error("No value present for the key {}", key);
         }
+
+        return null;
     }
 }

--- a/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/UserConfigFunction.java
+++ b/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/UserConfigFunction.java
@@ -24,9 +24,9 @@ import org.slf4j.Logger;
 
 import java.util.Optional;
 
-public class UserConfigFunction implements Function<String, String> {
+public class UserConfigFunction implements Function<String, Void> {
     @Override
-    public String process(String input, Context context) {
+    public Void process(String input, Context context) {
         String key = "config-key";
         Optional<String> maybeValue = context.getUserConfigValue(key);
         Logger LOG = context.getLogger();
@@ -34,10 +34,8 @@ public class UserConfigFunction implements Function<String, String> {
         if (maybeValue.isPresent()) {
             String value = maybeValue.get();
             LOG.info("The config value is {}", value);
-            return value;
         } else {
             LOG.error("No value present for the key {}", key);
-            return null;
         }
     }
 }

--- a/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/UserConfigFunction.java
+++ b/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/UserConfigFunction.java
@@ -20,11 +20,24 @@ package org.apache.pulsar.functions.api.examples;
 
 import org.apache.pulsar.functions.api.Context;
 import org.apache.pulsar.functions.api.Function;
+import org.slf4j.Logger;
+
+import java.util.Optional;
 
 public class UserConfigFunction implements Function<String, String> {
     @Override
     public String process(String input, Context context) {
-        context.getLogger().info("My Config is " + context.getUserConfigValue("MyOwnConfig"));
-        return input + context.getUserConfigValue("MyOwnConfig");
+        String key = "config-key";
+        Optional<String> maybeValue = context.getUserConfigValue(key);
+        Logger LOG = context.getLogger();
+
+        if (maybeValue.isPresent()) {
+            String value = maybeValue.get();
+            LOG.info("The config value is {}", value);
+            return value;
+        } else {
+            LOG.error("No value present for the key {}", key);
+            return null;
+        }
     }
 }


### PR DESCRIPTION
I think it's best in general to shield users from dealing with null values. This PR provides a null-free interface for interacting with user config values supplied to Pulsar Functions.