### PR TITLE
Ruby version reset to address website build errors

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -43,12 +43,12 @@ ENV JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
 
 ## Website build dependencies
 
-# Install Ruby-2.3.1
+# Install Ruby-2.4.1
 RUN apt-get install -y
 RUN gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB && \
     (curl -sSL https://get.rvm.io | bash -s stable)
 ENV PATH "$PATH:/usr/local/rvm/bin"
-RUN rvm install 2.3.1
+RUN rvm install 2.4.1
 
 # Install PIP and PDoc
 RUN wget https://bootstrap.pypa.io/get-pip.py && python get-pip.py

--- a/site/Gemfile
+++ b/site/Gemfile
@@ -18,6 +18,6 @@
 #
 
 source 'https://rubygems.org'
-ruby '2.3.1'
+ruby '2.4.1'
 
 gem 'jekyll', '3.7.3'

--- a/site/Gemfile.lock
+++ b/site/Gemfile.lock
@@ -60,7 +60,7 @@ DEPENDENCIES
   jekyll (= 3.7.3)
 
 RUBY VERSION
-   ruby 2.3.1p112
+   ruby 2.4.1p111
 
 BUNDLED WITH
    1.16.1

--- a/site/README.md
+++ b/site/README.md
@@ -39,7 +39,7 @@ This website is built using a wide range of tools. The most important among them
 
 > **Note**: at the moment, running the site locally *may* work on Linux but the site setup has been built with MacOS in mind. We will provide better cross-platform support in the near future.
 
-To build and run the site locally, you need to have Ruby 2.3.1 installed and set as the Ruby version here in the `site` directory. You can install and set the Ruby version using [rvm](https://rvm.io):
+To build and run the site locally, you need to have Ruby 2.4.1 installed and set as the Ruby version here in the `site` directory. You can install and set the Ruby version using [rvm](https://rvm.io):
 
 ```bash
 $ cd site


### PR DESCRIPTION
We recently downgraded the Ruby version to 2.3.1 (from 2.4.1). Ever since then, the Pulsar website has been failing to build due to inscrutable errors (pointed out in issue #1412). If my knowledge of Ruby were better I'd address the new issues that have arisen, but they're a bit beyond my ken. In this case, it's probably better to just go back to the original version and get the build fixed.