### PR TITLE
Compaction sets read compacted flag when reading

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
@@ -54,6 +54,7 @@ public class RawReaderImpl implements RawReader {
         consumerConfiguration.setSubscriptionName(subscription);
         consumerConfiguration.setSubscriptionType(SubscriptionType.Exclusive);
         consumerConfiguration.setReceiverQueueSize(DEFAULT_RECEIVER_QUEUE_SIZE);
+        consumerConfiguration.setReadCompacted(true);
 
         consumer = new RawConsumerImpl(client, consumerConfiguration,
                                        consumerFuture);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/auth/MockedPulsarServiceBaseTest.java
@@ -222,11 +222,11 @@ public abstract class MockedPulsarServiceBaseTest {
     }
 
     public static NonClosableMockBookKeeper createMockBookKeeper(ZooKeeper zookeeper) throws Exception {
-        return new NonClosableMockBookKeeper(new ClientConfiguration(), zookeeper);
+        return spy(new NonClosableMockBookKeeper(new ClientConfiguration(), zookeeper));
     }
 
     // Prevent the MockBookKeeper instance from being closed when the broker is restarted within a test
-    private static class NonClosableMockBookKeeper extends MockBookKeeper {
+    public static class NonClosableMockBookKeeper extends MockBookKeeper {
 
         public NonClosableMockBookKeeper(ClientConfiguration conf, ZooKeeper zk) throws Exception {
             super(zk);


### PR DESCRIPTION
Previously compaction would read the whole backlog again, even though
what was in the compacted topic ledger was sufficient for its
purposes. This patch flips the switch.
