### PR TITLE
Compaction commands for pulsar-admin

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawBatchConverter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawBatchConverter.java
@@ -47,8 +47,11 @@ public class RawBatchConverter {
     public static boolean isBatch(RawMessage msg) {
         ByteBuf payload = msg.getHeadersAndPayload();
         MessageMetadata metadata = Commands.parseMessageMetadata(payload);
-        int batchSize = metadata.getNumMessagesInBatch();
-        return batchSize > 1;
+        try {
+            return metadata.hasNumMessagesInBatch();
+        } finally {
+            metadata.recycle();
+        }
     }
 
     public static List<ImmutablePair<MessageId,String>> extractIdsAndKeys(RawMessage msg)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/TwoPhaseCompactor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/TwoPhaseCompactor.java
@@ -312,10 +312,14 @@ public class TwoPhaseCompactor extends Compactor {
     private static Pair<String,Integer> extractKeyAndSize(RawMessage m) {
         ByteBuf headersAndPayload = m.getHeadersAndPayload();
         MessageMetadata msgMetadata = Commands.parseMessageMetadata(headersAndPayload);
-        if (msgMetadata.hasPartitionKey()) {
-            return Pair.of(msgMetadata.getPartitionKey(), headersAndPayload.readableBytes());
-        } else {
-            return null;
+        try {
+            if (msgMetadata.hasPartitionKey()) {
+                return Pair.of(msgMetadata.getPartitionKey(), headersAndPayload.readableBytes());
+            } else {
+                return null;
+            }
+        } finally {
+            msgMetadata.recycle();
         }
     }
 


### PR DESCRIPTION
Adds an compact and compaction-status command in the persistent
subcommand of pulsar-admin.

This command differs from the compact-topic CLI (part of pulsar
command), in that it triggers compaction to occur via the REST api,
which causes the compaction to run in the broker process. The
compact-topic CLI spawns a new process to run the compaction.

Patch also fixes batch detection, which was broken (uncovered by a
change in the defaults), and recycles some metadata that wasn't being
recycled previously.
