### PR TITLE
Introduce admin api to get broker and namespace-isolation policy map

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -95,7 +95,7 @@ public class BrokersBase extends AdminResource {
             throw new RestException(e);
         }
     }
-    
+
     @POST
     @Path("/configuration/{configName}/{configValue}")
     @ApiOperation(value = "Update dynamic serviceconfiguration into zk only. This operation requires Pulsar super-user privileges.")

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/LoadManager.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.loadbalance;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
@@ -107,6 +108,14 @@ public interface LoadManager {
      * @throws Exception
      */
     public void disableBroker() throws Exception;
+    
+    /**
+     * Get list of available brokers in cluster
+     * 
+     * @return
+     * @throws Exception 
+     */
+    Set<String> getAvailableBrokers() throws Exception;
 
     public void stop() throws PulsarServerException;
 
@@ -139,4 +148,5 @@ public interface LoadManager {
         // If we failed to create a load manager, default to SimpleLoadManagerImpl.
         return new SimpleLoadManagerImpl(pulsar);
     }
+
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/ModularLoadManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/ModularLoadManager.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.loadbalance;
 
 import java.util.Optional;
+import java.util.Set;
 
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
@@ -103,4 +104,11 @@ public interface ModularLoadManager {
      * @return
      */
     Deserializer<? extends ServiceLookupData> getLoadReportDeserializer();
+
+    /**
+     * Get available broker list in cluster
+     * 
+     * @return
+     */
+    Set<String> getAvailableBrokers();
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -335,6 +335,7 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
         }
     }
 
