### PR TITLE
Added test to ensure property name can contain '_' characters.

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/naming/NamedEntity.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/naming/NamedEntity.java
@@ -18,12 +18,14 @@
  */
 package org.apache.pulsar.common.naming;
 
-import java.net.URI;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import lombok.experimental.UtilityClass;
+
 /**
  */
+@UtilityClass
 public class NamedEntity {
 
     // allowed characters for property, namespace, cluster and topic names are
@@ -37,11 +39,4 @@ public class NamedEntity {
             throw new IllegalArgumentException("Invalid named entity: " + name);
         }
     }
-
-    public static void checkURI(URI uri, String name) {
-        if (!String.format("%s://%s%s", uri.getScheme(), uri.getHost(), uri.getPath()).equals(name)) {
-            throw new IllegalArgumentException("Invalid trailing chars in named entity: " + name);
-        }
-    }
-
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicDomain.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicDomain.java
@@ -30,14 +30,14 @@ public enum TopicDomain {
     public String value() {
         return this.value;
     }
-    
+
     public static TopicDomain getEnum(String value) {
         for (TopicDomain e : values()) {
             if (e.value.equalsIgnoreCase(value)) {
                 return e;
             }
         }
-        throw new IllegalArgumentException("Invalid enum value " + value);
+        throw new IllegalArgumentException("Invalid topic domain: '" + value + "'");
     }
 
     @Override

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/naming/TopicName.java
@@ -105,7 +105,7 @@ public class TopicName implements ServiceUnitId {
             // legacy: persistent://property/cluster/namespace/topic
             if (!completeTopicName.contains("://")) {
                 throw new IllegalArgumentException(
-                        "Invalid completeTopicName name: " + completeTopicName + " -- Domain is missing");
+                        "Invalid topic name: " + completeTopicName + " -- Domain is missing");
             }
 
             List<String> parts = Splitter.on("://").limit(2).splitToList(completeTopicName);
@@ -139,15 +139,15 @@ public class TopicName implements ServiceUnitId {
                 this.partitionIndex = getPartitionIndex(completeTopicName);
                 this.namespaceName = NamespaceName.get(property, cluster, namespacePortion);
             } else {
-                throw new IllegalArgumentException("Invalid completeTopicName name: " + completeTopicName);
+                throw new IllegalArgumentException("Invalid topic name: " + completeTopicName);
             }
 
 
             if (localName == null || localName.isEmpty()) {
-                throw new IllegalArgumentException("Invalid completeTopicName name: " + completeTopicName);
+                throw new IllegalArgumentException("Invalid topic name: " + completeTopicName);
             }
         } catch (NullPointerException e) {
-            throw new IllegalArgumentException("Invalid completeTopicName name: " + completeTopicName, e);
+            throw new IllegalArgumentException("Invalid topic name: " + completeTopicName, e);
         }
 
     }


### PR DESCRIPTION
### Motivation

As reported in #1506, in 1.22 we still have inconsistencies between what's allowed as a valid property name and what is allowed when creating the namespace. 

This issue was already fixed in master. `_` are allowed in property name and invalid characters are correctly rejected when creating the property.

Adding here tests to ensure the behavior doesn't change.