### PR TITLE
make connection timeout config-able for consumer and producer

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -184,7 +184,9 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         }
 
         this.connectionHandler = new ConnectionHandler(this,
-            new Backoff(100, TimeUnit.MILLISECONDS, 60, TimeUnit.SECONDS, 0, TimeUnit.MILLISECONDS),
+            new Backoff(100, TimeUnit.MILLISECONDS,
+                client.getConfiguration().getOperationTimeoutMs(), TimeUnit.MILLISECONDS,
+                0, TimeUnit.MILLISECONDS),
             this);
 
         grabCnx();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -181,7 +181,9 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         }
 
         this.connectionHandler = new ConnectionHandler(this,
-            new Backoff(100, TimeUnit.MILLISECONDS, 60, TimeUnit.SECONDS, Math.max(100, conf.getSendTimeoutMs() - 100), TimeUnit.MILLISECONDS),
+            new Backoff(100, TimeUnit.MILLISECONDS,
+                client.getConfiguration().getOperationTimeoutMs(), TimeUnit.MILLISECONDS,
+                Math.max(100, conf.getSendTimeoutMs() - 100), TimeUnit.MILLISECONDS),
             this);
         grabCnx();
     }


### PR DESCRIPTION
### Motivation

In ConsumerImpl and ProducerImpl,  the max timeout for connection is hard code as 60 seconds.
This change try to make it config-able, and use value of client.configuration.getOperationTimeoutMs

### Modifications

change hard code 60s into client.configuration.getOperationTimeoutMs

### Result

connection timeout could be config-able.