### PR TITLE
If cursor update to BK fails, fallback to meta store

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -2064,7 +2064,7 @@ public class ManagedCursorImpl implements ManagedCursor {
                         if (log.isDebugEnabled()) {
                             log.debug(
                                     "[{}][{}] Updated cursor in meta store after previous failure in ledger at position {}",
-                                    position);
+                                    ledger.getName(), name, position);
                         }
                         callback.operationComplete();
                     }
@@ -2072,7 +2072,7 @@ public class ManagedCursorImpl implements ManagedCursor {
                     @Override
                     public void operationFailed(MetaStoreException e) {
                         log.warn("[{}][{}] Failed to update cursor in meta store after previous failure in ledger: {}",
-                                e.getMessage());
+                                ledger.getName(), name, e.getMessage());
                         callback.operationFailed(createManagedLedgerException(rc));
                     }
                 }, true);

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1820,6 +1820,7 @@ public class ManagedCursorImpl implements ManagedCursor {
                 new MetaStoreCallback<Void>() {
                     @Override
                     public void operationComplete(Void result, Stat stat) {
+                        cursorLedgerStat = stat;
                         callback.operationComplete(result, stat);
                     }
 
@@ -2055,7 +2056,26 @@ public class ManagedCursorImpl implements ManagedCursor {
                 // If we've had a write error, the ledger will be automatically closed, we need to create a new one,
                 // in the meantime the mark-delete will be queued.
                 STATE_UPDATER.compareAndSet(ManagedCursorImpl.this, State.Open, State.NoLedger);
-                callback.operationFailed(createManagedLedgerException(rc));
+
+                // Before giving up, try to persist the position in the metadata store
+                persistPositionMetaStore(-1, position, mdEntry.properties, new MetaStoreCallback<Void>() {
+                    @Override
+                    public void operationComplete(Void result, Stat stat) {
+                        if (log.isDebugEnabled()) {
+                            log.debug(
+                                    "[{}][{}] Updated cursor in meta store after previous failure in ledger at position {}",
+                                    position);
+                        }
+                        callback.operationComplete();
+                    }
+
+                    @Override
+                    public void operationFailed(MetaStoreException e) {
+                        log.warn("[{}][{}] Failed to update cursor in meta store after previous failure in ledger: {}",
+                                e.getMessage());
+                        callback.operationFailed(createManagedLedgerException(rc));
+                    }
+                }, true);
             }
         }, null);
     }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerErrorsTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerErrorsTest.java
@@ -486,6 +486,7 @@ public class ManagedLedgerErrorsTest extends MockedBookKeeperTestCase {
         Position position = ledger.addEntry("entry".getBytes());
 
         bkc.failNow(BKException.Code.BookieHandleNotAvailableException);
+        zkc.failNow(Code.CONNECTIONLOSS);
 
         try {
             cursor.markDelete(position);

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/NonDurableCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/NonDurableCursorTest.java
@@ -252,12 +252,8 @@ public class NonDurableCursorTest extends MockedBookKeeperTestCase {
         stopBookKeeper();
         assertEquals(entries.size(), 1);
 
-        try {
-            cursor.markDelete(entries.get(0).getPosition());
-            fail("call should have failed");
-        } catch (ManagedLedgerException e) {
-            // ok
-        }
+        // Mark-delete should succeed if BK is down
+        cursor.markDelete(entries.get(0).getPosition());
 
         entries.forEach(e -> e.release());
     }


### PR DESCRIPTION
### Motivation

If writes to BK are failing we cannot update the cursor. If the writes are failing because the disk is full, we have a circular problem, since we cannot easily delete old data by moving the cursors forward.

In case of BK write errors, try to update the cursor in ZK as a fallback strategy. If that fails as well, give up.