### PR TITLE
Reverting change in ManagedCursorImpl introduced in #1519 since it causes regression

### DIFF
--- a/managed-ledger/pom.xml
+++ b/managed-ledger/pom.xml
@@ -43,12 +43,12 @@
       <artifactId>pulsar-common</artifactId>
       <version>${project.version}</version>
     </dependency>
-
+    
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
-
+    
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
@@ -76,11 +76,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jctools</groupId>
-      <artifactId>jctools-core</artifactId>
     </dependency>
 
     <dependency>
@@ -112,7 +107,7 @@
       </plugin>
     </plugins>
   </build>
-
+ 
   <profiles>
     <profile>
       <id>protobuf</id>

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -38,6 +38,7 @@ import com.google.common.collect.TreeRangeSet;
 import com.google.common.util.concurrent.RateLimiter;
 import com.google.protobuf.InvalidProtocolBufferException;
 
+import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -81,9 +82,6 @@ import org.apache.bookkeeper.mledger.proto.MLDataFormats.LongProperty;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedCursorInfo;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.PositionInfo;
 import org.apache.commons.lang3.tuple.Pair;
-import org.jctools.queues.MessagePassingQueue;
-import org.jctools.queues.MpmcArrayQueue;
-import org.jctools.queues.MpscLinkedQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -151,8 +149,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         }
     }
 
-    private final MessagePassingQueue<MarkDeleteEntry> pendingMarkDeleteOps = MpscLinkedQueue.newMpscLinkedQueue();
-
+    private final ArrayDeque<MarkDeleteEntry> pendingMarkDeleteOps = new ArrayDeque<>();
     private static final AtomicIntegerFieldUpdater<ManagedCursorImpl> PENDING_MARK_DELETED_SUBMITTED_COUNT_UPDATER =
         AtomicIntegerFieldUpdater.newUpdater(ManagedCursorImpl.class, "pendingMarkDeletedSubmittedCount");
     @SuppressWarnings("unused")
