### PR TITLE
Fix: handle failure of topic stat update

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1075,7 +1075,12 @@ public class PersistentTopic implements Topic, AddEntryCallback {
         nsStats.replicatorCount += topicStats.remotePublishersStats.size();
         replicators.forEach((cluster, replicator) -> {
             // Update replicator cursor state
-            ((PersistentReplicator) replicator).updateCursorState();
+            try {
+                ((PersistentReplicator) replicator).updateCursorState();
+            } catch (Exception e) {
+                log.warn("[{}] Failed to update cursro state ", topic, e);
+            }
+            
 
             // Update replicator stats
             ReplicatorStats rStat = replicator.getStats();


### PR DESCRIPTION
### Motivation

Recently, we have seen multiple scenarios where due to incorrect state of one of the `ManagedCursor`, broker fails to prepare correct destinations metrics.
eg:
recently we have seen below stats failure, which prepares incorrect destination-json metrics and pulsar-admin tool fails to get the stats-response.

```
20:07:19.790 [pulsar-stats-updater-73-1] ERROR o.a.p.broker.service.PulsarStats     - Failed to generate topic stats for topic persistent://prop/global/ns/topic: null
java.lang.NullPointerException: null
        at org.apache.bookkeeper.mledger.impl.PositionImpl.<init>(PositionImpl.java:54) ~[managed-ledger-1.20.16-incubating-yahoo.jar:1.20.16-incubating-yahoo]
        at org.apache.bookkeeper.mledger.impl.PositionImpl.get(PositionImpl.java:63) ~[managed-ledger-1.20.16-incubating-yahoo.jar:1.20.16-incubating-yahoo]
        at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.getReadPosition(ManagedCursorImpl.java:1646) ~[managed-ledger-1.20.16-incubating-yahoo.jar:1.20.16-incubating-yahoo]
        at org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.deactivateCursor(ManagedLedgerImpl.java:2009) ~[managed-ledger-1.20.16-incubating-yahoo.jar:1.20.16-incubating-yahoo]
        at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.setInactive(ManagedCursorImpl.java:727) ~[managed-ledger-1.20.16-incubating-yahoo.jar:1.20.16-incubating-yahoo]
        at org.apache.pulsar.broker.service.persistent.PersistentReplicator.updateCursorState(PersistentReplicator.java:303) ~[pulsar-broker-1.20.16-incubating-yahoo.jar:1.20.16-incubating-yahoo]
        at org.apache.pulsar.broker.service.persistent.PersistentTopic.lambda$30(PersistentTopic.java:965) ~[pulsar-broker-1.20.16-incubating-yahoo.jar:1.20.16-incubating-yahoo]
        at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section.forEach(ConcurrentOpenHashMap.java:386) ~[pulsar-common-1.20.16-incubating-yahoo.jar:1.20.16-incubating-yahoo]
        at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap.forEach(ConcurrentOpenHashMap.java:160) ~[pulsar-common-1.20.16-incubating-yahoo.jar:1.20.16-incubating-yahoo]
        at org.apache.pulsar.broker.service.persistent.PersistentTopic.updateRates(PersistentTopic.java:963) ~[pulsar-broker-1.20.16-incubating-yahoo.jar:1.20.16-incubating-yahoo]
        at org.apache.pulsar.broker.service.PulsarStats.lambda$5(PulsarStats.java:124) ~[pulsar-broker-1.20.16-incubating-yahoo.jar:1.20.16-incubating-yahoo]
        at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section.forEach(ConcurrentOpenHashMap.java:386) ~[pulsar-common-1.20.16-incubating-yahoo.jar:1.20.16-incubating-yahoo]
        at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap.forEach(ConcurrentOpenHashMap.java:160) ~[pulsar-common-1.20.16-incubating-yahoo.jar:1.20.16-incubating-yahoo]
        at org.apache.pulsar.broker.service.PulsarStats.lambda$3(PulsarStats.java:122) ~[pulsar-broker-1.20.16-incubating-yahoo.jar:1.20.16-incubating-yahoo]
        at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section.forEach(ConcurrentOpenHashMap.java:386) ~[pulsar-common-1.20.16-incubating-yahoo.jar:1.20.16-incubating-yahoo]
        at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap.forEach(ConcurrentOpenHashMap.java:160) ~[pulsar-common-1.20.16-incubating-yahoo.jar:1.20.16-incubating-yahoo]


Root cause error of incorrect managed-cursor position (happened due to race condition at setAcknowledgedPosition which might be fixed with past merged PR)

19:17:28.298 [pulsar-io-72-47] WARN  o.a.b.mledger.impl.ManagedCursorImpl - [prop/global/ns/persistent/topic] [sub] Error while updating individualDeletedMessages [null]
java.lang.NullPointerException: null
        at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:192) ~[guava-15.0.jar:na]
        at com.google.common.collect.TreeRangeSet.rangeContaining(TreeRangeSet.java:98) ~[guava-15.0.jar:na]
        at com.google.common.collect.AbstractRangeSet.contains(AbstractRangeSet.java:29) ~[guava-15.0.jar:na]
        at com.google.common.collect.TreeRangeSet.contains(TreeRangeSet.java:42) ~[guava-15.0.jar:na]
        at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.setAcknowledgedPosition(ManagedCursorImpl.java:1248) ~[managed-ledger-1.20.16-incubating-yahoo.jar:1.20.16-incubating-yahoo]
        at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.asyncDelete(ManagedCursorImpl.java:1541) ~[managed-ledger-1.20.16-incubating-yahoo.jar:1.20.16-incubating-yahoo]
        at org.apache.pulsar.broker.service.persistent.PersistentSubscription.acknowledgeMessage(PersistentSubscription.java:182) [pulsar-broker-1.20.16-incubating-yahoo.jar:1.20.16-incubating-yahoo]
        at org.apache.pulsar.broker.service.Consumer.messageAcked(Consumer.java:346) [pulsar-broker-1.20.16-incubating-yahoo.jar:1.20.16-incubating-yahoo]
        at org.apache.pulsar.broker.service.ServerCnx.handleAck(ServerCnx.java:859) [pulsar-broker-1.20.16-incubating-yahoo.jar:1.20.16-incubating-yahoo]
```

### Modifications

Handle exception scenario while preparing stats.

### Result

Broker should be able to prepare stats with invalid cursor state.
