### PR TITLE
 Rename Connect `Message` interface to `Record`

### DIFF
--- a/pulsar-client-admin-shaded-for-functions/pom.xml
+++ b/pulsar-client-admin-shaded-for-functions/pom.xml
@@ -61,6 +61,7 @@
                 <includes>
                   <include>org.apache.pulsar:pulsar-common</include>
                   <include>org.apache.bookkeeper:circe-checksum</include>
+                  <include>org.apache.pulsar:pulsar-connect-core</include>
                   <include>org.apache.pulsar:pulsar-client-original</include>
                   <include>org.apache.pulsar:pulsar-client-admin-original</include>
                   <!-- client dependencies as below -->

--- a/pulsar-client-admin-shaded/pom.xml
+++ b/pulsar-client-admin-shaded/pom.xml
@@ -57,6 +57,7 @@
 
               <artifactSet>
                 <includes>
+                  <include>org.apache.pulsar:pulsar-connect-core</include>
                   <include>org.apache.pulsar:pulsar-client-original</include>
                   <include>org.apache.pulsar:pulsar-client-admin-original</include>
                   <include>org.apache.commons:commons-lang3</include>

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -59,6 +59,7 @@
 
               <artifactSet>
                 <includes>
+                  <include>org.apache.pulsar:pulsar-connect-core</include>
                   <include>org.apache.pulsar:pulsar-client-original</include>
                   <include>org.apache.commons:commons-lang3</include>
                   <include>commons-codec:commons-codec</include>

--- a/pulsar-client/pom.xml
+++ b/pulsar-client/pom.xml
@@ -40,6 +40,12 @@
     </dependency>
 
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-connect-core</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -43,10 +43,9 @@ import io.netty.buffer.Unpooled;
 import io.netty.util.Recycler;
 import io.netty.util.Recycler.Handle;
 
