### PR TITLE
Also log bookkeeper (and managed ledger) in tests

### DIFF
--- a/buildtools/src/main/resources/log4j2.xml
+++ b/buildtools/src/main/resources/log4j2.xml
@@ -30,5 +30,6 @@
             <AppenderRef ref="Console" />
         </Root>
         <Logger name="org.apache.pulsar" level="info"/>
+        <Logger name="org.apache.bookkeeper" level="info"/>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
Root level is warn, so we need to explicitly set org.apache.bookkeeper
to info to see the logs.
