### PR TITLE
Fix: NPE on http-lookup redirection

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -42,6 +42,7 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.admin.AdminResource;
@@ -264,7 +265,8 @@ public abstract class PulsarWebResource {
 
     private URI getRedirectionUrl(ClusterData differentClusterData) throws MalformedURLException {
         URL webUrl = null;
-        if (pulsar.getConfiguration().isTlsEnabled() && !differentClusterData.getServiceUrlTls().isEmpty()) {
+        if (isRequestHttps() && pulsar.getConfiguration().isTlsEnabled()
+                && StringUtils.isNotBlank(differentClusterData.getServiceUrlTls())) {
             webUrl = new URL(differentClusterData.getServiceUrlTls());
         } else {
             webUrl = new URL(differentClusterData.getServiceUrl());


### PR DESCRIPTION
### Motivation

- If broker has TLS enabled and broker's TLS url is not setup then http-redirection throws NPE.
- Also, broker should consider http-request's protocol (http/https) while redirecting to another cluster. Right now, if broker's TLS is enabled then it tries to redirect to HTTPS url even if request is made on HTTP.

### Modifications

Handle NPE and http-request's protocol.

### Result

- Broker will not throw NPE while http redirection
- Broker will redirect to another cluster's service url based on request's protocol.
