### PR TITLE
Use `AtomicInteger` in LoggingFunction

### DIFF
--- a/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/LoggingFunction.java
+++ b/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/LoggingFunction.java
@@ -31,6 +31,7 @@ public class LoggingFunction implements Function<String, String> {
 
     private static final AtomicIntegerFieldUpdater<LoggingFunction> COUNTER_UPDATER =
         AtomicIntegerFieldUpdater.newUpdater(LoggingFunction.class, "counter");
+    private volatile int counter = 0;
 
     @Override
     public String process(String input, Context context) {

--- a/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/LoggingFunction.java
+++ b/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/LoggingFunction.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.functions.api.examples;
 
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.pulsar.functions.api.Context;
 import org.apache.pulsar.functions.api.Function;
@@ -29,15 +29,13 @@ import org.slf4j.Logger;
  */
 public class LoggingFunction implements Function<String, String> {
 
-    private static final AtomicIntegerFieldUpdater<LoggingFunction> COUNTER_UPDATER =
-        AtomicIntegerFieldUpdater.newUpdater(LoggingFunction.class, "counter");
-    private volatile int counter = 0;
+    private final AtomicInteger counter = new AtomicInteger(0);
 
     @Override
     public String process(String input, Context context) {
         Logger LOG = context.getLogger();
 
-        int counterLocal = COUNTER_UPDATER.incrementAndGet(this);
+        int counterLocal = counter.incrementAndGet();
         if ((counterLocal & Integer.MAX_VALUE) % 100000 == 0) {
             LOG.info("Handled {} messages", counterLocal);
         }


### PR DESCRIPTION
AtomicFiledIntegerUpdater is good for performance. But it is not common to most of the developers. Change it to use `AtomicInteger` for the example LoggingFunction.