### PR TITLE
Fix fail in BrokerServiceTest#testLookupThrottlingForClientByClient

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerServiceTest.java
@@ -694,7 +694,7 @@ public class BrokerServiceTest extends BrokerTestBase {
      */
     @Test
     public void testLookupThrottlingForClientByClient() throws Exception {
-        final String topicName = "persistent://prop/my-ns/newTopic";
+        final String topicName = "persistent://prop/ns-abc/newTopic";
 
         String lookupUrl = new URI("pulsar://localhost:" + BROKER_PORT).toString();
         PulsarClient pulsarClient = PulsarClient.builder().serviceUrl(lookupUrl).statsInterval(0, TimeUnit.SECONDS)


### PR DESCRIPTION
Test fail with error: 
```
[pulsar-io-14-1:org.apache.pulsar.broker.service.ServerCnx@363] WARN  org.apache.pulsar.broker.service.ServerCnx - Failed to get Partitioned Metadata [/127.0.0.1:49717] persistent://prop/  my-ns/newTopic: Policies not found for prop/my-ns namespace
 org.apache.pulsar.broker.web.RestException: Policies not found for prop/my-ns namespace
     at org.apache.pulsar.broker.web.PulsarWebResource.lambda$4(PulsarWebResource.java:600) ~[classes/:?]
```
It is because we only create `prop/ns-abc` by default in `BrokerTestBase`, and `prop/ns-abc` was not there.
