### PR TITLE
Managed ledger uses ReadHandle in read path

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
@@ -24,7 +24,7 @@ import com.google.common.annotations.Beta;
 import com.google.common.base.Charsets;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
-import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.client.api.DigestType;
 
 /**
  * Configuration class for a ManagedLedger.

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCache.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCache.java
@@ -18,7 +18,7 @@
  */
 package org.apache.bookkeeper.mledger.impl;
 
-import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntriesCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntryCallback;
 import org.apache.bookkeeper.mledger.util.Pair;
@@ -94,7 +94,7 @@ public interface EntryCache extends Comparable<EntryCache> {
      * @param ctx
      *            the context object
      */
-    void asyncReadEntry(LedgerHandle lh, long firstEntry, long lastEntry, boolean isSlowestReader,
+    void asyncReadEntry(ReadHandle lh, long firstEntry, long lastEntry, boolean isSlowestReader,
             ReadEntriesCallback callback, Object ctx);
 
     /**
@@ -111,7 +111,7 @@ public interface EntryCache extends Comparable<EntryCache> {
      * @param ctx
      *            the context object
      */
-    void asyncReadEntry(LedgerHandle lh, PositionImpl position, ReadEntryCallback callback, Object ctx);
+    void asyncReadEntry(ReadHandle lh, PositionImpl position, ReadEntryCallback callback, Object ctx);
 
     /**
      * Get the total size in bytes of all the entries stored in this cache.

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryCacheImpl.java
@@ -28,10 +28,11 @@ import com.google.common.primitives.Longs;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
-import org.apache.bookkeeper.client.BKException;
-import org.apache.bookkeeper.client.LedgerEntry;
-import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.bookkeeper.client.api.BKException;
+import org.apache.bookkeeper.client.api.LedgerEntry;
+import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntriesCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntryCallback;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
@@ -159,7 +160,7 @@ public class EntryCacheImpl implements EntryCache {
     }
 
     @Override
-    public void asyncReadEntry(LedgerHandle lh, PositionImpl position, final ReadEntryCallback callback,
+    public void asyncReadEntry(ReadHandle lh, PositionImpl position, final ReadEntryCallback callback,
             final Object ctx) {
         if (log.isDebugEnabled()) {
             log.debug("[{}] Reading entry ledger {}: {}", ml.getName(), lh.getId(), position.getEntryId());
@@ -171,37 +172,40 @@ public class EntryCacheImpl implements EntryCache {
             manager.mlFactoryMBean.recordCacheHit(cachedEntry.getLength());
             callback.readEntryComplete(cachedEntry, ctx);
         } else {
-            lh.asyncReadEntries(position.getEntryId(), position.getEntryId(), (rc, ledgerHandle, sequence, obj) -> {
-                if (rc != BKException.Code.OK) {
-                    ml.invalidateLedgerHandle(ledgerHandle, rc);
-                    callback.readEntryFailed(createManagedLedgerException(rc), obj);
-                    return;
-                }
+            lh.readAsync(position.getEntryId(), position.getEntryId()).whenComplete(
+                    (ledgerEntries, exception) -> {
+                        if (exception != null) {
+                            ml.invalidateLedgerHandle(lh, exception);
+                            callback.readEntryFailed(createManagedLedgerException(exception), ctx);
+                            return;
+                        }
 
-                if (sequence.hasMoreElements()) {
-                    LedgerEntry ledgerEntry = sequence.nextElement();
-                    EntryImpl returnEntry = EntryImpl.create(ledgerEntry);
+                        try {
+                            Iterator<LedgerEntry> iterator = ledgerEntries.iterator();
+                            if (iterator.hasNext()) {
+                                LedgerEntry ledgerEntry = iterator.next();
+                                EntryImpl returnEntry = EntryImpl.create(ledgerEntry);
 
-                    // The EntryImpl is now the owner of the buffer, so we can release the original one
-                    ledgerEntry.getEntryBuffer().release();
-
-                    manager.mlFactoryMBean.recordCacheMiss(1, returnEntry.getLength());
-                    ml.mbean.addReadEntriesSample(1, returnEntry.getLength());
-
-                    ml.getExecutor().executeOrdered(ml.getName(), safeRun(() -> {
-                        callback.readEntryComplete(returnEntry, obj);
-                    }));
-                } else {
-                    // got an empty sequence
-                    callback.readEntryFailed(new ManagedLedgerException("Could not read given position"), obj);
-                }
-            }, ctx);
+                                manager.mlFactoryMBean.recordCacheMiss(1, returnEntry.getLength());
+                                ml.mbean.addReadEntriesSample(1, returnEntry.getLength());
+                                ml.getExecutor().executeOrdered(ml.getName(), safeRun(() -> {
+                                            callback.readEntryComplete(returnEntry, ctx);
+                                        }));
+                            } else {
+                                // got an empty sequence
+                                callback.readEntryFailed(new ManagedLedgerException("Could not read given position"),
+                                                         ctx);
+                            }
+                        } finally {
+                            ledgerEntries.close();
+                        }
+                    });
         }
     }
 
     @Override
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public void asyncReadEntry(LedgerHandle lh, long firstEntry, long lastEntry, boolean isSlowestReader,
+    public void asyncReadEntry(ReadHandle lh, long firstEntry, long lastEntry, boolean isSlowestReader,
             final ReadEntriesCallback callback, Object ctx) {
         final long ledgerId = lh.getId();
         final int entriesToRead = (int) (lastEntry - firstEntry) + 1;
@@ -239,43 +243,44 @@ public class EntryCacheImpl implements EntryCache {
             }
 
             // Read all the entries from bookkeeper
-            lh.asyncReadEntries(firstEntry, lastEntry, (rc, lh1, sequence, cb) -> {
+            lh.readAsync(firstEntry, lastEntry).whenComplete(
+                    (ledgerEntries, exception) -> {
+                        if (exception != null) {
+                            if (exception instanceof BKException
+                                && ((BKException)exception).getCode() == BKException.Code.TooManyRequestsException) {
+                                callback.readEntriesFailed(createManagedLedgerException(exception), ctx);
+                            } else {
+                                ml.invalidateLedgerHandle(lh, exception);
+                                ManagedLedgerException mlException = createManagedLedgerException(exception);
+                                callback.readEntriesFailed(mlException, ctx);
+                            }
+                            return;
+                        }
 
-                if (rc != BKException.Code.OK) {
-                    if (rc == BKException.Code.TooManyRequestsException) {
-                        callback.readEntriesFailed(createManagedLedgerException(rc), ctx);
-                    } else {
-                        ml.invalidateLedgerHandle(lh1, rc);
-                        ManagedLedgerException mlException = createManagedLedgerException(rc);
-                        callback.readEntriesFailed(mlException, ctx);
-                    }
-                    return;
-                }
+                        checkNotNull(ml.getName());
+                        checkNotNull(ml.getExecutor());
+                        ml.getExecutor().executeOrdered(ml.getName(), safeRun(() -> {
+                                    try {
+                                        // We got the entries, we need to transform them to a List<> type
+                                        long totalSize = 0;
+                                        final List<EntryImpl> entriesToReturn
+                                            = Lists.newArrayListWithExpectedSize(entriesToRead);
+                                        for (LedgerEntry e : ledgerEntries) {
+                                            EntryImpl entry = EntryImpl.create(e);
 
-                checkNotNull(ml.getName());
-                checkNotNull(ml.getExecutor());
-                ml.getExecutor().executeOrdered(ml.getName(), safeRun(() -> {
-                    // We got the entries, we need to transform them to a List<> type
-                    long totalSize = 0;
-                    final List<EntryImpl> entriesToReturn = Lists.newArrayListWithExpectedSize(entriesToRead);
-                    while (sequence.hasMoreElements()) {
-                        // Insert the entries at the end of the list (they will be unsorted for now)
-                        LedgerEntry ledgerEntry = sequence.nextElement();
-                        EntryImpl entry = EntryImpl.create(ledgerEntry);
-                        ledgerEntry.getEntryBuffer().release();
+                                            entriesToReturn.add(entry);
+                                            totalSize += entry.getLength();
+                                        }
 
-                        entriesToReturn.add(entry);
+                                        manager.mlFactoryMBean.recordCacheMiss(entriesToReturn.size(), totalSize);
+                                        ml.getMBean().addReadEntriesSample(entriesToReturn.size(), totalSize);
 
-                        totalSize += entry.getLength();
-
-                    }
-
-                    manager.mlFactoryMBean.recordCacheMiss(entriesToReturn.size(), totalSize);
-                    ml.getMBean().addReadEntriesSample(entriesToReturn.size(), totalSize);
-
-                    callback.readEntriesComplete((List) entriesToReturn, ctx);
-                }));
-            }, callback);
+                                        callback.readEntriesComplete((List) entriesToReturn, ctx);
+                                    } finally {
+                                        ledgerEntries.close();
+                                    }
+                                }));
+                    });
         }
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/EntryImpl.java
@@ -25,7 +25,7 @@ import io.netty.util.AbstractReferenceCounted;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
 import io.netty.util.ReferenceCounted;
-import org.apache.bookkeeper.client.LedgerEntry;
+import org.apache.bookkeeper.client.api.LedgerEntry;
 import org.apache.bookkeeper.mledger.Entry;
 
 public final class EntryImpl extends AbstractReferenceCounted implements Entry, Comparable<EntryImpl>, ReferenceCounted {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -92,6 +92,7 @@ public class ManagedCursorImpl implements ManagedCursor {
     protected final ManagedLedgerConfig config;
     protected final ManagedLedgerImpl ledger;
     private final String name;
+    private final BookKeeper.DigestType digestType;
 
     protected volatile PositionImpl markDeletePosition;
     protected volatile PositionImpl readPosition;
@@ -179,6 +180,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         this.config = config;
         this.ledger = ledger;
         this.name = cursorName;
+        this.digestType = BookKeeper.DigestType.fromApiDigestType(config.getDigestType());
         STATE_UPDATER.set(this, State.Uninitialized);
         PENDING_MARK_DELETED_SUBMITTED_COUNT_UPDATER.set(this, 0);
         PENDING_READ_OPS_UPDATER.set(this, 0);
@@ -253,7 +255,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         // a new ledger and write the position into it
         ledger.mbean.startCursorLedgerOpenOp();
         long ledgerId = info.getCursorsLedgerId();
-        bookkeeper.asyncOpenLedger(ledgerId, config.getDigestType(), config.getPassword(), (rc, lh, ctx) -> {
+        bookkeeper.asyncOpenLedger(ledgerId, digestType, config.getPassword(), (rc, lh, ctx) -> {
             if (log.isDebugEnabled()) {
                 log.debug("[{}] Opened ledger {} for consumer {}. rc={}", ledger.getName(), ledgerId, name, rc);
             }
@@ -1924,7 +1926,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         ledger.mbean.startCursorLedgerCreateOp();
 
         bookkeeper.asyncCreateLedger(config.getMetadataEnsemblesize(), config.getMetadataWriteQuorumSize(),
-                config.getMetadataAckQuorumSize(), config.getDigestType(), config.getPassword(), (rc, lh, ctx) -> {
+                config.getMetadataAckQuorumSize(), digestType, config.getPassword(), (rc, lh, ctx) -> {
                     ledger.getExecutor().execute(safeRun(() -> {
                         ledger.mbean.endCursorLedgerCreateOp();
                         if (rc != BKException.Code.OK) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -54,6 +54,8 @@ import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.LedgerHandle;
 import org.apache.bookkeeper.common.util.OrderedExecutor;
+import org.apache.bookkeeper.client.api.DigestType;
+import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.AddEntryCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.CloseCallback;
@@ -104,11 +106,12 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
     private final BookKeeper bookKeeper;
     private final String name;
+    private final BookKeeper.DigestType digestType;
 
     private ManagedLedgerConfig config;
     private final MetaStore store;
 
-    private final ConcurrentLongHashMap<CompletableFuture<LedgerHandle>> ledgerCache = new ConcurrentLongHashMap<>();
+    private final ConcurrentLongHashMap<CompletableFuture<ReadHandle>> ledgerCache = new ConcurrentLongHashMap<>();
     private final NavigableMap<Long, LedgerInfo> ledgers = new ConcurrentSkipListMap<>();
     private volatile Stat ledgersStat;
 
@@ -212,6 +215,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         this.config = config;
         this.store = store;
         this.name = name;
+        this.digestType = BookKeeper.DigestType.fromApiDigestType(config.getDigestType());
         this.scheduledExecutor = scheduledExecutor;
         this.executor = orderedExecutor;
         TOTAL_SIZE_UPDATER.set(this, 0);
@@ -278,7 +282,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                         log.debug("[{}] Opening legder {}", name, id);
                     }
                     mbean.startDataLedgerOpenOp();
-                    bookKeeper.asyncOpenLedger(id, config.getDigestType(), config.getPassword(), opencb, null);
+                    bookKeeper.asyncOpenLedger(id, digestType, config.getPassword(), opencb, null);
                 } else {
                     initializeBookKeeper(callback);
                 }
@@ -342,7 +346,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         this.lastLedgerCreationInitiationTimestamp = System.nanoTime();
         mbean.startDataLedgerCreateOp();
         bookKeeper.asyncCreateLedger(config.getEnsembleSize(), config.getWriteQuorumSize(), config.getAckQuorumSize(),
-                config.getDigestType(), config.getPassword(), (rc, lh, ctx) -> {
+                digestType, config.getPassword(), (rc, lh, ctx) -> {
                     executor.executeOrdered(name, safeRun(() -> {
                         mbean.endDataLedgerCreateOp();
                         if (rc != BKException.Code.OK) {
@@ -521,7 +525,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                 this.lastLedgerCreationInitiationTimestamp = System.nanoTime();
                 mbean.startDataLedgerCreateOp();
                 bookKeeper.asyncCreateLedger(config.getEnsembleSize(), config.getWriteQuorumSize(),
-                        config.getAckQuorumSize(), config.getDigestType(), config.getPassword(), this, ctx,
+                        config.getAckQuorumSize(), digestType, config.getPassword(), this, ctx,
                         Collections.emptyMap());
             }
         } else {
@@ -1256,7 +1260,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             this.lastLedgerCreationInitiationTimestamp = System.nanoTime();
             mbean.startDataLedgerCreateOp();
             bookKeeper.asyncCreateLedger(config.getEnsembleSize(), config.getWriteQuorumSize(),
-                    config.getAckQuorumSize(), config.getDigestType(), config.getPassword(), this, null,
+                    config.getAckQuorumSize(), digestType, config.getPassword(), this, null,
                     Collections.emptyMap());
         }
     }
@@ -1307,52 +1311,50 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
     }
 
-    CompletableFuture<LedgerHandle> getLedgerHandle(long ledgerId) {
-        CompletableFuture<LedgerHandle> ledgerHandle = ledgerCache.get(ledgerId);
+    CompletableFuture<ReadHandle> getLedgerHandle(long ledgerId) {
+        CompletableFuture<ReadHandle> ledgerHandle = ledgerCache.get(ledgerId);
         if (ledgerHandle != null) {
             return ledgerHandle;
         }
 
         // If not present try again and create if necessary
         return ledgerCache.computeIfAbsent(ledgerId, lid -> {
-            // Open the ledger for reading if it was not already opened
-            CompletableFuture<LedgerHandle> future = new CompletableFuture<>();
+                // Open the ledger for reading if it was not already opened
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}] Asynchronously opening ledger {} for read", name, ledgerId);
+                }
+                mbean.startDataLedgerOpenOp();
 
-            if (log.isDebugEnabled()) {
-                log.debug("[{}] Asynchronously opening ledger {} for read", name, ledgerId);
-            }
-            mbean.startDataLedgerOpenOp();
-            bookKeeper.asyncOpenLedger(ledgerId, config.getDigestType(), config.getPassword(),
-                    (int rc, LedgerHandle lh, Object ctx) -> {
-                        executor.executeOrdered(name, safeRun(() -> {
-                            mbean.endDataLedgerOpenOp();
-                            if (rc != BKException.Code.OK) {
-                                // Remove the ledger future from cache to give chance to reopen it later
-                                ledgerCache.remove(ledgerId, future);
-                                future.completeExceptionally(createManagedLedgerException(rc));
-                            } else {
-                                if (log.isDebugEnabled()) {
-                                    log.debug("[{}] Successfully opened ledger {} for reading", name, lh.getId());
-                                }
-                                future.complete(lh);
+                CompletableFuture<ReadHandle> future = bookKeeper.newOpenLedgerOp()
+                    .withRecovery(true)
+                    .withLedgerId(ledgerId)
+                    .withDigestType(config.getDigestType())
+                    .withPassword(config.getPassword()).execute();
+                future.whenCompleteAsync((res,ex) -> {
+                        mbean.endDataLedgerOpenOp();
+                        if (ex != null) {
+                            ledgerCache.remove(ledgerId, future);
+                        } else {
+                            if (log.isDebugEnabled()) {
+                                log.debug("[{}] Successfully opened ledger {} for reading", name, ledgerId);
                             }
-                        }));
-                    }, null);
-            return future;
-        });
+                        }
+                    }, executor.chooseThread(name));
+                return future;
+            });
     }
 
-    void invalidateLedgerHandle(LedgerHandle ledgerHandle, int rc) {
+    void invalidateLedgerHandle(ReadHandle ledgerHandle, Throwable t) {
         long ledgerId = ledgerHandle.getId();
         if (ledgerId != currentLedger.getId()) {
             // remove handle from ledger cache since we got a (read) error
             ledgerCache.remove(ledgerId);
             if (log.isDebugEnabled()) {
-                log.debug("[{}] Removed ledger {} from cache (after read error: {})", name, ledgerId, rc);
+                log.debug("[{}] Removed ledger {} from cache (after read error)", name, ledgerId, t);
             }
         } else {
             if (log.isDebugEnabled()) {
-                log.debug("[{}] Ledger that encountered read error {} is current ledger", name, rc);
+                log.debug("[{}] Ledger that encountered read error is current ledger", name, t);
             }
         }
     }
@@ -1377,7 +1379,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
     }
 
-    private void internalReadFromLedger(LedgerHandle ledger, OpReadEntry opReadEntry) {
+    private void internalReadFromLedger(ReadHandle ledger, OpReadEntry opReadEntry) {
 
         // Perform the read
         long firstEntry = opReadEntry.readPosition.getEntryId();
@@ -2246,6 +2248,14 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             return new NonRecoverableLedgerException(BKException.getMessage(bkErrorCode));
         } else {
             return new ManagedLedgerException(BKException.getMessage(bkErrorCode));
+        }
+    }
+
+    public static ManagedLedgerException createManagedLedgerException(Throwable t) {
+        if (t instanceof org.apache.bookkeeper.client.api.BKException) {
+            return createManagedLedgerException(((org.apache.bookkeeper.client.api.BKException)t).getCode());
+        } else {
+            return new ManagedLedgerException("Unknown exception");
         }
     }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerOfflineBacklog.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerOfflineBacklog.java
@@ -34,6 +34,7 @@ import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.BookKeeperAdmin;
 import org.apache.bookkeeper.client.LedgerEntry;
 import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.bookkeeper.client.api.DigestType;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats;
 import org.apache.pulsar.common.naming.TopicName;
@@ -52,9 +53,9 @@ public class ManagedLedgerOfflineBacklog {
     private boolean accurate = false;
     private String brokerName;
 
-    public ManagedLedgerOfflineBacklog(BookKeeper.DigestType digestType, byte[] password, String brokerName,
+    public ManagedLedgerOfflineBacklog(DigestType digestType, byte[] password, String brokerName,
             boolean accurate) {
-        this.digestType = digestType;
+        this.digestType = BookKeeper.DigestType.fromApiDigestType(digestType);
         this.password = password;
         this.accurate = accurate;
         this.brokerName = brokerName;

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -2473,7 +2473,8 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         latch2.await();
 
         try {
-            bkc.openLedgerNoRecovery(ledgerId, mlConfig.getDigestType(), mlConfig.getPassword());
+            bkc.openLedgerNoRecovery(ledgerId, DigestType.fromApiDigestType(mlConfig.getDigestType()),
+                                     mlConfig.getPassword());
             fail("ledger should have deleted due to update-cursor failure");
         } catch (BKException e) {
             // ok

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerBkTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerBkTest.java
@@ -33,8 +33,9 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.BookKeeperTestClient;
+import org.apache.bookkeeper.client.api.DigestType;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.AddEntryCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCallback;
 import org.apache.bookkeeper.mledger.Entry;
@@ -345,7 +346,7 @@ public class ManagedLedgerBkTest extends BookKeeperClusterTestCase {
         PositionImpl p1 = (PositionImpl) ledger.addEntry("entry-1".getBytes());
 
         // Trigger the closure of the data ledger
-        bkc.openLedger(p1.getLedgerId(), DigestType.CRC32C, new byte[] {});
+        bkc.openLedger(p1.getLedgerId(), BookKeeper.DigestType.CRC32C, new byte[] {});
 
         ledger.addEntry("entry-2".getBytes());
 
@@ -423,8 +424,8 @@ public class ManagedLedgerBkTest extends BookKeeperClusterTestCase {
         entries.forEach(e -> e.release());
         ledger.close();
 
-        ManagedLedgerOfflineBacklog offlineTopicBacklog = new ManagedLedgerOfflineBacklog(DigestType.CRC32,
-                "".getBytes(Charsets.UTF_8), "", false);
+        ManagedLedgerOfflineBacklog offlineTopicBacklog = new ManagedLedgerOfflineBacklog(
+                DigestType.CRC32, "".getBytes(Charsets.UTF_8), "", false);
         PersistentOfflineTopicStats offlineTopicStats = offlineTopicBacklog.getEstimatedUnloadedTopicBacklog(
                 (ManagedLedgerFactoryImpl) factory, "property/cluster/namespace/my-ledger");
         factory.shutdown();

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerErrorsTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerErrorsTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.bookkeeper.client.BKException;
-import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.client.api.DigestType;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.AddEntryCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.CloseCallback;
 import org.apache.bookkeeper.mledger.Entry;

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
-import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.client.api.DigestType;
 import org.apache.pulsar.broker.authorization.PulsarAuthorizationProvider;
 import org.apache.pulsar.common.configuration.FieldContext;
 import org.apache.pulsar.common.configuration.PulsarConfiguration;

--- a/pulsar-broker-common/src/test/java/org/apache/pulsar/common/configuration/PulsarConfigurationLoaderTest.java
+++ b/pulsar-broker-common/src/test/java/org/apache/pulsar/common/configuration/PulsarConfigurationLoaderTest.java
@@ -32,7 +32,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.util.Properties;
 
-import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.client.api.DigestType;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.testng.annotations.Test;
 

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/ManagedLedgerWriter.java
@@ -49,7 +49,7 @@ import java.util.stream.Collectors;
 
 import org.HdrHistogram.Histogram;
 import org.HdrHistogram.Recorder;
-import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.client.api.DigestType;
 import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.meta.HierarchicalLedgerManagerFactory;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.AddEntryCallback;


### PR DESCRIPTION
BookKeeper 4.6 introduced a new API for reading, called
ReadHandle. This API is an small interface, unlike LedgerHandle, so it
is possible to provide implementations of ReadHandle that read from
sources other than bookkeeper, while presenting the same interface as
when reading from bookkeeper.

This patch changes the managed ledger entry read path to use
ReadHandle. This is rquired to implement tiered storage (PIP-17).

Master issue: #1511