### PR TITLE
Handle unchecked exceptions on cursor to ensure read callback is triggered

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpReadEntry.java
@@ -137,12 +137,15 @@ class OpReadEntry implements ReadEntriesCallback {
             }));
         } else {
             // The reading was already completed, release resources and trigger callback
-            cursor.readOperationCompleted();
+            try {
+                cursor.readOperationCompleted();
 
-            cursor.ledger.getExecutor().executeOrdered(cursor.ledger.getName(), safeRun(() -> {
-                callback.readEntriesComplete(entries, ctx);
-                recycle();
-            }));
+            } finally {
+                cursor.ledger.getExecutor().executeOrdered(cursor.ledger.getName(), safeRun(() -> {
+                    callback.readEntriesComplete(entries, ctx);
+                    recycle();
+                }));
+            }
         }
     }
 


### PR DESCRIPTION
### Motivation

With the changes in #1519 (that are being reverted in #1628), a NPE was being thrown in few conditions. This could be happening during a "delete" call (where it was harmless) or when completing a `readEntried` operation, in which case the callback was not triggered.

### Modifications

Apart from fixing the NPE, added try/finally to ensure unexpected unchecked exception won't stop the delivery.