### PR TITLE
[WIP] Add key/value operations in StateContext

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/state/StateContext.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/state/StateContext.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.functions.instance.state;
 
+import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -25,8 +26,53 @@ import java.util.concurrent.CompletableFuture;
  */
 public interface StateContext {
 
+    /**
+     * Increment the given <i>key</i> by the given <i>amount</i>.
+     *
+     * @param key key to increment
+     * @param amount the amount incremented
+     */
     void incr(String key, long amount);
 
+    /**
+     * Update the given <i>key</i> to the provide <i>value</i>.
+     *
+     * <p>NOTE: the put operation might or might not be applied directly to the global state until
+     * the state is flushed via {@link #flush()} at the completion of function execution.
+     *
+     * <p>The behavior of `PUT` is non-deterministic, if two function instances attempt to update
+     * same key around the same time, there is no guarantee which update will be the final result.
+     * That says, if you attempt to get amount via {@link #getAmount(String)}, increment the amount
+     * based on the function computation logic, and update the computed amount back. one update will
+     * overwrite the other update. For this case, you are encouraged to use {@link #incr(String, long)}
+     * instead.
+     *
+     * @param key key to update.
+     * @param value value to update
+     */
+    void put(String key, ByteBuffer value);
+
+    /**
+     * Get the value of a given <i>key</i>.
+     *
+     * @param key key to retrieve
+     * @return a completable future representing the retrieve result.
+     */
+    CompletableFuture<ByteBuffer> getValue(String key);
+
+    /**
+     * Get the amount of a given <i>key</i>.
+     *
+     * @param key key to retrieve
+     * @return a completable future representing the retrieve result.
+     */
+    CompletableFuture<ByteBuffer> getAmount(String key);
+
+    /**
+     * Flush all the modification to the global state.
+     *
+     * @return a completable future representing the flush results.
+     */
     CompletableFuture<Void> flush();
 
 }


### PR DESCRIPTION


### Motivation

key/value state existing with bk table service. but we never expose it to function state. it might be convenient for people to use key/value state.

### Modifications

- add `put` operation to allow state to mutate key/value state
- add `get` operation to allow fetching key/value state


