### PR TITLE
Fix: NPE when cursor failed to close empty subscription

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -542,7 +542,9 @@ public class PersistentSubscription implements Subscription {
                     disconnectFuture.complete(null);
                 }).exceptionally(exception -> {
                     IS_FENCED_UPDATER.set(this, FALSE);
-                    dispatcher.reset();
+                    if (dispatcher != null) {
+                        dispatcher.reset();
+                    }
                     log.error("[{}][{}] Error disconnecting consumers from subscription", topicName, subName,
                             exception);
                     disconnectFuture.completeExceptionally(exception);


### PR DESCRIPTION
### Motivation

Recently we have seen that while unloading the topic, if empty-subscription fails to close-cursor with below exception, then it throws NPE and broker doesn't remove the topic from the cache. And topic will be in fence state after that. So, if broker again loads the same bundle then topic rejects adding producer/consumer because it is already in fence state.

```
01:06:07.303 [bookkeeper-ml-workers-60-1] ERROR o.a.p.b.s.p.PersistentSubscription   - [persistent://membership-asc/global/membership-v2/NotificationTopic][mischief-prod-iris-asc-cms-subscription] Error closing cursor for subscription
org.apache.bookkeeper.mledger.ManagedLedgerException$BadVersionException: org.apache.zookeeper.KeeperException$BadVersionException: KeeperErrorCode = BadVersion
Caused by: org.apache.zookeeper.KeeperException$BadVersionException: KeeperErrorCode = BadVersion
        at org.apache.zookeeper.KeeperException.create(KeeperException.java:115) ~[zookeeper-3.4.6.jar:3.4.6-1569965]
        at org.apache.bookkeeper.mledger.impl.MetaStoreImplZookeeper.lambda$null$11(MetaStoreImplZookeeper.java:273) [managed-ledger-1.20.16-incubating-yahoo.jar:1.20.16-incubating-yahoo]
        at org.apache.bookkeeper.mledger.util.SafeRun$1.safeRun(SafeRun.java:30) ~[managed-ledger-1.20.16-incubating-yahoo.jar:1.20.16-incubating-yahoo]
        at org.apache.bookkeeper.util.SafeRunnable.run(SafeRunnable.java:31) ~[bookkeeper-server-4.3.1.56.14-yahoo.jar:4.3.1.56.14-yahoo]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[na:1.8.0_131]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[na:1.8.0_131]
        at io.netty.util.concurrent.DefaultThreadFactory$DefaultRunnableDecorator.run(DefaultThreadFactory.java:144) ~[netty-all-4.0.46.Final.jar:4.0.46.Final]
        at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_131]
```

### Modifications

Fix NPE, so broker can remove failure topic.

### Result

Broker will clean the topic properly while unloading it.
