### PR TITLE
Fixed InvocationTargetException in pulsar-admin

### DIFF
--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PulsarAdmin.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PulsarAdmin.java
@@ -29,6 +29,7 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.admin.internal.BrokerStatsImpl;
 import org.apache.pulsar.client.admin.internal.BrokersImpl;
 import org.apache.pulsar.client.admin.internal.ClustersImpl;
@@ -121,9 +122,11 @@ public class PulsarAdmin implements Closeable {
         ClientBuilder clientBuilder = ClientBuilder.newBuilder().withConfig(httpConfig)
                 .register(JacksonConfigurator.class).register(JacksonFeature.class);
 
-        boolean useTls = clientConfigData.getServiceUrl().startsWith("https://");
+        boolean useTls = false;
 
-        if (clientConfigData != null && useTls) {
+        if (clientConfigData != null && StringUtils.isNotBlank(clientConfigData.getServiceUrl())
+                && clientConfigData.getServiceUrl().startsWith("https://")) {
+            useTls = true;
             try {
                 SSLContext sslCtx = null;
 

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PulsarAdmin.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PulsarAdmin.java
@@ -71,7 +71,7 @@ public class PulsarAdmin implements Closeable {
     private final PersistentTopics persistentTopics;
     private final NonPersistentTopics nonPersistentTopics;
     private final ResourceQuotas resourceQuotas;
-	private final ClientConfigurationData clientConfigData;
+    private final ClientConfigurationData clientConfigData;
     private final Client client;
     private final String serviceUrl;
     private final Lookup lookups;
@@ -104,7 +104,7 @@ public class PulsarAdmin implements Closeable {
     }
 
     public PulsarAdmin(String serviceUrl, ClientConfigurationData clientConfigData) throws PulsarClientException {
-    	this.clientConfigData = clientConfigData;
+        this.clientConfigData = clientConfigData;
         this.auth = clientConfigData != null ? clientConfigData.getAuthentication() : new AuthenticationDisabled();
         LOG.debug("created: serviceUrl={}, authMethodName={}", serviceUrl,
                 auth != null ? auth.getAuthMethodName() : null);
@@ -313,13 +313,13 @@ public class PulsarAdmin implements Closeable {
     public String getServiceUrl() {
         return serviceUrl;
     }
-    
+
     /**
      * @return the client Configuration Data that is being used
      */
     public ClientConfigurationData getClientConfigData() {
-		return clientConfigData;
-	}
+        return clientConfigData;
+    }
 
     /**
      * Close the Pulsar admin client to release all the resources

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/CmdFunctionsTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/CmdFunctionsTest.java
@@ -104,7 +104,7 @@ public class CmdFunctionsTest {
         this.functions = mock(Functions.class);
         when(admin.functions()).thenReturn(functions);
         when(admin.getServiceUrl()).thenReturn("http://localhost:1234");
-        when(admin.getClientConf()).thenReturn(new ClientConfigurationData());
+        when(admin.getClientConfigData()).thenReturn(new ClientConfigurationData());
         this.cmd = new CmdFunctions(admin);
 
         // mock reflections

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -637,7 +637,11 @@ public class CmdFunctions extends CmdBase {
 
     public CmdFunctions(PulsarAdmin admin) throws PulsarClientException {
         super("functions", admin);
-        this.fnAdmin = new PulsarAdminWithFunctions(admin.getServiceUrl(), admin.getClientConfigData());
+        if (admin instanceof PulsarAdminWithFunctions) {
+            this.fnAdmin = (PulsarAdminWithFunctions) admin;
+        } else {
+            this.fnAdmin = new PulsarAdminWithFunctions(admin.getServiceUrl(), admin.getClientConfigData());
+        }
         localRunner = new LocalRunner();
         creater = new CreateFunction();
         deleter = new DeleteFunction();

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -45,6 +45,7 @@ import org.apache.bookkeeper.clients.config.StorageClientSettings;
 import org.apache.bookkeeper.clients.utils.NetUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminWithFunctions;
+import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.functions.api.Function;
 import org.apache.pulsar.functions.api.utils.DefaultSerDe;
@@ -456,7 +457,7 @@ public class CmdFunctions extends CmdBase {
                 throw new RuntimeException("Missing arguments");
             }
 
-            String serviceUrl = ((PulsarAdminWithFunctions) admin).getClientConf().getServiceUrl();
+            String serviceUrl = admin.getServiceUrl();
             if (brokerServiceUrl != null) {
                 serviceUrl = brokerServiceUrl;
             }
@@ -634,9 +635,9 @@ public class CmdFunctions extends CmdBase {
         }
     }
 
-    public CmdFunctions(PulsarAdmin admin) {
+    public CmdFunctions(PulsarAdmin admin) throws PulsarClientException {
         super("functions", admin);
-        this.fnAdmin = (PulsarAdminWithFunctions) admin;
+        this.fnAdmin = new PulsarAdminWithFunctions(admin.getServiceUrl(), admin.getClientConfigData());
         localRunner = new LocalRunner();
         creater = new CreateFunction();
         deleter = new DeleteFunction();

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/admin/PulsarAdminWithFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/admin/PulsarAdminWithFunctions.java
@@ -37,10 +37,6 @@ public class PulsarAdminWithFunctions extends PulsarAdmin {
         this.clientConf = pulsarConfig;
     }
 
-    public ClientConfigurationData getClientConf() {
-        return clientConf;
-    }
-
     /**
      * @return the function management object
      */

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/admin/PulsarAdminWithFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/admin/PulsarAdminWithFunctions.java
@@ -19,7 +19,6 @@
 package org.apache.pulsar.client.admin;
 
 import org.apache.pulsar.client.admin.internal.FunctionsImpl;
-import org.apache.pulsar.client.admin.internal.PulsarAdminBuilderImpl;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 
@@ -32,14 +31,7 @@ public class PulsarAdminWithFunctions extends PulsarAdmin {
     private final Functions functions;
     private final ClientConfigurationData clientConf;
 
-    /**
-     * Creates a builder to construct an instance of {@link PulsarAdminWithFunctions}.
-     */
-    public static PulsarAdminBuilder builder() {
-        return new PulsarAdminBuilderImpl();
-    }
-
-    PulsarAdminWithFunctions(String serviceUrl, ClientConfigurationData pulsarConfig) throws PulsarClientException {
+    public PulsarAdminWithFunctions(String serviceUrl, ClientConfigurationData pulsarConfig) throws PulsarClientException {
         super(serviceUrl, pulsarConfig);
         this.functions = new FunctionsImpl(root, auth);
         this.clientConf = pulsarConfig;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/admin/PulsarAdminWithFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/admin/PulsarAdminWithFunctions.java
@@ -22,7 +22,6 @@ import org.apache.pulsar.client.admin.internal.FunctionsImpl;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 
-
 /**
  * Pulsar client admin client with functions support.
  */
@@ -31,7 +30,8 @@ public class PulsarAdminWithFunctions extends PulsarAdmin {
     private final Functions functions;
     private final ClientConfigurationData clientConf;
 
-    public PulsarAdminWithFunctions(String serviceUrl, ClientConfigurationData pulsarConfig) throws PulsarClientException {
+    public PulsarAdminWithFunctions(String serviceUrl, ClientConfigurationData pulsarConfig)
+            throws PulsarClientException {
         super(serviceUrl, pulsarConfig);
         this.functions = new FunctionsImpl(root, auth);
         this.clientConf = pulsarConfig;


### PR DESCRIPTION
Currently in master:
```
./bin/pulsar-admin 
class java.lang.reflect.InvocationTargetException: null
```
Reason is that in `CmdFunctions.java:639` we expect the admin to be an instance of `PulsarAdminWithFunctions` while `PulsarAdminBuilderImpl.build()` builds an instance `PulsarAdmin`

I tried building `PulsarAdminWithFunctions` in `PulsarAdminBuilderImpl` instead of `PulsarAdmin` but ran into lots of errors so I just commented out adding pulsar functions to `PulsarAdminTool`, in order to get master working since I need to develop on Admin Tools.

I believe the problematic PR is https://github.com/apache/incubator-pulsar/commit/6230ab4542c733f3390bd7ae7d4d6b0d5a661fb1 but can't say for sure since we use SNAPSHOT bookkeeper versions now.
