### PR TITLE
Make client keepAliveInterval configurable in client side

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
@@ -264,9 +264,10 @@ public interface ClientBuilder extends Serializable, Cloneable {
     ClientBuilder maxNumberOfRejectedRequestPerConnection(int maxNumberOfRejectedRequestPerConnection);
 
     /**
-     * Set keep alive interval in seconds for each client-broker-connection. <i>(default: 5000)</i>.
+     * Set keep alive interval in seconds for each client-broker-connection. <i>(default: 30)</i>.
      *
      * @param keepAliveIntervalSeconds
+     * @param unit time unit for {@code statsInterval}
      */
-    ClientBuilder keepAliveIntervalSeconds(int keepAliveIntervalSeconds);
+    ClientBuilder keepAliveInterval(int keepAliveIntervalSeconds, TimeUnit unit);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
@@ -262,4 +262,11 @@ public interface ClientBuilder extends Serializable, Cloneable {
      * @param maxNumberOfRejectedRequestPerConnection
      */
     ClientBuilder maxNumberOfRejectedRequestPerConnection(int maxNumberOfRejectedRequestPerConnection);
+
+    /**
+     * Set keep alive interval in seconds for each client-broker-connection. <i>(default: 5000)</i>.
+     *
+     * @param keepAliveIntervalSeconds
+     */
+    ClientBuilder keepAliveIntervalSeconds(int keepAliveIntervalSeconds);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
@@ -156,8 +156,8 @@ public class ClientBuilderImpl implements ClientBuilder {
     }
 
     @Override
-    public ClientBuilder keepAliveIntervalSeconds(int keepAliveIntervalSeconds) {
-        conf.setKeepAliveIntervalSeconds(keepAliveIntervalSeconds);
+    public ClientBuilder keepAliveInterval(int keepAliveIntervalSeconds, TimeUnit unit) {
+        conf.setKeepAliveIntervalSeconds((int)unit.toSeconds(keepAliveIntervalSeconds));
         return this;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
@@ -155,6 +155,12 @@ public class ClientBuilderImpl implements ClientBuilder {
         return this;
     }
 
+    @Override
+    public ClientBuilder keepAliveIntervalSeconds(int keepAliveIntervalSeconds) {
+        conf.setKeepAliveIntervalSeconds(keepAliveIntervalSeconds);
+        return this;
+    }
+
     public ClientConfigurationData getClientConfigurationData() {
         return conf;
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -107,7 +107,7 @@ public class ClientCnx extends PulsarHandler {
     }
 
     public ClientCnx(ClientConfigurationData conf, EventLoopGroup eventLoopGroup) {
-        super(30, TimeUnit.SECONDS);
+        super(conf.getKeepAliveIntervalSeconds(), TimeUnit.SECONDS);
         this.pendingLookupRequestSemaphore = new Semaphore(conf.getConcurrentLookupRequest(), true);
         this.authentication = conf.getAuthentication();
         this.eventLoopGroup = eventLoopGroup;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -53,6 +53,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
     private boolean tlsHostnameVerificationEnable = false;
     private int concurrentLookupRequest = 50000;
     private int maxNumberOfRejectedRequestPerConnection = 50;
+    private int keepAliveIntervalSeconds = 30;
 
     public ClientConfigurationData clone() {
         try {


### PR DESCRIPTION
### Motivation

Currently `keepAliveInterval` is hard coded as 30s in ClientCnx, Would like to make it configurable.

### Modifications

Add `keepAliveIntervalSeconds` in ClientConfigurationData, to make it configurable.

### Result

user could config client `keepAliveIntervalSeconds`