### PR TITLE
Issue #1618: Topic termination should work with no consumers connected to

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -677,8 +677,11 @@ public class PersistentSubscription implements Subscription {
 
     void topicTerminated() {
         if (cursor.getNumberOfEntriesInBacklog() == 0) {
-            // Immediately notify the consumer that there are no more available messages
-            dispatcher.getConsumers().forEach(Consumer::reachedEndOfTopic);
+            // notify the consumers if there are consumers connected to this topic.
+            if (null != dispatcher) {
+                // Immediately notify the consumer that there are no more available messages
+                dispatcher.getConsumers().forEach(Consumer::reachedEndOfTopic);
+            }
         }
     }
 


### PR DESCRIPTION
*Problem*

Topic termination fails with NPE when there is no consumers connected to.

*Solution*

If there is no consumers connected, we don't need to notify the consumers. This will prevent NPE.

*Result*

Fix the NPE issue and add a test to cover this case.

This fixes #1618 