+    @Override
     public Set<String> getAvailableBrokers() {
         try {
             return availableActiveBrokers.get();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerWrapper.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerWrapper.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.broker.loadbalance.impl;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
@@ -121,5 +122,10 @@ public class ModularLoadManagerWrapper implements LoadManager {
 
     public ModularLoadManager getLoadManager() {
         return loadManager;
+    }
+
+    @Override
+    public Set<String> getAvailableBrokers() throws Exception {
+        return loadManager.getAvailableBrokers();
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleLoadManagerImpl.java
@@ -351,6 +351,11 @@ public class SimpleLoadManagerImpl implements LoadManager, ZooKeeperCacheListene
         return this.availableActiveBrokers;
     }
 
+    @Override
+    public Set<String> getAvailableBrokers() throws Exception {
+        return this.availableActiveBrokers.get();
+    }
+    
     public ZooKeeperDataCache<LoadReport> getLoadReportCache() {
         return this.loadReportCacheZk;
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleResourceAllocationPolicies.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/SimpleResourceAllocationPolicies.java
@@ -26,6 +26,7 @@ import org.apache.pulsar.broker.admin.AdminResource;
 import org.apache.pulsar.broker.loadbalance.LoadReport;
 import org.apache.pulsar.broker.loadbalance.ResourceUnit;
 import org.apache.pulsar.broker.loadbalance.ServiceUnit;
+import static org.apache.pulsar.broker.namespace.NamespaceService.NAMESPACE_ISOLATION_POLICIES;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.policies.NamespaceIsolationPolicy;
 import org.apache.pulsar.common.policies.impl.NamespaceIsolationPolicies;
@@ -51,7 +52,7 @@ public class SimpleResourceAllocationPolicies {
     private Optional<NamespaceIsolationPolicies> getIsolationPolicies(String clusterName) {
         try {
             return namespaceIsolationPolicies
-                    .get(AdminResource.path("clusters", clusterName, "namespaceIsolationPolicies"));
+                    .get(AdminResource.path("clusters", clusterName, NAMESPACE_ISOLATION_POLICIES));
         } catch (Exception e) {
             LOG.warn("GetIsolationPolicies: Unable to get the namespaceIsolationPolicies [{}]", e);
             return Optional.empty();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -119,6 +119,8 @@ public class NamespaceService {
     public static final Pattern SLA_NAMESPACE_PATTERN = Pattern.compile(SLA_NAMESPACE_PROPERTY + "/[^/]+/([^:]+:\\d+)");
     public static final String HEARTBEAT_NAMESPACE_FMT = "pulsar/%s/%s:%s";
     public static final String SLA_NAMESPACE_FMT = SLA_NAMESPACE_PROPERTY + "/%s/%s:%s";
+    
+    public static final String NAMESPACE_ISOLATION_POLICIES = "namespaceIsolationPolicies";
 
     /**
      * Default constructor.
@@ -519,7 +521,7 @@ public class NamespaceService {
     private NamespaceIsolationPolicies getLocalNamespaceIsolationPolicies() throws Exception {
         String localCluster = pulsar.getConfiguration().getClusterName();
         return pulsar.getConfigurationCache().namespaceIsolationPoliciesCache()
-                .get(AdminResource.path("clusters", localCluster, "namespaceIsolationPolicies")).orElseGet(() -> {
+                .get(AdminResource.path("clusters", localCluster, NAMESPACE_ISOLATION_POLICIES)).orElseGet(() -> {
                     // the namespace isolation policies are empty/undefined = an empty object
                     return new NamespaceIsolationPolicies();
                 });

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Clusters.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Clusters.java
@@ -27,6 +27,7 @@ import org.apache.pulsar.client.admin.PulsarAdminException.ConflictException;
 import org.apache.pulsar.client.admin.PulsarAdminException.NotAuthorizedException;
 import org.apache.pulsar.client.admin.PulsarAdminException.NotFoundException;
 import org.apache.pulsar.client.admin.PulsarAdminException.PreconditionFailedException;
+import org.apache.pulsar.common.policies.data.BrokerNamespaceIsolationData;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.FailureDomain;
 import org.apache.pulsar.common.policies.data.NamespaceIsolationData;
@@ -227,6 +228,28 @@ public interface Clusters {
     void createNamespaceIsolationPolicy(String cluster, String policyName, NamespaceIsolationData namespaceIsolationData)
             throws PulsarAdminException;
 
+    
+    /**
+     * Returns list of active brokers with namespace-isolation policies attached to it.
+     * 
+     * @param cluster
+     * @return
+     * @throws PulsarAdminException
+     */
+    List<BrokerNamespaceIsolationData> getBrokersWithNamespaceIsolationPolicy(String cluster)
+            throws PulsarAdminException;
+
+    /**
+     * Returns active broker with namespace-isolation policies attached to it.
+     * 
+     * @param cluster
+     * @param broker
+     * @return
+     * @throws PulsarAdminException
+     */
+    BrokerNamespaceIsolationData getBrokerWithNamespaceIsolationPolicy(String cluster, String broker)
+            throws PulsarAdminException;
+    
 
     /**
      * Update a namespace isolation policy for a cluster

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ClustersImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/ClustersImpl.java
@@ -31,6 +31,7 @@ import javax.ws.rs.core.MediaType;
 import org.apache.pulsar.client.admin.Clusters;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.common.policies.data.BrokerNamespaceIsolationData;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.FailureDomain;
 import org.apache.pulsar.common.policies.data.ErrorData;
@@ -119,6 +120,30 @@ public class ClustersImpl extends BaseResource implements Clusters {
             return request(adminClusters.path(cluster).path("namespaceIsolationPolicies")).get(
                     new GenericType<Map<String, NamespaceIsolationData>>() {
                     });
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
+
+    
+    @Override
+    public List<BrokerNamespaceIsolationData> getBrokersWithNamespaceIsolationPolicy(String cluster)
+            throws PulsarAdminException {
+        try {
+            return request(adminClusters.path(cluster).path("namespaceIsolationPolicies").path("brokers"))
+                    .get(new GenericType<List<BrokerNamespaceIsolationData>>() {
+                    });
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
+
+    @Override
+    public BrokerNamespaceIsolationData getBrokerWithNamespaceIsolationPolicy(String cluster, String broker)
+            throws PulsarAdminException {
+        try {
+            return request(adminClusters.path(cluster).path("namespaceIsolationPolicies").path("brokers").path(broker))
+                    .get(BrokerNamespaceIsolationData.class);
         } catch (Exception e) {
             throw getApiException(e);
         }

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -23,9 +23,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
-
 import java.util.EnumSet;
 
 import org.apache.pulsar.client.admin.BrokerStats;
@@ -52,6 +49,9 @@ import org.mockito.ArgumentMatcher;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 @Test
 public class PulsarAdminToolTest {
@@ -426,6 +426,21 @@ public class PulsarAdminToolTest {
         verify(mockResourceQuotas).resetNamespaceBundleResourceQuota("myprop/clust/ns1", "0x80000000_0xffffffff");
     }
 
+    @Test
+    void namespaceIsolationPolicy() throws Exception {
+        PulsarAdmin admin = Mockito.mock(PulsarAdmin.class);
+        Clusters mockClusters = mock(Clusters.class);
+        when(admin.clusters()).thenReturn(mockClusters);
+
+        CmdNamespaceIsolationPolicy nsIsolationPoliciesCmd = new CmdNamespaceIsolationPolicy(admin);
+
+        nsIsolationPoliciesCmd.run(split("brokers use"));
+        verify(mockClusters).getBrokersWithNamespaceIsolationPolicy("use");
+
+        nsIsolationPoliciesCmd.run(split("broker use --broker my-broker"));
+        verify(mockClusters).getBrokerWithNamespaceIsolationPolicy("use", "my-broker");
+    }
+    
     @Test
     void persistentTopics() throws Exception {
         PulsarAdmin admin = Mockito.mock(PulsarAdmin.class);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaceIsolationPolicy.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdNamespaceIsolationPolicy.java
@@ -27,6 +27,7 @@ import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.policies.data.AutoFailoverPolicyData;
 import org.apache.pulsar.common.policies.data.AutoFailoverPolicyType;
+import org.apache.pulsar.common.policies.data.BrokerNamespaceIsolationData;
 import org.apache.pulsar.common.policies.data.NamespaceIsolationData;
 
 import com.beust.jcommander.Parameter;
@@ -79,6 +80,39 @@ public class CmdNamespaceIsolationPolicy extends CmdBase {
             Map<String, NamespaceIsolationData> policyMap = admin.clusters().getNamespaceIsolationPolicies(clusterName);
 
             print(policyMap);
+        }
+    }
+
+    @Parameters(commandDescription = "List all brokers with namespace-isolation policies attached to it. This operation requires Pulsar super-user privileges")
+    private class GetAllBrokersWithPolicies extends CliCommand {
+        @Parameter(description = "cluster-name\n", required = true)
+        private List<String> params;
+
+        void run() throws PulsarAdminException {
+            String clusterName = getOneArgument(params);
+
+            List<BrokerNamespaceIsolationData> brokers = admin.clusters()
+                    .getBrokersWithNamespaceIsolationPolicy(clusterName);
+
+            print(brokers);
+        }
+    }
+
+    @Parameters(commandDescription = "Get broker with namespace-isolation policies attached to it. This operation requires Pulsar super-user privileges")
+    private class GetBrokerWithPolicies extends CliCommand {
+        @Parameter(description = "cluster-name\n", required = true)
+        private List<String> params;
+
+        @Parameter(names = "--broker", description = "Broker-name to get namespace-isolation policies attached to it", required = true)
+        private String broker;
+
+        void run() throws PulsarAdminException {
+            String clusterName = getOneArgument(params);
+
+            BrokerNamespaceIsolationData brokerData = admin.clusters()
+                    .getBrokerWithNamespaceIsolationPolicy(clusterName, broker);
+
+            print(brokerData);
         }
     }
 
@@ -195,6 +229,8 @@ public class CmdNamespaceIsolationPolicy extends CmdBase {
         jcommander.addCommand("get", new GetPolicy());
         jcommander.addCommand("list", new GetAllPolicies());
         jcommander.addCommand("delete", new DeletePolicy());
+        jcommander.addCommand("brokers", new GetAllBrokersWithPolicies());
+        jcommander.addCommand("broker", new GetBrokerWithPolicies());
     }
 
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/BrokerNamespaceIsolationData.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/BrokerNamespaceIsolationData.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.policies.data;
+
+import java.util.List;
+
+import com.google.common.base.Objects;
+
+public class BrokerNamespaceIsolationData {
+
+    public String brokerName;
+    public List<String> namespaceRegex; //isolated namespace regex
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof BrokerNamespaceIsolationData) {
+            BrokerNamespaceIsolationData other = (BrokerNamespaceIsolationData) obj;
+            return Objects.equal(brokerName, other.brokerName) && Objects.equal(namespaceRegex, other.namespaceRegex);
+        }
+        return false;
+    }
+
+}


### PR DESCRIPTION
### Motivation

Right now, with multiple namespace-isolation-policies, it is little bit tricky to find out list of brokers which are part of shared pool by going through regex. we also want to know policies attached to every broker for isolation policy analysis.

### Modifications

Introduce admin api 
1. Get list of brokers with namespace isolation policy attached to them
2. get specific broker with namespace isolation policy attached to it

### Result

it will not impact any existing functionality.
