### PR TITLE
Pulsar Functions CLI fixes

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBase.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBase.java
@@ -77,7 +77,6 @@ public abstract class CmdBase {
                 System.err.println("Reason: " + e.getMessage());
                 return false;
             } catch (Exception e) {
-                System.err.println("Got exception: " + e.getMessage());
                 e.printStackTrace();
                 return false;
             }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.net.MalformedURLException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -292,6 +293,9 @@ public class CmdFunctions extends CmdBase {
             if (functionConfig.getInputs().isEmpty() && functionConfig.getCustomSerdeInputs().isEmpty()) {
                 throw new RuntimeException("No input topic(s) specified for the function");
             }
+
+            // Ensure that topics aren't being used as both input and output
+            verifyNoTopicClash(functionConfig.getInputs(), functionConfig.getOutput());;
 
             if (parallelism == null) {
                 if (functionConfig.getParallelism() == 0) {
@@ -834,6 +838,14 @@ public class CmdFunctions extends CmdBase {
 
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         return  mapper.readValue(file, FunctionConfig.class);
+    }
+
+    private static void verifyNoTopicClash(Collection<String> inputTopics, String outputTopic) throws IllegalArgumentException {
+        if (inputTopics.contains(outputTopic)) {
+            throw new IllegalArgumentException(
+                    String.format("Output topic %s is also being used as an input topic (topics must be one or the other)",
+                            outputTopic));
+        }
     }
 
     private static void checkRequiredFields(FunctionConfig config) throws IllegalArgumentException {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -442,7 +442,7 @@ public class CmdFunctions extends CmdBase {
         }
 
         private void doPythonSubmitChecks(FunctionConfig functionConfig) {
-            if (functionConfig.getClassname() == null) {
+            if (functionConfig.getClassName() == null) {
                 throw new IllegalArgumentException("You specified a Python file but no main class name");
             }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -437,6 +437,10 @@ public class CmdFunctions extends CmdBase {
         }
 
         private void doPythonSubmitChecks(FunctionConfig functionConfig) {
+            if (functionConfig.getClassname() == null) {
+                throw new IllegalArgumentException("You specified a Python file but no main class name");
+            }
+
             if (functionConfig.getProcessingGuarantees() == FunctionConfig.ProcessingGuarantees.EFFECTIVELY_ONCE) {
                 throw new RuntimeException("Effectively-once processing guarantees not yet supported in Python");
             }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -32,6 +32,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.IntStream;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -75,6 +76,7 @@ import net.jodah.typetools.TypeResolver;
 @Slf4j
 @Parameters(commandDescription = "Interface for managing Pulsar Functions (lightweight, Lambda-style compute processes that work with Pulsar)")
 public class CmdFunctions extends CmdBase {
+    private static final String DEFAULT_SERVICE_URL = "pulsar://localhost:6650";
 
     private final LocalRunner localRunner;
     private final CreateFunction creater;
@@ -238,7 +240,8 @@ public class CmdFunctions extends CmdBase {
             }
 
             if (null != inputs) {
-                Arrays.asList(inputs.split(",")).forEach(functionConfig.getInputs()::add);
+                List<String> inputTopics = Arrays.asList(inputs.split(","));
+                functionConfig.setInputs(inputTopics);
             }
             if (null != customSerdeInputString) {
                 Type type = new TypeToken<Map<String, String>>(){}.getType();
@@ -300,7 +303,7 @@ public class CmdFunctions extends CmdBase {
                     && functionConfig.getSubscriptionType() != FunctionConfig.SubscriptionType.FAILOVER
                     && functionConfig.getProcessingGuarantees() != null
                     && functionConfig.getProcessingGuarantees() == FunctionConfig.ProcessingGuarantees.EFFECTIVELY_ONCE) {
-                throw new IllegalArgumentException("Effectively Once can only be acheived with Failover subscription");
+                throw new IllegalArgumentException("Effectively-once processing semantics can only be achieved using a Failover subscription type");
             }
 
             functionConfig.setAutoAck(true);
@@ -522,7 +525,7 @@ public class CmdFunctions extends CmdBase {
                 serviceUrl = brokerServiceUrl;
             }
             if (serviceUrl == null) {
-                serviceUrl = "pulsar://localhost:6650";
+                serviceUrl = DEFAULT_SERVICE_URL;
             }
             try (ProcessRuntimeFactory containerFactory = new ProcessRuntimeFactory(
                     serviceUrl, null, null, null)) {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -283,7 +283,7 @@ public class CmdFunctions extends CmdBase {
                 throw new RuntimeException("Either a Java jar or a Python file needs to be specified for the function");
             }
 
-            if (functionConfig.getInputs().size() == 0 && functionConfig.getCustomSerdeInputs().size() == 0) {
+            if (functionConfig.getInputs().isEmpty() && functionConfig.getCustomSerdeInputs().isEmpty()) {
                 throw new RuntimeException("No input topic(s) specified for the function");
             }
 
@@ -836,7 +836,7 @@ public class CmdFunctions extends CmdBase {
             throw new IllegalArgumentException("You must specify a class name for the function");
         }
 
-        if (config.getInputs().size() == 0 || config.getCustomSerdeInputs().size() == 0) {
+        if (config.getInputs().isEmpty() && config.getCustomSerdeInputs().isEmpty()) {
             throw new IllegalArgumentException("You must specify one or more input topics for the function");
         }
     }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -829,7 +829,7 @@ public class CmdFunctions extends CmdBase {
             throw new IllegalArgumentException("You must specify a class name for the function");
         }
 
-        if (config.getInputs().size() == 0 || config.getCustomSerdeINputs().size() == 0) {
+        if (config.getInputs().size() == 0 || config.getCustomSerdeInputs().size() == 0) {
             throw new IllegalArgumentException("You must specify one or more input topics for the function");
         }
     }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -42,6 +42,7 @@ import org.apache.bookkeeper.api.kv.result.KeyValue;
 import org.apache.bookkeeper.clients.StorageClientBuilder;
 import org.apache.bookkeeper.clients.config.StorageClientSettings;
 import org.apache.bookkeeper.clients.utils.NetUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.internal.FunctionsImpl;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -458,16 +459,16 @@ public class CmdFunctions extends CmdBase {
         }
 
         private void inferMissingArguments(FunctionConfig functionConfig) {
-            if (functionConfig.getName() == null || functionConfig.getName().isEmpty()) {
+            if (StringUtils.isEmpty(functionConfig.getName())) {
                 inferMissingFunctionName(functionConfig);
             }
-            if (functionConfig.getTenant() == null || functionConfig.getTenant().isEmpty()) {
+            if (StringUtils.isEmpty(functionConfig.getTenant())) {
                 inferMissingTenant(functionConfig);
             }
-            if (functionConfig.getNamespace() == null || functionConfig.getNamespace().isEmpty()) {
+            if (StringUtils.isEmpty(functionConfig.getNamespace())) {
                 inferMissingNamespace(functionConfig);
             }
-            if (functionConfig.getOutput() == null || functionConfig.getOutput().isEmpty()) {
+            if (StringUtils.isEmpty(functionConfig.getOutput())) {
                 inferMissingOutput(functionConfig);
             }
         }
@@ -502,7 +503,8 @@ public class CmdFunctions extends CmdBase {
         private void inferMissingOutput(FunctionConfig functionConfig) {
             try {
                 String inputTopic = getUniqueInput(functionConfig);
-                functionConfig.setOutput(inputTopic + "-" + functionConfig.getName() + "-output");
+                String outputTopic = String.format("%s-%s-output", inputTopic, functionConfig.getName());
+                functionConfig.setOutput(outputTopic);
             } catch (IllegalArgumentException ex) {
                 // It might be that we really don't need an output topic
                 // So we cannot really throw an exception

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -241,14 +241,19 @@ public class CmdFunctions extends CmdBase {
 
             if (null != inputs) {
                 List<String> inputTopics = Arrays.asList(inputs.split(","));
+                inputTopics.forEach(this::validateTopicName);
                 functionConfig.setInputs(inputTopics);
             }
             if (null != customSerdeInputString) {
                 Type type = new TypeToken<Map<String, String>>(){}.getType();
                 Map<String, String> customSerdeInputMap = new Gson().fromJson(customSerdeInputString, type);
+                customSerdeInputMap.forEach((topic, serde) -> {
+                    validateTopicName(topic);
+                });
                 functionConfig.setCustomSerdeInputs(customSerdeInputMap);
             }
             if (null != output) {
+                validateTopicName(output);
                 functionConfig.setOutput(output);
             }
             if (null != logTopic) {
@@ -443,6 +448,12 @@ public class CmdFunctions extends CmdBase {
 
             if (functionConfig.getProcessingGuarantees() == FunctionConfig.ProcessingGuarantees.EFFECTIVELY_ONCE) {
                 throw new RuntimeException("Effectively-once processing guarantees not yet supported in Python");
+            }
+        }
+
+        private void validateTopicName(String topic) {
+            if (!TopicName.isValid(topic)) {
+                throw new IllegalArgumentException(String.format("The topic name %s is invalid", topic));
             }
         }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -308,6 +308,10 @@ public class CmdFunctions extends CmdBase {
         }
 
         private void doJavaSubmitChecks(FunctionConfig functionConfig) {
+            if (isNull(className)) {
+                throw new IllegalArgumentException("You supplied a jar file but no main class");
+            }
+
             File file = new File(jarFile);
             // check if the function class exists in Jar and it implements Function class
             if (!Reflections.classExistsInJar(file, functionConfig.getClassName())) {


### PR DESCRIPTION
This PR addresses a few issues with the Pulsar Functions command-line interface:

* Specifying a jar file but no class name was throwing NPEs due to lack of an explicit null check
* Exception output was being printed twice ("Got exception ..." plus the stack trace)
* Basic topic name validation is now performed
* More specific information about missing arguments is provided (e.g. `You must specify a tenant for the function` rather than `Missing arguments`).