### PR TITLE
GC improvement: Reduce string objects from Publisher and Consumer stats

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -130,10 +130,10 @@ public class Consumer {
         this.metadata = metadata != null ? metadata : Collections.emptyMap();
 
         stats = new ConsumerStats();
-        stats.address = cnx.clientAddress().toString();
+        stats.setAddress(cnx.clientAddress().toString());
         stats.consumerName = consumerName;
-        stats.connectedSince = DateFormatter.now();
-        stats.clientVersion = cnx.getClientVersion();
+        stats.setConnectedSince(DateFormatter.now());
+        stats.setClientVersion(cnx.getClientVersion());
         stats.metadata = this.metadata;
 
         if (subType == SubType.Shared) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Producer.java
@@ -98,10 +98,10 @@ public class Producer {
         this.metadata = metadata != null ? metadata : Collections.emptyMap();
 
         this.stats = isNonPersistentTopic ? new NonPersistentPublisherStats() : new PublisherStats();
-        stats.address = cnx.clientAddress().toString();
-        stats.connectedSince = DateFormatter.now();
-        stats.clientVersion = cnx.getClientVersion();
-        stats.producerName = producerName;
+        stats.setAddress(cnx.clientAddress().toString());
+        stats.setConnectedSince(DateFormatter.now());
+        stats.setClientVersion(cnx.getClientVersion());
+        stats.setProducerName(producerName);
         stats.producerId = producerId;
         stats.metadata = this.metadata;
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -437,8 +437,8 @@ public class ServerCnx extends PulsarHandler {
         commandConsumerStatsResponseBuilder.setAvailablePermits(consumerStats.availablePermits);
         commandConsumerStatsResponseBuilder.setUnackedMessages(consumerStats.unackedMessages);
         commandConsumerStatsResponseBuilder.setBlockedConsumerOnUnackedMsgs(consumerStats.blockedConsumerOnUnackedMsgs);
-        commandConsumerStatsResponseBuilder.setAddress(consumerStats.address);
-        commandConsumerStatsResponseBuilder.setConnectedSince(consumerStats.connectedSince);
+        commandConsumerStatsResponseBuilder.setAddress(consumerStats.getAddress());
+        commandConsumerStatsResponseBuilder.setConnectedSince(consumerStats.getConnectedSince());
 
         Subscription subscription = consumer.getSubscription();
         commandConsumerStatsResponseBuilder.setMsgBacklog(subscription.getNumberOfEntriesInBacklog());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -739,10 +739,10 @@ public class NonPersistentTopic implements Topic {
 
                     // Populate consumer specific stats here
                     topicStatsStream.startObject();
-                    topicStatsStream.writePair("address", consumerStats.address);
+                    topicStatsStream.writePair("address", consumerStats.getAddress());
                     topicStatsStream.writePair("consumerName", consumerStats.consumerName);
                     topicStatsStream.writePair("availablePermits", consumerStats.availablePermits);
-                    topicStatsStream.writePair("connectedSince", consumerStats.connectedSince);
+                    topicStatsStream.writePair("connectedSince", consumerStats.getConnectedSince());
                     topicStatsStream.writePair("msgRateOut", consumerStats.msgRateOut);
                     topicStatsStream.writePair("msgThroughputOut", consumerStats.msgThroughputOut);
                     topicStatsStream.writePair("msgRateRedeliver", consumerStats.msgRateRedeliver);
@@ -752,8 +752,8 @@ public class NonPersistentTopic implements Topic {
                         topicStatsStream.writePair("blockedConsumerOnUnackedMsgs",
                                 consumerStats.blockedConsumerOnUnackedMsgs);
                     }
-                    if (consumerStats.clientVersion != null) {
-                        topicStatsStream.writePair("clientVersion", consumerStats.clientVersion);
+                    if (consumerStats.getClientVersion() != null) {
+                        topicStatsStream.writePair("clientVersion", consumerStats.getClientVersion());
                     }
                     topicStatsStream.endObject();
                 }
@@ -848,8 +848,8 @@ public class NonPersistentTopic implements Topic {
             if (pubStats != null) {
                 ReplicatorStats.msgRateIn = pubStats.msgRateIn;
                 ReplicatorStats.msgThroughputIn = pubStats.msgThroughputIn;
-                ReplicatorStats.inboundConnection = pubStats.address;
-                ReplicatorStats.inboundConnectedSince = pubStats.connectedSince;
+                ReplicatorStats.inboundConnection = pubStats.getAddress();
+                ReplicatorStats.inboundConnectedSince = pubStats.getConnectedSince();
             }
 
             stats.msgRateOut += ReplicatorStats.msgRateOut;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1077,8 +1077,8 @@ public class PersistentTopic implements Topic, AddEntryCallback {
             if (pubStats != null) {
                 rStat.msgRateIn = pubStats.msgRateIn;
                 rStat.msgThroughputIn = pubStats.msgThroughputIn;
-                rStat.inboundConnection = pubStats.address;
-                rStat.inboundConnectedSince = pubStats.connectedSince;
+                rStat.inboundConnection = pubStats.getAddress();
+                rStat.inboundConnectedSince = pubStats.getConnectedSince();
             }
 
             topicStats.aggMsgRateOut += rStat.msgRateOut;
@@ -1152,10 +1152,10 @@ public class PersistentTopic implements Topic, AddEntryCallback {
 
                     // Populate consumer specific stats here
                     topicStatsStream.startObject();
-                    topicStatsStream.writePair("address", consumerStats.address);
+                    topicStatsStream.writePair("address", consumerStats.getAddress());
                     topicStatsStream.writePair("consumerName", consumerStats.consumerName);
                     topicStatsStream.writePair("availablePermits", consumerStats.availablePermits);
-                    topicStatsStream.writePair("connectedSince", consumerStats.connectedSince);
+                    topicStatsStream.writePair("connectedSince", consumerStats.getConnectedSince());
                     topicStatsStream.writePair("msgRateOut", consumerStats.msgRateOut);
                     topicStatsStream.writePair("msgThroughputOut", consumerStats.msgThroughputOut);
                     topicStatsStream.writePair("msgRateRedeliver", consumerStats.msgRateRedeliver);
@@ -1165,8 +1165,8 @@ public class PersistentTopic implements Topic, AddEntryCallback {
                         topicStatsStream.writePair("blockedConsumerOnUnackedMsgs",
                                 consumerStats.blockedConsumerOnUnackedMsgs);
                     }
-                    if (consumerStats.clientVersion != null) {
-                        topicStatsStream.writePair("clientVersion", consumerStats.clientVersion);
+                    if (consumerStats.getClientVersion() != null) {
+                        topicStatsStream.writePair("clientVersion", consumerStats.getClientVersion());
                     }
                     topicStatsStream.endObject();
                 }
@@ -1270,8 +1270,8 @@ public class PersistentTopic implements Topic, AddEntryCallback {
             if (pubStats != null) {
                 replicatorStats.msgRateIn = pubStats.msgRateIn;
                 replicatorStats.msgThroughputIn = pubStats.msgThroughputIn;
-                replicatorStats.inboundConnection = pubStats.address;
-                replicatorStats.inboundConnectedSince = pubStats.connectedSince;
+                replicatorStats.inboundConnection = pubStats.getAddress();
+                replicatorStats.inboundConnectedSince = pubStats.getConnectedSince();
             }
 
             stats.msgRateOut += replicatorStats.msgRateOut;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
@@ -54,6 +54,7 @@ import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.ConsumerStats;
 import org.apache.pulsar.common.policies.data.FailureDomain;
 import org.apache.pulsar.common.policies.data.NonPersistentTopicStats;
 import org.apache.pulsar.common.policies.data.PartitionedTopicStats;
@@ -62,6 +63,7 @@ import org.apache.pulsar.common.policies.data.PersistentTopicInternalStats;
 import org.apache.pulsar.common.policies.data.PersistentTopicStats;
 import org.apache.pulsar.common.policies.data.PropertyAdmin;
 import org.apache.pulsar.common.policies.data.RetentionPolicies;
+import org.apache.pulsar.common.policies.data.SubscriptionStats;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -721,5 +723,50 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         assertEquals(topicsInNs.size(), totalTopics);
         topicsInNs.removeAll(topicNames);
         assertEquals(topicsInNs.size(), 0);
+    }
+
+    @Test
+    public void testPublishConsumerStats() throws Exception {
+        final String topicName = "statTopic";
+        final String subscriberName = topicName + "-my-sub-1";
+        final String topic = "persistent://prop-xyz/use/ns1/" + topicName;
+        final String producerName = "myProducer";
+
+        URL pulsarUrl = new URL("http://127.0.0.1" + ":" + BROKER_WEBSERVICE_PORT);
+
+        PulsarClient client = PulsarClient.builder().serviceUrl(pulsarUrl.toString()).build();
+        Consumer<byte[]> consumer = client.newConsumer().topic(topic).subscriptionName(subscriberName)
+                .subscriptionType(SubscriptionType.Shared).subscribe();
+        Producer<byte[]> producer = client.newProducer().topic(topic).producerName(producerName).create();
+
+        retryStrategically((test) -> {
+            PersistentTopicStats stats;
+            try {
+                stats = admin.persistentTopics().getStats(topic);
+                return stats.publishers.size() > 0 && stats.subscriptions.get(subscriberName) != null
+                        && stats.subscriptions.get(subscriberName).consumers.size() > 0;
+            } catch (PulsarAdminException e) {
+                return false;
+            }
+        }, 5, 200);
+
+        PersistentTopicStats topicStats = admin.persistentTopics().getStats(topic);
+        assertEquals(topicStats.publishers.size(), 1);
+        assertNotNull(topicStats.publishers.get(0).getAddress());
+        assertNotNull(topicStats.publishers.get(0).getClientVersion());
+        assertNotNull(topicStats.publishers.get(0).getConnectedSince());
+        assertNotNull(topicStats.publishers.get(0).getProducerName());
+        assertEquals(topicStats.publishers.get(0).getProducerName(), producerName);
+
+        SubscriptionStats subscriber = topicStats.subscriptions.get(subscriberName);
+        assertNotNull(subscriber);
+        assertEquals(subscriber.consumers.size(), 1);
+        ConsumerStats consumerStats = subscriber.consumers.get(0);
+        assertNotNull(consumerStats.getAddress());
+        assertNotNull(consumerStats.getClientVersion());
+        assertNotNull(consumerStats.getConnectedSince());
+
+        producer.close();
+        consumer.close();
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -174,7 +174,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         assertTrue(stats.publishers.get(0).msgRateIn > 0.0);
         assertTrue(stats.publishers.get(0).msgThroughputIn > 0.0);
         assertTrue(stats.publishers.get(0).averageMsgSize > 0.0);
-        assertNotNull(stats.publishers.get(0).clientVersion);
+        assertNotNull(stats.publishers.get(0).getClientVersion());
 
         // aggregated publish stats
         assertEquals(stats.msgRateIn, stats.publishers.get(0).msgRateIn);
@@ -191,7 +191,7 @@ public class BrokerServiceTest extends BrokerTestBase {
         assertEquals(subStats.msgThroughputOut, subStats.consumers.get(0).msgThroughputOut);
         assertEquals(stats.msgRateOut, subStats.consumers.get(0).msgRateOut);
         assertEquals(stats.msgThroughputOut, subStats.consumers.get(0).msgThroughputOut);
-        assertNotNull(subStats.consumers.get(0).clientVersion);
+        assertNotNull(subStats.consumers.get(0).getClientVersion());
 
         Message<byte[]> msg;
         for (int i = 0; i < 10; i++) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ConsumerStats.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/ConsumerStats.java
@@ -39,24 +39,33 @@ public class ConsumerStats {
 
     /** Number of available message permits for the consumer */
     public int availablePermits;
-    
+
     /** Number of unacknowledged messages for the consumer */
     public int unackedMessages;
-    
+
     /** Flag to verify if consumer is blocked due to reaching threshold of unacked messages */
     public boolean blockedConsumerOnUnackedMsgs;
 
     /** Address of this consumer */
-    public String address;
+    private int addressOffset = -1;
+    private int addressLength;
 
     /** Timestamp of connection */
-    public String connectedSince;
-    
+    private int connectedSinceOffset = -1;
+    private int connectedSinceLength;
+
     /** Client library version */
-    public String clientVersion;
+    private int clientVersionOffset = -1;
+    private int clientVersionLength;
 
     /** Metadata (key/value strings) associated with this consumer */
     public Map<String, String> metadata;
+
+    /**
+     * In order to prevent multiple string object allocation under stats: create a string-buffer that stores data for all string
+     * place-holders
+     */
+    private StringBuilder stringBuffer = new StringBuilder();
 
     public ConsumerStats add(ConsumerStats stats) {
         checkNotNull(stats);
@@ -67,5 +76,49 @@ public class ConsumerStats {
         this.unackedMessages += stats.unackedMessages;
         this.blockedConsumerOnUnackedMsgs = stats.blockedConsumerOnUnackedMsgs;
         return this;
+    }
+
+    public String getAddress() {
+        return addressOffset == -1 ? null : stringBuffer.substring(addressOffset, addressOffset + addressLength);
+    }
+
+    public void setAddress(String address) {
+        if (address == null) {
+            this.addressOffset = -1;
+            return;
+        }
+        this.addressOffset = this.stringBuffer.length();
+        this.addressLength = address.length();
+        this.stringBuffer.append(address);
+    }
+
+    public String getConnectedSince() {
+        return connectedSinceOffset == -1 ? null
+                : stringBuffer.substring(connectedSinceOffset, connectedSinceOffset + connectedSinceLength);
+    }
+
+    public void setConnectedSince(String connectedSince) {
+        if (connectedSince == null) {
+            this.connectedSinceOffset = -1;
+            return;
+        }
+        this.connectedSinceOffset = this.stringBuffer.length();
+        this.connectedSinceLength = connectedSince.length();
+        this.stringBuffer.append(connectedSince);
+    }
+
+    public String getClientVersion() {
+        return clientVersionOffset == -1 ? null
+                : stringBuffer.substring(clientVersionOffset, clientVersionOffset + clientVersionLength);
+    }
+
+    public void setClientVersion(String clientVersion) {
+        if (clientVersion == null) {
+            this.clientVersionOffset = -1;
+            return;
+        }
+        this.clientVersionOffset = this.stringBuffer.length();
+        this.clientVersionLength = clientVersion.length();
+        this.stringBuffer.append(clientVersion);
     }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/PublisherStats.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/PublisherStats.java
@@ -38,16 +38,26 @@ public class PublisherStats {
     public long producerId;
 
     /** Producer name */
-    public String producerName;
+    private int producerNameOffset = -1;
+    private int producerNameLength;
 
     /** Address of this publisher */
-    public String address;
+    private int addressOffset = -1;
+    private int addressLength;
 
     /** Timestamp of connection */
-    public String connectedSince;
-    
+    private int connectedSinceOffset = -1;
+    private int connectedSinceLength;
+
     /** Client library version */
-    public String clientVersion;
+    private int clientVersionOffset = -1;
+    private int clientVersionLength;
+
+    /**
+     * In order to prevent multiple string objects under stats: create a string-buffer that stores data for all string
+     * place-holders
+     */
+    private StringBuilder stringBuffer = new StringBuilder();
 
     /** Metadata (key/value strings) associated with this publisher */
     public Map<String, String> metadata;
@@ -58,5 +68,64 @@ public class PublisherStats {
         this.msgThroughputIn += stats.msgThroughputIn;
         this.averageMsgSize += stats.averageMsgSize;
         return this;
+    }
+
+    public String getProducerName() {
+        return producerNameOffset == -1 ? null
+                : stringBuffer.substring(producerNameOffset, producerNameOffset + producerNameLength);
+    }
+
+    public void setProducerName(String producerName) {
+        if (producerName == null) {
+            this.producerNameOffset = -1;
+            return;
+        }
+        this.producerNameOffset = this.stringBuffer.length();
+        this.producerNameLength = producerName.length();
+        this.stringBuffer.append(producerName);
+    }
+
+    public String getAddress() {
+        return addressOffset == -1 ? null : stringBuffer.substring(addressOffset, addressOffset + addressLength);
+    }
+
+    public void setAddress(String address) {
+        if (address == null) {
+            this.addressOffset = -1;
+            return;
+        }
+        this.addressOffset = this.stringBuffer.length();
+        this.addressLength = address.length();
+        this.stringBuffer.append(address);
+    }
+
+    public String getConnectedSince() {
+        return connectedSinceOffset == -1 ? null
+                : stringBuffer.substring(connectedSinceOffset, connectedSinceOffset + connectedSinceLength);
+    }
+
+    public void setConnectedSince(String connectedSince) {
+        if (connectedSince == null) {
+            this.connectedSinceOffset = -1;
+            return;
+        }
+        this.connectedSinceOffset = this.stringBuffer.length();
+        this.connectedSinceLength = connectedSince.length();
+        this.stringBuffer.append(connectedSince);
+    }
+
+    public String getClientVersion() {
+        return clientVersionOffset == -1 ? null
+                : stringBuffer.substring(clientVersionOffset, clientVersionOffset + clientVersionLength);
+    }
+
+    public void setClientVersion(String clientVersion) {
+        if (clientVersion == null) {
+            this.clientVersionOffset = -1;
+            return;
+        }
+        this.clientVersionOffset = this.stringBuffer.length();
+        this.clientVersionLength = clientVersion.length();
+        this.stringBuffer.append(clientVersion);
     }
 }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/ConsumerStatsTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/ConsumerStatsTest.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.policies.data;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ConsumerStatsTest {
+
+    @Test
+    public void testConsumerStats() {
+        ConsumerStats stats = new ConsumerStats();
+        Assert.assertNull(stats.getAddress());
+        Assert.assertNull(stats.getClientVersion());
+        Assert.assertNull(stats.getConnectedSince());
+        
+        stats.setAddress("address");
+        Assert.assertEquals(stats.getAddress(), "address");
+        stats.setAddress("address1");
+        Assert.assertEquals(stats.getAddress(), "address1");
+        
+        stats.setClientVersion("version");
+        Assert.assertEquals(stats.getClientVersion(), "version");
+        Assert.assertEquals(stats.getAddress(), "address1");
+        
+        stats.setConnectedSince("connected");
+        Assert.assertEquals(stats.getConnectedSince(), "connected");
+        Assert.assertEquals(stats.getAddress(), "address1");
+        Assert.assertEquals(stats.getClientVersion(), "version");
+        
+        stats.setAddress(null);
+        Assert.assertEquals(stats.getAddress(), null);
+        
+        stats.setConnectedSince("");
+        Assert.assertEquals(stats.getConnectedSince(), "");
+        
+        stats.setClientVersion("version2");
+        Assert.assertEquals(stats.getClientVersion(), "version2");
+        
+        Assert.assertEquals(stats.getAddress(), null);
+        
+        Assert.assertEquals(stats.getClientVersion(), "version2");
+        
+        stats.setConnectedSince(null);
+        stats.setClientVersion(null);
+        Assert.assertNull(stats.getConnectedSince());
+        Assert.assertNull(stats.getClientVersion());
+    }
+}

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/PublisherStatsTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/policies/data/PublisherStatsTest.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.policies.data;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class PublisherStatsTest {
+
+    @Test
+    public void testPublisherStats() {
+        PublisherStats stats = new PublisherStats();
+        Assert.assertNull(stats.getAddress());
+        Assert.assertNull(stats.getClientVersion());
+        Assert.assertNull(stats.getConnectedSince());
+        Assert.assertNull(stats.getProducerName());
+        
+        stats.setAddress("address");
+        Assert.assertEquals(stats.getAddress(), "address");
+        stats.setAddress("address1");
+        Assert.assertEquals(stats.getAddress(), "address1");
+        
+        stats.setClientVersion("version");
+        Assert.assertEquals(stats.getClientVersion(), "version");
+        Assert.assertEquals(stats.getAddress(), "address1");
+        
+        stats.setConnectedSince("connected");
+        Assert.assertEquals(stats.getConnectedSince(), "connected");
+        Assert.assertEquals(stats.getAddress(), "address1");
+        Assert.assertEquals(stats.getClientVersion(), "version");
+        
+        stats.setProducerName("producer");
+        Assert.assertEquals(stats.getProducerName(), "producer");
+        Assert.assertEquals(stats.getConnectedSince(), "connected");
+        Assert.assertEquals(stats.getAddress(), "address1");
+        Assert.assertEquals(stats.getClientVersion(), "version");
+        
+        stats.setAddress(null);
+        Assert.assertEquals(stats.getAddress(), null);
+        
+        stats.setConnectedSince("");
+        Assert.assertEquals(stats.getConnectedSince(), "");
+        
+        stats.setClientVersion("version2");
+        Assert.assertEquals(stats.getClientVersion(), "version2");
+        
+        stats.setProducerName(null);
+        Assert.assertEquals(stats.getProducerName(), null);
+        
+        Assert.assertEquals(stats.getAddress(), null);
+        
+        Assert.assertEquals(stats.getClientVersion(), "version2");
+        
+        stats.setConnectedSince(null);
+        stats.setClientVersion(null);
+        Assert.assertNull(stats.getConnectedSince());
+        Assert.assertNull(stats.getClientVersion());
+    }
+}


### PR DESCRIPTION
### Motivation

We have seen large young GC-pause in broker in specific states. Below is one of the example where broker's young gc reached to 1 sec and after capturing heap-dump it shows large number of string and char[] objects allocated by the producer/consumer stats of the topic and .

**Young GC > 1.2 sec** 
![snip20180330_24](https://user-images.githubusercontent.com/2898254/38151253-5b3d2eb8-3417-11e8-99ce-6094870b51b2.png)

**Highest object allocation classes: String, char[]**

![snip20180327_19](https://user-images.githubusercontent.com/2898254/38151392-ea69f436-3417-11e8-989e-5e6211dd8562.png)


### Modifications

Producer/Consumer stats stores 4 String objects (address, producerName, connectedSince, version) which don't get modified once they are set. So, reducing 4 strings and char[] to 1 and store offsets of stats-placeholder which will reduce number of string and char[] objects.

### Result

It will help to reduce GC when broker is serving many topics.
I am going to make some more GC enhancement in separate PR.