### PR TITLE
Reduce un-necessary work when doing bundle lookup for partitioned topic

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -53,7 +53,6 @@ import org.apache.pulsar.broker.loadbalance.ResourceUnit;
 import org.apache.pulsar.broker.lookup.LookupResult;
 import org.apache.pulsar.broker.service.BrokerServiceException.ServerMetadataException;
 import org.apache.pulsar.broker.service.BrokerServiceException.ServiceUnitNotReadyException;
-import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.common.lookup.data.LookupData;
 import org.apache.pulsar.common.naming.TopicName;
@@ -121,7 +120,7 @@ public class NamespaceService {
     public static final Pattern SLA_NAMESPACE_PATTERN = Pattern.compile(SLA_NAMESPACE_PROPERTY + "/[^/]+/([^:]+:\\d+)");
     public static final String HEARTBEAT_NAMESPACE_FMT = "pulsar/%s/%s:%s";
     public static final String SLA_NAMESPACE_FMT = SLA_NAMESPACE_PROPERTY + "/%s/%s:%s";
-    
+
     public static final String NAMESPACE_ISOLATION_POLICIES = "namespaceIsolationPolicies";
 
     /**
@@ -277,9 +276,9 @@ public class NamespaceService {
         }
     }
 
-    static ConcurrentOpenHashMap<NamespaceBundle, CompletableFuture<Optional<LookupResult>>> findingBundlesAuth
+    static ConcurrentOpenHashMap<NamespaceBundle, CompletableFuture<Optional<LookupResult>>> findingBundlesAuthoritative
         = new ConcurrentOpenHashMap<>();
-    static ConcurrentOpenHashMap<NamespaceBundle, CompletableFuture<Optional<LookupResult>>> findingBundlesNoAuth
+    static ConcurrentOpenHashMap<NamespaceBundle, CompletableFuture<Optional<LookupResult>>> findingBundlesNotAuthoritative
         = new ConcurrentOpenHashMap<>();
 
     /**
@@ -299,9 +298,9 @@ public class NamespaceService {
 
         ConcurrentOpenHashMap<NamespaceBundle, CompletableFuture<Optional<LookupResult>>> targetMap;
         if (authoritative) {
-            targetMap = findingBundlesAuth;
+            targetMap = findingBundlesAuthoritative;
         } else {
-            targetMap = findingBundlesNoAuth;
+            targetMap = findingBundlesNotAuthoritative;
         }
 
         return targetMap.computeIfAbsent(bundle, (k) -> {


### PR DESCRIPTION
### Motivation
 
For partitioned topic, when create producer or consumer for each partition concurrently, it will call `pularclient.getConnection` and will finally call into `namespace.searchForCandidateBroker` to acquire target bundle. If this bundle contains more then one partitioned topic, then each of them will call the bundle related handling(acquire ownership, loadNamespaceTopics), this waste some resource.
This change tries to let the first partition topic do the real work once, and do the piggy back
for other concurrent topics handling.

e.g.
```
 Apr 05 01:43:25 ip-10-0-0-145.us-west-2.compute.internal pulsar[12989]: 01:43:25.301 [pulsar-1-17] INFO  org.apache.pulsar.broker.namespace.OwnershipCache - Trying to acquire ownership of benchmark/ local/ns-CeV_hcU/0x14000000_0x18000000
.....
.....
 Apr 05 01:43:25 ip-10-0-0-145.us-west-2.compute.internal pulsar[12989]: 01:43:25.301 [pulsar-1-10] INFO  org.apache.pulsar.broker.namespace.OwnershipCache - Trying to acquire ownership of benchmark/ local/ns-CeV_hcU/0x14000000_0x18000000
 Apr 05 01:43:25 ip-10-0-0-145.us-west-2.compute.internal pulsar[12989]: 01:43:25.301 [pulsar-1-15] INFO  org.apache.pulsar.broker.namespace.OwnershipCache - Trying to acquire ownership of benchmark/ local/ns-CeV_hcU/0x14000000_0x18000000
 Apr 05 01:43:25 ip-10-0-0-145.us-west-2.compute.internal pulsar[12989]: 01:43:25.304 [pulsar-ordered-OrderedExecutor-7-0-EventThread] INFO  org.apache.pulsar.broker.namespace.OwnershipCache -        Successfully acquired ownership of /namespace/benchmark/local/ns-CeV_hcU/0x14000000_0x18000000
 Apr 05 01:43:25 ip-10-0-0-145.us-west-2.compute.internal pulsar[12989]: 01:43:25.304 [pulsar-ordered-OrderedExecutor-7-0-EventThread] INFO  org.apache.pulsar.broker.namespace.OwnershipCache -        Successfully acquired ownership of /namespace/benchmark/local/ns-CeV_hcU/0x14000000_0x18000000
......
``` 

### Modifications

This change tries to let the first partition topic do the real work only once, and do the piggy back
for other concurrent topics handling.

### Result

getConnection for partitioned consumer and producer would be more efficient.