### PR TITLE
Use standard format when generating SHA signatures for release

### DIFF
--- a/src/sign-release.sh
+++ b/src/sign-release.sh
@@ -25,9 +25,9 @@ do
    echo "Signing $FILE"
    gpg --armor --output $FILE.asc --detach-sig $FILE
 
-   # Checksum
-   gpg --print-md MD5 $FILE > $FILE.md5
+   # SHA-1 signature
+   shasum -a 1 $FILE > $FILE.sha1
 
    # SHA-512 signature
-   gpg --print-md SHA512 $FILE > $FILE.sha512
+   shasum -a 512 $FILE > $FILE.sha512
 done


### PR DESCRIPTION
### Motivation

As described in #1337 : 
 * Drop MD5 checksum as it's now deprecated
 * Use SHA-1 and SHA-512
 * Use standard format (lowercase with no spaces) 