### PR TITLE
Handle NPE for output producer is null for function

### DIFF
--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/utils/DefaultSerDe.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/utils/DefaultSerDe.java
@@ -36,6 +36,7 @@ public class DefaultSerDe implements SerDe<Object> {
             Integer.class,
             Double.class,
             Long.class,
+            Boolean.class,
             String.class,
             Short.class,
             Byte.class,

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/processors/AtLeastOnceProcessor.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/processors/AtLeastOnceProcessor.java
@@ -54,7 +54,7 @@ public class AtLeastOnceProcessor extends MessageProcessorBase {
 
     @Override
     public void sendOutputMessage(InputMessage inputMsg, MessageBuilder outputMsgBuilder) {
-        if (null == outputMsgBuilder) {
+        if (null == outputMsgBuilder || null == producer) {
             inputMsg.ack();
             return;
         }


### PR DESCRIPTION
### Motivation

If output topic is not present for function then [MessageProcessor](https://github.com/apache/incubator-pulsar/blob/master/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/processors/MessageProcessorBase.java?utf8=%E2%9C%93#L134) doesn't initialize producer which creates NPE when MessageProcessor tries to process output message.
```
13/41/22.054 [pulsar/replicator/Kinesis-external-r
```

### Modifications

Handle NPE for null producer of MessageProcessor.
