### PR TITLE
Fix: handle invalid markDelete position at managed-cursor

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -1302,16 +1302,6 @@ public class ManagedCursorImpl implements ManagedCursor {
         checkNotNull(position);
         checkArgument(position instanceof PositionImpl);
         
-        if (((PositionImpl) ledger.getLastConfirmedEntry()).compareTo((PositionImpl) position) <= 0) {
-            if (log.isDebugEnabled()) {
-                log.debug(
-                        "[{}] Failed mark delete due to invalid markDelete {} is ahead of last-confirmed-entry {} for cursor [{}]",
-                        ledger.getName(), position, ledger.getLastConfirmedEntry(), name);
-            }
-            callback.markDeleteFailed(new ManagedLedgerException("Invalid mark deleted position"), ctx);
-            return;
-        }
-
         if (STATE_UPDATER.get(this) == State.Closed) {
             callback.markDeleteFailed(new ManagedLedgerException("Cursor was already closed"), ctx);
             return;
@@ -1332,6 +1322,16 @@ public class ManagedCursorImpl implements ManagedCursor {
             log.debug("[{}] Mark delete cursor {} up to position: {}", ledger.getName(), name, position);
         }
         PositionImpl newPosition = (PositionImpl) position;
+        
+        if (((PositionImpl) ledger.getLastConfirmedEntry()).compareTo(newPosition) < 0) {
+            if (log.isDebugEnabled()) {
+                log.debug(
+                        "[{}] Failed mark delete due to invalid markDelete {} is ahead of last-confirmed-entry {} for cursor [{}]",
+                        ledger.getName(), position, ledger.getLastConfirmedEntry(), name);
+            }
+            callback.markDeleteFailed(new ManagedLedgerException("Invalid mark deleted position"), ctx);
+            return;
+        }
 
         lock.writeLock().lock();
         try {
@@ -1548,7 +1548,7 @@ public class ManagedCursorImpl implements ManagedCursor {
             for (Position pos : positions) {
                 PositionImpl position  = (PositionImpl) checkNotNull(pos);
                 
-                if (((PositionImpl) ledger.getLastConfirmedEntry()).compareTo(position) <= 0) {
+                if (((PositionImpl) ledger.getLastConfirmedEntry()).compareTo(position) < 0) {
                     if (log.isDebugEnabled()) {
                         log.debug(
                                 "[{}] Failed mark delete due to invalid markDelete {} is ahead of last-confirmed-entry {} for cursor [{}]",

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorTest.java
@@ -46,6 +46,7 @@ import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.LedgerEntry;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.AddEntryCallback;
+import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.MarkDeleteCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntriesCallback;
 import org.apache.bookkeeper.mledger.Entry;
@@ -2629,5 +2630,60 @@ public class ManagedCursorTest extends MockedBookKeeperTestCase {
         assertEquals(entries.size(), totalAddEntries / 2);
     }
 
+    @Test
+    public void testInvalidMarkDelete() throws Exception {
+        ManagedLedger ledger = factory.open("my_test_ledger", new ManagedLedgerConfig());
+
+        ManagedCursor cursor = ledger.openCursor("c1");
+        Position readPosition = cursor.getReadPosition();
+        Position markDeletePosition = cursor.getMarkDeletedPosition();
+
+        List<Position> addedPositions = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            Position p = ledger.addEntry(("dummy-entry-" + i).getBytes(Encoding));
+            addedPositions.add(p);
+        }
+
+        // validate: cursor.asyncMarkDelete(..)
+        CountDownLatch markDeleteCallbackLatch = new CountDownLatch(1);
+        Position position = PositionImpl.get(100, 100);
+        AtomicBoolean markDeleteCallFailed = new AtomicBoolean(false);
+        cursor.asyncMarkDelete(position, new MarkDeleteCallback() {
+            @Override
+            public void markDeleteComplete(Object ctx) {
+                markDeleteCallbackLatch.countDown();
+            }
+
+            @Override
+            public void markDeleteFailed(ManagedLedgerException exception, Object ctx) {
+                markDeleteCallFailed.set(true);
+                markDeleteCallbackLatch.countDown();
+            }
+        }, null);
+        markDeleteCallbackLatch.await();
+        assertEquals(readPosition, cursor.getReadPosition());
+        assertEquals(markDeletePosition, cursor.getMarkDeletedPosition());
+
+        // validate : cursor.asyncDelete(..)
+        CountDownLatch deleteCallbackLatch = new CountDownLatch(1);
+        markDeleteCallFailed.set(false);
+        cursor.asyncDelete(position, new DeleteCallback() {
+            @Override
+            public void deleteComplete(Object ctx) {
+                deleteCallbackLatch.countDown();
+            }
+
+            @Override
+            public void deleteFailed(ManagedLedgerException exception, Object ctx) {
+                markDeleteCallFailed.set(true);
+                deleteCallbackLatch.countDown();
+            }
+        }, null);
+
+        deleteCallbackLatch.await();
+        assertEquals(readPosition, cursor.getReadPosition());
+        assertEquals(markDeletePosition, cursor.getMarkDeletedPosition());
+    }
+    
     private static final Logger log = LoggerFactory.getLogger(ManagedCursorTest.class);
 }


### PR DESCRIPTION
### Motivation

If client acks with invalid message-id (message-id > ledger.lastConfirmedEntry) then broker doesn't do validation and it tries to process it which can corrupt the state of cursor. 

eg: if `newMarkDeletePosition` is invalid then [ledger.getNextValidPosition()](https://github.com/apache/incubator-pulsar/blob/branch-1.22/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java?utf8=%E2%9C%93#L1245) returns null and broker stores `readPosition=null` 
```
readPosition = ledger.getNextValidPosition(newMarkDeletePosition);
```
and it creates below exception:
```
19:17:28.298 [pulsar-io-72-47] WARN  o.a.b.mledger.impl.ManagedCursorImpl - [prop/global/ns/persistent/topic] [sub] Error while updating individualDeletedMessages [null]
java.lang.NullPointerException: null
        at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:192) ~[guava-15.0.jar:na]
        at com.google.common.collect.TreeRangeSet.rangeContaining(TreeRangeSet.java:98) ~[guava-15.0.jar:na]
        at com.google.common.collect.AbstractRangeSet.contains(AbstractRangeSet.java:29) ~[guava-15.0.jar:na]
        at com.google.common.collect.TreeRangeSet.contains(TreeRangeSet.java:42) ~[guava-15.0.jar:na]
        at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.setAcknowledgedPosition(ManagedCursorImpl.java:1248) ~[managed-ledger-1.20.16-incubating-yahoo.jar:1.20.16-incubating-yahoo]
        at org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.asyncDelete(ManagedCursorImpl.java:1541) ~[managed-ledger-1.20.16-incubating-yahoo.jar:1.20.16-incubating-yahoo]
        at org.apache.pulsar.broker.service.persistent.PersistentSubscription.acknowledgeMessage(PersistentSubscription.java:182) [pulsar-broker-1.20.16-incubating-yahoo.jar:1.20.16-incubating-yahoo]
        at org.apache.pulsar.broker.service.Consumer.messageAcked(Consumer.java:346) [pulsar-broker-1.20.16-incubating-yahoo.jar:1.20.16-incubating-yahoo]
        at org.apache.pulsar.broker.service.ServerCnx.handleAck(ServerCnx.java:859) [pulsar-broker-1.20.16-incubating-yahoo.jar:1.20.16-incubating-yahoo]
```

### Modifications

validate mark-delete position before processing it.

### Result

Prevents any state corruption at cursor.
