### PR TITLE
Delayed acks impl

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -20,6 +20,15 @@ package org.apache.pulsar.broker.service;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.Lists;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -30,13 +39,13 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.stream.Collectors;
 
 import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.bookkeeper.mledger.util.Rate;
 import org.apache.bookkeeper.util.collections.ConcurrentLongLongPairHashMap;
 import org.apache.bookkeeper.util.collections.ConcurrentLongLongPairHashMap.LongPair;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
-
 import org.apache.pulsar.common.api.Commands;
 import org.apache.pulsar.common.api.proto.PulsarApi;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck;
@@ -50,14 +59,6 @@ import org.apache.pulsar.common.policies.data.ConsumerStats;
 import org.apache.pulsar.common.util.DateFormatter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.MoreObjects;
-import com.google.common.collect.Lists;
-
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelFutureListener;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelPromise;
 
 /**
  * A Consumer is a consumer currently connected and associated with a Subscription
@@ -288,7 +289,7 @@ public class Consumer {
                 iter.remove();
                 PositionImpl pos = (PositionImpl) entry.getPosition();
                 entry.release();
-                subscription.acknowledgeMessage(pos, AckType.Individual, Collections.emptyMap());
+                subscription.acknowledgeMessage(Collections.singletonList(pos), AckType.Individual, Collections.emptyMap());
                 continue;
             }
             if (pendingAcks != null) {
@@ -363,31 +364,46 @@ public class Consumer {
     }
 
     void messageAcked(CommandAck ack) {
-        MessageIdData msgId = ack.getMessageId();
-        PositionImpl position = PositionImpl.get(msgId.getLedgerId(), msgId.getEntryId());
-
-        if (ack.hasValidationError()) {
-            log.error("[{}] [{}] Received ack for corrupted message at {} - Reason: {}", subscription, consumerId,
-                    position, ack.getValidationError());
-        }
-
         Map<String,Long> properties = Collections.emptyMap();
         if (ack.getPropertiesCount() > 0) {
             properties = ack.getPropertiesList().stream()
                 .collect(Collectors.toMap((e) -> e.getKey(),
                                           (e) -> e.getValue()));
         }
-        if (subType == SubType.Shared) {
-            // On shared subscriptions, cumulative ack is not supported
-            checkArgument(ack.getAckType() == AckType.Individual);
 
-            // Only ack a single message
-            removePendingAcks(position);
-            subscription.acknowledgeMessage(position, AckType.Individual, properties);
+        if (ack.getAckType() == AckType.Cumulative) {
+            if (ack.getMessageIdCount() != 1) {
+                log.warn("[{}] [{}] Received multi-message ack at {} - Reason: {}", subscription, consumerId);
+                return;
+            }
+
+            if (subType == SubType.Shared) {
+                log.warn("[{}] [{}] Received cumulative ack on shared subscription, ignoring", subscription, consumerId);
+                return;
+            }
+
+            MessageIdData msgId = ack.getMessageId(0);
+            PositionImpl position = PositionImpl.get(msgId.getLedgerId(), msgId.getEntryId());
+            subscription.acknowledgeMessage(Collections.singletonList(position), AckType.Cumulative, properties);
         } else {
-            subscription.acknowledgeMessage(position, ack.getAckType(), properties);
-        }
+            // Individual ack
+            List<Position> positionsAcked = new ArrayList<>();
+            for (int i = 0; i < ack.getMessageIdCount(); i++) {
+                MessageIdData msgId = ack.getMessageId(i);
+                PositionImpl position = PositionImpl.get(msgId.getLedgerId(), msgId.getEntryId());
+                positionsAcked.add(position);
 
+                if (subType == SubType.Shared) {
+                    removePendingAcks(position);
+                }
+
+                if (ack.hasValidationError()) {
+                    log.error("[{}] [{}] Received ack for corrupted message at {} - Reason: {}", subscription,
+                            consumerId, position, ack.getValidationError());
+                }
+            }
+            subscription.acknowledgeMessage(positionsAcked, AckType.Individual, properties);
+        }
     }
 
     void flowPermits(int additionalNumberOfMessages) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
@@ -40,7 +40,7 @@ public interface Subscription {
 
     void consumerFlow(Consumer consumer, int additionalNumberOfMessages);
 
-    void acknowledgeMessage(PositionImpl position, AckType ackType, Map<String,Long> properties);
+    void acknowledgeMessage(List<Position> positions, AckType ackType, Map<String,Long> properties);
 
     String getTopicName();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentSubscription.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.broker.service.nonpersistent;
 
+import com.google.common.base.MoreObjects;
+
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -42,8 +44,6 @@ import org.apache.pulsar.common.policies.data.NonPersistentSubscriptionStats;
 import org.apache.pulsar.utils.CopyOnWriteArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.base.MoreObjects;
 
 public class NonPersistentSubscription implements Subscription {
     private final NonPersistentTopic topic;
@@ -139,7 +139,7 @@ public class NonPersistentSubscription implements Subscription {
     }
 
     @Override
-    public void acknowledgeMessage(PositionImpl position, AckType ackType, Map<String,Long> properties) {
+    public void acknowledgeMessage(List<Position> position, AckType ackType, Map<String, Long> properties) {
         // No-op
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
@@ -99,7 +99,7 @@ public class RawReaderImpl implements RawReader {
         final BlockingQueue<RawMessageAndCnx> incomingRawMessages;
         final Queue<CompletableFuture<RawMessage>> pendingRawReceives;
 
-        RawConsumerImpl(PulsarClientImpl client, ConsumerConfigurationData conf,
+        RawConsumerImpl(PulsarClientImpl client, ConsumerConfigurationData<byte[]> conf,
                 CompletableFuture<Consumer<byte[]>> consumerFuture) {
             super(client, conf.getSingleTopic(), conf, client.externalExecutorProvider().getExecutor(), -1,
                     consumerFuture, SubscriptionMode.Durable, MessageId.earliest, Schema.IDENTITY);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -1399,7 +1399,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
 
         // create consumer and subscription
         Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName("my-sub")
-                .subscriptionType(SubscriptionType.Exclusive).subscribe();
+                .subscriptionType(SubscriptionType.Exclusive).acknowledmentGroupTime(0, TimeUnit.SECONDS).subscribe();
 
         assertEquals(admin.persistentTopics().getSubscriptions(topicName), Lists.newArrayList("my-sub"));
 
@@ -1450,7 +1450,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
 
         // create consumer and subscription
         Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName("my-sub")
-                .subscriptionType(SubscriptionType.Exclusive).subscribe();
+                .subscriptionType(SubscriptionType.Exclusive).acknowledmentGroupTime(0, TimeUnit.SECONDS).subscribe();
 
         assertEquals(admin.persistentTopics().getSubscriptions(topicName), Lists.newArrayList("my-sub"));
 
@@ -1521,7 +1521,7 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
 
         // create consumer and subscription
         Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName("my-sub")
-                .subscriptionType(SubscriptionType.Exclusive).subscribe();
+                .subscriptionType(SubscriptionType.Exclusive).acknowledmentGroupTime(0, TimeUnit.SECONDS).subscribe();
 
         List<String> topics = admin.persistentTopics().getList("prop-xyz/use/ns1");
         assertEquals(topics.size(), 4);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -140,7 +140,8 @@ public class BrokerServiceTest extends BrokerTestBase {
         PersistentTopicStats stats;
         SubscriptionStats subStats;
 
-        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName).subscribe();
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                .acknowledmentGroupTime(0, TimeUnit.SECONDS).subscribe();
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);
@@ -217,7 +218,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         SubscriptionStats subStats;
 
         Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
-                .subscriptionType(SubscriptionType.Shared).subscribe();
+                .subscriptionType(SubscriptionType.Shared).acknowledmentGroupTime(0, TimeUnit.SECONDS).subscribe();
         Thread.sleep(ASYNC_EVENT_COMPLETION_WAIT);
 
         PersistentTopic topicRef = (PersistentTopic) pulsar.getBrokerService().getTopicReference(topicName);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentFailoverE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentFailoverE2ETest.java
@@ -135,12 +135,12 @@ public class PersistentFailoverE2ETest extends BrokerTestBase {
         TestConsumerStateEventListener listener1 = new TestConsumerStateEventListener();
         TestConsumerStateEventListener listener2 = new TestConsumerStateEventListener();
         ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
-                .subscriptionType(SubscriptionType.Failover);
+                .acknowledmentGroupTime(0, TimeUnit.SECONDS).subscriptionType(SubscriptionType.Failover);
 
 
         // 1. two consumers on the same subscription
         ConsumerBuilder<byte[]> consumerBulder1 = consumerBuilder.clone().consumerName("1")
-                .consumerEventListener(listener1);
+                .consumerEventListener(listener1).acknowledmentGroupTime(0, TimeUnit.SECONDS);
         Consumer<byte[]> consumer1 = consumerBulder1.subscribe();
         Consumer<byte[]> consumer2 = consumerBuilder.clone().consumerName("2").consumerEventListener(listener2)
                 .subscribe();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentQueueE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentQueueE2ETest.java
@@ -500,7 +500,8 @@ public class PersistentQueueE2ETest extends BrokerTestBase {
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
 
         ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
-                .receiverQueueSize(10).subscriptionType(SubscriptionType.Shared);
+                .receiverQueueSize(10).subscriptionType(SubscriptionType.Shared)
+                .acknowledmentGroupTime(0, TimeUnit.SECONDS);
         ConsumerImpl<byte[]> consumer1 = (ConsumerImpl<byte[]>) consumerBuilder.subscribe();
 
         for (int i = 0; i < numMsgs; i++) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -1243,8 +1243,8 @@ public class PersistentTopicTest {
                                                                cursorMock);
         PositionImpl position = new PositionImpl(1, 1);
         long ledgerId = 0xc0bfefeL;
-        sub.acknowledgeMessage(position, AckType.Cumulative,
-                               ImmutableMap.of(Compactor.COMPACTED_TOPIC_LEDGER_PROPERTY, ledgerId));
+        sub.acknowledgeMessage(Collections.singletonList(position), AckType.Cumulative,
+                ImmutableMap.of(Compactor.COMPACTED_TOPIC_LEDGER_PROPERTY, ledgerId));
         verify(compactedTopic, Mockito.times(1)).newCompactedLedger(position, ledgerId);
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ResendRequestTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ResendRequestTest.java
@@ -246,7 +246,8 @@ public class ResendRequestTest extends BrokerTestBase {
 
         // 2. Create consumer
         ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer().topic(topicName)
-                .subscriptionName(subscriptionName).receiverQueueSize(10).subscriptionType(SubscriptionType.Failover);
+                .subscriptionName(subscriptionName).receiverQueueSize(10).subscriptionType(SubscriptionType.Failover)
+                .acknowledmentGroupTime(0, TimeUnit.SECONDS);
         Consumer<byte[]> consumer1 = consumerBuilder.clone().consumerName("consumer-1").subscribe();
         Consumer<byte[]> consumer2 = consumerBuilder.clone().consumerName("consumer-2").subscribe();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DispatcherBlockConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/DispatcherBlockConsumerTest.java
@@ -597,7 +597,7 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
         final int totalProducedMsgs = 500;
 
         Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriberName)
-                .subscriptionType(SubscriptionType.Shared).subscribe();
+                .subscriptionType(SubscriptionType.Shared).acknowledmentGroupTime(0, TimeUnit.SECONDS).subscribe();
 
         Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/unacked-topic")
                 .create();
@@ -701,15 +701,15 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
 
             ConsumerImpl<byte[]> consumer1Sub1 = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(topicName)
                     .subscriptionName(subscriberName1).receiverQueueSize(receiverQueueSize)
-                    .subscriptionType(SubscriptionType.Shared).subscribe();
+                    .subscriptionType(SubscriptionType.Shared).acknowledmentGroupTime(0, TimeUnit.SECONDS).subscribe();
             // create subscription-2 and 3
             ConsumerImpl<byte[]> consumer1Sub2 = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(topicName)
                     .subscriptionName(subscriberName2).receiverQueueSize(receiverQueueSize)
-                    .subscriptionType(SubscriptionType.Shared).subscribe();
+                    .subscriptionType(SubscriptionType.Shared).acknowledmentGroupTime(0, TimeUnit.SECONDS).subscribe();
             consumer1Sub2.close();
             ConsumerImpl<byte[]> consumer1Sub3 = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(topicName)
                     .subscriptionName(subscriberName3).receiverQueueSize(receiverQueueSize)
-                    .subscriptionType(SubscriptionType.Shared).subscribe();
+                    .subscriptionType(SubscriptionType.Shared).acknowledmentGroupTime(0, TimeUnit.SECONDS).subscribe();
             consumer1Sub3.close();
 
             Producer<byte[]> producer = pulsarClient.newProducer()
@@ -749,7 +749,7 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
             // (1.b) consumer2 with same sub should not receive any more messages as subscription is blocked
             ConsumerImpl<byte[]> consumer2Sub1 = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(topicName)
                     .subscriptionName(subscriberName1).receiverQueueSize(receiverQueueSize)
-                    .subscriptionType(SubscriptionType.Shared).subscribe();
+                    .subscriptionType(SubscriptionType.Shared).acknowledmentGroupTime(0, TimeUnit.SECONDS).subscribe();
             int consumer2Msgs = 0;
             for (int j = 0; j < totalProducedMsgs; j++) {
                 msg = consumer2Sub1.receive(100, TimeUnit.MILLISECONDS);
@@ -774,7 +774,7 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
              **/
             ConsumerImpl<byte[]> consumerSub2 = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(topicName)
                     .subscriptionName(subscriberName2).receiverQueueSize(receiverQueueSize)
