### PR TITLE
Add rate limit for client lookup requests

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -697,7 +697,7 @@ public class BrokerServiceTest extends BrokerTestBase {
 
         String lookupUrl = new URI("pulsar://localhost:" + BROKER_PORT).toString();
         PulsarClient pulsarClient = PulsarClient.builder().serviceUrl(lookupUrl).statsInterval(0, TimeUnit.SECONDS)
-                .maxConcurrentLookupRequests(0).build();
+                .maxConcurrentLookupRequests(0).maxLookupRequests(0).build();
 
         try {
             pulsarClient.newConsumer().topic(topicName).subscriptionName("mysub").subscribe();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -697,13 +697,34 @@ public class BrokerServiceTest extends BrokerTestBase {
 
         String lookupUrl = new URI("pulsar://localhost:" + BROKER_PORT).toString();
         PulsarClient pulsarClient = PulsarClient.builder().serviceUrl(lookupUrl).statsInterval(0, TimeUnit.SECONDS)
-                .maxConcurrentLookupRequests(0).maxLookupRequests(0).build();
+                .maxConcurrentLookupRequests(1).maxLookupRequests(2).build();
 
+        // 2 lookup will success.
         try {
-            pulsarClient.newConsumer().topic(topicName).subscriptionName("mysub").subscribe();
-            fail("It should fail as throttling should not receive any request");
-        } catch (org.apache.pulsar.client.api.PulsarClientException.TooManyRequestsException e) {
-            // ok as throttling set to 0
+            CompletableFuture<Consumer<byte[]>> consumer1 = pulsarClient.newConsumer().topic(topicName).subscriptionName("mysub1").subscribeAsync();
+            CompletableFuture<Consumer<byte[]>> consumer2 = pulsarClient.newConsumer().topic(topicName).subscriptionName("mysub2").subscribeAsync();
+
+            consumer1.get().close();
+            consumer2.get().close();
+        } catch (Exception e) {
+            fail("Subscribe should success with 2 requests");
+        }
+
+        // 3 lookup will fail
+        try {
+            CompletableFuture<Consumer<byte[]>> consumer1 = pulsarClient.newConsumer().topic(topicName).subscriptionName("mysub11").subscribeAsync();
+            CompletableFuture<Consumer<byte[]>> consumer2 = pulsarClient.newConsumer().topic(topicName).subscriptionName("mysub22").subscribeAsync();
+            CompletableFuture<Consumer<byte[]>> consumer3 = pulsarClient.newConsumer().topic(topicName).subscriptionName("mysub33").subscribeAsync();
+
+            consumer1.get().close();
+            consumer2.get().close();
+            consumer3.get().close();
+            fail("It should fail as throttling should only receive 2 requests");
+        } catch (Exception e) {
+            if (!(e.getCause() instanceof
+                org.apache.pulsar.client.api.PulsarClientException.TooManyRequestsException)) {
+                fail("Subscribe should fail with TooManyRequestsException");
+            }
         }
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
@@ -246,13 +246,23 @@ public interface ClientBuilder extends Serializable, Cloneable {
     ClientBuilder statsInterval(long statsInterval, TimeUnit unit);
 
     /**
-     * Number of concurrent lookup-requests allowed on each broker-connection to prevent overload on broker.
+     * Number of concurrent lookup-requests allowed to send on each broker-connection to prevent overload on broker.
      * <i>(default: 5000)</i> It should be configured with higher value only in case of it requires to produce/subscribe
      * on thousands of topic using created {@link PulsarClient}
      *
      * @param maxConcurrentLookupRequests
      */
     ClientBuilder maxConcurrentLookupRequests(int maxConcurrentLookupRequests);
+
+    /**
+     * Number of max lookup-requests allowed on each broker-connection to prevent overload on broker.
+     * <i>(default: 20000)</i> It should not be smaller than maxConcurrentLookupRequests.
+     * Requests that inside maxConcurrentLookupRequests already send to broker, and requests beyond
+     * maxConcurrentLookupRequests and under maxLookupRequests will wait in each client cnx.
+     *
+     * @param maxLookupRequests
+     */
+    ClientBuilder maxLookupRequests(int maxLookupRequests);
 
     /**
      * Set max number of broker-rejected requests in a certain time-frame (30 seconds) after which current connection

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
@@ -256,7 +256,7 @@ public interface ClientBuilder extends Serializable, Cloneable {
 
     /**
      * Number of max lookup-requests allowed on each broker-connection to prevent overload on broker.
-     * <i>(default: 20000)</i> It should not be smaller than maxConcurrentLookupRequests.
+     * <i>(default: 50000)</i> It should be bigger than maxConcurrentLookupRequests.
      * Requests that inside maxConcurrentLookupRequests already send to broker, and requests beyond
      * maxConcurrentLookupRequests and under maxLookupRequests will wait in each client cnx.
      *

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
@@ -150,6 +150,12 @@ public class ClientBuilderImpl implements ClientBuilder {
     }
 
     @Override
+    public ClientBuilder maxLookupRequests(int maxLookupRequests) {
+        conf.setMaxLookupRequest(maxLookupRequests);
+        return this;
+    }
+
+    @Override
     public ClientBuilder maxNumberOfRejectedRequestPerConnection(int maxNumberOfRejectedRequestPerConnection) {
         conf.setMaxNumberOfRejectedRequestPerConnection(maxNumberOfRejectedRequestPerConnection);
         return this;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -52,7 +52,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
     private boolean tlsAllowInsecureConnection = false;
     private boolean tlsHostnameVerificationEnable = false;
     private int concurrentLookupRequest = 5000;
-    private int maxLookupRequest = 20000;
+    private int maxLookupRequest = 50000;
     private int maxNumberOfRejectedRequestPerConnection = 50;
     private int keepAliveIntervalSeconds = 30;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -51,7 +51,8 @@ public class ClientConfigurationData implements Serializable, Cloneable {
     private String tlsTrustCertsFilePath = "";
     private boolean tlsAllowInsecureConnection = false;
     private boolean tlsHostnameVerificationEnable = false;
-    private int concurrentLookupRequest = 50000;
+    private int concurrentLookupRequest = 5000;
+    private int maxLookupRequest = 20000;
     private int maxNumberOfRejectedRequestPerConnection = 50;
     private int keepAliveIntervalSeconds = 30;
 


### PR DESCRIPTION
### Motivation

Currently broker side has config `maxConcurrentLookupRequest`, and client side has config `concurrentLookupRequest `.  If client side send too much lookup request, broker will fail the lookup request with `ServerError.TooManyRequests`. This change try to make rate limit of lookup request from client side.

### Modifications

Add new parameter `maxLookupRequest` in clientConfiguration, and do rate limit in ClientCnx.

### Result

Client side lookup could be rate-limited, and avoid server side return error.