@@ -763,12 +760,14 @@ public class ManagedCursorImpl implements ManagedCursor {
 
         log.info("[{}] Initiate reset position to {} on cursor {}", ledger.getName(), position, name);
 
-        if (!RESET_CURSOR_IN_PROGRESS_UPDATER.compareAndSet(this, FALSE, TRUE)) {
-            log.error("[{}] reset requested - position [{}], previous reset in progress - cursor {}", ledger.getName(),
-                    position, name);
-            resetCursorCallback.resetFailed(
-                    new ManagedLedgerException.ConcurrentFindCursorPositionException("reset already in progress"),
-                    position);
+        synchronized (pendingMarkDeleteOps) {
+            if (!RESET_CURSOR_IN_PROGRESS_UPDATER.compareAndSet(this, FALSE, TRUE)) {
+                log.error("[{}] reset requested - position [{}], previous reset in progress - cursor {}",
+                        ledger.getName(), position, name);
+                resetCursorCallback.resetFailed(
+                        new ManagedLedgerException.ConcurrentFindCursorPositionException("reset already in progress"),
+                        position);
+            }
         }
 
         final AsyncCallbacks.ResetCursorCallback callback = resetCursorCallback;
@@ -808,20 +807,24 @@ public class ManagedCursorImpl implements ManagedCursor {
                 } finally {
                     lock.writeLock().unlock();
                 }
-
-                pendingMarkDeleteOps.drain(entry -> entry.callback.markDeleteComplete(entry.ctx));
-                if (!RESET_CURSOR_IN_PROGRESS_UPDATER.compareAndSet(ManagedCursorImpl.this, TRUE, FALSE)) {
-                    log.error("[{}] expected reset position [{}], but another reset in progress on cursor {}",
-                            ledger.getName(), newPosition, name);
+                synchronized (pendingMarkDeleteOps) {
+                    pendingMarkDeleteOps.clear();
+                    if (!RESET_CURSOR_IN_PROGRESS_UPDATER.compareAndSet(ManagedCursorImpl.this, TRUE, FALSE)) {
+                        log.error("[{}] expected reset position [{}], but another reset in progress on cursor {}",
+                                ledger.getName(), newPosition, name);
+                    }
                 }
                 callback.resetComplete(newPosition);
+
             }
 
             @Override
             public void operationFailed(ManagedLedgerException exception) {
-                if (!RESET_CURSOR_IN_PROGRESS_UPDATER.compareAndSet(ManagedCursorImpl.this, TRUE, FALSE)) {
-                    log.error("[{}] expected reset position [{}], but another reset in progress on cursor {}",
-                            ledger.getName(), newPosition, name);
+                synchronized (pendingMarkDeleteOps) {
+                    if (!RESET_CURSOR_IN_PROGRESS_UPDATER.compareAndSet(ManagedCursorImpl.this, TRUE, FALSE)) {
+                        log.error("[{}] expected reset position [{}], but another reset in progress on cursor {}",
+                                ledger.getName(), newPosition, name);
+                    }
                 }
                 callback.resetFailed(new ManagedLedgerException.InvalidCursorPositionException(
                         "unable to persist position for cursor reset " + newPosition.toString()), newPosition);
@@ -1274,7 +1277,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         // markDelete-position and clear out deletedMsgSet
         markDeletePosition = PositionImpl.get(newMarkDeletePosition);
         individualDeletedMessages.remove(Range.atMost(markDeletePosition));
-
+        
         if (readPosition.compareTo(newMarkDeletePosition) <= 0) {
             // If the position that is mark-deleted is past the read position, it
             // means that the client has skipped some entries. We need to move
@@ -1359,48 +1362,36 @@ public class ManagedCursorImpl implements ManagedCursor {
         MarkDeleteEntry mdEntry = new MarkDeleteEntry(newPosition, properties, callback, ctx);
 
         // We cannot write to the ledger during the switch, need to wait until the new metadata ledger is available
-        // The state might have changed while we were waiting on the queue mutex
-        switch (state) {
-        case Closed:
-            callback.markDeleteFailed(new ManagedLedgerException("Cursor was already closed"), ctx);
-            return;
-
-        case NoLedger:
-            // We need to create a new ledger to write into
-            startCreatingNewMetadataLedger();
-            // fall through
-        case SwitchingLedger:
-            if (!pendingMarkDeleteOps.offer(mdEntry)) {
-                callback.markDeleteFailed(new ManagedLedgerException("Cursor queue of mark-delete operations full"), ctx);
+        synchronized (pendingMarkDeleteOps) {
+            // The state might have changed while we were waiting on the queue mutex
+            switch (STATE_UPDATER.get(this)) {
+            case Closed:
+                callback.markDeleteFailed(new ManagedLedgerException("Cursor was already closed"), ctx);
                 return;
-            }
-            if (state != State.SwitchingLedger) {
-                // If state changed since we checked. Trigger a flush since we could have missed the current entry
-                flushPendingMarkDeletes();
-            }
-            break;
 
-        case Open:
-            if (pendingReadOps > 0) {
-                // Wait until no read operation are pending
-                if (!pendingMarkDeleteOps.offer(mdEntry)) {
-                    callback.markDeleteFailed(new ManagedLedgerException("Cursor queue of mark-delete operations full"), ctx);
-                    return;
-                }
-                if (pendingReadOps == 0) {
-                    // If the value changed while enqueuing, trigger a flush to make sure we don't delay current request
-                    flushPendingMarkDeletes();
-                }
-            } else {
-                // Execute the mark delete immediately
-                internalMarkDelete(mdEntry);
-            }
-            break;
+            case NoLedger:
+                // We need to create a new ledger to write into
+                startCreatingNewMetadataLedger();
+                // fall through
+            case SwitchingLedger:
+                pendingMarkDeleteOps.add(mdEntry);
+                break;
 
-        default:
-            log.error("[{}][{}] Invalid cursor state: {}", ledger.getName(), name, state);
-            callback.markDeleteFailed(new ManagedLedgerException("Cursor was in invalid state: " + state), ctx);
-            break;
+            case Open:
+                if (PENDING_READ_OPS_UPDATER.get(this) > 0) {
+                    // Wait until no read operation are pending
+                    pendingMarkDeleteOps.add(mdEntry);
+                } else {
+                    // Execute the mark delete immediately
+                    internalMarkDelete(mdEntry);
+                }
+                break;
+
+            default:
+                log.error("[{}][{}] Invalid cursor state: {}", ledger.getName(), name, state);
+                callback.markDeleteFailed(new ManagedLedgerException("Cursor was in invalid state: " + state), ctx);
+                break;
+            }
         }
     }
 
@@ -1912,38 +1903,41 @@ public class ManagedCursorImpl implements ManagedCursor {
             @Override
             public void operationComplete() {
                 // We now have a new ledger where we can write
-                flushPendingMarkDeletes();
+                synchronized (pendingMarkDeleteOps) {
+                    flushPendingMarkDeletes();
 
-                // Resume normal mark-delete operations
-                state = State.Open;
+                    // Resume normal mark-delete operations
+                    STATE_UPDATER.set(ManagedCursorImpl.this, State.Open);
+                }
             }
 
             @Override
             public void operationFailed(ManagedLedgerException exception) {
                 log.error("[{}][{}] Metadata ledger creation failed", ledger.getName(), name, exception);
 
-                // At this point we don't have a ledger ready
-                state = State.NoLedger;
+                synchronized (pendingMarkDeleteOps) {
+                    while (!pendingMarkDeleteOps.isEmpty()) {
+                        MarkDeleteEntry entry = pendingMarkDeleteOps.poll();
+                        entry.callback.markDeleteFailed(exception, entry.ctx);
+                    }
 
-                pendingMarkDeleteOps.drain(entry -> entry.callback.markDeleteFailed(exception, entry.ctx));
+                    // At this point we don't have a ledger ready
+                    STATE_UPDATER.set(ManagedCursorImpl.this, State.NoLedger);
+                }
             }
         });
     }
 
     private void flushPendingMarkDeletes() {
-        if (pendingMarkDeleteOps.isEmpty()) {
-            return;
+        if (!pendingMarkDeleteOps.isEmpty()) {
+            internalFlushPendingMarkDeletes();
         }
+    }
 
-        List<MarkDeleteEntry> entries = Lists.newArrayListWithExpectedSize(pendingMarkDeleteOps.size());
-        pendingMarkDeleteOps.drain(entries::add);
-
-        if (entries.isEmpty()) {
-            return;
-        }
-
-        MarkDeleteEntry lastEntry = entries.get(entries.size() - 1);
-        lastEntry.callbackGroup = entries;
+    void internalFlushPendingMarkDeletes() {
+        MarkDeleteEntry lastEntry = pendingMarkDeleteOps.getLast();
+        lastEntry.callbackGroup = Lists.newArrayList(pendingMarkDeleteOps);
+        pendingMarkDeleteOps.clear();
 
         internalMarkDelete(lastEntry);
     }
@@ -2216,12 +2210,15 @@ public class ManagedCursorImpl implements ManagedCursor {
 
     void readOperationCompleted() {
         if (PENDING_READ_OPS_UPDATER.decrementAndGet(this) == 0) {
-            if (state == State.Open) {
-                // Flush the pending writes only if the state is open.
-                flushPendingMarkDeletes();
-            } else if (PENDING_MARK_DELETED_SUBMITTED_COUNT_UPDATER.get(this) != 0) {
-                log.info("[{}] read operation completed and cursor was closed. need to call any queued cursor close",
-                        name);
+            synchronized (pendingMarkDeleteOps) {
+                if (STATE_UPDATER.get(this) == State.Open) {
+                    // Flush the pending writes only if the state is open.
+                    flushPendingMarkDeletes();
+                } else if (PENDING_MARK_DELETED_SUBMITTED_COUNT_UPDATER.get(this) != 0) {
+                    log.info(
+                            "[{}] read operation completed and cursor was closed. need to call any queued cursor close",
+                            name);
+                }
             }
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,6 @@ flexible messaging model and an intuitive client API.</description>
     <protoc-gen-grpc-java.version>1.0.0</protoc-gen-grpc-java.version>
     <gson.version>2.8.2</gson.version>
     <sketches.version>0.8.3</sketches.version>
-    <jctools.version>2.1.1</jctools.version>
     <hbc-core.version>2.2.0</hbc-core.version>
     <cassandra-driver-core.version>3.4.0</cassandra-driver-core.version>
     <aerospike-client.version>4.1.5</aerospike-client.version>
@@ -430,12 +429,6 @@ flexible messaging model and an intuitive client API.</description>
         <artifactId>log4j-api</artifactId>
         <type>test-jar</type>
         <version>${log4j2.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.jctools</groupId>
-        <artifactId>jctools-core</artifactId>
-        <version>${jctools.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Revert "Fix for cursorPersistenceAsyncMarkDeleteSameThread (#1544)"
This reverts commit ede7ffe540b4ea8c715c3af9f30f739ea133da94.

Revert "Fixed flaky test in managed ledger close path (#1539)"
This reverts commit b22769bb57defe435cc4faedcbebe1d3260cdee4.

Revert "Avoid contention in ManagedCursorImpl generated by locking on pendingMarkDeleteOps (#1519)"
This reverts commit ed8d1a5d39b5bde796954e79feda579dc7f64c2f.

### Motivation

A regression was introduced in #1519 and #1544 combined that was causing the `pendingMarkDeleteQueue` to grow to a huge size under certain conditions. 

Draining the queue to a local array list was causing allocation of enourmous array size that were filling up the JVM heap.

### Modifications

Reverted to original state, will investigate further on how to remove mutex in a safer way.