### PR TITLE
Disable AnnotationListener for integration tests

### DIFF
--- a/tests/integration-tests-base/pom.xml
+++ b/tests/integration-tests-base/pom.xml
@@ -95,6 +95,14 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+              <properties>
+                <property>
+                  <name>listener</name>
+                  <!-- AnnotationListener breaks arquillian, so don't use it //-->
+                  <value>org.apache.pulsar.tests.PulsarTestListener</value>
+                </property>
+              </properties>
+
               <argLine>-Xmx2G -XX:MaxDirectMemorySize=8G
               -Dio.netty.leakDetectionLevel=advanced
               </argLine>


### PR DESCRIPTION
The annotation listener adds timeouts to all tests, which changes the
threading model, which breaks arquillian.

I've created an issue[1] on arquillian for this, but until that is fixed,
timeouts cannot be used with arquillian.

[1] https://github.com/arquillian/arquillian-core/issues/168
