### PR TITLE
PIP-17: provide DataBlockHeader and implementation

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/DataBlockHeader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/DataBlockHeader.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.broker.s3offload;
 import java.io.IOException;
 import java.io.InputStream;
 import org.apache.bookkeeper.common.annotation.InterfaceStability.Unstable;
-import org.apache.pulsar.broker.s3offload.impl.DataBlockHeaderImpl;
 
 /**
  * The data block header in code storage for each data block
@@ -53,22 +52,6 @@ public interface DataBlockHeader {
      * Get the content of the data block header as InputStream.
      * Read out in current format.
      */
-    InputStream toStream() throws IOException;
-
-    /**
-     * Get the payload start offset in this block.
-     * Space before this offset is for header and alignment.
-     */
-    static int getDataStartOffset() {
-        return DataBlockHeaderImpl.getDataStartOffset();
-    }
-
-    /**
-     * Get Magic Word for data block.
-     * It is a sequence of bytes used to identify the start of a block.
-     */
-    static int getBlockMagicWord() {
-        return DataBlockHeaderImpl.getBlockMagicWord();
-    }
+    InputStream toStream();
 }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/DataBlockHeader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/DataBlockHeader.java
@@ -27,17 +27,12 @@ import org.apache.pulsar.broker.s3offload.impl.DataBlockHeaderImpl;
  * The data block header in code storage for each data block
  *
  * Currently, It is in format:
- * [ magic_word -- int ][ block_len -- int ][ first_entry_id  -- long]
+ * [ magic_word -- int ][ block_len -- int ][ first_entry_id  -- long][padding]
  *
- * with the size: 4 + 4 + 8 = 16 Bytes
+ * with the size: 4 + 4 + 8 + padding = 128 Bytes
  */
 @Unstable
 public interface DataBlockHeader {
-    /**
-     * Get Magic Word for data block.
-     * It is a sequence of bytes used to identify the start of a block.
-     */
-    int getBlockMagicWord();
 
     /**
      * Get the length of the block in bytes, including the header.
@@ -66,6 +61,14 @@ public interface DataBlockHeader {
      */
     static int getDataStartOffset() {
         return DataBlockHeaderImpl.getDataStartOffset();
+    }
+
+    /**
+     * Get Magic Word for data block.
+     * It is a sequence of bytes used to identify the start of a block.
+     */
+    static int getBlockMagicWord() {
+        return DataBlockHeaderImpl.getBlockMagicWord();
     }
 }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/DataBlockHeader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/DataBlockHeader.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.s3offload;
+
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.bookkeeper.common.annotation.InterfaceStability.Unstable;
+import org.apache.pulsar.broker.s3offload.impl.DataBlockHeaderImpl;
+
+/**
+ * The data block header in code storage for each data block
+ *
+ * Currently, It is in format:
+ * [ magic_word -- int ][ block_len -- int ][ first_entry_id  -- long]
+ *
+ * with the size: 4 + 4 + 8 = 16 Bytes
+ */
+@Unstable
+public interface DataBlockHeader {
+    /**
+     * Get Magic Word for data block.
+     * It is a sequence of bytes used to identify the start of a block.
+     */
+    int getBlockMagicWord();
+
+    /**
+     * Get the length of the block in bytes, including the header.
+     */
+    int getBlockLength();
+
+    /**
+     * Get the message entry Id for the first message that stored in this data block.
+     */
+    long getFirstEntryId();
+
+    /**
+     * Get the size of this DataBlockHeader.
+     */
+    int getHeaderSize();
+
+    /**
+     * Get the content of the data block header as InputStream.
+     * Read out in current format.
+     */
+    InputStream toStream() throws IOException;
+
+    /**
+     * Get the payload start offset in this block.
+     * Space before this offset is for header and alignment.
+     */
+    static int getDataStartOffset() {
+        return DataBlockHeaderImpl.getDataStartOffset();
+    }
+}
+

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/impl/DataBlockHeaderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/impl/DataBlockHeaderImpl.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.s3offload.impl;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.buffer.PooledByteBufAllocator;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.pulsar.broker.s3offload.DataBlockHeader;
+
+/**
+ *
+ * The data block header in code storage for each data block.
+ *
+ */
+public class DataBlockHeaderImpl implements DataBlockHeader {
+    // Magic Word for data block.
+    // It is a sequence of bytes used to identify the start of a block.
+    private static final int dataBlockMagicWord = 0xDBDBDBDB;
+    // This is bigger than header size. Leaving some place for alignment and future enhancement.
+    // Payload use this as the start offset.
+    private static final int dataBlockHeaderAlign = 128;
+    // The size of this header.
+    private static final int dataBlockHeaderSize = 4 /* magic word */
+        + 4 /* index block length */
+        + 8 /* first entry id */;
+
+    public static DataBlockHeaderImpl of(int blockLength, long firstEntryId) {
+        return new DataBlockHeaderImpl(blockLength, firstEntryId);
+    }
+
+    // Construct DataBlockHeader from InputStream
+    public static DataBlockHeaderImpl fromStream(InputStream stream) throws IOException {
+        DataInputStream dis = new DataInputStream(stream);
+        int magic = dis.readInt();
+        checkState(magic == dataBlockMagicWord);
+        return new DataBlockHeaderImpl(dis.readInt(), dis.readLong());
+    }
+
+    private final int blockLength;
+    private final long firstEntryId;
+
+    @Override
+    public int getBlockMagicWord() {
+        return dataBlockMagicWord;
+    }
+
+    @Override
+    public int getBlockLength() {
+        return this.blockLength;
+    }
+
+    @Override
+    public long getFirstEntryId() {
+        return this.firstEntryId;
+    }
+
+    @Override
+    public int getHeaderSize() {
+        return dataBlockHeaderSize;
+    }
+
+    static public int getDataStartOffset() {
+        return dataBlockHeaderAlign;
+    }
+
+    public DataBlockHeaderImpl(int blockLength, long firstEntryId) {
+        this.blockLength = blockLength;
+        this.firstEntryId = firstEntryId;
+    }
+
+    /**
+     * Get the content of the data block header as InputStream.
+     * Read out in format:
+     *   [ magic_word -- int ][ block_len -- int ][ first_entry_id  -- long]
+     */
+    public InputStream toStream() throws IOException {
+        int headerSize = 4 /* magic word */
+            + 4 /* index block length */
+            + 8 /* first entry id */;
+
+        ByteBuf out = PooledByteBufAllocator.DEFAULT.buffer(headerSize, headerSize);
+        out.writeInt(dataBlockMagicWord)
+            .writeInt(blockLength)
+            .writeLong(firstEntryId);
+
+        return new ByteBufInputStream(out, true);
+    }
+}
+

