### PR TITLE
Enable dispatch-throttling for non backlog consumers by default.

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -140,9 +140,9 @@ dispatchThrottlingRatePerTopicInMsg=0
 # default message-byte dispatch-throttling
 dispatchThrottlingRatePerTopicInByte=0
 
-# Default dispatch-throttling is disabled for consumers which already caught-up with published messages and
-# don't have backlog. This enables dispatch-throttling for non-backlog consumers as well.
-dispatchThrottlingOnNonBacklogConsumerEnabled=false
+# By default we enable dispatch-throttling for both caught up consumers as well as consumers who have
+# backlog.
+dispatchThrottlingOnNonBacklogConsumerEnabled=true
 
 # Max number of concurrent lookup request broker allows to throttle heavy incoming lookup traffic
 maxConcurrentLookupRequest=10000

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -129,9 +129,9 @@ dispatchThrottlingRatePerTopicInMsg=0
 # default message-byte dispatch-throttling
 dispatchThrottlingRatePerTopicInByte=0
 
-# Default dispatch-throttling is disabled for consumers which already caught-up with published messages and
-# don't have backlog. This enables dispatch-throttling for non-backlog consumers as well.
-dispatchThrottlingOnNonBacklogConsumerEnabled=false
+# By default we enable dispatch-throttling for both caught up consumers as well as consumers who have
+# backlog.
+dispatchThrottlingOnNonBacklogConsumerEnabled=true
 
 # Max number of concurrent lookup request broker allows to throttle heavy incoming lookup traffic
 maxConcurrentLookupRequest=10000


### PR DESCRIPTION
### Motivation

Currently dispatch-throttling for non backlogged consumers is disabled by default. However when I use pulsar-admin tool to actually set/get dispatch throttle everything seems to indicate that the values are set by the system, its just that the system never enforces them. This creates an inconsistent behavior for the users. This change makes the default behavior to allow dispatch-throttling for everyone so new users trying pulsar do not face this inconsistency.
### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
