### PR TITLE
On tenants cli tool, default tenant to all clusters if not specified

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTenants.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTenants.java
@@ -21,11 +21,10 @@ package org.apache.pulsar.admin.cli;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.converters.CommaParameterSplitter;
-import com.google.common.collect.Sets;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Set;
 
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -60,26 +59,26 @@ public class CmdTenants extends CmdBase {
 
         @Parameter(names = { "--admin-roles",
                 "-r" }, description = "Comma separated list of auth principal allowed to administrate the tenant", required = false, splitter = CommaParameterSplitter.class)
-        private Set<String> adminRoles;
+        private java.util.List<String> adminRoles;
 
         @Parameter(names = { "--allowed-clusters",
                 "-c" }, description = "Comma separated allowed clusters. If empty, the tenant will have access to all clusters", required = false, splitter = CommaParameterSplitter.class)
-        private Set<String> allowedClusters;
+        private java.util.List<String> allowedClusters;
 
         @Override
         void run() throws PulsarAdminException {
             String tenant = getOneArgument(params);
 
             if (adminRoles == null) {
-                adminRoles = Collections.emptySet();
+                adminRoles = Collections.emptyList();
             }
 
             if (allowedClusters == null || allowedClusters.isEmpty()) {
                 // Default to all available cluster
-                allowedClusters = new HashSet<>(admin.clusters().getClusters());
+                allowedClusters = admin.clusters().getClusters();
             }
 
-            TenantInfo tenantInfo = new TenantInfo(Sets.newHashSet(adminRoles), Sets.newHashSet(allowedClusters));
+            TenantInfo tenantInfo = new TenantInfo(new HashSet<>(adminRoles), new HashSet<>(allowedClusters));
             admin.tenants().createTenant(tenant, tenantInfo);
         }
     }
@@ -91,25 +90,25 @@ public class CmdTenants extends CmdBase {
 
         @Parameter(names = { "--admin-roles",
                 "-r" }, description = "Comma separated list of auth principal allowed to administrate the tenant. If empty the current set of roles won't be modified", required = false, splitter = CommaParameterSplitter.class)
-        private Set<String> adminRoles;
+        private java.util.List<String> adminRoles;
 
         @Parameter(names = { "--allowed-clusters",
                 "-c" }, description = "Comma separated allowed clusters. If omitted, the current set of clusters will be preserved", required = false, splitter = CommaParameterSplitter.class)
-        private Set<String> allowedClusters;
+        private java.util.List<String> allowedClusters;
 
         @Override
         void run() throws PulsarAdminException {
             String tenant = getOneArgument(params);
 
             if (adminRoles == null) {
-                adminRoles = admin.tenants().getTenantInfo(tenant).getAdminRoles();
+                adminRoles = new ArrayList<>(admin.tenants().getTenantInfo(tenant).getAdminRoles());
             }
 
             if (allowedClusters == null) {
-                allowedClusters = admin.tenants().getTenantInfo(tenant).getAllowedClusters();
+                allowedClusters = new ArrayList<>(admin.tenants().getTenantInfo(tenant).getAllowedClusters());
             }
 
-            TenantInfo tenantInfo = new TenantInfo(adminRoles, allowedClusters);
+            TenantInfo tenantInfo = new TenantInfo(new HashSet<>(adminRoles), new HashSet<>(allowedClusters));
             admin.tenants().updateTenant(tenant, tenantInfo);
         }
     }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/TenantInfo.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/TenantInfo.java
@@ -18,14 +18,16 @@
  */
 package org.apache.pulsar.common.policies.data;
 
-import java.util.Objects;
+import com.google.common.collect.Sets;
+
 import java.util.Set;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
-import com.google.common.collect.Sets;
+import lombok.Data;
 
 @XmlRootElement
+@Data
 public class TenantInfo {
     /**
      * List of role enabled as admin for this tenant
@@ -62,16 +64,4 @@ public class TenantInfo {
     public void setAllowedClusters(Set<String> allowedClusters) {
         this.allowedClusters = allowedClusters;
     }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj instanceof TenantInfo) {
-            TenantInfo other = (TenantInfo) obj;
-            return Objects.equals(adminRoles, other.adminRoles)
-                    && Objects.equals(allowedClusters, other.allowedClusters);
-        }
-
-        return false;
-    }
-
 }


### PR DESCRIPTION
### Motivation

Currently, the create tenant CLI tool is requiring 2 arguments to be passed: 
 * List of admin roles (principal names that can act as administrators for the tenant) 
 * List of clusters the tenant is allowed to use

In many cases, these parameters are not important to pass. For example:
 * If authentication is disabled, admin roles would be meaningless
 * If there's 1 single cluster or if you want to white list tenants to use all clusters, the CLI args become repetitive

### Modifications

Let the 2 arguments to be optional. When issuing a command like: 

```shell
bin/pulsar-admin tenants create my-tenant
```
This will create a tenant with: 
 * No admin roles defined
 * Allowed to use *all* available clusters (at the tenant creation time, if more clusters are added later, the tenant would need to be given permission to use)