### PR TITLE
Fixed test_producer_send_async in Python

### DIFF
--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -87,7 +87,10 @@ class PulsarTest(TestCase):
         producer.send_async('hello', send_callback)
         producer.send_async('hello', send_callback)
 
-        time.sleep(0.1)
+        i = 0
+        while len(sent_messages) < 3 and i < 100:
+            time.sleep(0.1)
+            i += 1
         self.assertEqual(len(sent_messages), 3)
         client.close()
 


### PR DESCRIPTION
Seen a couple of times: 

```
======================================================================
FAIL: test_producer_send_async (__main__.PulsarTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "pulsar_test.py", line 91, in test_producer_send_async
    self.assertEqual(len(sent_messages), 3)
AssertionError: 0 != 3
```