### PR TITLE
Offloading prints wrong log on exception

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2092,7 +2092,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                                        }
                                    })
             .whenComplete((result, exception) -> {
-                    if (exception != null) {
+                    if (exception == null) {
                         log.info("[{}] End Offload. ledger={}, uuid={}", name, ledgerId, uuid);
                     } else {
                         log.warn("[{}] Failed to complete offload of ledger {}, uuid {}",


### PR DESCRIPTION
The check for exception was backwards, so it was always warning in the
happy case, and reporting success in the case of failure.

Master Issue: #1511