-                    .subscriptionType(SubscriptionType.Shared).subscribe();
+                    .subscriptionType(SubscriptionType.Shared).acknowledmentGroupTime(0, TimeUnit.SECONDS).subscribe();
             Set<MessageId> messages2 = Sets.newHashSet();
             for (int j = 0; j < totalProducedMsgs; j++) {
                 msg = consumerSub2.receive(100, TimeUnit.MILLISECONDS);
@@ -791,7 +791,7 @@ public class DispatcherBlockConsumerTest extends ProducerConsumerBase {
             /** (3) if Subscription3 is acking then it shouldn't be blocked **/
             consumer1Sub3 = (ConsumerImpl<byte[]>) pulsarClient.newConsumer().topic(topicName)
                     .subscriptionName(subscriberName3).receiverQueueSize(receiverQueueSize)
-                    .subscriptionType(SubscriptionType.Shared).subscribe();
+                    .subscriptionType(SubscriptionType.Shared).acknowledmentGroupTime(0, TimeUnit.SECONDS).subscribe();
             int consumedMsgsSub3 = 0;
             for (int j = 0; j < totalProducedMsgs; j++) {
                 msg = consumer1Sub3.receive(100, TimeUnit.MILLISECONDS);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -941,7 +941,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer()
                 .topic("persistent://my-property/use/my-ns/my-topic1").subscriptionName("my-subscriber-name")
-                .receiverQueueSize(1).subscriptionType(SubscriptionType.Shared);
+                .receiverQueueSize(1).subscriptionType(SubscriptionType.Shared)
+                .acknowledmentGroupTime(0, TimeUnit.SECONDS);
         Consumer<byte[]> consumer1 = consumerBuilder.subscribe();
         Consumer<byte[]> consumer2 = consumerBuilder.subscribe();
 
@@ -1125,7 +1126,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             pulsar.getConfiguration().setMaxUnackedMessagesPerConsumer(unAckedMessagesBufferSize);
             Consumer<byte[]> consumer = pulsarClient.newConsumer()
                     .topic("persistent://my-property/use/my-ns/unacked-topic").subscriptionName("subscriber-1")
-                    .receiverQueueSize(receiverQueueSize).subscriptionType(SubscriptionType.Shared).subscribe();
+                    .receiverQueueSize(receiverQueueSize).subscriptionType(SubscriptionType.Shared)
+                    .acknowledmentGroupTime(0, TimeUnit.SECONDS).subscribe();
 
             Producer<byte[]> producer = pulsarClient.newProducer()
                     .topic("persistent://my-property/use/my-ns/unacked-topic").create();
@@ -1289,7 +1291,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
             ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer()
                     .topic("persistent://my-property/use/my-ns/unacked-topic").subscriptionName("subscriber-1")
                     .receiverQueueSize(receiverQueueSize).ackTimeout(1, TimeUnit.SECONDS)
-                    .subscriptionType(SubscriptionType.Shared).subscribe();
+                    .subscriptionType(SubscriptionType.Shared).acknowledmentGroupTime(0, TimeUnit.SECONDS).subscribe();
 
             Producer<byte[]> producer = pulsarClient.newProducer()
                     .topic("persistent://my-property/use/my-ns/unacked-topic").create();
@@ -1861,7 +1863,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer()
                 .topic("persistent://my-property/use/my-ns/my-topic2").subscriptionName("my-subscriber-name")
-                .subscriptionType(SubscriptionType.Shared).receiverQueueSize(queueSize);
+                .subscriptionType(SubscriptionType.Shared).receiverQueueSize(queueSize)
+                .acknowledmentGroupTime(0, TimeUnit.SECONDS);
         Consumer<byte[]> c1 = consumerBuilder.subscribe();
         Consumer<byte[]> c2 = consumerBuilder.subscribe();
         Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/my-topic2")
@@ -1961,7 +1964,8 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         // Only subscribe consumer
         ConsumerImpl<byte[]> consumer = (ConsumerImpl<byte[]>) pulsarClient.newConsumer()
                 .topic("persistent://my-property/use/my-ns/unacked-topic").subscriptionName("subscriber-1")
-                .receiverQueueSize(receiverQueueSize).subscriptionType(SubscriptionType.Failover).subscribe();
+                .receiverQueueSize(receiverQueueSize).subscriptionType(SubscriptionType.Failover)
+                .acknowledmentGroupTime(0, TimeUnit.SECONDS).subscribe();
 
         Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/use/my-ns/unacked-topic")
                 .create();
@@ -2255,8 +2259,9 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         Message<byte[]> msg = null;
         Set<String> messageSet = Sets.newHashSet();
-        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/myenc-ns/myenc-topic1")
-                .subscriptionName("my-subscriber-name").subscribe();
+        Consumer<byte[]> consumer = pulsarClient.newConsumer()
+                .topic("persistent://my-property/use/myenc-ns/myenc-topic1").subscriptionName("my-subscriber-name")
+                .acknowledmentGroupTime(0, TimeUnit.SECONDS).subscribe();
 
         // 1. Invalid key name
         try {
@@ -2286,7 +2291,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         consumer.close();
         consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/myenc-ns/myenc-topic1")
                 .subscriptionName("my-subscriber-name").cryptoFailureAction(ConsumerCryptoFailureAction.CONSUME)
-                .subscribe();
+                .acknowledmentGroupTime(0, TimeUnit.SECONDS).subscribe();
 
         int msgNum = 0;
         try {
@@ -2307,7 +2312,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         // Set keyreader
         consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/myenc-ns/myenc-topic1")
                 .subscriptionName("my-subscriber-name").cryptoFailureAction(ConsumerCryptoFailureAction.FAIL)
-                .cryptoKeyReader(new EncKeyReader()).subscribe();
+                .cryptoKeyReader(new EncKeyReader()).acknowledmentGroupTime(0, TimeUnit.SECONDS).subscribe();
 
         for (int i = msgNum; i < totalMsg - 1; i++) {
             msg = consumer.receive(5, TimeUnit.SECONDS);
@@ -2324,7 +2329,7 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         consumer.close();
         consumer = pulsarClient.newConsumer().topic("persistent://my-property/use/myenc-ns/myenc-topic1")
                 .subscriptionName("my-subscriber-name").cryptoFailureAction(ConsumerCryptoFailureAction.DISCARD)
-                .subscribe();
+                .acknowledmentGroupTime(0, TimeUnit.SECONDS).subscribe();
 
         // Receive should proceed and discard encrypted messages
         msg = consumer.receive(5, TimeUnit.SECONDS);
@@ -2350,11 +2355,13 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
 
         // 2, create consumer
         Consumer<byte[]> defaultConsumer = pulsarClient.newConsumer().topic(topicName)
-            .subscriptionName("test-subscription-default").subscribe();
+                .acknowledmentGroupTime(0, TimeUnit.SECONDS).subscriptionName("test-subscription-default").subscribe();
         Consumer<byte[]> latestConsumer = pulsarClient.newConsumer().topic(topicName)
-            .subscriptionName("test-subscription-latest").subscriptionInitialPosition(SubscriptionInitialPosition.Latest).subscribe();
+                .acknowledmentGroupTime(0, TimeUnit.SECONDS).subscriptionName("test-subscription-latest")
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Latest).subscribe();
         Consumer<byte[]> earliestConsumer = pulsarClient.newConsumer().topic(topicName)
-            .subscriptionName("test-subscription-earliest").subscriptionInitialPosition(SubscriptionInitialPosition.Earliest).subscribe();
+                .acknowledmentGroupTime(0, TimeUnit.SECONDS).subscriptionName("test-subscription-earliest")
+                .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest).subscribe();
 
         // 3, produce 5 messages more
         for (int i = 5; i < 10; i++) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/stats/client/PulsarBrokerStatsClientTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/stats/client/PulsarBrokerStatsClientTest.java
@@ -105,7 +105,7 @@ public class PulsarBrokerStatsClientTest extends ProducerConsumerBase {
         final String topicName = "persistent://my-property/use/my-ns/my-topic1";
         final String subscriptionName = "my-subscriber-name";
         Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subscriptionName)
-                .subscribe();
+                .acknowledmentGroupTime(0, TimeUnit.SECONDS).subscribe();
         Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).create();
         final int numberOfMsgs = 1000;
         for (int i = 0; i < numberOfMsgs; i++) {

--- a/pulsar-client-cpp/lib/Commands.cc
+++ b/pulsar-client-cpp/lib/Commands.cc
@@ -245,7 +245,7 @@ SharedBuffer Commands::newAck(uint64_t consumerId, const MessageIdData& messageI
     if (CommandAck_AckType_IsValid(validationError)) {
         ack->set_validation_error((CommandAck_ValidationError)validationError);
     }
-    *(ack->mutable_message_id()) = messageId;
+    *(ack->add_message_id()) = messageId;
     return writeMessageWithSize(cmd);
 }
 

--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/consumer/PulsarKafkaConsumer.java
@@ -539,6 +539,7 @@ public class PulsarKafkaConsumer<K, V> implements Consumer<K, V>, MessageListene
             if (isAutoCommit) {
                 commitAsync();
             }
+
             client.closeAsync().get(timeout, unit);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             throw new RuntimeException(e);

--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/pulsar/client/kafka/compat/PulsarConsumerKafkaConfig.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/pulsar/client/kafka/compat/PulsarConsumerKafkaConfig.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.client.kafka.compat;
 
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.pulsar.client.api.ConsumerBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
@@ -28,6 +29,7 @@ public class PulsarConsumerKafkaConfig {
     /// Config variables
     public static final String CONSUMER_NAME = "pulsar.consumer.name";
     public static final String RECEIVER_QUEUE_SIZE = "pulsar.consumer.receiver.queue.size";
+    public static final String ACKNOWLEDGEMENTS_GROUP_TIME_MILLIS = "pulsar.consumer.acknowledgments.group.time.millis";
     public static final String TOTAL_RECEIVER_QUEUE_SIZE_ACROSS_PARTITIONS = "pulsar.consumer.total.receiver.queue.size.across.partitions";
 
     public static ConsumerBuilder<byte[]> getConsumerBuilder(PulsarClient client, Properties properties) {
@@ -44,6 +46,11 @@ public class PulsarConsumerKafkaConfig {
         if (properties.containsKey(TOTAL_RECEIVER_QUEUE_SIZE_ACROSS_PARTITIONS)) {
             consumerBuilder.maxTotalReceiverQueueSizeAcrossPartitions(
                     Integer.parseInt(properties.getProperty(TOTAL_RECEIVER_QUEUE_SIZE_ACROSS_PARTITIONS)));
+        }
+
+        if (properties.containsKey(ACKNOWLEDGEMENTS_GROUP_TIME_MILLIS)) {
+            consumerBuilder.acknowledmentGroupTime(
+                    Long.parseLong(properties.getProperty(ACKNOWLEDGEMENTS_GROUP_TIME_MILLIS)), TimeUnit.MILLISECONDS);
         }
 
         return consumerBuilder;

--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/test/java/org/apache/pulsar/client/kafka/compat/tests/KafkaConsumerTest.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/test/java/org/apache/pulsar/client/kafka/compat/tests/KafkaConsumerTest.java
@@ -249,6 +249,7 @@ public class KafkaConsumerTest extends BrokerTestBase {
         props.put("enable.auto.commit", "false");
         props.put("key.deserializer", StringDeserializer.class.getName());
         props.put("value.deserializer", StringDeserializer.class.getName());
+        props.put("pulsar.consumer.acknowledgments.group.time.millis", "0");
 
         Consumer<String, String> consumer = new PulsarKafkaConsumer<>(props);
         consumer.subscribe(Arrays.asList(topic));
@@ -305,6 +306,7 @@ public class KafkaConsumerTest extends BrokerTestBase {
         props.put("enable.auto.commit", "false");
         props.put("key.deserializer", StringDeserializer.class.getName());
         props.put("value.deserializer", StringDeserializer.class.getName());
+        props.put("pulsar.consumer.acknowledgments.group.time.millis", "0");
 
         Consumer<String, String> consumer = new PulsarKafkaConsumer<>(props);
         consumer.subscribe(Arrays.asList(topic));

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -200,6 +200,20 @@ public interface ConsumerBuilder<T> extends Serializable, Cloneable {
     ConsumerBuilder<T> receiverQueueSize(int receiverQueueSize);
 
     /**
+     * Group the consumer acknowledgments for the specified time.
+     * <p>
+     * By default, the consumer will use a 100 ms grouping time to send out the acknowledgments to the broker.
+     * <p>
+     * Setting a group time of 0, will send out the acknowledgments immediately.
+     *
+     * @param delay
+     *            the max amount of time an acknowledgemnt can be delayed
+     * @param unit
+     *            the time unit for the delay
+     */
+    ConsumerBuilder<T> acknowledmentGroupTime(long delay, TimeUnit unit);
+
+    /**
      * Set the max total receiver queue size across partitons.
      * <p>
      * This setting will be used to reduce the receiver queue size for individual partitions

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerConfiguration.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerConfiguration.java
@@ -47,6 +47,12 @@ public class ConsumerConfiguration implements Serializable {
     private final ConsumerConfigurationData<byte[]> conf = new ConsumerConfigurationData<>();
 
     private boolean initializeSubscriptionOnLatest = true;
+
+    public ConsumerConfiguration() {
+        // Disable acknowledgment grouping when using v1 API
+        conf.setAcknowledgementsGroupTimeMicros(0);
+    }
+
     /**
      * @return the configured timeout in milliseconds for unacked messages.
      */
@@ -340,8 +346,8 @@ public class ConsumerConfiguration implements Serializable {
     public ConsumerConfigurationData<byte[]> getConfigurationData() {
         return conf;
     }
-    
-     /** 
+
+     /**
      * @param subscriptionInitialPosition the initial position at which to set
      * set cursor  when subscribing to the topic first time
      * Default is {@value InitialPosition.Latest}
@@ -349,12 +355,12 @@ public class ConsumerConfiguration implements Serializable {
     public ConsumerConfiguration setSubscriptionInitialPosition(SubscriptionInitialPosition subscriptionInitialPosition) {
         conf.setSubscriptionInitialPosition(subscriptionInitialPosition);
         return this;
-    }   
+    }
 
-    /** 
+    /**
      * @return the configured {@link subscriptionInitailPosition} for the consumer
      */
     public SubscriptionInitialPosition getSubscriptionInitialPosition(){
         return conf.getSubscriptionInitialPosition();
-    }   
+    }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AcknowledgmentsGroupingTracker.java
@@ -1,0 +1,211 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.EventLoopGroup;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
+import org.apache.pulsar.common.api.Commands;
+import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType;
+import org.apache.pulsar.common.util.collections.Pair;
+
+/**
+ * Group the acknowledgments for a certain time and then sends them out in a single protobuf command.
+ */
+@Slf4j
+public class AcknowledgmentsGroupingTracker implements Closeable {
+
+    /**
+     * When reaching the max group size, an ack command is sent out immediately
+     */
+    private static final int MAX_ACK_GROUP_SIZE = 1000;
+
+    private final ConsumerImpl<?> consumer;
+
+    private final long acknowledgementGroupTimeMicros;
+
+    /**
+     * Latest cumulative ack sent to broker
+     */
+    private volatile MessageIdImpl lastCumulativeAck = (MessageIdImpl) MessageId.earliest;
+
+    private static final AtomicReferenceFieldUpdater<AcknowledgmentsGroupingTracker, MessageIdImpl> LAST_CUMULATIVE_ACK_UPDATER = AtomicReferenceFieldUpdater
+            .newUpdater(AcknowledgmentsGroupingTracker.class, MessageIdImpl.class, "lastCumulativeAck");
+
+    /**
+     * This is a set of all the individual acks that the application has issued and that were not already sent to
+     * broker.
+     */
+    private final ConcurrentSkipListSet<MessageIdImpl> pendingIndividualAcks;
+
+    private final ScheduledFuture<?> scheduledTask;
+
+    public AcknowledgmentsGroupingTracker(ConsumerImpl<?> consumer, ConsumerConfigurationData<?> conf,
+            EventLoopGroup eventLoopGroup) {
+        this.consumer = consumer;
+        this.pendingIndividualAcks = new ConcurrentSkipListSet<>();
+        this.acknowledgementGroupTimeMicros = conf.getAcknowledgementsGroupTimeMicros();
+
+        if (acknowledgementGroupTimeMicros > 0) {
+            scheduledTask = eventLoopGroup.next().scheduleWithFixedDelay(this::flush, acknowledgementGroupTimeMicros,
+                    acknowledgementGroupTimeMicros, TimeUnit.MICROSECONDS);
+        } else {
+            scheduledTask = null;
+        }
+    }
+
+    /**
+     * Since the ack are delayed, we need to do some best-effort duplicate check to discard messages that are being
+     * resent after a disconnection and for which the user has already sent an acknowlowdgement.
+     */
+    public boolean isDuplicate(MessageId messageId) {
+        if (messageId.compareTo(lastCumulativeAck) <= 0) {
+            // Already included in a cumulative ack
+            return true;
+        } else {
+            return pendingIndividualAcks.contains(messageId);
+        }
+    }
+
+    public void addAcknowledgment(MessageIdImpl msgId, AckType ackType, Map<String, Long> properties) {
+        if (acknowledgementGroupTimeMicros == 0 || !properties.isEmpty()) {
+            // We cannot group acks if the delay is 0 or when there are properties attached to it. Fortunately that's an
+            // uncommon condition since it's only used for the compaction subscription.
+            doImmediateAck(msgId, ackType, properties);
+        } else if (ackType == AckType.Cumulative) {
+            doCumulativeAck(msgId);
+        } else {
+            // Individual ack
+            pendingIndividualAcks.add(msgId);
+            if (pendingIndividualAcks.size() >= MAX_ACK_GROUP_SIZE) {
+                flush();
+            }
+        }
+    }
+
+    private void doCumulativeAck(MessageIdImpl msgId) {
+        // Handle concurrent updates from different threads
+        while (true) {
+            MessageIdImpl lastCumlativeAck = this.lastCumulativeAck;
+            if (msgId.compareTo(lastCumlativeAck) > 0) {
+                if (LAST_CUMULATIVE_ACK_UPDATER.compareAndSet(this, lastCumlativeAck, msgId)) {
+                    // Successfully updated the last cumlative ack. Next flush iteration will send this to broker.
+                    return;
+                }
+            } else {
+                // message id acknowledging an before the current last cumulative ack
+                return;
+            }
+        }
+    }
+
+    private boolean doImmediateAck(MessageIdImpl msgId, AckType ackType, Map<String, Long> properties) {
+        ClientCnx cnx = consumer.getClientCnx();
+
+        if (cnx == null) {
+            return false;
+        }
+
+        final ByteBuf cmd = Commands.newAck(consumer.consumerId, msgId.getLedgerId(), msgId.getEntryId(), ackType, null,
+                properties);
+
+        cnx.ctx().writeAndFlush(cmd, cnx.ctx().voidPromise());
+        return true;
+    }
+
+    /**
+     * Flush all the pending acks and send them to the broker
+     */
+    public void flush() {
+        if (log.isDebugEnabled()) {
+            log.debug("[{}] Flushing pending acks to broker: last-cumulative-ack: {} -- individual-acks: {}", consumer,
+                    lastCumulativeAck, pendingIndividualAcks);
+        }
+
+        ClientCnx cnx = consumer.getClientCnx();
+
+        if (cnx == null) {
+            if (log.isDebugEnabled()) {
+                log.debug("[{}] Cannot flush pending acks since we're not connected to broker", consumer);
+            }
+            return;
+        }
+
+        if (!lastCumulativeAck.equals(MessageId.earliest)) {
+            ByteBuf cmd = Commands.newAck(consumer.consumerId, lastCumulativeAck.ledgerId, lastCumulativeAck.entryId,
+                    AckType.Cumulative, null, Collections.emptyMap());
+            cnx.ctx().write(cmd, cnx.ctx().voidPromise());
+        }
+
+        // Flush all individual acks
+        if (!pendingIndividualAcks.isEmpty()) {
+            if (Commands.peerSupportsMultiMessageAcknowledgment(cnx.getRemoteEndpointProtocolVersion())) {
+                // We can send 1 single protobuf command with all individual acks
+                List<Pair<Long, Long>> entriesToAck = new ArrayList<>(pendingIndividualAcks.size());
+                while (true) {
+                    MessageIdImpl msgId = pendingIndividualAcks.pollFirst();
+                    if (msgId == null) {
+                        break;
+                    }
+
+                    entriesToAck.add(Pair.of(msgId.getLedgerId(), msgId.getEntryId()));
+                }
+
+                cnx.ctx().write(Commands.newMultiMessageAck(consumer.consumerId, entriesToAck),
+                        cnx.ctx().voidPromise());
+            } else {
+                // When talking to older brokers, send the acknowledgments individually
+                while (true) {
+                    MessageIdImpl msgId = pendingIndividualAcks.pollFirst();
+                    if (msgId == null) {
+                        break;
+                    }
+
+                    cnx.ctx().write(Commands.newAck(consumer.consumerId, msgId.getLedgerId(), msgId.getEntryId(),
+                            AckType.Individual, null, Collections.emptyMap()), cnx.ctx().voidPromise());
+                }
+            }
+        }
+
+        cnx.ctx().flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+        flush();
+        if (scheduledTask != null) {
+            scheduledTask.cancel(true);
+        }
+    }
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/AcknowledgmentsGroupingTracker.java
@@ -202,7 +202,7 @@ public class AcknowledgmentsGroupingTracker implements Closeable {
     }
 
     @Override
-    public void close() throws IOException {
+    public void close() {
         flush();
         if (scheduledTask != null) {
             scheduledTask.cancel(true);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -183,6 +183,13 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
     }
 
     @Override
+    public ConsumerBuilder<T> acknowledmentGroupTime(long delay, TimeUnit unit) {
+        checkArgument(delay >= 0);
+        conf.setAcknowledgementsGroupTimeMicros(unit.toMicros(delay));
+        return this;
+    }
+
+    @Override
     public ConsumerBuilder<T> consumerName(String consumerName) {
         conf.setConsumerName(consumerName);
         return this;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -605,6 +605,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
 
         setState(State.Closing);
 
+        acknowledgmentsGroupingTracker.close();
+
         long requestId = client.newRequestId();
         ByteBuf cmd = Commands.newCloseConsumer(consumerId, requestId);
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -25,6 +25,11 @@ import static java.lang.String.format;
 import static org.apache.pulsar.common.api.Commands.hasChecksum;
 import static org.apache.pulsar.common.api.Commands.readChecksum;
 
+import com.google.common.collect.Iterables;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.Timeout;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -51,8 +56,8 @@ import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
-import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
 import org.apache.pulsar.common.api.Commands;
 import org.apache.pulsar.common.api.PulsarDecoder;
@@ -70,17 +75,10 @@ import org.apache.pulsar.common.util.FutureUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.Iterables;
-
-import io.netty.buffer.ByteBuf;
-import io.netty.util.Timeout;
-import io.netty.util.concurrent.Future;
-import io.netty.util.concurrent.GenericFutureListener;
-
 public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandler.Connection {
     private static final int MAX_REDELIVER_UNACKNOWLEDGED = 1000;
 
-    private final long consumerId;
+    final long consumerId;
 
     // Number of messages that have delivered to the application. Every once in a while, this number will be sent to the
     // broker to notify that we are ready to get (and store in the incoming messages queue) more messages
@@ -106,6 +104,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
     private final ReadWriteLock zeroQueueLock;
 
     private final UnAckedMessageTracker unAckedMessageTracker;
+    private final AcknowledgmentsGroupingTracker acknowledgmentsGroupingTracker;
 
     protected final ConsumerStatsRecorder stats;
     private final int priorityLevel;
@@ -152,6 +151,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         this.priorityLevel = conf.getPriorityLevel();
         this.readCompacted = conf.isReadCompacted();
         this.subscriptionInitialPosition = conf.getSubscriptionInitialPosition();
+        this.acknowledgmentsGroupingTracker = new AcknowledgmentsGroupingTracker(this, conf, client.eventLoopGroup());
 
         if (client.getConfiguration().getStatsIntervalSeconds() > 0) {
             stats = new ConsumerStatsRecorderImpl(client, conf, this);
@@ -415,43 +415,23 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
     private CompletableFuture<Void> sendAcknowledge(MessageId messageId, AckType ackType,
                                                     Map<String,Long> properties) {
         MessageIdImpl msgId = (MessageIdImpl) messageId;
-        final ByteBuf cmd = Commands.newAck(consumerId, msgId.getLedgerId(), msgId.getEntryId(),
-                                            ackType, null, properties);
 
-        // There's no actual response from ack messages
-        final CompletableFuture<Void> ackFuture = new CompletableFuture<Void>();
 
-        if (isConnected()) {
-            cnx().ctx().writeAndFlush(cmd).addListener(new GenericFutureListener<Future<Void>>() {
-                @Override
-                public void operationComplete(Future<Void> future) throws Exception {
-                    if (future.isSuccess()) {
-                        if (ackType == AckType.Individual) {
-                            unAckedMessageTracker.remove(msgId);
-                            // increment counter by 1 for non-batch msg
-                            if (!(messageId instanceof BatchMessageIdImpl)) {
-                                stats.incrementNumAcksSent(1);
-                            }
-                        } else if (ackType == AckType.Cumulative) {
-                            stats.incrementNumAcksSent(unAckedMessageTracker.removeMessagesTill(msgId));
-                        }
-                        if (log.isDebugEnabled()) {
-                            log.debug("[{}] [{}] [{}] Successfully acknowledged message - {}, acktype {}", subscription,
-                                    topic, consumerName, messageId, ackType);
-                        }
-                        ackFuture.complete(null);
-                    } else {
-                        stats.incrementNumAcksFailed();
-                        ackFuture.completeExceptionally(new PulsarClientException(future.cause()));
-                    }
-                }
-            });
-        } else {
-            stats.incrementNumAcksFailed();
-            ackFuture.completeExceptionally(new PulsarClientException("Not connected to broker. State: " + getState()));
+        if (ackType == AckType.Individual) {
+            unAckedMessageTracker.remove(msgId);
+            // increment counter by 1 for non-batch msg
+            if (!(messageId instanceof BatchMessageIdImpl)) {
+                stats.incrementNumAcksSent(1);
+            }
+        } else if (ackType == AckType.Cumulative) {
+            stats.incrementNumAcksSent(unAckedMessageTracker.removeMessagesTill(msgId));
         }
 
-        return ackFuture;
+        acknowledgmentsGroupingTracker.addAcknowledgment(msgId, ackType, properties);
+
+        // Consumer acknowledgment operation immediately succeeds. In any case, if we're not able to send ack to broker,
+        // the messages will be re-delivered
+        return CompletableFuture.completedFuture(null);
     }
 
     @Override
@@ -688,6 +668,15 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                     messageId.getEntryId());
         }
 
+        MessageIdImpl msgId = new MessageIdImpl(messageId.getLedgerId(), messageId.getEntryId(), getPartitionIndex());
+        if (acknowledgmentsGroupingTracker.isDuplicate(msgId)) {
+            if (log.isDebugEnabled()) {
+                log.debug("[{}][{}] Ignoring message as it was already being acked earlier by same consumer {}/{}",
+                        topic, subscription, msgId);
+            }
+            return;
+        }
+
         MessageMetadata msgMetadata = null;
         ByteBuf payload = headersAndPayload;
 
@@ -719,8 +708,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         final int numMessages = msgMetadata.getNumMessagesInBatch();
 
         if (numMessages == 1 && !msgMetadata.hasNumMessagesInBatch()) {
-            final MessageImpl<T> message = new MessageImpl<>(messageId, msgMetadata, uncompressedPayload,
-                    getPartitionIndex(), cnx, schema);
+            final MessageImpl<T> message = new MessageImpl<>(msgId, msgMetadata, uncompressedPayload, cnx, schema);
             uncompressedPayload.release();
             msgMetadata.recycle();
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -34,7 +34,6 @@ import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.api.Commands;
 import org.apache.pulsar.common.api.proto.PulsarApi;
 import org.apache.pulsar.common.api.proto.PulsarApi.KeyValue;
-import org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
 
 import com.google.common.collect.Maps;
@@ -80,10 +79,10 @@ public class MessageImpl<T> implements Message<T> {
     }
 
     // Constructor for incoming message
-    MessageImpl(MessageIdData messageId, MessageMetadata msgMetadata, ByteBuf payload, int partitionIndex,
-                ClientCnx cnx, Schema<T> schema) {
+    MessageImpl(MessageIdImpl messageId, MessageMetadata msgMetadata, ByteBuf payload, ClientCnx cnx,
+            Schema<T> schema) {
         this.msgMetadataBuilder = MessageMetadata.newBuilder(msgMetadata);
-        this.messageId = new MessageIdImpl(messageId.getLedgerId(), messageId.getEntryId(), partitionIndex);
+        this.messageId = messageId;
         this.cnx = cnx;
 
         // Need to make a copy since the passed payload is using a ref-count buffer that we don't know when could

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedConsumerImpl.java
@@ -424,6 +424,10 @@ public class PartitionedConsumerImpl<T> extends ConsumerBase<T> {
         internalConsumerConfig.setSubscriptionName(conf.getSubscriptionName());
         internalConsumerConfig.setSubscriptionType(conf.getSubscriptionType());
         internalConsumerConfig.setConsumerName(consumerName);
+        internalConsumerConfig.setAcknowledgementsGroupTimeMicros(conf.getAcknowledgementsGroupTimeMicros());
+        internalConsumerConfig.setPriorityLevel(conf.getPriorityLevel());
+        internalConsumerConfig.setProperties(conf.getProperties());
+        internalConsumerConfig.setReadCompacted(conf.isReadCompacted());
         if (null != conf.getConsumerEventListener()) {
             internalConsumerConfig.setConsumerEventListener(conf.getConsumerEventListener());
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConsumerConfigurationData.java
@@ -27,6 +27,8 @@ import java.io.Serializable;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+
 import lombok.Data;
 
 import java.util.regex.Pattern;
@@ -56,6 +58,8 @@ public class ConsumerConfigurationData<T> implements Serializable, Cloneable {
     private ConsumerEventListener consumerEventListener;
 
     private int receiverQueueSize = 1000;
+
+    private long acknowledgementsGroupTimeMicros = TimeUnit.MILLISECONDS.toMicros(100);
 
     private int maxTotalReceiverQueueSizeAcrossPartitions = 50000;
 

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AcknowledgementsGroupingTrackerTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/AcknowledgementsGroupingTrackerTest.java
@@ -1,0 +1,204 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
+import org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType;
+import org.apache.pulsar.common.api.proto.PulsarApi.ProtocolVersion;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class AcknowledgementsGroupingTrackerTest {
+
+    private ClientCnx cnx;
+    private ConsumerImpl<?> consumer;
+    private EventLoopGroup eventLoopGroup;
+
+    @BeforeClass
+    public void setup() {
+        eventLoopGroup = new NioEventLoopGroup(1);
+        consumer = mock(ConsumerImpl.class);
+        cnx = mock(ClientCnx.class);
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        when(cnx.ctx()).thenReturn(ctx);
+    }
+
+    @AfterClass
+    public void teardown() {
+        eventLoopGroup.shutdownGracefully();
+    }
+
+    @Test
+    public void testAckTracker() throws Exception {
+        ConsumerConfigurationData<?> conf = new ConsumerConfigurationData<>();
+        conf.setAcknowledgementsGroupTimeMicros(TimeUnit.SECONDS.toMicros(10));
+        AcknowledgmentsGroupingTracker tracker = new AcknowledgmentsGroupingTracker(consumer, conf, eventLoopGroup);
+
+        MessageIdImpl msg1 = new MessageIdImpl(5, 1, 0);
+        MessageIdImpl msg2 = new MessageIdImpl(5, 2, 0);
+        MessageIdImpl msg3 = new MessageIdImpl(5, 3, 0);
+        MessageIdImpl msg4 = new MessageIdImpl(5, 4, 0);
+        MessageIdImpl msg5 = new MessageIdImpl(5, 5, 0);
+        MessageIdImpl msg6 = new MessageIdImpl(5, 6, 0);
+
+        assertFalse(tracker.isDuplicate(msg1));
+
+        tracker.addAcknowledgment(msg1, AckType.Individual, Collections.emptyMap());
+        assertTrue(tracker.isDuplicate(msg1));
+
+        assertFalse(tracker.isDuplicate(msg2));
+
+        tracker.addAcknowledgment(msg5, AckType.Cumulative, Collections.emptyMap());
+        assertTrue(tracker.isDuplicate(msg1));
+        assertTrue(tracker.isDuplicate(msg2));
+        assertTrue(tracker.isDuplicate(msg3));
+
+        assertTrue(tracker.isDuplicate(msg4));
+        assertTrue(tracker.isDuplicate(msg5));
+        assertFalse(tracker.isDuplicate(msg6));
+
+        // Flush while disconnected. the internal tracking will not change
+        tracker.flush();
+
+        assertTrue(tracker.isDuplicate(msg1));
+        assertTrue(tracker.isDuplicate(msg2));
+        assertTrue(tracker.isDuplicate(msg3));
+
+        assertTrue(tracker.isDuplicate(msg4));
+        assertTrue(tracker.isDuplicate(msg5));
+        assertFalse(tracker.isDuplicate(msg6));
+
+        tracker.addAcknowledgment(msg6, AckType.Individual, Collections.emptyMap());
+        assertTrue(tracker.isDuplicate(msg6));
+
+        when(consumer.getClientCnx()).thenReturn(cnx);
+
+        tracker.flush();
+
+        assertTrue(tracker.isDuplicate(msg1));
+        assertTrue(tracker.isDuplicate(msg2));
+        assertTrue(tracker.isDuplicate(msg3));
+
+        assertTrue(tracker.isDuplicate(msg4));
+        assertTrue(tracker.isDuplicate(msg5));
+        assertFalse(tracker.isDuplicate(msg6));
+
+        tracker.close();
+    }
+
+    @Test
+    public void testImmediateAckingTracker() throws Exception {
+        ConsumerConfigurationData<?> conf = new ConsumerConfigurationData<>();
+        conf.setAcknowledgementsGroupTimeMicros(0);
+        AcknowledgmentsGroupingTracker tracker = new AcknowledgmentsGroupingTracker(consumer, conf, eventLoopGroup);
+
+        MessageIdImpl msg1 = new MessageIdImpl(5, 1, 0);
+        MessageIdImpl msg2 = new MessageIdImpl(5, 2, 0);
+
+        assertFalse(tracker.isDuplicate(msg1));
+
+        when(consumer.getClientCnx()).thenReturn(null);
+
+        tracker.addAcknowledgment(msg1, AckType.Individual, Collections.emptyMap());
+        assertFalse(tracker.isDuplicate(msg1));
+
+        when(consumer.getClientCnx()).thenReturn(cnx);
+
+        tracker.flush();
+        assertFalse(tracker.isDuplicate(msg1));
+
+        tracker.addAcknowledgment(msg2, AckType.Individual, Collections.emptyMap());
+        // Since we were connected, the ack went out immediately
+        assertFalse(tracker.isDuplicate(msg2));
+        tracker.close();
+    }
+
+    @Test
+    public void testAckTrackerMultiAck() throws Exception {
+        ConsumerConfigurationData<?> conf = new ConsumerConfigurationData<>();
+        conf.setAcknowledgementsGroupTimeMicros(TimeUnit.SECONDS.toMicros(10));
+        AcknowledgmentsGroupingTracker tracker = new AcknowledgmentsGroupingTracker(consumer, conf, eventLoopGroup);
+
+        when(cnx.getRemoteEndpointProtocolVersion()).thenReturn(ProtocolVersion.v12_VALUE);
+
+        MessageIdImpl msg1 = new MessageIdImpl(5, 1, 0);
+        MessageIdImpl msg2 = new MessageIdImpl(5, 2, 0);
+        MessageIdImpl msg3 = new MessageIdImpl(5, 3, 0);
+        MessageIdImpl msg4 = new MessageIdImpl(5, 4, 0);
+        MessageIdImpl msg5 = new MessageIdImpl(5, 5, 0);
+        MessageIdImpl msg6 = new MessageIdImpl(5, 6, 0);
+
+        assertFalse(tracker.isDuplicate(msg1));
+
+        tracker.addAcknowledgment(msg1, AckType.Individual, Collections.emptyMap());
+        assertTrue(tracker.isDuplicate(msg1));
+
+        assertFalse(tracker.isDuplicate(msg2));
+
+        tracker.addAcknowledgment(msg5, AckType.Cumulative, Collections.emptyMap());
+        assertTrue(tracker.isDuplicate(msg1));
+        assertTrue(tracker.isDuplicate(msg2));
+        assertTrue(tracker.isDuplicate(msg3));
+
+        assertTrue(tracker.isDuplicate(msg4));
+        assertTrue(tracker.isDuplicate(msg5));
+        assertFalse(tracker.isDuplicate(msg6));
+
+        // Flush while disconnected. the internal tracking will not change
+        tracker.flush();
+
+        assertTrue(tracker.isDuplicate(msg1));
+        assertTrue(tracker.isDuplicate(msg2));
+        assertTrue(tracker.isDuplicate(msg3));
+
+        assertTrue(tracker.isDuplicate(msg4));
+        assertTrue(tracker.isDuplicate(msg5));
+        assertFalse(tracker.isDuplicate(msg6));
+
+        tracker.addAcknowledgment(msg6, AckType.Individual, Collections.emptyMap());
+        assertTrue(tracker.isDuplicate(msg6));
+
+        when(consumer.getClientCnx()).thenReturn(cnx);
+
+        tracker.flush();
+
+        assertTrue(tracker.isDuplicate(msg1));
+        assertTrue(tracker.isDuplicate(msg2));
+        assertTrue(tracker.isDuplicate(msg3));
+
+        assertTrue(tracker.isDuplicate(msg4));
+        assertTrue(tracker.isDuplicate(msg5));
+        assertFalse(tracker.isDuplicate(msg6));
+
+        tracker.close();
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/Commands.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/Commands.java
@@ -75,6 +75,7 @@ import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
 import org.apache.pulsar.common.api.proto.PulsarApi.ProtocolVersion;
 import org.apache.pulsar.common.api.proto.PulsarApi.ServerError;
 import org.apache.pulsar.common.schema.SchemaVersion;
+import org.apache.pulsar.common.util.collections.Pair;
 import org.apache.pulsar.common.util.protobuf.ByteBufCodedInputStream;
 import org.apache.pulsar.common.util.protobuf.ByteBufCodedOutputStream;
 
@@ -519,6 +520,37 @@ public class Commands {
         return res;
     }
 
+    public static ByteBuf newMultiMessageAck(long consumerId, List<Pair<Long, Long>> entries) {
+        CommandAck.Builder ackBuilder = CommandAck.newBuilder();
+        ackBuilder.setConsumerId(consumerId);
+        ackBuilder.setAckType(AckType.Individual);
+
+        int entriesCount = entries.size();
+        for (int i = 0; i < entriesCount; i++) {
+            long ledgerId = entries.get(i).getFirst();
+            long entryId = entries.get(i).getSecond();
+
+            MessageIdData.Builder messageIdDataBuilder = MessageIdData.newBuilder();
+            messageIdDataBuilder.setLedgerId(ledgerId);
+            messageIdDataBuilder.setEntryId(entryId);
+            MessageIdData messageIdData = messageIdDataBuilder.build();
+            ackBuilder.addMessageId(messageIdData);
+
+            messageIdDataBuilder.recycle();
+        }
+
+        CommandAck ack = ackBuilder.build();
+
+        ByteBuf res = serializeWithSize(BaseCommand.newBuilder().setType(Type.ACK).setAck(ack));
+
+        for (int i = 0; i < entriesCount; i++) {
+            ack.getMessageId(i).recycle();
+        }
+        ack.recycle();
+        ackBuilder.recycle();
+        return res;
+    }
+
     public static ByteBuf newAck(long consumerId, long ledgerId, long entryId, AckType ackType,
                                  ValidationError validationError, Map<String,Long> properties) {
         CommandAck.Builder ackBuilder = CommandAck.newBuilder();
@@ -528,7 +560,7 @@ public class Commands {
         messageIdDataBuilder.setLedgerId(ledgerId);
         messageIdDataBuilder.setEntryId(entryId);
         MessageIdData messageIdData = messageIdDataBuilder.build();
-        ackBuilder.setMessageId(messageIdData);
+        ackBuilder.addMessageId(messageIdData);
         if (validationError != null) {
             ackBuilder.setValidationError(validationError);
         }
@@ -998,6 +1030,10 @@ public class Commands {
     }
 
     public static boolean peerSupportsActiveConsumerListener(int peerVersion) {
+        return peerVersion >= ProtocolVersion.v12.getNumber();
+    }
+
+    public static boolean peerSupportsMultiMessageAcknowledgment(int peerVersion) {
         return peerVersion >= ProtocolVersion.v12.getNumber();
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/PulsarDecoder.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/PulsarDecoder.java
@@ -118,9 +118,12 @@ public abstract class PulsarDecoder extends ChannelInboundHandlerAdapter {
 
             case ACK:
                 checkArgument(cmd.hasAck());
-                handleAck(cmd.getAck());
-                cmd.getAck().getMessageId().recycle();
-                cmd.getAck().recycle();
+                CommandAck ack = cmd.getAck();
+                handleAck(ack);
+                for (int i = 0; i < ack.getMessageIdCount(); i++) {
+                    ack.getMessageId(i).recycle();
+                }
+                ack.recycle();
                 break;
 
             case CLOSE_CONSUMER:

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/api/proto/PulsarApi.java
@@ -14014,9 +14014,11 @@ public final class PulsarApi {
     boolean hasAckType();
     org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType getAckType();
     
-    // required .pulsar.proto.MessageIdData message_id = 3;
-    boolean hasMessageId();
-    org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData getMessageId();
+    // repeated .pulsar.proto.MessageIdData message_id = 3;
+    java.util.List<org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData> 
+        getMessageIdList();
+    org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData getMessageId(int index);
+    int getMessageIdCount();
     
     // optional .pulsar.proto.CommandAck.ValidationError validation_error = 4;
     boolean hasValidationError();
@@ -14176,21 +14178,32 @@ public final class PulsarApi {
       return ackType_;
     }
     
-    // required .pulsar.proto.MessageIdData message_id = 3;
+    // repeated .pulsar.proto.MessageIdData message_id = 3;
     public static final int MESSAGE_ID_FIELD_NUMBER = 3;
-    private org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData messageId_;
-    public boolean hasMessageId() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
-    }
-    public org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData getMessageId() {
+    private java.util.List<org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData> messageId_;
+    public java.util.List<org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData> getMessageIdList() {
       return messageId_;
+    }
+    public java.util.List<? extends org.apache.pulsar.common.api.proto.PulsarApi.MessageIdDataOrBuilder> 
+        getMessageIdOrBuilderList() {
+      return messageId_;
+    }
+    public int getMessageIdCount() {
+      return messageId_.size();
+    }
+    public org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData getMessageId(int index) {
+      return messageId_.get(index);
+    }
+    public org.apache.pulsar.common.api.proto.PulsarApi.MessageIdDataOrBuilder getMessageIdOrBuilder(
+        int index) {
+      return messageId_.get(index);
     }
     
     // optional .pulsar.proto.CommandAck.ValidationError validation_error = 4;
     public static final int VALIDATION_ERROR_FIELD_NUMBER = 4;
     private org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.ValidationError validationError_;
     public boolean hasValidationError() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+      return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     public org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.ValidationError getValidationError() {
       return validationError_;
@@ -14220,7 +14233,7 @@ public final class PulsarApi {
     private void initFields() {
       consumerId_ = 0L;
       ackType_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType.Individual;
-      messageId_ = org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.getDefaultInstance();
+      messageId_ = java.util.Collections.emptyList();
       validationError_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.ValidationError.UncompressedSizeCorruption;
       properties_ = java.util.Collections.emptyList();
     }
@@ -14237,13 +14250,11 @@ public final class PulsarApi {
         memoizedIsInitialized = 0;
         return false;
       }
-      if (!hasMessageId()) {
-        memoizedIsInitialized = 0;
-        return false;
-      }
-      if (!getMessageId().isInitialized()) {
-        memoizedIsInitialized = 0;
-        return false;
+      for (int i = 0; i < getMessageIdCount(); i++) {
+        if (!getMessageId(i).isInitialized()) {
+          memoizedIsInitialized = 0;
+          return false;
+        }
       }
       for (int i = 0; i < getPropertiesCount(); i++) {
         if (!getProperties(i).isInitialized()) {
@@ -14269,10 +14280,10 @@ public final class PulsarApi {
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         output.writeEnum(2, ackType_.getNumber());
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        output.writeMessage(3, messageId_);
+      for (int i = 0; i < messageId_.size(); i++) {
+        output.writeMessage(3, messageId_.get(i));
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
         output.writeEnum(4, validationError_.getNumber());
       }
       for (int i = 0; i < properties_.size(); i++) {
@@ -14294,11 +14305,11 @@ public final class PulsarApi {
         size += com.google.protobuf.CodedOutputStream
           .computeEnumSize(2, ackType_.getNumber());
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      for (int i = 0; i < messageId_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
-          .computeMessageSize(3, messageId_);
+          .computeMessageSize(3, messageId_.get(i));
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
         size += com.google.protobuf.CodedOutputStream
           .computeEnumSize(4, validationError_.getNumber());
       }
@@ -14423,7 +14434,7 @@ public final class PulsarApi {
         bitField0_ = (bitField0_ & ~0x00000001);
         ackType_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.AckType.Individual;
         bitField0_ = (bitField0_ & ~0x00000002);
-        messageId_ = org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.getDefaultInstance();
+        messageId_ = java.util.Collections.emptyList();
         bitField0_ = (bitField0_ & ~0x00000004);
         validationError_ = org.apache.pulsar.common.api.proto.PulsarApi.CommandAck.ValidationError.UncompressedSizeCorruption;
         bitField0_ = (bitField0_ & ~0x00000008);
@@ -14470,12 +14481,13 @@ public final class PulsarApi {
           to_bitField0_ |= 0x00000002;
         }
         result.ackType_ = ackType_;
-        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
-          to_bitField0_ |= 0x00000004;
+        if (((bitField0_ & 0x00000004) == 0x00000004)) {
+          messageId_ = java.util.Collections.unmodifiableList(messageId_);
+          bitField0_ = (bitField0_ & ~0x00000004);
         }
         result.messageId_ = messageId_;
         if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
-          to_bitField0_ |= 0x00000008;
+          to_bitField0_ |= 0x00000004;
         }
         result.validationError_ = validationError_;
         if (((bitField0_ & 0x00000010) == 0x00000010)) {
@@ -14495,8 +14507,15 @@ public final class PulsarApi {
         if (other.hasAckType()) {
           setAckType(other.getAckType());
         }
-        if (other.hasMessageId()) {
-          mergeMessageId(other.getMessageId());
+        if (!other.messageId_.isEmpty()) {
+          if (messageId_.isEmpty()) {
+            messageId_ = other.messageId_;
+            bitField0_ = (bitField0_ & ~0x00000004);
+          } else {
+            ensureMessageIdIsMutable();
+            messageId_.addAll(other.messageId_);
+          }
+          
         }
         if (other.hasValidationError()) {
           setValidationError(other.getValidationError());
@@ -14523,13 +14542,11 @@ public final class PulsarApi {
           
           return false;
         }
-        if (!hasMessageId()) {
-          
-          return false;
-        }
-        if (!getMessageId().isInitialized()) {
-          
-          return false;
+        for (int i = 0; i < getMessageIdCount(); i++) {
+          if (!getMessageId(i).isInitialized()) {
+            
+            return false;
+          }
         }
         for (int i = 0; i < getPropertiesCount(); i++) {
           if (!getProperties(i).isInitialized()) {
@@ -14578,12 +14595,8 @@ public final class PulsarApi {
             }
             case 26: {
               org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.Builder subBuilder = org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.newBuilder();
-              if (hasMessageId()) {
-                subBuilder.mergeFrom(getMessageId());
-              }
               input.readMessage(subBuilder, extensionRegistry);
-              setMessageId(subBuilder.buildPartial());
-              subBuilder.recycle();
+              addMessageId(subBuilder.buildPartial());
               break;
             }
             case 32: {
@@ -14652,46 +14665,92 @@ public final class PulsarApi {
         return this;
       }
       
-      // required .pulsar.proto.MessageIdData message_id = 3;
-      private org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData messageId_ = org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.getDefaultInstance();
-      public boolean hasMessageId() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+      // repeated .pulsar.proto.MessageIdData message_id = 3;
+      private java.util.List<org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData> messageId_ =
+        java.util.Collections.emptyList();
+      private void ensureMessageIdIsMutable() {
+        if (!((bitField0_ & 0x00000004) == 0x00000004)) {
+          messageId_ = new java.util.ArrayList<org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData>(messageId_);
+          bitField0_ |= 0x00000004;
+         }
       }
-      public org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData getMessageId() {
-        return messageId_;
+      
+      public java.util.List<org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData> getMessageIdList() {
+        return java.util.Collections.unmodifiableList(messageId_);
       }
-      public Builder setMessageId(org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData value) {
+      public int getMessageIdCount() {
+        return messageId_.size();
+      }
+      public org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData getMessageId(int index) {
+        return messageId_.get(index);
+      }
+      public Builder setMessageId(
+          int index, org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData value) {
         if (value == null) {
           throw new NullPointerException();
         }
-        messageId_ = value;
+        ensureMessageIdIsMutable();
+        messageId_.set(index, value);
         
-        bitField0_ |= 0x00000004;
         return this;
       }
       public Builder setMessageId(
-          org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.Builder builderForValue) {
-        messageId_ = builderForValue.build();
+          int index, org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.Builder builderForValue) {
+        ensureMessageIdIsMutable();
+        messageId_.set(index, builderForValue.build());
         
-        bitField0_ |= 0x00000004;
         return this;
       }
-      public Builder mergeMessageId(org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData value) {
-        if (((bitField0_ & 0x00000004) == 0x00000004) &&
-            messageId_ != org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.getDefaultInstance()) {
-          messageId_ =
-            org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.newBuilder(messageId_).mergeFrom(value).buildPartial();
-        } else {
-          messageId_ = value;
+      public Builder addMessageId(org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData value) {
+        if (value == null) {
+          throw new NullPointerException();
         }
+        ensureMessageIdIsMutable();
+        messageId_.add(value);
         
-        bitField0_ |= 0x00000004;
+        return this;
+      }
+      public Builder addMessageId(
+          int index, org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        ensureMessageIdIsMutable();
+        messageId_.add(index, value);
+        
+        return this;
+      }
+      public Builder addMessageId(
+          org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.Builder builderForValue) {
+        ensureMessageIdIsMutable();
+        messageId_.add(builderForValue.build());
+        
+        return this;
+      }
+      public Builder addMessageId(
+          int index, org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.Builder builderForValue) {
+        ensureMessageIdIsMutable();
+        messageId_.add(index, builderForValue.build());
+        
+        return this;
+      }
+      public Builder addAllMessageId(
+          java.lang.Iterable<? extends org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData> values) {
+        ensureMessageIdIsMutable();
+        super.addAll(values, messageId_);
+        
         return this;
       }
       public Builder clearMessageId() {
-        messageId_ = org.apache.pulsar.common.api.proto.PulsarApi.MessageIdData.getDefaultInstance();
-        
+        messageId_ = java.util.Collections.emptyList();
         bitField0_ = (bitField0_ & ~0x00000004);
+        
+        return this;
+      }
+      public Builder removeMessageId(int index) {
+        ensureMessageIdIsMutable();
+        messageId_.remove(index);
+        
         return this;
       }
       

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/Pair.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/collections/Pair.java
@@ -16,21 +16,22 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.common.schema;
+package org.apache.pulsar.common.util.collections;
 
-import java.util.HashMap;
-import java.util.Map;
-import lombok.Builder;
-import lombok.Data;
+import lombok.Value;
 
-@Builder
-@Data
-public class SchemaData {
-    private final SchemaType type;
-    private final boolean isDeleted;
-    private final long timestamp;
-    private final String user;
-    private final byte[] data;
-    @Builder.Default
-    private Map<String, String> props = new HashMap<>();
+/**
+ * Basic holder of a pair of values.
+ *
+ * Use as: <br/>
+ * <pre><code>
+ * Pair&lt;String, String&gt; p = Pair.of("a", "b");
+ * p.getFirst();
+ * p.getSecond();
+ * </code></pre>
+ */
+@Value(staticConstructor = "of")
+public class Pair<X, Y> {
+    private final X first;
+    private final Y second;
 }

--- a/pulsar-common/src/main/proto/PulsarApi.proto
+++ b/pulsar-common/src/main/proto/PulsarApi.proto
@@ -337,7 +337,9 @@ message CommandAck {
 
 	required uint64 consumer_id       = 1;
 	required AckType ack_type         = 2;
-	required MessageIdData message_id = 3;
+
+	// In case of individual acks, the client can pass a list of message ids
+	repeated MessageIdData message_id = 3;
 
 	// Acks can contain a flag to indicate the consumer
 	// received an invalid message that got discarded
@@ -351,7 +353,7 @@ message CommandAck {
 	}
 
 	optional ValidationError validation_error = 4;
-        repeated KeyLongValue properties = 5;
+	repeated KeyLongValue properties = 5;
 }
 
 // changes on active consumer

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -92,6 +92,9 @@ public class PerformanceConsumer {
         @Parameter(names = { "-q", "--receiver-queue-size" }, description = "Size of the receiver queue")
         public int receiverQueueSize = 1000;
 
+        @Parameter(names = { "--acks-delay-millis" }, description = "Acknowlegments grouping delay in millis")
+        public int acknowledgmentsGroupingDelayMillis = 100;
+
         @Parameter(names = { "-c",
                 "--max-connections" }, description = "Max number of TCP connections to a single broker")
         public int maxConnections = 100;
@@ -249,6 +252,7 @@ public class PerformanceConsumer {
         ConsumerBuilder<byte[]> consumerBuilder = pulsarClient.newConsumer() //
                 .messageListener(listener) //
                 .receiverQueueSize(arguments.receiverQueueSize) //
+                .acknowledmentGroupTime(arguments.acknowledgmentsGroupingDelayMillis, TimeUnit.MILLISECONDS) //
                 .subscriptionType(arguments.subscriptionType);
 
         if (arguments.encKeyName != null) {


### PR DESCRIPTION
### Motivation

This PR is based on top of #1450. I'll rebase once first one is merged.

The processing of acknowledgments constitutes is broker a big chunk of CPU work. Even then, we throttle the persistence of acks to BK (default is once per sec).

In addition to that, acknowledgments generates a large number of very small IP packets and these are most expensive to process by OS/NIC (compared to fewer bigger packets).

This change introduces client side batching for acknowledgments. By default client, will group the acks and send out a single protobuf command every 100ms. Consumer can configure the delay, or set it to 0 to fall back to original behavior.
