### PR TITLE
Removed duplicated declaration of log4j test in dependenciesManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -431,12 +431,6 @@ flexible messaging model and an intuitive client API.</description>
         <type>test-jar</type>
         <version>${log4j2.version}</version>
       </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-core</artifactId>
-        <type>test-jar</type>
-        <version>${log4j2.version}</version>
-      </dependency>
 
       <dependency>
         <groupId>org.jctools</groupId>


### PR DESCRIPTION
### Motivation

Duplicate declaration is making maven to print warnings