### PR TITLE
pulsar-client-admin should not shade dependency on pulsar-common

### DIFF
--- a/pulsar-client-admin-shaded/pom.xml
+++ b/pulsar-client-admin-shaded/pom.xml
@@ -121,10 +121,6 @@
                   <shadedPattern>org.apache.pulsar.admin.shade.io.netty</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>org.apache.pulsar.common</pattern>
-                  <shadedPattern>org.apache.pulsar.admin.shade.org.apache.pulsar.common</shadedPattern>
-                </relocation>
-                <relocation>
                   <pattern>org.apache.pulsar.policies</pattern>
                   <shadedPattern>org.apache.pulsar.admin.shade.org.apache.pulsar.policies</shadedPattern>
                 </relocation>


### PR DESCRIPTION
### Motivation

Pojo classes from `pulsar-common` are exposed in `pulsar-client-admin` methods, so that cannot be relocated.