### PR TITLE
Used defaults for Netty allocator used in entry cache

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheImpl.java
@@ -69,15 +69,14 @@ public class EntryCacheImpl implements EntryCache {
         return ml.getName();
     }
 
-    public final static PooledByteBufAllocator ALLOCATOR = new PooledByteBufAllocator(
-            true, // preferDirect
+    public final static PooledByteBufAllocator ALLOCATOR = new PooledByteBufAllocator(true, // preferDirect
             0, // nHeapArenas,
-            1, // nDirectArena
-            8192, // pageSize
-            11, // maxOrder
-            64, // tinyCacheSize
-            32, // smallCacheSize
-            8, // normalCacheSize,
+            PooledByteBufAllocator.defaultNumDirectArena(), // nDirectArena
+            PooledByteBufAllocator.defaultPageSize(), // pageSize
+            PooledByteBufAllocator.defaultMaxOrder(), // maxOrder
+            PooledByteBufAllocator.defaultTinyCacheSize(), // tinyCacheSize
+            PooledByteBufAllocator.defaultSmallCacheSize(), // smallCacheSize
+            PooledByteBufAllocator.defaultNormalCacheSize(), // normalCacheSize,
             true // Use cache for all threads
     );
 


### PR DESCRIPTION
### Motivation

The custom setting was a workaround for an older issue. The single direct arena becomes a main contention point between threads.