### PR TITLE
Encryption semi-support for Compaction

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawBatchConverter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawBatchConverter.java
@@ -50,10 +50,11 @@ public class RawBatchConverter {
     public static boolean isReadableBatch(RawMessage msg) {
         ByteBuf payload = msg.getHeadersAndPayload();
         MessageMetadata metadata = Commands.parseMessageMetadata(payload);
-        boolean encrypted = metadata.getEncryptionKeysCount() > 0;
-        int batchSize = metadata.getNumMessagesInBatch();
-        metadata.recycle();
-        return batchSize > 1 && !encrypted;
+        try {
+            return metadata.hasNumMessagesInBatch() && metadata.getEncryptionKeysCount() == 0;
+        } finally {
+            metadata.recycle();
+        }
     }
 
     public static List<ImmutablePair<MessageId,String>> extractIdsAndKeys(RawMessage msg)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawBatchConverter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawBatchConverter.java
@@ -47,14 +47,13 @@ import org.slf4j.LoggerFactory;
 public class RawBatchConverter {
     private static final Logger log = LoggerFactory.getLogger(RawBatchConverter.class);
 
-    public static boolean isBatch(RawMessage msg) {
+    public static boolean isReadableBatch(RawMessage msg) {
         ByteBuf payload = msg.getHeadersAndPayload();
         MessageMetadata metadata = Commands.parseMessageMetadata(payload);
-        try {
-            return metadata.hasNumMessagesInBatch();
-        } finally {
-            metadata.recycle();
-        }
+        boolean encrypted = metadata.getEncryptionKeysCount() > 0;
+        int batchSize = metadata.getNumMessagesInBatch();
+        metadata.recycle();
+        return batchSize > 1 && !encrypted;
     }
 
     public static List<ImmutablePair<MessageId,String>> extractIdsAndKeys(RawMessage msg)

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/TwoPhaseCompactor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/TwoPhaseCompactor.java
@@ -116,7 +116,7 @@ public class TwoPhaseCompactor extends Compactor {
                             return;
                         }
                         MessageId id = m.getMessageId();
-                        if (RawBatchConverter.isBatch(m)) {
+                        if (RawBatchConverter.isReadableBatch(m)) {
                             try {
                                 RawBatchConverter.extractIdsAndKeys(m)
                                     .forEach(e -> latestForKey.put(e.getRight(), e.getLeft()));
@@ -208,7 +208,7 @@ public class TwoPhaseCompactor extends Compactor {
                     }
                     MessageId id = m.getMessageId();
                     Optional<RawMessage> messageToAdd = Optional.empty();
-                    if (RawBatchConverter.isBatch(m)) {
+                    if (RawBatchConverter.isReadableBatch(m)) {
                         try {
                             messageToAdd = RawBatchConverter.rebatchMessage(
                                     m, (key, subid) -> latestForKey.get(key).equals(subid));


### PR DESCRIPTION
Without batching, compaction of encrypted topics works as it does with
any other topic.

However, with batching, compaction of encrypted topics is unable to
break the batched messages into individual messages, so it's unable to
read the keys which is uses for compaction, as compaction doesn't have
access to the encryption key which was used to encrypt the payload.

This change makes it possible to use compaction with an encrypted
topic, though when it comes across a batched message, it just lets the
whole batch pass through.
