### PR TITLE
Add properties alias for tenants in pulsar-admin

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTenants.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTenants.java
@@ -112,4 +112,16 @@ public class CmdTenants extends CmdBase {
         jcommander.addCommand("delete", new Delete());
     }
 
+    @Parameters(hidden = true)
+    static class CmdProperties extends CmdTenants {
+        public CmdProperties(PulsarAdmin admin) {
+            super(admin);
+        }
+
+        @Override
+        public boolean run(String[] args) {
+            System.err.println("WARN: The properties subcommand is deprecated. Please use tenants instead");
+            return super.run(args);
+        }
+    }
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
@@ -72,6 +72,7 @@ public class PulsarAdminTool {
         commandMap.put("brokers", CmdBrokers.class);
         commandMap.put("broker-stats", CmdBrokerStats.class);
         commandMap.put("tenants", CmdTenants.class);
+        commandMap.put("properties", CmdTenants.CmdProperties.class); // deprecated, doesn't show in usage()
         commandMap.put("namespaces", CmdNamespaces.class);
         commandMap.put("persistent", CmdPersistentTopics.class);
         commandMap.put("non-persistent", CmdNonPersistentTopics.class);
@@ -132,7 +133,7 @@ public class PulsarAdminTool {
         if (help) {
             setupCommands(adminFactory);
             jcommander.usage();
-            return false;
+            return true;
         }
 
         if (cmdPos == args.length) {

--- a/tests/integration/cli/pom.xml
+++ b/tests/integration/cli/pom.xml
@@ -19,22 +19,29 @@
     under the License.
 
 -->
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <packaging>pom</packaging>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="
+  http://maven.apache.org/POM/4.0.0
+  http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.pulsar.tests</groupId>
-    <artifactId>tests-parent</artifactId>
+    <artifactId>integration-tests-base</artifactId>
     <version>2.0.0-incubating-SNAPSHOT</version>
+    <relativePath>../../integration-tests-base</relativePath>
   </parent>
 
-  <groupId>org.apache.pulsar.tests</groupId>
-  <artifactId>integration</artifactId>
-  <name>Apache Pulsar :: Tests :: Integration</name>
-  <modules>
-    <module>smoke</module>
-    <module>compaction</module>
-    <module>cli</module>
-  </modules>
+  <groupId>org.apache.pulsar.tests.integration</groupId>
+  <artifactId>cli</artifactId>
+  <packaging>jar</packaging>
+  <name>Apache Pulsar :: Tests :: Integration Tests :: CLI</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.pulsar</groupId>
+      <artifactId>pulsar-client</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
 </project>

--- a/tests/integration/cli/src/test/java/org/apache/pulsar/tests/integration/TestCLI.java
+++ b/tests/integration/cli/src/test/java/org/apache/pulsar/tests/integration/TestCLI.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests.integration;
+
+import com.github.dockerjava.api.DockerClient;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.pulsar.tests.DockerUtils;
+import org.apache.pulsar.tests.PulsarClusterUtils;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.testng.Arquillian;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class TestCLI extends Arquillian {
+    private static String clusterName = "test";
+
+    @ArquillianResource
+    DockerClient docker;
+
+    @BeforeMethod
+    public void waitServicesUp() throws Exception {
+        Assert.assertTrue(PulsarClusterUtils.waitZooKeeperUp(docker, clusterName, 30, TimeUnit.SECONDS));
+        Assert.assertTrue(PulsarClusterUtils.waitAllBrokersUp(docker, clusterName));
+    }
+
+    @Test
+    public void testDeprecatedCommands() throws Exception {
+        String broker = PulsarClusterUtils.brokerSet(docker, clusterName).stream().findAny().get();
+
+        Assert.assertFalse(DockerUtils.runCommand(docker, broker, "/pulsar/bin/pulsar-admin", "--help")
+                           .contains("Usage: properties "));
+        Assert.assertTrue(DockerUtils.runCommand(docker, broker,
+                                                 "/pulsar/bin/pulsar-admin", "properties",
+                                                 "create", "compaction-test-cli", "--allowed-clusters", clusterName,
+                                                 "--admin-roles", "admin").contains("deprecated"));
+        Assert.assertTrue(DockerUtils.runCommand(docker, broker, "/pulsar/bin/pulsar-admin", "properties", "list")
+                          .contains("compaction-test-cli"));
+        Assert.assertTrue(DockerUtils.runCommand(docker, broker, "/pulsar/bin/pulsar-admin", "tenants", "list")
+                          .contains("compaction-test-cli"));
+
+    }
+}

--- a/tests/integration/cli/src/test/resources/arquillian.xml
+++ b/tests/integration/cli/src/test/resources/arquillian.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!--
 
     Licensed to the Apache Software Foundation (ASF) under one
@@ -19,22 +19,14 @@
     under the License.
 
 -->
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <packaging>pom</packaging>
-  <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>org.apache.pulsar.tests</groupId>
-    <artifactId>tests-parent</artifactId>
-    <version>2.0.0-incubating-SNAPSHOT</version>
-  </parent>
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://jboss.org/schema/arquillian"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian
+                                http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
-  <groupId>org.apache.pulsar.tests</groupId>
-  <artifactId>integration</artifactId>
-  <name>Apache Pulsar :: Tests :: Integration</name>
-  <modules>
-    <module>smoke</module>
-    <module>compaction</module>
-    <module>cli</module>
-  </modules>
-</project>
+  <extension qualifier="docker">
+    <property name="definitionFormat">CUBE</property>
+    <property name="dockerContainersResource">cube-definitions/single-cluster-3-bookie-2-broker.yaml</property>
+  </extension>
+
+</arquillian>


### PR DESCRIPTION
Recently properties was renamed to tenants in the pulsar-admin
CLI. However, people may already have scripts that depend on the
properties command existing, which will break with such a change.

This patch adds an alias for tenants, which so that the commands will
not break. However, it will not show up in the usage command, so
people will be encouraged to use tenants.

The change also makes pulsar-admin exit with a non-error code when
--help is run. This is needed to test, and is standard on unix utils.
