### PR TITLE
offloadPrefix implementation for managed ledger

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloader.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloader.java
@@ -39,16 +39,22 @@ public interface LedgerOffloader {
      * When the returned future completes, the ledger has been persisted to the
      * loadterm storage, so it is safe to delete the original copy in bookkeeper.
      *
-     * The returned futures completes with a opaque byte[] which contains context
-     * information required to identify the ledger in the longterm storage. This
-     * context is stored alongside the ledger info in the managed ledger metadata.
-     * It is passed to #readOffloaded(byte[]) to read back the ledger.
+     * The uid is used to identify an attempt to offload. The implementation should
+     * use this to deterministically generate a unique name for the offloaded object.
+     * This uid will be stored in the managed ledger metadata before attempting the
+     * call to offload(). If a subsequent or concurrent call to offload() finds
+     * a uid in the metadata, it will attempt to cleanup this attempt with a call
+     * to #deleteOffloaded(ReadHandle,UUID). Once the offload attempt completes,
+     * the managed ledger will update its metadata again, to record the completion,
+     * ensuring that subsequent calls will not attempt to offload the same ledger
+     * again.
      *
      * @param ledger the ledger to offload
+     * @param uid unique id to identity this offload attempt
      * @param extraMetadata metadata to be stored with the ledger for informational
      *                      purposes
-     * @return a future, which when completed, returns a context byte[] to identify
-     *         the stored ledger
+     * @return a future, which when completed, denotes that the offload has been
+     *         successful
      */
     CompletableFuture<Void> offload(ReadHandle ledger,
                                     UUID uid,
@@ -58,11 +64,11 @@ public interface LedgerOffloader {
      * Create a ReadHandle which can be used to read a ledger back from longterm
      * storage.
      *
-     * The passed offloadContext should be a byte[] that has previously been received
-     * from a call to #offload(ReadHandle,Map).
+     * The passed uid, will be match the uid of a previous successful call to
+     * #offload(ReadHandle,UUID,Map).
      *
      * @param ledgerId the ID of the ledger to load from longterm storage
-     * @param offloadContext a context that identifies the ledger in longterm storage
+     * @param uid unique ID for previous successful offload attempt
      * @return a future, which when completed, returns a ReadHandle
      */
     CompletableFuture<ReadHandle> readOffloaded(long ledgerId, UUID uid);
@@ -70,11 +76,11 @@ public interface LedgerOffloader {
     /**
      * Delete a ledger from long term storage.
      *
-     * The passed offloadContext should be a byte[] that has previously been received
-     * from a call to #offload(ReadHandle,Map).
+     * The passed uid, will be match the uid of a previous call to
+     * #offload(ReadHandle,UUID,Map), which may or may not have been successful.
      *
      * @param ledgerId the ID of the ledger to delete from longterm storage
-     * @param offloadContext a context that identifies the ledger in longterm storage
+     * @param uid unique ID for previous offload attempt
      * @return a future, which when completed, signifies that the ledger has
      *         been deleted
      */

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloader.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloader.java
@@ -21,6 +21,7 @@ package org.apache.bookkeeper.mledger;
 import com.google.common.annotations.Beta;
 
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.bookkeeper.client.api.ReadHandle;
@@ -49,8 +50,9 @@ public interface LedgerOffloader {
      * @return a future, which when completed, returns a context byte[] to identify
      *         the stored ledger
      */
-    CompletableFuture<byte[]> offload(ReadHandle ledger,
-                                      Map<String, String> extraMetadata);
+    CompletableFuture<Void> offload(ReadHandle ledger,
+                                    UUID uid,
+                                    Map<String, String> extraMetadata);
 
     /**
      * Create a ReadHandle which can be used to read a ledger back from longterm
@@ -63,7 +65,7 @@ public interface LedgerOffloader {
      * @param offloadContext a context that identifies the ledger in longterm storage
      * @return a future, which when completed, returns a ReadHandle
      */
-    CompletableFuture<ReadHandle> readOffloaded(long ledgerId, byte[] offloadContext);
+    CompletableFuture<ReadHandle> readOffloaded(long ledgerId, UUID uid);
 
     /**
      * Delete a ledger from long term storage.
@@ -76,6 +78,6 @@ public interface LedgerOffloader {
      * @return a future, which when completed, signifies that the ledger has
      *         been deleted
      */
-    CompletableFuture<Void> deleteOffloaded(long ledgerId, byte[] offloadContext);
+    CompletableFuture<Void> deleteOffloaded(long ledgerId, UUID uid);
 }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1895,7 +1895,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
             long firstLedgerRetained = current;
             for (LedgerInfo ls : ledgers.headMap(current).values()) {
                 if (requestOffloadTo.getLedgerId() > ls.getLedgerId()) {
-                    if (!ls.hasOffloadContext()) {
+                    if (!ls.getOffloadContext().getComplete()) {
                         ledgersToOffload.add(ls);
                     }
                 } else {
@@ -1907,6 +1907,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
 
         if (ledgersToOffload.isEmpty()) {
+            log.info("[{}] No ledgers to offload", name);
             callback.offloadComplete(firstUnoffloaded, ctx);
             return;
         }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/NullLedgerOffloader.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/NullLedgerOffloader.java
@@ -19,6 +19,7 @@
 package org.apache.bookkeeper.mledger.impl;
 
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.bookkeeper.client.api.ReadHandle;
@@ -31,22 +32,23 @@ public class NullLedgerOffloader implements LedgerOffloader {
     public static NullLedgerOffloader INSTANCE = new NullLedgerOffloader();
 
     @Override
-    public CompletableFuture<byte[]> offload(ReadHandle ledger,
-                                             Map<String, String> extraMetadata) {
-        CompletableFuture<byte[]> promise = new CompletableFuture<>();
+    public CompletableFuture<Void> offload(ReadHandle ledger,
+                                           UUID uid,
+                                           Map<String, String> extraMetadata) {
+        CompletableFuture<Void> promise = new CompletableFuture<>();
         promise.completeExceptionally(new UnsupportedOperationException());
         return promise;
     }
 
     @Override
-    public CompletableFuture<ReadHandle> readOffloaded(long ledgerId, byte[] offloadContext) {
+    public CompletableFuture<ReadHandle> readOffloaded(long ledgerId, UUID uid) {
         CompletableFuture<ReadHandle> promise = new CompletableFuture<>();
         promise.completeExceptionally(new UnsupportedOperationException());
         return promise;
     }
 
     @Override
-    public CompletableFuture<Void> deleteOffloaded(long ledgerId, byte[] offloadContext) {
+    public CompletableFuture<Void> deleteOffloaded(long ledgerId, UUID uid) {
         CompletableFuture<Void> promise = new CompletableFuture<>();
         promise.completeExceptionally(new UnsupportedOperationException());
         return promise;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/proto/MLDataFormats.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/proto/MLDataFormats.java
@@ -8,6 +8,458 @@ public final class MLDataFormats {
   public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistry registry) {
   }
+  public interface OffloadContextOrBuilder
+      extends com.google.protobuf.MessageOrBuilder {
+    
+    // optional int64 uidMsb = 1;
+    boolean hasUidMsb();
+    long getUidMsb();
+    
+    // optional int64 uidLsb = 2;
+    boolean hasUidLsb();
+    long getUidLsb();
+    
+    // optional bool complete = 3;
+    boolean hasComplete();
+    boolean getComplete();
+  }
+  public static final class OffloadContext extends
+      com.google.protobuf.GeneratedMessage
+      implements OffloadContextOrBuilder {
+    // Use OffloadContext.newBuilder() to construct.
+    private OffloadContext(Builder builder) {
+      super(builder);
+    }
+    private OffloadContext(boolean noInit) {}
+    
+    private static final OffloadContext defaultInstance;
+    public static OffloadContext getDefaultInstance() {
+      return defaultInstance;
+    }
+    
+    public OffloadContext getDefaultInstanceForType() {
+      return defaultInstance;
+    }
+    
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.apache.bookkeeper.mledger.proto.MLDataFormats.internal_static_OffloadContext_descriptor;
+    }
+    
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.apache.bookkeeper.mledger.proto.MLDataFormats.internal_static_OffloadContext_fieldAccessorTable;
+    }
+    
+    private int bitField0_;
+    // optional int64 uidMsb = 1;
+    public static final int UIDMSB_FIELD_NUMBER = 1;
+    private long uidMsb_;
+    public boolean hasUidMsb() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    public long getUidMsb() {
+      return uidMsb_;
+    }
+    
+    // optional int64 uidLsb = 2;
+    public static final int UIDLSB_FIELD_NUMBER = 2;
+    private long uidLsb_;
+    public boolean hasUidLsb() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    public long getUidLsb() {
+      return uidLsb_;
+    }
+    
+    // optional bool complete = 3;
+    public static final int COMPLETE_FIELD_NUMBER = 3;
+    private boolean complete_;
+    public boolean hasComplete() {
+      return ((bitField0_ & 0x00000004) == 0x00000004);
+    }
+    public boolean getComplete() {
+      return complete_;
+    }
+    
+    private void initFields() {
+      uidMsb_ = 0L;
+      uidLsb_ = 0L;
+      complete_ = false;
+    }
+    private byte memoizedIsInitialized = -1;
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized != -1) return isInitialized == 1;
+      
+      memoizedIsInitialized = 1;
+      return true;
+    }
+    
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getSerializedSize();
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        output.writeInt64(1, uidMsb_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeInt64(2, uidLsb_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        output.writeBool(3, complete_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+    
+    private int memoizedSerializedSize = -1;
+    public int getSerializedSize() {
+      int size = memoizedSerializedSize;
+      if (size != -1) return size;
+    
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(1, uidMsb_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(2, uidLsb_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeBoolSize(3, complete_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSerializedSize = size;
+      return size;
+    }
+    
+    private static final long serialVersionUID = 0L;
+    @java.lang.Override
+    protected java.lang.Object writeReplace()
+        throws java.io.ObjectStreamException {
+      return super.writeReplace();
+    }
+    
+    public static org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data).buildParsed();
+    }
+    public static org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data).buildParsed();
+    }
+    public static org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return newBuilder().mergeFrom(data, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input).buildParsed();
+    }
+    public static org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input, extensionRegistry)
+               .buildParsed();
+    }
+    public static org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      Builder builder = newBuilder();
+      if (builder.mergeDelimitedFrom(input)) {
+        return builder.buildParsed();
+      } else {
+        return null;
+      }
+    }
+    public static org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      Builder builder = newBuilder();
+      if (builder.mergeDelimitedFrom(input, extensionRegistry)) {
+        return builder.buildParsed();
+      } else {
+        return null;
+      }
+    }
+    public static org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input).buildParsed();
+    }
+    public static org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return newBuilder().mergeFrom(input, extensionRegistry)
+               .buildParsed();
+    }
+    
+    public static Builder newBuilder() { return Builder.create(); }
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder(org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext prototype) {
+      return newBuilder().mergeFrom(prototype);
+    }
+    public Builder toBuilder() { return newBuilder(this); }
+    
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder>
+       implements org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContextOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.apache.bookkeeper.mledger.proto.MLDataFormats.internal_static_OffloadContext_descriptor;
+      }
+      
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.apache.bookkeeper.mledger.proto.MLDataFormats.internal_static_OffloadContext_fieldAccessorTable;
+      }
+      
+      // Construct using org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+      
+      private Builder(BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+        }
+      }
+      private static Builder create() {
+        return new Builder();
+      }
+      
+      public Builder clear() {
+        super.clear();
+        uidMsb_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        uidLsb_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000002);
+        complete_ = false;
+        bitField0_ = (bitField0_ & ~0x00000004);
+        return this;
+      }
+      
+      public Builder clone() {
+        return create().mergeFrom(buildPartial());
+      }
+      
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext.getDescriptor();
+      }
+      
+      public org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext getDefaultInstanceForType() {
+        return org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext.getDefaultInstance();
+      }
+      
+      public org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext build() {
+        org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+      
+      private org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext buildParsed()
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(
+            result).asInvalidProtocolBufferException();
+        }
+        return result;
+      }
+      
+      public org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext buildPartial() {
+        org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext result = new org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.uidMsb_ = uidMsb_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.uidLsb_ = uidLsb_;
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        result.complete_ = complete_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+      
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext) {
+          return mergeFrom((org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+      
+      public Builder mergeFrom(org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext other) {
+        if (other == org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext.getDefaultInstance()) return this;
+        if (other.hasUidMsb()) {
+          setUidMsb(other.getUidMsb());
+        }
+        if (other.hasUidLsb()) {
+          setUidLsb(other.getUidLsb());
+        }
+        if (other.hasComplete()) {
+          setComplete(other.getComplete());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        return this;
+      }
+      
+      public final boolean isInitialized() {
+        return true;
+      }
+      
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder(
+            this.getUnknownFields());
+        while (true) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              this.setUnknownFields(unknownFields.build());
+              onChanged();
+              return this;
+            default: {
+              if (!parseUnknownField(input, unknownFields,
+                                     extensionRegistry, tag)) {
+                this.setUnknownFields(unknownFields.build());
+                onChanged();
+                return this;
+              }
+              break;
+            }
+            case 8: {
+              bitField0_ |= 0x00000001;
+              uidMsb_ = input.readInt64();
+              break;
+            }
+            case 16: {
+              bitField0_ |= 0x00000002;
+              uidLsb_ = input.readInt64();
+              break;
+            }
+            case 24: {
+              bitField0_ |= 0x00000004;
+              complete_ = input.readBool();
+              break;
+            }
+          }
+        }
+      }
+      
+      private int bitField0_;
+      
+      // optional int64 uidMsb = 1;
+      private long uidMsb_ ;
+      public boolean hasUidMsb() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      public long getUidMsb() {
+        return uidMsb_;
+      }
+      public Builder setUidMsb(long value) {
+        bitField0_ |= 0x00000001;
+        uidMsb_ = value;
+        onChanged();
+        return this;
+      }
+      public Builder clearUidMsb() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        uidMsb_ = 0L;
+        onChanged();
+        return this;
+      }
+      
+      // optional int64 uidLsb = 2;
+      private long uidLsb_ ;
+      public boolean hasUidLsb() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      public long getUidLsb() {
+        return uidLsb_;
+      }
+      public Builder setUidLsb(long value) {
+        bitField0_ |= 0x00000002;
+        uidLsb_ = value;
+        onChanged();
+        return this;
+      }
+      public Builder clearUidLsb() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        uidLsb_ = 0L;
+        onChanged();
+        return this;
+      }
+      
+      // optional bool complete = 3;
+      private boolean complete_ ;
+      public boolean hasComplete() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      public boolean getComplete() {
+        return complete_;
+      }
+      public Builder setComplete(boolean value) {
+        bitField0_ |= 0x00000004;
+        complete_ = value;
+        onChanged();
+        return this;
+      }
+      public Builder clearComplete() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        complete_ = false;
+        onChanged();
+        return this;
+      }
+      
+      // @@protoc_insertion_point(builder_scope:OffloadContext)
+    }
+    
+    static {
+      defaultInstance = new OffloadContext(true);
+      defaultInstance.initFields();
+    }
+    
+    // @@protoc_insertion_point(class_scope:OffloadContext)
+  }
+  
   public interface ManagedLedgerInfoOrBuilder
       extends com.google.protobuf.MessageOrBuilder {
     
@@ -73,9 +525,10 @@ public final class MLDataFormats {
       boolean hasTimestamp();
       long getTimestamp();
       
-      // optional bytes offloadContext = 5;
+      // optional .OffloadContext offloadContext = 5;
       boolean hasOffloadContext();
-      com.google.protobuf.ByteString getOffloadContext();
+      org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext getOffloadContext();
+      org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContextOrBuilder getOffloadContextOrBuilder();
     }
     public static final class LedgerInfo extends
         com.google.protobuf.GeneratedMessage
@@ -146,13 +599,16 @@ public final class MLDataFormats {
         return timestamp_;
       }
       
-      // optional bytes offloadContext = 5;
+      // optional .OffloadContext offloadContext = 5;
       public static final int OFFLOADCONTEXT_FIELD_NUMBER = 5;
-      private com.google.protobuf.ByteString offloadContext_;
+      private org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext offloadContext_;
       public boolean hasOffloadContext() {
         return ((bitField0_ & 0x00000010) == 0x00000010);
       }
-      public com.google.protobuf.ByteString getOffloadContext() {
+      public org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext getOffloadContext() {
+        return offloadContext_;
+      }
+      public org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContextOrBuilder getOffloadContextOrBuilder() {
         return offloadContext_;
       }
       
@@ -161,7 +617,7 @@ public final class MLDataFormats {
         entries_ = 0L;
         size_ = 0L;
         timestamp_ = 0L;
-        offloadContext_ = com.google.protobuf.ByteString.EMPTY;
+        offloadContext_ = org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext.getDefaultInstance();
       }
       private byte memoizedIsInitialized = -1;
       public final boolean isInitialized() {
@@ -192,7 +648,7 @@ public final class MLDataFormats {
           output.writeInt64(4, timestamp_);
         }
         if (((bitField0_ & 0x00000010) == 0x00000010)) {
-          output.writeBytes(5, offloadContext_);
+          output.writeMessage(5, offloadContext_);
         }
         getUnknownFields().writeTo(output);
       }
@@ -221,7 +677,7 @@ public final class MLDataFormats {
         }
         if (((bitField0_ & 0x00000010) == 0x00000010)) {
           size += com.google.protobuf.CodedOutputStream
-            .computeBytesSize(5, offloadContext_);
+            .computeMessageSize(5, offloadContext_);
         }
         size += getUnknownFields().getSerializedSize();
         memoizedSerializedSize = size;
@@ -339,6 +795,7 @@ public final class MLDataFormats {
         }
         private void maybeForceBuilderInitialization() {
           if (com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders) {
+            getOffloadContextFieldBuilder();
           }
         }
         private static Builder create() {
@@ -355,7 +812,11 @@ public final class MLDataFormats {
           bitField0_ = (bitField0_ & ~0x00000004);
           timestamp_ = 0L;
           bitField0_ = (bitField0_ & ~0x00000008);
-          offloadContext_ = com.google.protobuf.ByteString.EMPTY;
+          if (offloadContextBuilder_ == null) {
+            offloadContext_ = org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext.getDefaultInstance();
+          } else {
+            offloadContextBuilder_.clear();
+          }
           bitField0_ = (bitField0_ & ~0x00000010);
           return this;
         }
@@ -414,7 +875,11 @@ public final class MLDataFormats {
           if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
             to_bitField0_ |= 0x00000010;
           }
-          result.offloadContext_ = offloadContext_;
+          if (offloadContextBuilder_ == null) {
+            result.offloadContext_ = offloadContext_;
+          } else {
+            result.offloadContext_ = offloadContextBuilder_.build();
+          }
           result.bitField0_ = to_bitField0_;
           onBuilt();
           return result;
@@ -444,7 +909,7 @@ public final class MLDataFormats {
             setTimestamp(other.getTimestamp());
           }
           if (other.hasOffloadContext()) {
-            setOffloadContext(other.getOffloadContext());
+            mergeOffloadContext(other.getOffloadContext());
           }
           this.mergeUnknownFields(other.getUnknownFields());
           return this;
@@ -502,8 +967,12 @@ public final class MLDataFormats {
                 break;
               }
               case 42: {
-                bitField0_ |= 0x00000010;
-                offloadContext_ = input.readBytes();
+                org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext.Builder subBuilder = org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext.newBuilder();
+                if (hasOffloadContext()) {
+                  subBuilder.mergeFrom(getOffloadContext());
+                }
+                input.readMessage(subBuilder, extensionRegistry);
+                setOffloadContext(subBuilder.buildPartial());
                 break;
               }
             }
@@ -596,28 +1065,94 @@ public final class MLDataFormats {
           return this;
         }
         
-        // optional bytes offloadContext = 5;
-        private com.google.protobuf.ByteString offloadContext_ = com.google.protobuf.ByteString.EMPTY;
+        // optional .OffloadContext offloadContext = 5;
+        private org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext offloadContext_ = org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext.getDefaultInstance();
+        private com.google.protobuf.SingleFieldBuilder<
+            org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext, org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext.Builder, org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContextOrBuilder> offloadContextBuilder_;
         public boolean hasOffloadContext() {
           return ((bitField0_ & 0x00000010) == 0x00000010);
         }
-        public com.google.protobuf.ByteString getOffloadContext() {
-          return offloadContext_;
+        public org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext getOffloadContext() {
+          if (offloadContextBuilder_ == null) {
+            return offloadContext_;
+          } else {
+            return offloadContextBuilder_.getMessage();
+          }
         }
-        public Builder setOffloadContext(com.google.protobuf.ByteString value) {
-          if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000010;
-          offloadContext_ = value;
-          onChanged();
+        public Builder setOffloadContext(org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext value) {
+          if (offloadContextBuilder_ == null) {
+            if (value == null) {
+              throw new NullPointerException();
+            }
+            offloadContext_ = value;
+            onChanged();
+          } else {
+            offloadContextBuilder_.setMessage(value);
+          }
+          bitField0_ |= 0x00000010;
+          return this;
+        }
+        public Builder setOffloadContext(
+            org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext.Builder builderForValue) {
+          if (offloadContextBuilder_ == null) {
+            offloadContext_ = builderForValue.build();
+            onChanged();
+          } else {
+            offloadContextBuilder_.setMessage(builderForValue.build());
+          }
+          bitField0_ |= 0x00000010;
+          return this;
+        }
+        public Builder mergeOffloadContext(org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext value) {
+          if (offloadContextBuilder_ == null) {
+            if (((bitField0_ & 0x00000010) == 0x00000010) &&
+                offloadContext_ != org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext.getDefaultInstance()) {
+              offloadContext_ =
+                org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext.newBuilder(offloadContext_).mergeFrom(value).buildPartial();
+            } else {
+              offloadContext_ = value;
+            }
+            onChanged();
+          } else {
+            offloadContextBuilder_.mergeFrom(value);
+          }
+          bitField0_ |= 0x00000010;
           return this;
         }
         public Builder clearOffloadContext() {
+          if (offloadContextBuilder_ == null) {
+            offloadContext_ = org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext.getDefaultInstance();
+            onChanged();
+          } else {
+            offloadContextBuilder_.clear();
+          }
           bitField0_ = (bitField0_ & ~0x00000010);
-          offloadContext_ = getDefaultInstance().getOffloadContext();
-          onChanged();
           return this;
+        }
+        public org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext.Builder getOffloadContextBuilder() {
+          bitField0_ |= 0x00000010;
+          onChanged();
+          return getOffloadContextFieldBuilder().getBuilder();
+        }
+        public org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContextOrBuilder getOffloadContextOrBuilder() {
+          if (offloadContextBuilder_ != null) {
+            return offloadContextBuilder_.getMessageOrBuilder();
+          } else {
+            return offloadContext_;
+          }
+        }
+        private com.google.protobuf.SingleFieldBuilder<
+            org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext, org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext.Builder, org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContextOrBuilder> 
+            getOffloadContextFieldBuilder() {
+          if (offloadContextBuilder_ == null) {
+            offloadContextBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+                org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext, org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext.Builder, org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContextOrBuilder>(
+                    offloadContext_,
+                    getParentForChildren(),
+                    isClean());
+            offloadContext_ = null;
+          }
+          return offloadContextBuilder_;
         }
         
         // @@protoc_insertion_point(builder_scope:ManagedLedgerInfo.LedgerInfo)
@@ -4776,6 +5311,11 @@ public final class MLDataFormats {
   }
   
   private static com.google.protobuf.Descriptors.Descriptor
+    internal_static_OffloadContext_descriptor;
+  private static
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_OffloadContext_fieldAccessorTable;
+  private static com.google.protobuf.Descriptors.Descriptor
     internal_static_ManagedLedgerInfo_descriptor;
   private static
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
@@ -4819,35 +5359,45 @@ public final class MLDataFormats {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\"src/main/proto/MLDataFormats.proto\"\341\001\n" +
-      "\021ManagedLedgerInfo\0221\n\nledgerInfo\030\001 \003(\0132\035" +
-      ".ManagedLedgerInfo.LedgerInfo\022/\n\022termina" +
-      "tedPosition\030\002 \001(\0132\023.NestedPositionInfo\032h" +
-      "\n\nLedgerInfo\022\020\n\010ledgerId\030\001 \002(\003\022\017\n\007entrie" +
-      "s\030\002 \001(\003\022\014\n\004size\030\003 \001(\003\022\021\n\ttimestamp\030\004 \001(\003" +
-      "\022\026\n\016offloadContext\030\005 \001(\014\"\206\001\n\014PositionInf" +
-      "o\022\020\n\010ledgerId\030\001 \002(\003\022\017\n\007entryId\030\002 \002(\003\0220\n\031" +
-      "individualDeletedMessages\030\003 \003(\0132\r.Messag" +
-      "eRange\022!\n\nproperties\030\004 \003(\0132\r.LongPropert",
-      "y\"7\n\022NestedPositionInfo\022\020\n\010ledgerId\030\001 \002(" +
-      "\003\022\017\n\007entryId\030\002 \002(\003\"f\n\014MessageRange\022*\n\rlo" +
-      "werEndpoint\030\001 \002(\0132\023.NestedPositionInfo\022*" +
-      "\n\rupperEndpoint\030\002 \002(\0132\023.NestedPositionIn" +
-      "fo\"+\n\014LongProperty\022\014\n\004name\030\001 \002(\t\022\r\n\005valu" +
-      "e\030\002 \002(\003\"\270\001\n\021ManagedCursorInfo\022\027\n\017cursors" +
-      "LedgerId\030\001 \002(\003\022\032\n\022markDeleteLedgerId\030\002 \001" +
-      "(\003\022\031\n\021markDeleteEntryId\030\003 \001(\003\0220\n\031individ" +
-      "ualDeletedMessages\030\004 \003(\0132\r.MessageRange\022" +
-      "!\n\nproperties\030\005 \003(\0132\r.LongPropertyB\'\n#or",
-      "g.apache.bookkeeper.mledger.protoH\001"
+      "\n\"src/main/proto/MLDataFormats.proto\"B\n\016" +
+      "OffloadContext\022\016\n\006uidMsb\030\001 \001(\003\022\016\n\006uidLsb" +
+      "\030\002 \001(\003\022\020\n\010complete\030\003 \001(\010\"\362\001\n\021ManagedLedg" +
+      "erInfo\0221\n\nledgerInfo\030\001 \003(\0132\035.ManagedLedg" +
+      "erInfo.LedgerInfo\022/\n\022terminatedPosition\030" +
+      "\002 \001(\0132\023.NestedPositionInfo\032y\n\nLedgerInfo" +
+      "\022\020\n\010ledgerId\030\001 \002(\003\022\017\n\007entries\030\002 \001(\003\022\014\n\004s" +
+      "ize\030\003 \001(\003\022\021\n\ttimestamp\030\004 \001(\003\022\'\n\016offloadC" +
+      "ontext\030\005 \001(\0132\017.OffloadContext\"\206\001\n\014Positi" +
+      "onInfo\022\020\n\010ledgerId\030\001 \002(\003\022\017\n\007entryId\030\002 \002(",
+      "\003\0220\n\031individualDeletedMessages\030\003 \003(\0132\r.M" +
+      "essageRange\022!\n\nproperties\030\004 \003(\0132\r.LongPr" +
+      "operty\"7\n\022NestedPositionInfo\022\020\n\010ledgerId" +
+      "\030\001 \002(\003\022\017\n\007entryId\030\002 \002(\003\"f\n\014MessageRange\022" +
+      "*\n\rlowerEndpoint\030\001 \002(\0132\023.NestedPositionI" +
+      "nfo\022*\n\rupperEndpoint\030\002 \002(\0132\023.NestedPosit" +
+      "ionInfo\"+\n\014LongProperty\022\014\n\004name\030\001 \002(\t\022\r\n" +
+      "\005value\030\002 \002(\003\"\270\001\n\021ManagedCursorInfo\022\027\n\017cu" +
+      "rsorsLedgerId\030\001 \002(\003\022\032\n\022markDeleteLedgerI" +
+      "d\030\002 \001(\003\022\031\n\021markDeleteEntryId\030\003 \001(\003\0220\n\031in",
+      "dividualDeletedMessages\030\004 \003(\0132\r.MessageR" +
+      "ange\022!\n\nproperties\030\005 \003(\0132\r.LongPropertyB" +
+      "\'\n#org.apache.bookkeeper.mledger.protoH\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
         public com.google.protobuf.ExtensionRegistry assignDescriptors(
             com.google.protobuf.Descriptors.FileDescriptor root) {
           descriptor = root;
-          internal_static_ManagedLedgerInfo_descriptor =
+          internal_static_OffloadContext_descriptor =
             getDescriptor().getMessageTypes().get(0);
+          internal_static_OffloadContext_fieldAccessorTable = new
+            com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+              internal_static_OffloadContext_descriptor,
+              new java.lang.String[] { "UidMsb", "UidLsb", "Complete", },
+              org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext.class,
+              org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext.Builder.class);
+          internal_static_ManagedLedgerInfo_descriptor =
+            getDescriptor().getMessageTypes().get(1);
           internal_static_ManagedLedgerInfo_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_ManagedLedgerInfo_descriptor,
@@ -4863,7 +5413,7 @@ public final class MLDataFormats {
               org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo.class,
               org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo.Builder.class);
           internal_static_PositionInfo_descriptor =
-            getDescriptor().getMessageTypes().get(1);
+            getDescriptor().getMessageTypes().get(2);
           internal_static_PositionInfo_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_PositionInfo_descriptor,
@@ -4871,7 +5421,7 @@ public final class MLDataFormats {
               org.apache.bookkeeper.mledger.proto.MLDataFormats.PositionInfo.class,
               org.apache.bookkeeper.mledger.proto.MLDataFormats.PositionInfo.Builder.class);
           internal_static_NestedPositionInfo_descriptor =
-            getDescriptor().getMessageTypes().get(2);
+            getDescriptor().getMessageTypes().get(3);
           internal_static_NestedPositionInfo_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_NestedPositionInfo_descriptor,
@@ -4879,7 +5429,7 @@ public final class MLDataFormats {
               org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.class,
               org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo.Builder.class);
           internal_static_MessageRange_descriptor =
-            getDescriptor().getMessageTypes().get(3);
+            getDescriptor().getMessageTypes().get(4);
           internal_static_MessageRange_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_MessageRange_descriptor,
@@ -4887,7 +5437,7 @@ public final class MLDataFormats {
               org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.class,
               org.apache.bookkeeper.mledger.proto.MLDataFormats.MessageRange.Builder.class);
           internal_static_LongProperty_descriptor =
-            getDescriptor().getMessageTypes().get(4);
+            getDescriptor().getMessageTypes().get(5);
           internal_static_LongProperty_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_LongProperty_descriptor,
@@ -4895,7 +5445,7 @@ public final class MLDataFormats {
               org.apache.bookkeeper.mledger.proto.MLDataFormats.LongProperty.class,
               org.apache.bookkeeper.mledger.proto.MLDataFormats.LongProperty.Builder.class);
           internal_static_ManagedCursorInfo_descriptor =
-            getDescriptor().getMessageTypes().get(5);
+            getDescriptor().getMessageTypes().get(6);
           internal_static_ManagedCursorInfo_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_ManagedCursorInfo_descriptor,

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/proto/MLDataFormats.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/proto/MLDataFormats.java
@@ -72,6 +72,10 @@ public final class MLDataFormats {
       // optional int64 timestamp = 4;
       boolean hasTimestamp();
       long getTimestamp();
+      
+      // optional bytes offloadContext = 5;
+      boolean hasOffloadContext();
+      com.google.protobuf.ByteString getOffloadContext();
     }
     public static final class LedgerInfo extends
         com.google.protobuf.GeneratedMessage
@@ -142,11 +146,22 @@ public final class MLDataFormats {
         return timestamp_;
       }
       
+      // optional bytes offloadContext = 5;
+      public static final int OFFLOADCONTEXT_FIELD_NUMBER = 5;
+      private com.google.protobuf.ByteString offloadContext_;
+      public boolean hasOffloadContext() {
+        return ((bitField0_ & 0x00000010) == 0x00000010);
+      }
+      public com.google.protobuf.ByteString getOffloadContext() {
+        return offloadContext_;
+      }
+      
       private void initFields() {
         ledgerId_ = 0L;
         entries_ = 0L;
         size_ = 0L;
         timestamp_ = 0L;
+        offloadContext_ = com.google.protobuf.ByteString.EMPTY;
       }
       private byte memoizedIsInitialized = -1;
       public final boolean isInitialized() {
@@ -176,6 +191,9 @@ public final class MLDataFormats {
         if (((bitField0_ & 0x00000008) == 0x00000008)) {
           output.writeInt64(4, timestamp_);
         }
+        if (((bitField0_ & 0x00000010) == 0x00000010)) {
+          output.writeBytes(5, offloadContext_);
+        }
         getUnknownFields().writeTo(output);
       }
       
@@ -200,6 +218,10 @@ public final class MLDataFormats {
         if (((bitField0_ & 0x00000008) == 0x00000008)) {
           size += com.google.protobuf.CodedOutputStream
             .computeInt64Size(4, timestamp_);
+        }
+        if (((bitField0_ & 0x00000010) == 0x00000010)) {
+          size += com.google.protobuf.CodedOutputStream
+            .computeBytesSize(5, offloadContext_);
         }
         size += getUnknownFields().getSerializedSize();
         memoizedSerializedSize = size;
@@ -333,6 +355,8 @@ public final class MLDataFormats {
           bitField0_ = (bitField0_ & ~0x00000004);
           timestamp_ = 0L;
           bitField0_ = (bitField0_ & ~0x00000008);
+          offloadContext_ = com.google.protobuf.ByteString.EMPTY;
+          bitField0_ = (bitField0_ & ~0x00000010);
           return this;
         }
         
@@ -387,6 +411,10 @@ public final class MLDataFormats {
             to_bitField0_ |= 0x00000008;
           }
           result.timestamp_ = timestamp_;
+          if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
+            to_bitField0_ |= 0x00000010;
+          }
+          result.offloadContext_ = offloadContext_;
           result.bitField0_ = to_bitField0_;
           onBuilt();
           return result;
@@ -414,6 +442,9 @@ public final class MLDataFormats {
           }
           if (other.hasTimestamp()) {
             setTimestamp(other.getTimestamp());
+          }
+          if (other.hasOffloadContext()) {
+            setOffloadContext(other.getOffloadContext());
           }
           this.mergeUnknownFields(other.getUnknownFields());
           return this;
@@ -468,6 +499,11 @@ public final class MLDataFormats {
               case 32: {
                 bitField0_ |= 0x00000008;
                 timestamp_ = input.readInt64();
+                break;
+              }
+              case 42: {
+                bitField0_ |= 0x00000010;
+                offloadContext_ = input.readBytes();
                 break;
               }
             }
@@ -556,6 +592,30 @@ public final class MLDataFormats {
         public Builder clearTimestamp() {
           bitField0_ = (bitField0_ & ~0x00000008);
           timestamp_ = 0L;
+          onChanged();
+          return this;
+        }
+        
+        // optional bytes offloadContext = 5;
+        private com.google.protobuf.ByteString offloadContext_ = com.google.protobuf.ByteString.EMPTY;
+        public boolean hasOffloadContext() {
+          return ((bitField0_ & 0x00000010) == 0x00000010);
+        }
+        public com.google.protobuf.ByteString getOffloadContext() {
+          return offloadContext_;
+        }
+        public Builder setOffloadContext(com.google.protobuf.ByteString value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000010;
+          offloadContext_ = value;
+          onChanged();
+          return this;
+        }
+        public Builder clearOffloadContext() {
+          bitField0_ = (bitField0_ & ~0x00000010);
+          offloadContext_ = getDefaultInstance().getOffloadContext();
           onChanged();
           return this;
         }
@@ -4759,27 +4819,27 @@ public final class MLDataFormats {
       descriptor;
   static {
     java.lang.String[] descriptorData = {
-      "\n\"src/main/proto/MLDataFormats.proto\"\311\001\n" +
+      "\n\"src/main/proto/MLDataFormats.proto\"\341\001\n" +
       "\021ManagedLedgerInfo\0221\n\nledgerInfo\030\001 \003(\0132\035" +
       ".ManagedLedgerInfo.LedgerInfo\022/\n\022termina" +
-      "tedPosition\030\002 \001(\0132\023.NestedPositionInfo\032P" +
+      "tedPosition\030\002 \001(\0132\023.NestedPositionInfo\032h" +
       "\n\nLedgerInfo\022\020\n\010ledgerId\030\001 \002(\003\022\017\n\007entrie" +
       "s\030\002 \001(\003\022\014\n\004size\030\003 \001(\003\022\021\n\ttimestamp\030\004 \001(\003" +
-      "\"\206\001\n\014PositionInfo\022\020\n\010ledgerId\030\001 \002(\003\022\017\n\007e" +
-      "ntryId\030\002 \002(\003\0220\n\031individualDeletedMessage" +
-      "s\030\003 \003(\0132\r.MessageRange\022!\n\nproperties\030\004 \003" +
-      "(\0132\r.LongProperty\"7\n\022NestedPositionInfo\022",
-      "\020\n\010ledgerId\030\001 \002(\003\022\017\n\007entryId\030\002 \002(\003\"f\n\014Me" +
-      "ssageRange\022*\n\rlowerEndpoint\030\001 \002(\0132\023.Nest" +
-      "edPositionInfo\022*\n\rupperEndpoint\030\002 \002(\0132\023." +
-      "NestedPositionInfo\"+\n\014LongProperty\022\014\n\004na" +
-      "me\030\001 \002(\t\022\r\n\005value\030\002 \002(\003\"\270\001\n\021ManagedCurso" +
-      "rInfo\022\027\n\017cursorsLedgerId\030\001 \002(\003\022\032\n\022markDe" +
-      "leteLedgerId\030\002 \001(\003\022\031\n\021markDeleteEntryId\030" +
-      "\003 \001(\003\0220\n\031individualDeletedMessages\030\004 \003(\013" +
-      "2\r.MessageRange\022!\n\nproperties\030\005 \003(\0132\r.Lo" +
-      "ngPropertyB\'\n#org.apache.bookkeeper.mled",
-      "ger.protoH\001"
+      "\022\026\n\016offloadContext\030\005 \001(\014\"\206\001\n\014PositionInf" +
+      "o\022\020\n\010ledgerId\030\001 \002(\003\022\017\n\007entryId\030\002 \002(\003\0220\n\031" +
+      "individualDeletedMessages\030\003 \003(\0132\r.Messag" +
+      "eRange\022!\n\nproperties\030\004 \003(\0132\r.LongPropert",
+      "y\"7\n\022NestedPositionInfo\022\020\n\010ledgerId\030\001 \002(" +
+      "\003\022\017\n\007entryId\030\002 \002(\003\"f\n\014MessageRange\022*\n\rlo" +
+      "werEndpoint\030\001 \002(\0132\023.NestedPositionInfo\022*" +
+      "\n\rupperEndpoint\030\002 \002(\0132\023.NestedPositionIn" +
+      "fo\"+\n\014LongProperty\022\014\n\004name\030\001 \002(\t\022\r\n\005valu" +
+      "e\030\002 \002(\003\"\270\001\n\021ManagedCursorInfo\022\027\n\017cursors" +
+      "LedgerId\030\001 \002(\003\022\032\n\022markDeleteLedgerId\030\002 \001" +
+      "(\003\022\031\n\021markDeleteEntryId\030\003 \001(\003\0220\n\031individ" +
+      "ualDeletedMessages\030\004 \003(\0132\r.MessageRange\022" +
+      "!\n\nproperties\030\005 \003(\0132\r.LongPropertyB\'\n#or",
+      "g.apache.bookkeeper.mledger.protoH\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
       new com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner() {
@@ -4799,7 +4859,7 @@ public final class MLDataFormats {
           internal_static_ManagedLedgerInfo_LedgerInfo_fieldAccessorTable = new
             com.google.protobuf.GeneratedMessage.FieldAccessorTable(
               internal_static_ManagedLedgerInfo_LedgerInfo_descriptor,
-              new java.lang.String[] { "LedgerId", "Entries", "Size", "Timestamp", },
+              new java.lang.String[] { "LedgerId", "Entries", "Size", "Timestamp", "OffloadContext", },
               org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo.class,
               org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo.Builder.class);
           internal_static_PositionInfo_descriptor =

--- a/managed-ledger/src/main/proto/MLDataFormats.proto
+++ b/managed-ledger/src/main/proto/MLDataFormats.proto
@@ -27,6 +27,7 @@ message ManagedLedgerInfo {
     	optional int64 entries  = 2;
     	optional int64 size     = 3;
     	optional int64 timestamp = 4;
+        optional bytes offloadContext = 5;
     }
     
     repeated LedgerInfo ledgerInfo = 1;

--- a/managed-ledger/src/main/proto/MLDataFormats.proto
+++ b/managed-ledger/src/main/proto/MLDataFormats.proto
@@ -21,13 +21,19 @@ syntax = "proto2";
 option java_package = "org.apache.bookkeeper.mledger.proto";
 option optimize_for = SPEED;
 
+message OffloadContext {
+    optional int64 uidMsb = 1;
+    optional int64 uidLsb = 2;
+    optional bool complete = 3;
+}
+
 message ManagedLedgerInfo {
     message LedgerInfo {
     	required int64 ledgerId = 1;
     	optional int64 entries  = 2;
     	optional int64 size     = 3;
     	optional int64 timestamp = 4;
-        optional bytes offloadContext = 5;
+        optional OffloadContext offloadContext = 5;
     }
     
     repeated LedgerInfo ledgerInfo = 1;

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
@@ -1,0 +1,548 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+import java.util.stream.Collectors;
+
+import org.apache.bookkeeper.client.BKException;
+import org.apache.bookkeeper.client.api.ReadHandle;
+import org.apache.bookkeeper.mledger.AsyncCallbacks.OffloadCallback;
+import org.apache.bookkeeper.mledger.LedgerOffloader;
+import org.apache.bookkeeper.mledger.ManagedCursor;
+import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
+import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class OffloadPrefixTest extends MockedBookKeeperTestCase {
+    private static final Logger log = LoggerFactory.getLogger(OffloadPrefixTest.class);
+
+    @Test
+    public void testNullOffloader() throws Exception {
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setMaxEntriesPerLedger(10);
+        config.setMinimumRolloverTime(0, TimeUnit.SECONDS);
+        config.setRetentionTime(10, TimeUnit.MINUTES);
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl)factory.open("my_test_ledger", config);
+
+        int i = 0;
+        for (; i < 25; i++) {
+            String content = "entry-" + i;
+            ledger.addEntry(content.getBytes());
+        }
+        Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 3);
+
+        Position p = ledger.getLastConfirmedEntry();
+
+        for (; i < 45; i++) {
+            String content = "entry-" + i;
+            ledger.addEntry(content.getBytes());
+        }
+        Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 5);
+        Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
+                            .filter(e -> e.hasOffloadContext()).count(), 0);
+        try {
+            ledger.offloadPrefix(p);
+            Assert.fail("Should have thrown an exception");
+        } catch (ManagedLedgerException e) {
+            Assert.assertEquals(e.getCause().getClass(), CompletionException.class);
+        }
+        Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 5);
+        Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
+                            .filter(e -> e.hasOffloadContext()).count(), 0);
+
+        // add more entries to ensure we can update the ledger list
+        for (; i < 55; i++) {
+            String content = "entry-" + i;
+            ledger.addEntry(content.getBytes());
+        }
+        Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 6);
+        Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
+                            .filter(e -> e.hasOffloadContext()).count(), 0);
+    }
+
+    @Test
+    public void testOffload() throws Exception {
+        MockLedgerOffloader offloader = new MockLedgerOffloader();
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setMaxEntriesPerLedger(10);
+        config.setMinimumRolloverTime(0, TimeUnit.SECONDS);
+        config.setRetentionTime(10, TimeUnit.MINUTES);
+        config.setLedgerOffloader(offloader);
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl)factory.open("my_test_ledger", config);
+
+        int i = 0;
+        for (; i < 25; i++) {
+            String content = "entry-" + i;
+            ledger.addEntry(content.getBytes());
+        }
+        Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 3);
+
+        ledger.offloadPrefix(ledger.getLastConfirmedEntry());
+
+        Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 3);
+        Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
+                            .filter(e -> e.hasOffloadContext())
+                            .map(e -> e.getLedgerId()).collect(Collectors.toSet()),
+                            offloader.offloadedLedgers());
+    }
+
+    @Test
+    public void testPositionOutOfRange() throws Exception {
+        MockLedgerOffloader offloader = new MockLedgerOffloader();
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setMaxEntriesPerLedger(10);
+        config.setMinimumRolloverTime(0, TimeUnit.SECONDS);
+        config.setRetentionTime(10, TimeUnit.MINUTES);
+        config.setLedgerOffloader(offloader);
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl)factory.open("my_test_ledger", config);
+
+        int i = 0;
+        for (; i < 25; i++) {
+            String content = "entry-" + i;
+            ledger.addEntry(content.getBytes());
+        }
+        Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 3);
+
+        try {
+            ledger.offloadPrefix(PositionImpl.earliest);
+            Assert.fail("Should have thrown an exception");
+        } catch (ManagedLedgerException.InvalidCursorPositionException e) {
+            // expected
+        }
+        try {
+            ledger.offloadPrefix(PositionImpl.latest);
+            Assert.fail("Should have thrown an exception");
+        } catch (ManagedLedgerException.InvalidCursorPositionException e) {
+            // expected
+        }
+
+        Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
+                            .filter(e -> e.hasOffloadContext()).count(), 0);
+        Assert.assertEquals(offloader.offloadedLedgers().size(), 0);
+    }
+
+    @Test
+    public void testPositionOnEdgeOfLedger() throws Exception {
+        MockLedgerOffloader offloader = new MockLedgerOffloader();
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setMaxEntriesPerLedger(10);
+        config.setMinimumRolloverTime(0, TimeUnit.SECONDS);
+        config.setRetentionTime(10, TimeUnit.MINUTES);
+        config.setLedgerOffloader(offloader);
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl)factory.open("my_test_ledger", config);
+
+        int i = 0;
+        for (; i < 20; i++) {
+            String content = "entry-" + i;
+            ledger.addEntry(content.getBytes());
+        }
+        Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 2);
+
+        Position p = ledger.getLastConfirmedEntry(); // position at end of second ledger
+
+        ledger.addEntry("entry-blah".getBytes());
+        Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 3);
+
+        PositionImpl firstUnoffloaded = (PositionImpl)ledger.offloadPrefix(p);
+
+        // only the first ledger should have been offloaded
+        Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 3);
+        Assert.assertEquals(offloader.offloadedLedgers().size(), 1);
+        Assert.assertTrue(offloader.offloadedLedgers().contains(ledger.getLedgersInfoAsList().get(0).getLedgerId()));
+        Assert.assertTrue(ledger.getLedgersInfoAsList().get(0).hasOffloadContext());
+        Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
+                            .filter(e -> e.hasOffloadContext()).count(), 1);
+        Assert.assertEquals(firstUnoffloaded.getLedgerId(), ledger.getLedgersInfoAsList().get(1).getLedgerId());
+        Assert.assertEquals(firstUnoffloaded.getEntryId(), 0);
+
+        // offload again, with the position in the third ledger
+        PositionImpl firstUnoffloaded2 = (PositionImpl)ledger.offloadPrefix(ledger.getLastConfirmedEntry());
+        Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 3);
+        Assert.assertEquals(offloader.offloadedLedgers().size(), 2);
+        Assert.assertTrue(offloader.offloadedLedgers().contains(ledger.getLedgersInfoAsList().get(0).getLedgerId()));
+        Assert.assertTrue(offloader.offloadedLedgers().contains(ledger.getLedgersInfoAsList().get(1).getLedgerId()));
+        Assert.assertTrue(ledger.getLedgersInfoAsList().get(0).hasOffloadContext());
+        Assert.assertTrue(ledger.getLedgersInfoAsList().get(1).hasOffloadContext());
+        Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
+                            .filter(e -> e.hasOffloadContext()).count(), 2);
+        Assert.assertEquals(firstUnoffloaded2.getLedgerId(), ledger.getLedgersInfoAsList().get(2).getLedgerId());
+    }
+
+    @Test
+    public void testTrimOccursDuringOffload() throws Exception {
+        CountDownLatch offloadStarted = new CountDownLatch(1);
+        CompletableFuture<Void> blocker = new CompletableFuture<>();
+        MockLedgerOffloader offloader = new MockLedgerOffloader() {
+                @Override
+                public CompletableFuture<byte[]> offload(ReadHandle ledger,
+                                                         Map<String, String> extraMetadata) {
+                    offloadStarted.countDown();
+                    return blocker.thenCompose((f) -> super.offload(ledger, extraMetadata));
+                }
+            };
+
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setMaxEntriesPerLedger(10);
+        config.setMinimumRolloverTime(0, TimeUnit.SECONDS);
+        config.setRetentionTime(0, TimeUnit.MINUTES);
+        config.setLedgerOffloader(offloader);
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl)factory.open("my_test_ledger", config);
+        ManagedCursor cursor = ledger.openCursor("foobar");
+
+        // Create 3 ledgers, saving position at start of each
+        for (int i = 0; i < 21; i++) {
+            String content = "entry-" + i;
+            ledger.addEntry(content.getBytes());
+        }
+        Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 3);
+
+        PositionImpl startOfSecondLedger = PositionImpl.get(ledger.getLedgersInfoAsList().get(1).getLedgerId(), 0);
+        PositionImpl startOfThirdLedger = PositionImpl.get(ledger.getLedgersInfoAsList().get(2).getLedgerId(), 0);
+
+        // trigger an offload which should offload the first two ledgers
+        OffloadCallbackPromise cbPromise = new OffloadCallbackPromise();
+        ledger.asyncOffloadPrefix(startOfThirdLedger, cbPromise, null);
+        offloadStarted.await();
+
+        // trim first ledger
+        cursor.markDelete(startOfSecondLedger, new HashMap<>());
+        assertEventuallyTrue(() -> ledger.getLedgersInfoAsList().size() == 2);
+        Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
+                            .filter(e -> e.hasOffloadContext()).count(), 0);
+
+        // complete offloading
+        blocker.complete(null);
+        cbPromise.get();
+
+        Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 2);
+        Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
+                            .filter(e -> e.hasOffloadContext()).count(), 1);
+        Assert.assertTrue(ledger.getLedgersInfoAsList().get(0).hasOffloadContext());
+        Assert.assertEquals(offloader.offloadedLedgers().size(), 1);
+        Assert.assertTrue(offloader.offloadedLedgers().contains(ledger.getLedgersInfoAsList().get(0).getLedgerId()));
+    }
+
+    @Test
+    public void testTrimOccursDuringOffloadLedgerDeletedBeforeOffload() throws Exception {
+        CountDownLatch offloadStarted = new CountDownLatch(1);
+        CompletableFuture<Long> blocker = new CompletableFuture<>();
+        MockLedgerOffloader offloader = new MockLedgerOffloader() {
+                @Override
+                public CompletableFuture<byte[]> offload(ReadHandle ledger,
+                                                         Map<String, String> extraMetadata) {
+                    offloadStarted.countDown();
+                    return blocker.thenCompose(
+                            (trimmedLedger) -> {
+                                if (trimmedLedger == ledger.getId()) {
+                                    CompletableFuture<byte[]> future = new CompletableFuture<>();
+                                    future.completeExceptionally(new BKException.BKNoSuchLedgerExistsException());
+                                    return future;
+                                } else {
+                                    return super.offload(ledger, extraMetadata);
+                                }
+                            });
+                }
+            };
+
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setMaxEntriesPerLedger(10);
+        config.setMinimumRolloverTime(0, TimeUnit.SECONDS);
+        config.setRetentionTime(0, TimeUnit.MINUTES);
+        config.setLedgerOffloader(offloader);
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl)factory.open("my_test_ledger", config);
+        ManagedCursor cursor = ledger.openCursor("foobar");
+
+        for (int i = 0; i < 21; i++) {
+            String content = "entry-" + i;
+            ledger.addEntry(content.getBytes());
+        }
+        Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 3);
+
+        PositionImpl startOfSecondLedger = PositionImpl.get(ledger.getLedgersInfoAsList().get(1).getLedgerId(), 0);
+        PositionImpl startOfThirdLedger = PositionImpl.get(ledger.getLedgersInfoAsList().get(2).getLedgerId(), 0);
+
+        // trigger an offload which should offload the first two ledgers
+        OffloadCallbackPromise cbPromise = new OffloadCallbackPromise();
+        ledger.asyncOffloadPrefix(startOfThirdLedger, cbPromise, null);
+        offloadStarted.await();
+
+        // trim first ledger
+        long trimmedLedger = ledger.getLedgersInfoAsList().get(0).getLedgerId();
+        cursor.markDelete(startOfSecondLedger, new HashMap<>());
+        assertEventuallyTrue(() -> ledger.getLedgersInfoAsList().size() == 2);
+        Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
+                            .filter(e -> e.getLedgerId() == trimmedLedger).count(), 0);
+        Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
+                            .filter(e -> e.hasOffloadContext()).count(), 0);
+
+        // complete offloading
+        blocker.complete(trimmedLedger);
+        cbPromise.get();
+
+        Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 2);
+        Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
+                            .filter(e -> e.hasOffloadContext()).count(), 1);
+        Assert.assertTrue(ledger.getLedgersInfoAsList().get(0).hasOffloadContext());
+        Assert.assertEquals(offloader.offloadedLedgers().size(), 1);
+        Assert.assertTrue(offloader.offloadedLedgers().contains(ledger.getLedgersInfoAsList().get(0).getLedgerId()));
+    }
+
+    @Test
+    public void testOffloadClosedManagedLedger() throws Exception {
+        MockLedgerOffloader offloader = new MockLedgerOffloader();
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setMaxEntriesPerLedger(10);
+        config.setMinimumRolloverTime(0, TimeUnit.SECONDS);
+        config.setRetentionTime(10, TimeUnit.MINUTES);
+        config.setLedgerOffloader(offloader);
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl)factory.open("my_test_ledger", config);
+
+        for (int i = 0; i < 21; i++) {
+            String content = "entry-" + i;
+            ledger.addEntry(content.getBytes());
+        }
+
+        Position p = ledger.getLastConfirmedEntry();
+        ledger.close();
+
+        try {
+            ledger.offloadPrefix(p);
+            Assert.fail("Should fail because ML is closed");
+        } catch (ManagedLedgerException.ManagedLedgerAlreadyClosedException e) {
+            // expected
+        }
+
+        Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 3);
+        Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
+                            .filter(e -> e.hasOffloadContext()).count(), 0);
+        Assert.assertEquals(offloader.offloadedLedgers().size(), 0);
+    }
+
+    @Test
+    public void testOffloadSamePositionTwice() throws Exception {
+        MockLedgerOffloader offloader = new MockLedgerOffloader();
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setMaxEntriesPerLedger(10);
+        config.setMinimumRolloverTime(0, TimeUnit.SECONDS);
+        config.setRetentionTime(10, TimeUnit.MINUTES);
+        config.setLedgerOffloader(offloader);
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl)factory.open("my_test_ledger", config);
+
+        int i = 0;
+        for (; i < 25; i++) {
+            String content = "entry-" + i;
+            ledger.addEntry(content.getBytes());
+        }
+        Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 3);
+
+        ledger.offloadPrefix(ledger.getLastConfirmedEntry());
+
+        Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 3);
+        Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
+                            .filter(e -> e.hasOffloadContext())
+                            .map(e -> e.getLedgerId()).collect(Collectors.toSet()),
+                            offloader.offloadedLedgers());
+
+        ledger.offloadPrefix(ledger.getLastConfirmedEntry());
+
+        Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 3);
+        Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
+                            .filter(e -> e.hasOffloadContext())
+                            .map(e -> e.getLedgerId()).collect(Collectors.toSet()),
+                            offloader.offloadedLedgers());
+
+    }
+
+    public void offloadThreeOneFails(int failIndex) throws Exception {
+        CompletableFuture<Set<Long>> promise = new CompletableFuture<>();
+        MockLedgerOffloader offloader = new ErroringMockLedgerOffloader(promise);
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setMaxEntriesPerLedger(10);
+        config.setMinimumRolloverTime(0, TimeUnit.SECONDS);
+        config.setRetentionTime(10, TimeUnit.MINUTES);
+        config.setLedgerOffloader(offloader);
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl)factory.open("my_test_ledger", config);
+
+        int i = 0;
+        for (; i < 35; i++) {
+            String content = "entry-" + i;
+            ledger.addEntry(content.getBytes());
+        }
+        Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 4);
+
+        // mark ledgers to fail
+        promise.complete(ImmutableSet.of(ledger.getLedgersInfoAsList().get(failIndex).getLedgerId()));
+
+        try {
+            ledger.offloadPrefix(ledger.getLastConfirmedEntry());
+        } catch (ManagedLedgerException e) {
+            Assert.assertEquals(e.getCause().getClass(), CompletionException.class);
+        }
+
+        Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 4);
+        Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
+                            .filter(e -> e.hasOffloadContext())
+                            .map(e -> e.getLedgerId()).collect(Collectors.toSet()),
+                            offloader.offloadedLedgers());
+        Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
+                            .filter(e -> e.hasOffloadContext()).count(), 2);
+        Assert.assertFalse(ledger.getLedgersInfoAsList().get(failIndex).hasOffloadContext());
+    }
+
+    @Test
+    public void testOffloadThreeFirstFails() throws Exception {
+        offloadThreeOneFails(0);
+    }
+
+    @Test
+    public void testOffloadThreeSecondFails() throws Exception {
+        offloadThreeOneFails(1);
+    }
+
+    @Test
+    public void testOffloadThreeThirdFails() throws Exception {
+        offloadThreeOneFails(2);
+    }
+
+    @Test
+    public void testOffloadNewML() throws Exception {
+        MockLedgerOffloader offloader = new MockLedgerOffloader();
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setMaxEntriesPerLedger(10);
+        config.setMinimumRolloverTime(0, TimeUnit.SECONDS);
+        config.setRetentionTime(10, TimeUnit.MINUTES);
+        config.setLedgerOffloader(offloader);
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl)factory.open("my_test_ledger", config);
+
+        try {
+            ledger.offloadPrefix(ledger.getLastConfirmedEntry());
+        } catch (ManagedLedgerException.InvalidCursorPositionException e) {
+            // expected
+        }
+        // add one entry and try again
+        ledger.addEntry("foobar".getBytes());
+
+        Position p = ledger.getLastConfirmedEntry();
+        Assert.assertEquals(p, ledger.offloadPrefix(ledger.getLastConfirmedEntry()));
+        Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 1);
+        Assert.assertEquals(offloader.offloadedLedgers().size(), 0);
+    }
+
+    void assertEventuallyTrue(BooleanSupplier predicate) throws Exception {
+        // wait up to 3 seconds
+        for (int i = 0; i < 30 && !predicate.getAsBoolean(); i++) {
+            Thread.sleep(100);
+        }
+        Assert.assertTrue(predicate.getAsBoolean());
+    }
+
+    static class OffloadCallbackPromise extends CompletableFuture<Position> implements OffloadCallback {
+        @Override
+        public void offloadComplete(Position pos, Object ctx) {
+            complete(pos);
+        }
+
+        @Override
+        public void offloadFailed(ManagedLedgerException exception, Object ctx) {
+            completeExceptionally(exception);
+        }
+    }
+
+    static class MockLedgerOffloader implements LedgerOffloader {
+        ConcurrentHashMap<Long, UUID> offloads = new ConcurrentHashMap<Long, UUID>();
+
+        Set<Long> offloadedLedgers() {
+            return offloads.keySet();
+        }
+
+        @Override
+        public CompletableFuture<byte[]> offload(ReadHandle ledger,
+                                                 Map<String, String> extraMetadata) {
+            CompletableFuture<byte[]> promise = new CompletableFuture<>();
+            UUID uuid = UUID.randomUUID();
+            if (offloads.putIfAbsent(ledger.getId(), uuid) == null) {
+                promise.complete(uuid.toString().getBytes());
+            } else {
+                promise.completeExceptionally(new Exception("Already exists exception"));
+            }
+            return promise;
+        }
+
+        @Override
+        public CompletableFuture<ReadHandle> readOffloaded(long ledgerId, byte[] offloadContext) {
+            CompletableFuture<ReadHandle> promise = new CompletableFuture<>();
+            promise.completeExceptionally(new UnsupportedOperationException());
+            return promise;
+        }
+
+        @Override
+        public CompletableFuture<Void> deleteOffloaded(long ledgerId, byte[] offloadContext) {
+            CompletableFuture<Void> promise = new CompletableFuture<>();
+            UUID uuid = UUID.fromString(new String(offloadContext));
+            if (offloads.remove(ledgerId, uuid)) {
+                promise.complete(null);
+            } else {
+                promise.completeExceptionally(new Exception("Not found"));
+            }
+            return promise;
+        };
+    }
+
+    static class ErroringMockLedgerOffloader extends MockLedgerOffloader {
+        CompletableFuture<Set<Long>> errorLedgers = new CompletableFuture<>();
+
+        ErroringMockLedgerOffloader(CompletableFuture<Set<Long>> errorLedgers) {
+            this.errorLedgers = errorLedgers;
+        }
+
+        @Override
+        public CompletableFuture<byte[]> offload(ReadHandle ledger,
+                                                 Map<String, String> extraMetadata) {
+            return errorLedgers.thenCompose(
+                            (errors) -> {
+                                if (errors.contains(ledger.getId())) {
+                                    CompletableFuture<byte[]> future = new CompletableFuture<>();
+                                    future.completeExceptionally(new Exception("Some kind of error"));
+                                    return future;
+                                } else {
+                                    return super.offload(ledger, extraMetadata);
+                                }
+                            });
+        }
+    }
+}


### PR DESCRIPTION
When given a position, will select all complete ledgers before that
position, and offload them. When the offload completes, updates the
managed ledger metadata with the context information for the offload.

Master issue #1511
