### PR TITLE
Increase integration test service wait default timeouts

### DIFF
--- a/tests/integration-tests-utils/src/main/java/org/apache/pulsar/tests/PulsarClusterUtils.java
+++ b/tests/integration-tests-utils/src/main/java/org/apache/pulsar/tests/PulsarClusterUtils.java
@@ -166,13 +166,13 @@ public class PulsarClusterUtils {
 
     public static boolean waitAllBrokersUp(DockerClient docker, String cluster) {
         return brokerSet(docker, cluster).stream()
-            .map((b) -> waitBrokerUp(docker, b, 10, TimeUnit.SECONDS))
+            .map((b) -> waitBrokerUp(docker, b, 60, TimeUnit.SECONDS))
             .reduce(true, (accum, res) -> accum && res);
     }
 
     public static boolean waitAllBrokersDown(DockerClient docker, String cluster) {
         return brokerSet(docker, cluster).stream()
-            .map((b) -> waitBrokerDown(docker, b, 10, TimeUnit.SECONDS))
+            .map((b) -> waitBrokerDown(docker, b, 60, TimeUnit.SECONDS))
             .reduce(true, (accum, res) -> accum && res);
     }
 
@@ -243,7 +243,7 @@ public class PulsarClusterUtils {
 
     public static boolean waitAllProxiesUp(DockerClient docker, String cluster) {
         return proxySet(docker, cluster).stream()
-            .map((b) -> waitProxyUp(docker, b, 10, TimeUnit.SECONDS))
+            .map((b) -> waitProxyUp(docker, b, 60, TimeUnit.SECONDS))
             .reduce(true, (accum, res) -> accum && res);
     }
 


### PR DESCRIPTION
The integration tests have a set utility methods to wait for all
brokers or all proxy nodes to come up.

The timeout on these were set to 10 seconds, which was a bit short for a
heavily loaded machine, as can be common in CI. Increased to 60 seconds.
