### PR TITLE
remove unnecessary proto def in FunctionsConfig

### DIFF
--- a/pulsar-functions/proto/src/main/proto/Function.proto
+++ b/pulsar-functions/proto/src/main/proto/Function.proto
@@ -53,9 +53,6 @@ message FunctionConfig {
     bool autoAck = 13;
     repeated string inputs = 14;
     int32 parallelism = 15;
-    // Fully qualified function name
-    // (alternative to specifying tenant/namespace/name)
-    string fqfn = 16;
 }
 
 message PackageLocationMetaData {


### PR DESCRIPTION
Remove unnecessary proto def in FunctionsConfig. We don't need to fqfn field in FunctionsConfig