### PR TITLE
Remove --user-install flag from gem install

### DIFF
--- a/site/Makefile
+++ b/site/Makefile
@@ -41,7 +41,7 @@ clean_local:
 	rm -rf generated
 
 ruby_setup:
-	gem install --user-install bundler \
+	gem install bundler \
 		--no-rdoc \
 		--no-ri
 	NOKOGIRI_USE_SYSTEM_LIBRARIES=true $(BUNDLE) install \


### PR DESCRIPTION
At the moment the website build is broken due to the introduction of the `--user-install` flag to the bundle install (which has removed the Ruby executables from the `PATH`).