### PR TITLE
Include generate_protobuf.sh in src archive

### DIFF
--- a/all/src/assemble/src.xml
+++ b/all/src/assemble/src.xml
@@ -42,6 +42,7 @@
         <include>**/conf/**</include>
         <include>**/bin/**</include>
         <include>**/*.txt</include>
+        <include>pulsar-common/*.sh</include>
         <include>docker/**</include>
         <include>dashboard/**</include>
         <include>deployment/**</include>


### PR DESCRIPTION
### Motivation

#1337 Scripts to generate Java code from protobuf were missing from src archive.