### PR TITLE
Fix init of Input CustomSerDe of function

### DIFF
--- a/pulsar-client-admin/pom.xml
+++ b/pulsar-client-admin/pom.xml
@@ -46,15 +46,15 @@
       <version>${project.version}</version>
     </dependency>
 
-	<dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>pulsar-functions-proto-shaded</artifactId>
       <version>${project.version}</version>
       <exclusions>
-      	<exclusion>
-      		<groupId>*</groupId>
-      		<artifactId>*</artifactId>
-      	</exclusion>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -723,7 +723,10 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable, ConsumerEv
         this.inputSerDe = new HashMap<>();
         instanceConfig.getFunctionConfig().getCustomSerdeInputsMap().forEach((k, v) -> this.inputSerDe.put(k, initializeSerDe(v, clsLoader, typeArgs, true)));
         for (String topicName : instanceConfig.getFunctionConfig().getInputsList()) {
-            this.inputSerDe.put(topicName, initializeDefaultSerDe(typeArgs, true));
+            // initialize Default-SerDe if custom-SerDe is not attached to the topic
+            if (!inputSerDe.containsKey(topicName)) {
+                this.inputSerDe.put(topicName, initializeDefaultSerDe(typeArgs, true));
+            }
         }
 
         if (Void.class.equals(typeArgs[0])) {


### PR DESCRIPTION
### Motivation

Right now, if topic has provided CustomSerDe for input param. still Instance tries to initialize it with DefaultSerDe and fails it argument doesn't supported by DefaultSerDe.

### Modifications

- Ignore initializing SerDe if CustomSerDe is provided for topic.
- Fix test cases.

### Result

CustomSerDe will work for input param.
