### PR TITLE
When running standalone broker, force the proxy redirection flag

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -59,6 +59,9 @@ public class ServiceConfiguration implements PulsarConfiguration {
     // Enable the WebSocket API service
     private boolean webSocketServiceEnabled = false;
 
+    // Flag to control features that are meant to be used when running in standalone mode
+    private boolean isRunningStandalone = false;
+
     // Name of the cluster to which this broker belongs to
     @FieldContext(required = true)
     private String clusterName;
@@ -1506,5 +1509,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     public boolean isFunctionsWorkerEnabled() {
         return functionsWorkerEnabled;
+    }
+
+    public boolean isRunningStandalone() {
+        return isRunningStandalone;
+    }
+
+    public void setRunningStandalone(boolean isRunningStandalone) {
+        this.isRunningStandalone = isRunningStandalone;
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandaloneStarter.java
@@ -134,6 +134,7 @@ public class PulsarStandaloneStarter {
         // Set ZK server's host to localhost
         config.setZookeeperServers(zkServers + ":" + zkPort);
         config.setGlobalZookeeperServers(zkServers + ":" + zkPort);
+        config.setRunningStandalone(true);
 
         Runtime.getRuntime().addShutdownHook(new Thread() {
             public void run() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/lookup/TopicLookup.java
@@ -279,9 +279,14 @@ public class TopicLookup extends PulsarWebResource {
                                         newLookupResponse(lookupData.getBrokerUrl(), lookupData.getBrokerUrlTls(),
                                                 newAuthoritative, LookupType.Redirect, requestId, false));
                             } else {
+                                // When running in standalone mode we want to redirect the client through the service
+                                // url, so that the advertised address configuration is not relevant anymore.
+                                boolean redirectThroughServiceUrl = pulsarService.getConfiguration()
+                                        .isRunningStandalone();
+
                                 lookupfuture.complete(
                                         newLookupResponse(lookupData.getBrokerUrl(), lookupData.getBrokerUrlTls(),
-                                                true /* authoritative */, LookupType.Connect, requestId, false));
+                                                true /* authoritative */, LookupType.Connect, requestId, redirectThroughServiceUrl));
                             }
                         }).exceptionally(ex -> {
                             if (ex instanceof CompletionException && ex.getCause() instanceof IllegalStateException) {


### PR DESCRIPTION
### Motivation

Since standalone is running a "real" Pulsar service (along with ZK and BookKeeper) it uses the same discovery mechanism used in a full blown cluster.

One of the problematic aspect is that brokers need to advertise an IP/hostname that is routable by clients. 

Since in standalone mode we have 1 single broker, we can get away with that additional configuration by forcing client to treat the standalone as a proxy.

### Modifications

 * Added a configuration flag for standalone mode. When the flag is set it will force the clients to connect through the same service url they have been already connecting to. 

### Result

No need to specify `advertisedAddress` when running standalone service.


Fixes #1152
Closes #1318