### PR TITLE
Delete offloaded ledger when ledger deleted

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
@@ -541,6 +541,100 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         Assert.assertTrue(ledger.getLedgersInfoAsList().get(0).getOffloadContext().getComplete());
     }
 
+    @Test
+    public void testOffloadDelete() throws Exception {
+        Set<Pair<Long, UUID>> deleted = ConcurrentHashMap.newKeySet();
+        CompletableFuture<Set<Long>> errorLedgers = new CompletableFuture<>();
+        Set<Pair<Long, UUID>> failedOffloads = ConcurrentHashMap.newKeySet();
+
+        MockLedgerOffloader offloader = new MockLedgerOffloader();
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setMaxEntriesPerLedger(10);
+        config.setMinimumRolloverTime(0, TimeUnit.SECONDS);
+        config.setRetentionTime(0, TimeUnit.MINUTES);
+        config.setLedgerOffloader(offloader);
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl)factory.open("my_test_ledger", config);
+        ManagedCursor cursor = ledger.openCursor("foobar");
+        for (int i = 0; i < 15; i++) {
+            String content = "entry-" + i;
+            ledger.addEntry(content.getBytes());
+        }
+
+        Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 2);
+        ledger.offloadPrefix(ledger.getLastConfirmedEntry());
+        Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 2);
+
+        Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
+                            .filter(e -> e.getOffloadContext().getComplete()).count(), 1);
+        Assert.assertTrue(ledger.getLedgersInfoAsList().get(0).getOffloadContext().getComplete());
+        long firstLedger = ledger.getLedgersInfoAsList().get(0).getLedgerId();
+        long secondLedger = ledger.getLedgersInfoAsList().get(1).getLedgerId();
+
+        cursor.markDelete(ledger.getLastConfirmedEntry());
+        assertEventuallyTrue(() -> ledger.getLedgersInfoAsList().size() == 1);
+        Assert.assertEquals(ledger.getLedgersInfoAsList().get(0).getLedgerId(), secondLedger);
+
+        Assert.assertEquals(offloader.deletedOffloads().stream().findFirst().get(),
+                            Long.valueOf(firstLedger));
+    }
+
+    @Test
+    public void testOffloadDeleteIncomplete() throws Exception {
+        Set<Pair<Long, UUID>> deleted = ConcurrentHashMap.newKeySet();
+        CompletableFuture<Set<Long>> errorLedgers = new CompletableFuture<>();
+        Set<Pair<Long, UUID>> failedOffloads = ConcurrentHashMap.newKeySet();
+
+        MockLedgerOffloader offloader = new MockLedgerOffloader() {
+                @Override
+                public CompletableFuture<Void> offload(ReadHandle ledger,
+                                                       UUID uuid,
+                                                       Map<String, String> extraMetadata) {
+                    return super.offload(ledger, uuid, extraMetadata)
+                        .thenCompose((res) -> {
+                                CompletableFuture<Void> f = new CompletableFuture<>();
+                                f.completeExceptionally(new Exception("Fail after offload occurred"));
+                                return f;
+                            });
+                }
+            };
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setMaxEntriesPerLedger(10);
+        config.setMinimumRolloverTime(0, TimeUnit.SECONDS);
+        config.setRetentionTime(0, TimeUnit.MINUTES);
+        config.setLedgerOffloader(offloader);
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl)factory.open("my_test_ledger", config);
+        ManagedCursor cursor = ledger.openCursor("foobar");
+        for (int i = 0; i < 15; i++) {
+            String content = "entry-" + i;
+            ledger.addEntry(content.getBytes());
+        }
+
+        Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 2);
+        try {
+            ledger.offloadPrefix(ledger.getLastConfirmedEntry());
+        } catch (ManagedLedgerException mle) {
+            // expected
+        }
+
+        Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 2);
+
+        Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
+                            .filter(e -> e.getOffloadContext().getComplete()).count(), 0);
+        Assert.assertEquals(ledger.getLedgersInfoAsList().stream()
+                            .filter(e -> e.getOffloadContext().hasUidMsb()).count(), 1);
+        Assert.assertTrue(ledger.getLedgersInfoAsList().get(0).getOffloadContext().hasUidMsb());
+
+        long firstLedger = ledger.getLedgersInfoAsList().get(0).getLedgerId();
+        long secondLedger = ledger.getLedgersInfoAsList().get(1).getLedgerId();
+
+        cursor.markDelete(ledger.getLastConfirmedEntry());
+        assertEventuallyTrue(() -> ledger.getLedgersInfoAsList().size() == 1);
+        Assert.assertEquals(ledger.getLedgersInfoAsList().get(0).getLedgerId(), secondLedger);
+
+        Assert.assertEquals(offloader.deletedOffloads().stream().findFirst().get(),
+                            Long.valueOf(firstLedger));
+    }
+
     void assertEventuallyTrue(BooleanSupplier predicate) throws Exception {
         // wait up to 3 seconds
         for (int i = 0; i < 30 && !predicate.getAsBoolean(); i++) {
@@ -563,9 +657,14 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
 
     static class MockLedgerOffloader implements LedgerOffloader {
         ConcurrentHashMap<Long, UUID> offloads = new ConcurrentHashMap<Long, UUID>();
+        ConcurrentHashMap<Long, UUID> deletes = new ConcurrentHashMap<Long, UUID>();
 
         Set<Long> offloadedLedgers() {
             return offloads.keySet();
+        }
+
+        Set<Long> deletedOffloads() {
+            return deletes.keySet();
         }
 
         @Override
@@ -592,6 +691,7 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         public CompletableFuture<Void> deleteOffloaded(long ledgerId, UUID uuid) {
             CompletableFuture<Void> promise = new CompletableFuture<>();
             if (offloads.remove(ledgerId, uuid)) {
+                deletes.put(ledgerId, uuid);
                 promise.complete(null);
             } else {
                 promise.completeExceptionally(new Exception("Not found"));

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
@@ -574,8 +574,7 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         assertEventuallyTrue(() -> ledger.getLedgersInfoAsList().size() == 1);
         Assert.assertEquals(ledger.getLedgersInfoAsList().get(0).getLedgerId(), secondLedger);
 
-        Assert.assertEquals(offloader.deletedOffloads().stream().findFirst().get(),
-                            Long.valueOf(firstLedger));
+        assertEventuallyTrue(() -> offloader.deletedOffloads().contains(firstLedger));
     }
 
     @Test
@@ -631,8 +630,7 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         assertEventuallyTrue(() -> ledger.getLedgersInfoAsList().size() == 1);
         Assert.assertEquals(ledger.getLedgersInfoAsList().get(0).getLedgerId(), secondLedger);
 
-        Assert.assertEquals(offloader.deletedOffloads().stream().findFirst().get(),
-                            Long.valueOf(firstLedger));
+        assertEventuallyTrue(() -> offloader.deletedOffloads().contains(firstLedger));
     }
 
     void assertEventuallyTrue(BooleanSupplier predicate) throws Exception {


### PR DESCRIPTION
When a managed ledger trims a ledger, if that ledger has been
offloaded to long term storage, delete it from long term storage
also.

Currently, it will always try to delete the bookkeeper ledger also,
even if the ledger has already been offloaded. Handling for this case
will be added in a later patch along with delayed bookkeeper ledger
deletion in the case of offload.

Master Issue: #1511
