### PR TITLE
Compaction allows keyless messages to pass through

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawBatchConverter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawBatchConverter.java
@@ -105,12 +105,15 @@ public class RawBatchConverter {
                 ByteBuf singleMessagePayload = Commands.deSerializeSingleMessageInBatch(payload,
                                                                                         singleMessageMetadataBuilder,
                                                                                         0, batchSize);
-                String key = singleMessageMetadataBuilder.getPartitionKey();
                 MessageId id = new BatchMessageIdImpl(msg.getMessageIdData().getLedgerId(),
                                                       msg.getMessageIdData().getEntryId(),
                                                       msg.getMessageIdData().getPartition(),
                                                       i);
-                if (filter.test(key, id)) {
+                if (!singleMessageMetadataBuilder.hasPartitionKey()) {
+                    messagesRetained++;
+                    Commands.serializeSingleMessageInBatchWithPayload(singleMessageMetadataBuilder,
+                                                                      singleMessagePayload, batchBuffer);
+                } else if (filter.test(singleMessageMetadataBuilder.getPartitionKey(), id)) {
                     messagesRetained++;
                     Commands.serializeSingleMessageInBatchWithPayload(singleMessageMetadataBuilder,
                                                                       singleMessagePayload, batchBuffer);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactionTest.java
@@ -442,4 +442,74 @@ public class CompactionTest extends MockedPulsarServiceBaseTest {
             Assert.assertEquals(new String(message.getData()), "my-message-4");
         }
     }
+
+    @Test
+    public void testKeyLessMessagesPassThrough() throws Exception {
+        String topic = "persistent://my-property/use/my-ns/my-topic1";
+
+        // subscribe before sending anything, so that we get all messages
+        pulsarClient.newConsumer().topic(topic).subscriptionName("sub1")
+            .readCompacted(true).subscribe().close();
+
+        try (Producer producerNormal = pulsarClient.newProducer().topic(topic).create();
+             Producer producerBatch = pulsarClient.newProducer().topic(topic).maxPendingMessages(3)
+                .enableBatching(true).batchingMaxMessages(3)
+                .batchingMaxPublishDelay(1, TimeUnit.HOURS).create()) {
+            producerNormal.sendAsync(MessageBuilder.create()
+                                     .setContent("my-message-1".getBytes()).build()).get();
+
+            producerBatch.sendAsync(MessageBuilder.create()
+                                    .setContent("my-message-2".getBytes()).build());
+            producerBatch.sendAsync(MessageBuilder.create()
+                                    .setKey("key1")
+                                    .setContent("my-message-3".getBytes()).build());
+            producerBatch.sendAsync(MessageBuilder.create()
+                                    .setKey("key1")
+                                    .setContent("my-message-4".getBytes()).build()).get();
+
+            producerBatch.sendAsync(MessageBuilder.create()
+                                    .setKey("key2")
+                                    .setContent("my-message-5".getBytes()).build());
+            producerBatch.sendAsync(MessageBuilder.create()
+                                    .setKey("key2")
+                                    .setContent("my-message-6".getBytes()).build());
+            producerBatch.sendAsync(MessageBuilder.create()
+                                    .setContent("my-message-7".getBytes()).build()).get();
+
+            producerNormal.sendAsync(MessageBuilder.create()
+                                     .setContent("my-message-8".getBytes()).build()).get();
+        }
+
+        // compact the topic
+        Compactor compactor = new TwoPhaseCompactor(conf, pulsarClient, bk, compactionScheduler);
+        compactor.compact(topic).get();
+
+        try (Consumer consumer = pulsarClient.newConsumer().topic(topic)
+                .subscriptionName("sub1").readCompacted(true).subscribe()){
+            Message message1 = consumer.receive();
+            Assert.assertFalse(message1.hasKey());
+            Assert.assertEquals(new String(message1.getData()), "my-message-1");
+
+            Message message2 = consumer.receive();
+            Assert.assertFalse(message2.hasKey());
+            Assert.assertEquals(new String(message2.getData()), "my-message-2");
+
+            Message message3 = consumer.receive();
+            Assert.assertEquals(message3.getKey(), "key1");
+            Assert.assertEquals(new String(message3.getData()), "my-message-4");
+
+            Message message4 = consumer.receive();
+            Assert.assertEquals(message4.getKey(), "key2");
+            Assert.assertEquals(new String(message4.getData()), "my-message-6");
+
+            Message message5 = consumer.receive();
+            Assert.assertFalse(message5.hasKey());
+            Assert.assertEquals(new String(message5.getData()), "my-message-7");
+
+            Message message6 = consumer.receive();
+            Assert.assertFalse(message6.hasKey());
+            Assert.assertEquals(new String(message6.getData()), "my-message-8");
+        }
+    }
+
 }


### PR DESCRIPTION
If a message has no key it's impossible to know if a later message
supercedes it, so in this case, it should be simply passed through
compaction (i.e. it should appear when reading from a compacted
topic).