### PR TITLE
Use signSafeMod in RoundRobinPartitionMessageRouter

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/SinglePartitionMessageRouterImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/SinglePartitionMessageRouterImpl.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.client.impl;
 
+import static org.apache.pulsar.client.util.MathUtils.signSafeMod;
+
 import org.apache.pulsar.client.api.HashingScheme;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.TopicMetadata;
@@ -37,7 +39,7 @@ public class SinglePartitionMessageRouterImpl extends MessageRouterBase {
     public int choosePartition(Message<?> msg, TopicMetadata metadata) {
         // If the message has a key, it supersedes the single partition routing policy
         if (msg.hasKey()) {
-            return hash.makeHash(msg.getKey()) % metadata.numPartitions();
+            return signSafeMod(hash.makeHash(msg.getKey()), metadata.numPartitions());
         }
 
         return partitionIndex;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/util/MathUtils.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/util/MathUtils.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.util;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class MathUtils {
+    /**
+     * Compute sign safe mod
+     *
+     * @param dividend
+     * @param divisor
+     * @return
+     */
+    public static int signSafeMod(long dividend, int divisor) {
+        int mod = (int) (dividend % divisor);
+
+        if (mod < 0) {
+            mod += divisor;
+        }
+
+        return mod;
+    }
+}


### PR DESCRIPTION
### Motivation

I have seen this errors in master with the round-robin message router (used with `perf-producer`) : 

```
00:11:08.789 [pulsar-perf-producer-exec-1-1] ERROR org.apache.pulsar.testclient.PerformanceProducer - Got error
java.lang.IllegalArgumentException: Illegal partition index chosen by the message routing policy
    at com.google.common.base.Preconditions.checkArgument(Preconditions.java:122) ~[com.google.guava-guava-20.0.jar:?]
    at org.apache.pulsar.client.impl.PartitionedProducerImpl.sendAsync(PartitionedProducerImpl.java:170) ~[org.apache.pulsar-pulsar-client-original-2.0.0-incubating-SNAPSHOT.jar:2.0.0-incubating-SNAPSHOT]
    at org.apache.pulsar.client.impl.ProducerBase.sendAsync(ProducerBase.java:54) ~[org.apache.pulsar-pulsar-client-original-2.0.0-incubating-SNAPSHOT.jar:2.0.0-incubating-SNAPSHOT]
    at org.apache.pulsar.testclient.PerformanceProducer.lambda$0(PerformanceProducer.java:347) ~[org.apache.pulsar-pulsar-testclient-2.0.0-incubating-SNAPSHOT.jar:2.0.0-incubating-SNAPSHOT]
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_161]
    at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_161]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_161]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_161]
    at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [io.netty-netty-all-4.1.21.Final.jar:4.1.21.Final]
    at java.lang.Thread.run(Thread.java:748) [?:1.8.0_161]
```

Fixed by consistently using `signSafeMod()` function. Imported from BK code since client doesn't depend on BK.