--- a/pulsar-broker/src/test/java/org/apache/pulsar/s3offload/DataBlockHeaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/s3offload/DataBlockHeaderTest.java
@@ -56,21 +56,21 @@ public class DataBlockHeaderTest {
         assertEquals(stream.read(), -1);
 
         stream.reset();
-        byte streamContent[] = new byte[DataBlockHeader.getDataStartOffset()];
+        byte streamContent[] = new byte[DataBlockHeaderImpl.getDataStartOffset()];
 
         // stream with all 0, simulate junk data, should throw exception for header magic not match.
-        try(InputStream stream2 = new ByteArrayInputStream(streamContent, 0, DataBlockHeader.getDataStartOffset())) {
+        try(InputStream stream2 = new ByteArrayInputStream(streamContent, 0, DataBlockHeaderImpl.getDataStartOffset())) {
             DataBlockHeader rebuild2 = DataBlockHeaderImpl.fromStream(stream2);
             fail("Should throw IOException");
         } catch (Exception e) {
             assertTrue(e instanceof IOException);
-            assertTrue(e.getMessage().equals("Data block header magic word not match."));
+            assertTrue(e.getMessage().contains("Data block header magic word not match"));
         }
 
         // simulate read header too small, throw EOFException.
         stream.read(streamContent);
         try(InputStream stream3 =
-                new ByteArrayInputStream(streamContent, 0, DataBlockHeader.getDataStartOffset() - 1)) {
+                new ByteArrayInputStream(streamContent, 0, DataBlockHeaderImpl.getDataStartOffset() - 1)) {
             DataBlockHeader rebuild3 = DataBlockHeaderImpl.fromStream(stream3);
             fail("Should throw EOFException");
         } catch (Exception e) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/s3offload/DataBlockHeaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/s3offload/DataBlockHeaderTest.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.s3offload;
+
+import static org.testng.Assert.assertTrue;
+
+import java.io.InputStream;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.s3offload.impl.DataBlockHeaderImpl;
+import org.testng.annotations.Test;
+
+@Slf4j
+public class DataBlockHeaderTest {
+
+    @Test
+    public void dataBlockHeaderImplTest() throws Exception {
+        int headerLength = 1024 * 1024;
+        long firstEntryId = 3333L;
+
+        DataBlockHeaderImpl dataBlockHeader = DataBlockHeaderImpl.of(headerLength,
+            firstEntryId);
+
+        // verify get methods
+        assertTrue(dataBlockHeader.getBlockMagicWord() == 0xDBDBDBDB);
+        assertTrue(dataBlockHeader.getBlockLength() == headerLength);
+        assertTrue(dataBlockHeader.getFirstEntryId() == firstEntryId);
+
+        // verify toStream and fromStream
+        InputStream stream = dataBlockHeader.toStream();
+        DataBlockHeaderImpl rebuild = DataBlockHeaderImpl.fromStream(stream);
+
+        assertTrue(rebuild.getBlockMagicWord() == 0xDBDBDBDB);
+        assertTrue(rebuild.getBlockLength() == headerLength);
+        assertTrue(rebuild.getFirstEntryId() == firstEntryId);
+    }
+
+}


### PR DESCRIPTION
### Motivation
Provide DataBlockHeader implementation. A block header is in format:
`[ magic_word -- int ][ block_len -- int ][ first_entry_id  -- long][alignment padding]`

Master issue #1511 

### Modifications

Add class DataBlockHeader and test for it.

### Result

unit test pass.