### PR TITLE
LedgerOffloader interface allows two phase update

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/NullLedgerOffloader.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/NullLedgerOffloader.java
@@ -19,6 +19,7 @@
 package org.apache.bookkeeper.mledger.impl;
 
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.bookkeeper.client.api.ReadHandle;
@@ -31,22 +32,23 @@ public class NullLedgerOffloader implements LedgerOffloader {
     public static NullLedgerOffloader INSTANCE = new NullLedgerOffloader();
 
     @Override
-    public CompletableFuture<byte[]> offload(ReadHandle ledger,
-                                             Map<String, String> extraMetadata) {
-        CompletableFuture<byte[]> promise = new CompletableFuture<>();
+    public CompletableFuture<Void> offload(ReadHandle ledger,
+                                           UUID uid,
+                                           Map<String, String> extraMetadata) {
+        CompletableFuture<Void> promise = new CompletableFuture<>();
         promise.completeExceptionally(new UnsupportedOperationException());
         return promise;
     }
 
     @Override
-    public CompletableFuture<ReadHandle> readOffloaded(long ledgerId, byte[] offloadContext) {
+    public CompletableFuture<ReadHandle> readOffloaded(long ledgerId, UUID uid) {
         CompletableFuture<ReadHandle> promise = new CompletableFuture<>();
         promise.completeExceptionally(new UnsupportedOperationException());
         return promise;
     }
 
     @Override
-    public CompletableFuture<Void> deleteOffloaded(long ledgerId, byte[] offloadContext) {
+    public CompletableFuture<Void> deleteOffloaded(long ledgerId, UUID uid) {
         CompletableFuture<Void> promise = new CompletableFuture<>();
         promise.completeExceptionally(new UnsupportedOperationException());
         return promise;


### PR DESCRIPTION
This patch modifies the LedgerOffloader interface to allow the caller
to first record that parameters used for an offload, and then confirm
these parameters after offload has successfully completed. The first
record of offload can then be used for cleanup if an error occurred or
the node offloading crashed while the offload was in progress.

The patch adds a new parameter, uid, or Unique Identifier, to all
calls, and removes the concept of offload context. The ledger ID and
uid should be enough information to find the offloaded object in
longterm storage.

When an offload is requested for a ledger, the managed ledger will
generate a random unique identifier for the offload attempt. It will
store this in the managed ledger metadata, before starting to copy
data to the longterm storage. If there is a failure, or crash before
the offload completes, the ledger ID and uid are used to cleanup the
attempt. If the attempt is successful, a completed flag is set in the
metadata.

Master Issue: #1511
