### PR TITLE
Fix for C++ test BasicEndToEndTest.testStatsLatencies

### DIFF
--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -25,7 +25,7 @@ zookeeperServers=
 # Global Zookeeper quorum connection string
 globalZookeeperServers=
 
-brokerServicePort=8885
+brokerServicePort=6650
 
 # Port to use to server HTTP request
 webServicePort=8080

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -25,7 +25,7 @@ zookeeperServers=
 # Global Zookeeper quorum connection string
 globalZookeeperServers=
 
-brokerServicePort=6650
+brokerServicePort=8885
 
 # Port to use to server HTTP request
 webServicePort=8080

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -915,17 +915,11 @@ TEST(BasicEndToEndTest, testStatsLatencies) {
     // Start Producer and Consumer
     int numOfMessages = 1000;
 
-    Promise<Result, Producer> producerPromise;
-    client.createProducerAsync(topicName, WaitForCallbackValue<Producer>(producerPromise));
-    Future<Result, Producer> producerFuture = producerPromise.getFuture();
-    Result result = producerFuture.get(producer);
+    Result result = client.createProducer(topicName, producer);
     ASSERT_EQ(ResultOk, result);
 
     Consumer consumer;
-    Promise<Result, Consumer> consumerPromise;
-    client.subscribeAsync(topicName, subName, WaitForCallbackValue<Consumer>(consumerPromise));
-    Future<Result, Consumer> consumerFuture = consumerPromise.getFuture();
-    result = consumerFuture.get(consumer);
+    result = client.subscribe(topicName, subName, consumer);
     ASSERT_EQ(ResultOk, result);
 
     // handling dangling subscriptions
@@ -948,7 +942,7 @@ TEST(BasicEndToEndTest, testStatsLatencies) {
                           .setContent(messageContent)
                           .setProperty("msgIndex", boost::lexical_cast<std::string>(i))
                           .build();
-        producer.sendAsync(msg, boost::bind(&sendCallBack, _1, _2, prefix, 15, 20 * 1e3));
+        producer.sendAsync(msg, boost::bind(&sendCallBack, _1, _2, prefix, 15, 2 * 1e3));
         LOG_DEBUG("sending message " << messageContent);
     }
 
@@ -973,13 +967,13 @@ TEST(BasicEndToEndTest, testStatsLatencies) {
     ASSERT_EQ((uint64_t)latencies[2], (uint64_t)totalLatencies[2]);
     ASSERT_EQ((uint64_t)latencies[3], (uint64_t)totalLatencies[3]);
 
-    ASSERT_GE((uint64_t)latencies[1], 20 * 1000);
-    ASSERT_GE((uint64_t)latencies[2], 20 * 1000);
-    ASSERT_GE((uint64_t)latencies[3], 20 * 1000);
+    ASSERT_GE((uint64_t)latencies[1], 20 * 100);
+    ASSERT_GE((uint64_t)latencies[2], 20 * 100);
+    ASSERT_GE((uint64_t)latencies[3], 20 * 100);
 
-    ASSERT_GE((uint64_t)totalLatencies[1], 20 * 1000);
-    ASSERT_GE((uint64_t)totalLatencies[2], 20 * 1000);
-    ASSERT_GE((uint64_t)totalLatencies[3], 20 * 1000);
+    ASSERT_GE((uint64_t)totalLatencies[1], 20 * 100);
+    ASSERT_GE((uint64_t)totalLatencies[2], 20 * 100);
+    ASSERT_GE((uint64_t)totalLatencies[3], 20 * 100);
 
     while (producerStatsImplPtr->getNumMsgsSent() != 0) {
         usleep(1e6);  // wait till stats flush


### PR DESCRIPTION
### Motivation

The testStatsLatencies test is based on introducing a random delay when publishing and then verifying the producer latencies are filled up. If the random delay exceed the 5 seconds some sample could be recorded in next window, making the validation to fail.

Fixes #784 