### PR TITLE
Revert "Recycle OpAddEntry when ledger-ops fails (#1415)"

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -99,7 +99,6 @@ class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallback {
         if (cb != null) {
             cb.addFailed(e, ctx);
             ml.mbean.recordAddEntryError();
-            this.recycle();
         }
     }
 


### PR DESCRIPTION
If the OpAddEntry is recycled before the callback is triggered, the callback is calling into a dead object.

This reverts commit f5ffbbe1ed2b79be1caf4a59688eab006e932ced.
