### PR TITLE
Log warn message if exception occurs while WebSocket proxy is sending…

### DIFF
--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ProducerHandler.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/ProducerHandler.java
@@ -187,6 +187,8 @@ public class ProducerHandler extends AbstractWebSocketHandler {
                 sendAckResponse(new ProducerAck(messageId, sendRequest.context));
             }
         }).exceptionally(exception -> {
+            log.warn("[{}] Error occurred while producer handler was sending msg from {}: {}", producer.getTopic(),
+                    getRemote().getInetSocketAddress().toString(), exception.getMessage());
             numMsgsFailed.increment();
             sendAckResponse(
                     new ProducerAck(UnknownError, exception.getMessage(), null, sendRequest.context));


### PR DESCRIPTION
…/receiving message

Currently, even if an exception occurs while a producer/consumer inside WebSocket proxy is sending/receiving a message, it is difficult to notice it.
Therefore, I will add some logs.