### PR TITLE
Add metadata to compacted topic ledger on creation

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/TwoPhaseCompactor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/TwoPhaseCompactor.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.compaction;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.google.common.collect.ImmutableMap;
 import io.netty.buffer.ByteBuf;
 
@@ -155,8 +157,9 @@ public class TwoPhaseCompactor extends Compactor {
 
     private CompletableFuture<Long> phaseTwo(RawReader reader, MessageId from, MessageId to,
                                              Map<String,MessageId> latestForKey, BookKeeper bk) {
-
-        return createLedger(bk).thenCompose((ledger) -> {
+        Map<String, byte[]> metadata = ImmutableMap.of("compactedTopic", reader.getTopic().getBytes(UTF_8),
+                                                       "compactedTo", to.toByteArray());
+        return createLedger(bk, metadata).thenCompose((ledger) -> {
                 log.info("Commencing phase two of compaction for {}, from {} to {}, compacting {} keys to ledger {}",
                          reader.getTopic(), from, to, latestForKey.size(), ledger.getId());
                 return phaseTwoSeekThenLoop(reader, from, to, latestForKey, bk, ledger);
@@ -252,7 +255,7 @@ public class TwoPhaseCompactor extends Compactor {
                 }, scheduler);
     }
 
-    private CompletableFuture<LedgerHandle> createLedger(BookKeeper bk) {
+    private CompletableFuture<LedgerHandle> createLedger(BookKeeper bk, Map<String,byte[]> metadata) {
         CompletableFuture<LedgerHandle> bkf = new CompletableFuture<>();
         bk.asyncCreateLedger(conf.getManagedLedgerDefaultEnsembleSize(),
                              conf.getManagedLedgerDefaultWriteQuorum(),
@@ -265,7 +268,7 @@ public class TwoPhaseCompactor extends Compactor {
                                  } else {
                                      bkf.complete(ledger);
                                  }
-                             }, null, Collections.emptyMap());
+                             }, null, metadata);
         return bkf;
     }
 


### PR DESCRIPTION
This can be used by ops to identify what the ledger is, and where it
can be cleaned up. There are corner cases where a compacted topic
ledger may be created, but never attached to the topic, just as there
are with managed ledger ledgers, so we need some way that these can be
identified for garbage collection later.
