### PR TITLE
Compaction considers messages with empty payload as deleting the key

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawBatchConverter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawBatchConverter.java
@@ -113,7 +113,8 @@ public class RawBatchConverter {
                     messagesRetained++;
                     Commands.serializeSingleMessageInBatchWithPayload(singleMessageMetadataBuilder,
                                                                       singleMessagePayload, batchBuffer);
-                } else if (filter.test(singleMessageMetadataBuilder.getPartitionKey(), id)) {
+                } else if (filter.test(singleMessageMetadataBuilder.getPartitionKey(), id)
+                           && singleMessagePayload.readableBytes() > 0) {
                     messagesRetained++;
                     Commands.serializeSingleMessageInBatchWithPayload(singleMessageMetadataBuilder,
                                                                       singleMessagePayload, batchBuffer);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/TwoPhaseCompactor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/TwoPhaseCompactor.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.common.api.Commands;
@@ -122,9 +123,9 @@ public class TwoPhaseCompactor extends Compactor {
                                          id, ioe);
                             }
                         } else {
-                            String key = extractKey(m);
-                            if (key != null) {
-                                latestForKey.put(key, id);
+                            Pair<String,Integer> keyAndSize = extractKeyAndSize(m);
+                            if (keyAndSize != null) {
+                                latestForKey.put(keyAndSize.getLeft(), id);
                             }
                         }
 
@@ -214,10 +215,11 @@ public class TwoPhaseCompactor extends Compactor {
                             messageToAdd = Optional.of(m);
                         }
                     } else {
-                        String key = extractKey(m);
-                        if (key == null) { // pass through messages without a key
+                        Pair<String,Integer> keyAndSize = extractKeyAndSize(m);
+                        if (keyAndSize == null) { // pass through messages without a key
                             messageToAdd = Optional.of(m);
-                        } else if (latestForKey.get(key).equals(id)) {
+                        } else if (latestForKey.get(keyAndSize.getLeft()).equals(id)
+                                   && keyAndSize.getRight() > 0) {
                             messageToAdd = Optional.of(m);
                         } else {
                             m.close();
@@ -307,11 +309,11 @@ public class TwoPhaseCompactor extends Compactor {
         return bkf;
     }
 
-    private static String extractKey(RawMessage m) {
+    private static Pair<String,Integer> extractKeyAndSize(RawMessage m) {
         ByteBuf headersAndPayload = m.getHeadersAndPayload();
         MessageMetadata msgMetadata = Commands.parseMessageMetadata(headersAndPayload);
         if (msgMetadata.hasPartitionKey()) {
-            return msgMetadata.getPartitionKey();
+            return Pair.of(msgMetadata.getPartitionKey(), headersAndPayload.readableBytes());
         } else {
             return null;
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageBuilderImpl.java
@@ -33,10 +33,10 @@ import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
 import com.google.common.base.Preconditions;
 
 public class MessageBuilderImpl<T> implements MessageBuilder<T> {
-
+    private static final ByteBuffer EMPTY_CONTENT = ByteBuffer.allocate(0);
     private final MessageMetadata.Builder msgMetadataBuilder = MessageMetadata.newBuilder();
     private final Schema<T> schema;
-    private ByteBuffer content;
+    private ByteBuffer content = EMPTY_CONTENT;
 
     public MessageBuilderImpl(Schema<T> schema) {
         this.schema = schema;


### PR DESCRIPTION
If the latest message with a key has an empty payload, compaction
will take this to mean that the key has been deleted, so it will not
be stored in the compacted topic ledger.

This patch also introduces empty messages, which were not previously
possible.
