### PR TITLE
Avoid creating different message object for pulsar sink connector

### DIFF
--- a/pulsar-connect/aerospike/src/main/java/org/apache/pulsar/connect/aerospike/AerospikeSink.java
+++ b/pulsar-connect/aerospike/src/main/java/org/apache/pulsar/connect/aerospike/AerospikeSink.java
@@ -32,7 +32,7 @@ import com.aerospike.client.listener.WriteListener;
 import com.aerospike.client.policy.ClientPolicy;
 import com.aerospike.client.policy.WritePolicy;
 import org.apache.pulsar.common.util.KeyValue;
-import org.apache.pulsar.connect.core.Message;
+import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.connect.core.Sink;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -80,8 +80,8 @@ public class AerospikeSink<K, V> implements Sink<KeyValue<K, V>> {
     @Override
     public CompletableFuture<Void> write(Message<KeyValue<K, V>> tuple) {
         CompletableFuture<Void> future = new CompletableFuture<>();
-        Key key = new Key(aerospikeSinkConfig.getKeyspace(), aerospikeSinkConfig.getKeySet(), tuple.getData().getKey().toString());
-        Bin bin = new Bin(aerospikeSinkConfig.getColumnName(), Value.getAsBlob(tuple.getData().getValue()));
+        Key key = new Key(aerospikeSinkConfig.getKeyspace(), aerospikeSinkConfig.getKeySet(), tuple.getValue().getKey().toString());
+        Bin bin = new Bin(aerospikeSinkConfig.getColumnName(), Value.getAsBlob(tuple.getValue().getValue()));
         AWriteListener listener = null;
         try {
             listener = queue.take();

--- a/pulsar-connect/cassandra/src/main/java/org/apache/pulsar/connect/cassandra/CassandraSink.java
+++ b/pulsar-connect/cassandra/src/main/java/org/apache/pulsar/connect/cassandra/CassandraSink.java
@@ -23,7 +23,7 @@ import com.datastax.driver.core.*;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import org.apache.pulsar.common.util.KeyValue;
-import org.apache.pulsar.connect.core.Message;
+import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.connect.core.Sink;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,7 +68,7 @@ public class CassandraSink<K, V> implements Sink<KeyValue<K, V>> {
 
     @Override
     public CompletableFuture<Void> write(Message<KeyValue<K, V>> tuple) {
-        BoundStatement bound = statement.bind(tuple.getData().getKey(), tuple.getData().getValue());
+        BoundStatement bound = statement.bind(tuple.getValue().getKey(), tuple.getValue().getValue());
         ResultSetFuture future = session.executeAsync(bound);
         CompletableFuture<Void> completable = new CompletableFuture<Void>();
         Futures.addCallback(future,

--- a/pulsar-connect/core/pom.xml
+++ b/pulsar-connect/core/pom.xml
@@ -29,5 +29,13 @@
 
   <artifactId>pulsar-connect-core</artifactId>
   <name>Pulsar Connect :: Connect</name>
+  
+  <dependencies>
+  	<dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-client-original</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
 
 </project>

--- a/pulsar-connect/core/src/main/java/org/apache/pulsar/connect/core/Sink.java
+++ b/pulsar-connect/core/src/main/java/org/apache/pulsar/connect/core/Sink.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.connect.core;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.client.api.Message;
 
 /**
  * Pulsar's Sink interface. Sink read data from

--- a/pulsar-connect/kafka/src/main/java/org/apache/pulsar/connect/kafka/KafkaSink.java
+++ b/pulsar-connect/kafka/src/main/java/org/apache/pulsar/connect/kafka/KafkaSink.java
@@ -24,7 +24,7 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.pulsar.common.util.KeyValue;
-import org.apache.pulsar.connect.core.Message;
+import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.connect.core.Sink;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,7 +49,7 @@ public class KafkaSink<K, V> implements Sink<KeyValue<K, V>> {
 
     @Override
     public CompletableFuture<Void> write(Message<KeyValue<K, V>> message) {
-        ProducerRecord<K, V> record = new ProducerRecord<>(kafkaSinkConfig.getTopic(), message.getData().getKey(), message.getData().getValue());
+        ProducerRecord<K, V> record = new ProducerRecord<>(kafkaSinkConfig.getTopic(), message.getValue().getKey(), message.getValue().getValue());
         LOG.debug("Message sending to kafka, record={}.", record);
         Future f = producer.send(record);
         return CompletableFuture.supplyAsync(() -> {


### PR DESCRIPTION
### Motivation

As per discussion for pulsar-replicator #1594, replicator can use pulsar-connectors to publish pulsar messages to external system. However, pulsar-connector input has different [Message](https://github.com/apache/incubator-pulsar/blob/master/pulsar-connect/core/src/main/java/org/apache/pulsar/connect/core/Message.java) type than pulsar [Message](https://github.com/apache/incubator-pulsar/blob/master/pulsar-client/src/main/java/org/apache/pulsar/client/api/Message.java), which requires replicator to create unnecessary additional message object while sending messages from pulsar to external system.

Therefore, pulsar connector should use same pulsar message to avoid unnecessary object creation. 

### Modifications

Reuse pulsar message for pulsar connector's write-api.
