### PR TITLE
use v1 admin api for anti-affinity cluster endpoint

### DIFF
--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/NamespacesImpl.java
@@ -252,7 +252,7 @@ public class NamespacesImpl extends BaseResource implements Namespaces {
     public List<String> getAntiAffinityNamespaces(String property, String cluster, String namespaceAntiAffinityGroup)
             throws PulsarAdminException {
         try {
-            WebTarget path = adminV2Namespaces.path(cluster).path("antiAffinity").path(namespaceAntiAffinityGroup);
+            WebTarget path = adminNamespaces.path(cluster).path("antiAffinity").path(namespaceAntiAffinityGroup);
             return request(path.queryParam("property", property)).get(new GenericType<List<String>>() {});
         } catch (Exception e) {
             throw getApiException(e);


### PR DESCRIPTION
### Motivation

AdminApi should use v1 end-point for `getAntiAffinityNamespaces-api` as this api uses `clusters` and only present in v1-admin api 

```
FAILED: namespaceAntiAffinity
org.apache.pulsar.client.admin.PulsarAdminException$NotFoundException: HTTP 404 Not Found
	at org.apache.pulsar.client.admin.internal.BaseResource.getApiException(BaseResource.java:173)
	at org.apache.pulsar.client.admin.internal.NamespacesImpl.getAntiAffinityNamespaces(NamespacesImpl.java:258)
	at org.apache.pulsar.broker.admin.AdminApiTest2.namespaceAntiAffinity(AdminApiTest2.java:691)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
```

