### PR TITLE
Check if request is HTTPs before redirecting to TLS URL

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -39,6 +39,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriBuilder;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.admin.AdminResource;
@@ -73,8 +74,6 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Sets.SetView;
-
-import dlshade.org.apache.commons.lang3.StringUtils;
 
 public abstract class NamespacesBase extends AdminResource {
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -74,6 +74,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Sets.SetView;
 
+import dlshade.org.apache.commons.lang3.StringUtils;
+
 public abstract class NamespacesBase extends AdminResource {
 
     private static final long MAX_BUNDLES = ((long) 1) << 32;
@@ -145,9 +147,9 @@ public abstract class NamespacesBase extends AdminResource {
                             .orElseThrow(() -> new RestException(Status.NOT_FOUND,
                                     "Cluster " + replCluster + " does not exist"));
                     URL replClusterUrl;
-                    if (!config().isTlsEnabled()) {
+                    if (!config().isTlsEnabled() || !isRequestHttps()) {
                         replClusterUrl = new URL(replClusterData.getServiceUrl());
-                    } else if (!replClusterData.getServiceUrlTls().isEmpty()) {
+                    } else if (StringUtils.isNotBlank(replClusterData.getServiceUrlTls())) {
                         replClusterUrl = new URL(replClusterData.getServiceUrlTls());
                     } else {
                         throw new RestException(Status.PRECONDITION_FAILED,
@@ -246,9 +248,9 @@ public abstract class NamespacesBase extends AdminResource {
                             .orElseThrow(() -> new RestException(Status.NOT_FOUND,
                                     "Cluser " + replCluster + " does not exist"));
                     URL replClusterUrl;
-                    if (!config().isTlsEnabled()) {
+                    if (!config().isTlsEnabled() || !isRequestHttps()) {
                         replClusterUrl = new URL(replClusterData.getServiceUrl());
-                    } else if (!replClusterData.getServiceUrlTls().isEmpty()) {
+                    } else if (StringUtils.isNotBlank(replClusterData.getServiceUrlTls())) {
                         replClusterUrl = new URL(replClusterData.getServiceUrlTls());
                     } else {
                         throw new RestException(Status.PRECONDITION_FAILED,


### PR DESCRIPTION
Code review bug: While deciding whether to return the `serviceUrl` or `serviceUrlTls` of a replication cluster we should check whether the request is HTTPS and since `getServiceUrlTls` can be null we should use `StringUtils.isNotBlank` instead of `isEmpty`