### PR TITLE
Add MultiTopicsConsumerImpl with leaked commit from partitionedConsumer

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -480,6 +480,15 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         internalConsumerConfig.setReceiverQueueSize(conf.getReceiverQueueSize());
         internalConsumerConfig.setSubscriptionType(conf.getSubscriptionType());
         internalConsumerConfig.setConsumerName(consumerName);
+        internalConsumerConfig.setAcknowledgementsGroupTimeMicros(conf.getAcknowledgementsGroupTimeMicros());
+        internalConsumerConfig.setPriorityLevel(conf.getPriorityLevel());
+        internalConsumerConfig.setProperties(conf.getProperties());
+        internalConsumerConfig.setReadCompacted(conf.isReadCompacted());
+
+        if (null != conf.getConsumerEventListener()) {
+            internalConsumerConfig.setConsumerEventListener(conf.getConsumerEventListener());
+        }
+
         if (conf.getCryptoKeyReader() != null) {
             internalConsumerConfig.setCryptoKeyReader(conf.getCryptoKeyReader());
             internalConsumerConfig.setCryptoFailureAction(conf.getCryptoFailureAction());

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -767,12 +767,12 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
             consumers.values().stream().filter(consumer1 -> {
                 String consumerTopicName = consumer1.getTopic();
                 if (TopicName.get(consumerTopicName).getPartitionedTopicName().equals(topicName)) {
+                    toCloseNum.incrementAndGet();
                     return true;
                 } else {
                     return false;
                 }
-            }).forEach(consumer2 -> {
-                toCloseNum.incrementAndGet();
+            }).collect(Collectors.toList()).forEach(consumer2 -> {
                 consumer2.closeAsync().whenComplete((r, ex) -> {
                     consumer2.subscribeFuture().completeExceptionally(error);
                     allTopicPartitionsNumber.decrementAndGet();


### PR DESCRIPTION
### Motivation

MultiTopicsConsumerImpl leaked merge the change in partitionedConsumer in [PR1462](https://github.com/apache/incubator-pulsar/pull/1462/files#diff-bbced2cbb73414dfcac0c55dc9169d37R427). 
It will cause unit-test `AdminApiTest.partitionedTopicsCursorReset` fail some times, when there is a delay of `AcknowledgmentsGroupingTracker.flush`

### Modifications

add leaked changes back.

### Result

should pass all unit-test