-public class MessageImpl<T> implements Message<T> {
+public class MessageImpl<T> extends MessageRecordImpl<T, MessageId> {
 
     private MessageMetadata.Builder msgMetadataBuilder;
-    private MessageId messageId;
     private ClientCnx cnx;
     private ByteBuf payload;
     private Schema<T> schema;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageRecordImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageRecordImpl.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.connect.core.Record;
+
+/**
+ * Abstract class that implements message api and connect record api.
+ */
+public abstract class MessageRecordImpl<T, M extends MessageId> implements Message<T>, Record<T> {
+
+    protected M messageId;
+    private Consumer<T> consumer;
+
+    public void setConsumer(Consumer<T> consumer) {
+        this.consumer = consumer;
+    }
+
+    @Override
+    public void ack() {
+        if (null != consumer && null != messageId) {
+            consumer.acknowledgeAsync(messageId);
+        }
+    }
+
+    @Override
+    public void fail() {
+        // no-op
+    }
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageImpl.java
@@ -23,17 +23,16 @@ import java.util.Map;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 
-public class TopicMessageImpl<T> implements Message<T> {
+public class TopicMessageImpl<T> extends MessageRecordImpl<T, TopicMessageIdImpl> {
 
     private final String topicName;
     private final Message<T> msg;
-    private final TopicMessageIdImpl msgId;
 
     TopicMessageImpl(String topicName,
                      Message<T> msg) {
         this.topicName = topicName;
         this.msg = msg;
-        this.msgId = new TopicMessageIdImpl(topicName, msg.getMessageId());
+        this.messageId = new TopicMessageIdImpl(topicName, msg.getMessageId());
     }
 
     /**
@@ -46,11 +45,11 @@ public class TopicMessageImpl<T> implements Message<T> {
 
     @Override
     public MessageId getMessageId() {
-        return msgId;
+        return messageId;
     }
 
     public MessageId getInnerMessageId() {
-        return msgId.getInnerMessageId();
+        return messageId.getInnerMessageId();
     }
 
     @Override

--- a/pulsar-connect/aerospike/src/main/java/org/apache/pulsar/connect/aerospike/AerospikeSink.java
+++ b/pulsar-connect/aerospike/src/main/java/org/apache/pulsar/connect/aerospike/AerospikeSink.java
@@ -32,7 +32,6 @@ import com.aerospike.client.listener.WriteListener;
 import com.aerospike.client.policy.ClientPolicy;
 import com.aerospike.client.policy.WritePolicy;
 import org.apache.pulsar.common.util.KeyValue;
-import org.apache.pulsar.connect.core.Message;
 import org.apache.pulsar.connect.core.Sink;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,10 +77,10 @@ public class AerospikeSink<K, V> implements Sink<KeyValue<K, V>> {
     }
 
     @Override
-    public CompletableFuture<Void> write(Message<KeyValue<K, V>> tuple) {
+    public CompletableFuture<Void> write(KeyValue<K, V> record) {
         CompletableFuture<Void> future = new CompletableFuture<>();
-        Key key = new Key(aerospikeSinkConfig.getKeyspace(), aerospikeSinkConfig.getKeySet(), tuple.getData().getKey().toString());
-        Bin bin = new Bin(aerospikeSinkConfig.getColumnName(), Value.getAsBlob(tuple.getData().getValue()));
+        Key key = new Key(aerospikeSinkConfig.getKeyspace(), aerospikeSinkConfig.getKeySet(), record.getKey().toString());
+        Bin bin = new Bin(aerospikeSinkConfig.getColumnName(), Value.getAsBlob(record.getValue()));
         AWriteListener listener = null;
         try {
             listener = queue.take();

--- a/pulsar-connect/cassandra/src/main/java/org/apache/pulsar/connect/cassandra/CassandraSink.java
+++ b/pulsar-connect/cassandra/src/main/java/org/apache/pulsar/connect/cassandra/CassandraSink.java
@@ -23,7 +23,6 @@ import com.datastax.driver.core.*;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import org.apache.pulsar.common.util.KeyValue;
-import org.apache.pulsar.connect.core.Message;
 import org.apache.pulsar.connect.core.Sink;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -67,8 +66,8 @@ public class CassandraSink<K, V> implements Sink<KeyValue<K, V>> {
     }
 
     @Override
-    public CompletableFuture<Void> write(Message<KeyValue<K, V>> tuple) {
-        BoundStatement bound = statement.bind(tuple.getData().getKey(), tuple.getData().getValue());
+    public CompletableFuture<Void> write(KeyValue<K, V> record) {
+        BoundStatement bound = statement.bind(record.getKey(), record.getValue());
         ResultSetFuture future = session.executeAsync(bound);
         CompletableFuture<Void> completable = new CompletableFuture<Void>();
         Futures.addCallback(future,

--- a/pulsar-connect/core/src/main/java/org/apache/pulsar/connect/core/PushSource.java
+++ b/pulsar-connect/core/src/main/java/org/apache/pulsar/connect/core/PushSource.java
@@ -48,5 +48,5 @@ public interface PushSource<T> extends AutoCloseable {
      * to pass messages whenever there is data to be pushed to Pulsar.
      * @param consumer
      */
-    void setConsumer(Function<Message<T>, CompletableFuture<Void>> consumer);
+    void setConsumer(Function<Record<T>, CompletableFuture<Void>> consumer);
 }

--- a/pulsar-connect/core/src/main/java/org/apache/pulsar/connect/core/Record.java
+++ b/pulsar-connect/core/src/main/java/org/apache/pulsar/connect/core/Record.java
@@ -19,35 +19,35 @@
 package org.apache.pulsar.connect.core;
 
 /**
- * Pulsar Connect's Message interface. Message encapsulates the
- * information about a message being read/written from/to a Source/Sink.
+ * Pulsar Connect's Record interface. Record encapsulates the
+ * information about a record being read from a Source.
  */
-public interface Message<T> {
+public interface Record<T> {
     /**
-     * Retrieves the partition information if any of the message
+     * Retrieves the partition information if any of the record.
      * @return The partition id where the
      */
     default String getPartitionId() { return null; }
 
     /**
-     * Retrieves the sequence id of the message
-     * @return Sequence Id associated with the message
+     * Retrieves the sequence of the record from a source partition.
+     * @return Sequence Id associated with the record
      */
-    default Long getSequenceId() { return -1L; }
+    default long getRecordSequence() { return -1L; }
 
     /**
-     * Retrieves the actual data of the message
-     * @return The message data
+     * Retrieves the actual data of the record
+     * @return The record data
      */
-    T getData();
+    T getValue();
 
     /**
-     * Acknowledge that this message is fully processed
+     * Acknowledge that this record is fully processed
      */
-    default void ack() {};
+    default void ack() {}
 
     /**
-     * To indicate that this message has failed to be processed
+     * To indicate that this record has failed to be processed
      */
-    default void fail() {};
+    default void fail() {}
 }

--- a/pulsar-connect/core/src/main/java/org/apache/pulsar/connect/core/Sink.java
+++ b/pulsar-connect/core/src/main/java/org/apache/pulsar/connect/core/Sink.java
@@ -42,8 +42,8 @@ public interface Sink<T> extends AutoCloseable {
     /**
      * Attempt to publish a type safe collection of messages
      *
-     * @param message Object to publish to the sink
+     * @param outputValue output value
      * @return Completable future fo async publish request
      */
-    CompletableFuture<Void> write(final Message<T> message);
+    CompletableFuture<Void> write(T outputValue);
 }

--- a/pulsar-connect/core/src/main/java/org/apache/pulsar/connect/core/Source.java
+++ b/pulsar-connect/core/src/main/java/org/apache/pulsar/connect/core/Source.java
@@ -35,5 +35,5 @@ public interface Source<T> extends AutoCloseable {
      * @return next message from source or null, if no new messages are available.
      * @throws Exception
      */
-    Message<T> read() throws Exception;
+    Record<T> read() throws Exception;
 }

--- a/pulsar-connect/kafka/src/main/java/org/apache/pulsar/connect/kafka/KafkaSink.java
+++ b/pulsar-connect/kafka/src/main/java/org/apache/pulsar/connect/kafka/KafkaSink.java
@@ -24,7 +24,6 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.pulsar.common.util.KeyValue;
-import org.apache.pulsar.connect.core.Message;
 import org.apache.pulsar.connect.core.Sink;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,9 +47,9 @@ public class KafkaSink<K, V> implements Sink<KeyValue<K, V>> {
     private KafkaSinkConfig kafkaSinkConfig;
 
     @Override
-    public CompletableFuture<Void> write(Message<KeyValue<K, V>> message) {
-        ProducerRecord<K, V> record = new ProducerRecord<>(kafkaSinkConfig.getTopic(), message.getData().getKey(), message.getData().getValue());
-        LOG.debug("Message sending to kafka, record={}.", record);
+    public CompletableFuture<Void> write(KeyValue<K, V> message) {
+        ProducerRecord<K, V> record = new ProducerRecord<>(kafkaSinkConfig.getTopic(), message.getKey(), message.getValue());
+        LOG.debug("Record sending to kafka, record={}.", record);
         Future f = producer.send(record);
         return CompletableFuture.supplyAsync(() -> {
             try {

--- a/pulsar-connect/rabbitmq/src/main/java/org/apache/pulsar/connect/rabbitmq/RabbitMQSource.java
+++ b/pulsar-connect/rabbitmq/src/main/java/org/apache/pulsar/connect/rabbitmq/RabbitMQSource.java
@@ -20,7 +20,7 @@
 package org.apache.pulsar.connect.rabbitmq;
 
 import com.rabbitmq.client.*;
-import org.apache.pulsar.connect.core.Message;
+import org.apache.pulsar.connect.core.Record;
 import org.apache.pulsar.connect.core.PushSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,13 +37,13 @@ public class RabbitMQSource implements PushSource<byte[]> {
 
     private static Logger logger = LoggerFactory.getLogger(RabbitMQSource.class);
 
-    private Function<Message<byte[]>, CompletableFuture<Void>> consumer;
+    private Function<Record<byte[]>, CompletableFuture<Void>> consumer;
     private Connection rabbitMQConnection;
     private Channel rabbitMQChannel;
     private RabbitMQConfig rabbitMQConfig;
 
     @Override
-    public void setConsumer(Function<Message<byte[]>, CompletableFuture<Void>> consumeFunction) {
+    public void setConsumer(Function<Record<byte[]>, CompletableFuture<Void>> consumeFunction) {
         this.consumer = consumeFunction;
     }
 
@@ -75,28 +75,28 @@ public class RabbitMQSource implements PushSource<byte[]> {
     }
 
     private class RabbitMQConsumer extends DefaultConsumer {
-        private Function<Message<byte[]>, CompletableFuture<Void>> consumeFunction;
+        private Function<Record<byte[]>, CompletableFuture<Void>> consumeFunction;
 
-        public RabbitMQConsumer(Function<Message<byte[]>, CompletableFuture<Void>> consumeFunction, Channel channel) {
+        public RabbitMQConsumer(Function<Record<byte[]>, CompletableFuture<Void>> consumeFunction, Channel channel) {
             super(channel);
             this.consumeFunction = consumeFunction;
         }
 
         @Override
         public void handleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties, byte[] body) throws IOException {
-            consumeFunction.apply(new RabbitMQMessage(body));
+            consumeFunction.apply(new RabbitMQRecord(body));
         }
     }
 
-    static private class RabbitMQMessage implements Message<byte[]> {
-        private byte[] data;
+    static private class RabbitMQRecord implements Record<byte[]> {
+        private final byte[] data;
 
-        public RabbitMQMessage(byte[] data) {
+        public RabbitMQRecord(byte[] data) {
             this.data = data;
         }
 
         @Override
-        public byte[] getData() {
+        public byte[] getValue() {
             return data;
         }
     }

--- a/pulsar-connect/twitter/src/main/java/org/apache/pulsar/connect/twitter/TwitterFireHose.java
+++ b/pulsar-connect/twitter/src/main/java/org/apache/pulsar/connect/twitter/TwitterFireHose.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
-import org.apache.pulsar.connect.core.Message;
+import org.apache.pulsar.connect.core.Record;
 import org.apache.pulsar.connect.core.PushSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,7 +52,7 @@ public class TwitterFireHose implements PushSource<String> {
 
     // ----- Runtime fields
     private Object waitObject;
-    private Function<Message<String>, CompletableFuture<Void>> consumeFunction;
+    private Function<Record<String>, CompletableFuture<Void>> consumeFunction;
 
     @Override
     public void open(Map<String, String> config) throws IOException {
@@ -68,7 +68,7 @@ public class TwitterFireHose implements PushSource<String> {
     }
 
     @Override
-    public void setConsumer(Function<Message<String>, CompletableFuture<Void>> consumeFunction) {
+    public void setConsumer(Function<Record<String>, CompletableFuture<Void>> consumeFunction) {
         this.consumeFunction = consumeFunction;
     }
 
@@ -127,7 +127,7 @@ public class TwitterFireHose implements PushSource<String> {
                             // We don't really care if the future succeeds or not.
                             // However might be in the future to count failures
                             // TODO:- Figure out the metrics story for connectors
-                            consumeFunction.apply(new TwitterMessage(line));
+                            consumeFunction.apply(new TwitterRecord(line));
                         } catch (Exception e) {
                             LOG.error("Exception thrown");
                         }
@@ -165,15 +165,15 @@ public class TwitterFireHose implements PushSource<String> {
         }
     }
 
-    static private class TwitterMessage implements Message<String> {
+    static private class TwitterRecord implements Record<String> {
         private String tweet;
 
-        public TwitterMessage(String tweet) {
+        public TwitterRecord(String tweet) {
             this.tweet = tweet;
         }
 
         @Override
-        public String getData() {
+        public String getValue() {
             return tweet;
         }
     }


### PR DESCRIPTION
*Motivation*

Having two different `Message` interfaces is a bit confusing and also introduced unnecessary object allocation.

*Solution*

- rename connect `Message` interface to `Record` interface
- introduce an abstract base implementation for both `api.Message` and `connect.Record`
- change the places to the new class