### PR TITLE
Allow proxy to come up before any brokers have

### DIFF
--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/util/ZookeeperCacheLoader.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/util/ZookeeperCacheLoader.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.proxy.server.util;
 
 import java.io.Closeable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -32,6 +33,7 @@ import org.apache.pulsar.zookeeper.ZooKeeperCache;
 import org.apache.pulsar.zookeeper.ZooKeeperChildrenCache;
 import org.apache.pulsar.zookeeper.ZooKeeperClientFactory;
 import org.apache.pulsar.zookeeper.ZooKeeperDataCache;
+import org.apache.zookeeper.KeeperException.NoNodeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -95,16 +97,15 @@ public class ZookeeperCacheLoader implements Closeable {
         });
 
         // Do initial fetch of brokers list
-        availableBrokersSet = availableBrokersCache.get();
-        updateBrokerList(availableBrokersSet);
+        try {
+            updateBrokerList(availableBrokersCache.get());
+        } catch (NoNodeException nne) { // can happen if no broker started yet
+            updateBrokerList(Collections.emptySet());
+        }
     }
 
     public List<LoadManagerReport> getAvailableBrokers() {
         return availableBrokers;
-    }
-
-    public Set<String> getAvailableBrokersSet() {
-        return availableBrokersSet;
     }
 
     public ZooKeeperCache getLocalZkCache() {


### PR DESCRIPTION
If no brokers have come up, then /loadbalance/brokers will not have
been created. Previously, if a proxy came up at this point, it would
get a NoNodeException when it tried to watch the children of this
path, and the proxy itself would hang.

This change modifies the ZooKeeper cache, so that if you try to
getChildren on a node that doesn't exist, a watcher on that path's
existance will be created before the NoNodeException is thrown.

Callers can then call getChildren with a watcher, and expect the
watcher to trigger when the the node is created and has another node
created below it.
