### PR TITLE
Cleanup ThreadRuntime Exception Management

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceMain.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceMain.java
@@ -189,7 +189,7 @@ public class JavaInstanceMain {
                 instanceConfig,
                 jarFile,
                 containerFactory,
-                0);
+                30000);
 
         server = ServerBuilder.forPort(port)
                 .addService(new InstanceControlImpl(runtimeSpawner))

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntime.java
@@ -213,6 +213,8 @@ class ProcessRuntime implements Runtime {
     public void stop() {
         process.destroy();
         channel.shutdown();
+        channel = null;
+        stub = null;
     }
 
     @Override

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntime.java
@@ -313,18 +313,6 @@ class ProcessRuntime implements Runtime {
             }
             return false;
         }
-        FunctionStatus status;
-        try {
-            status = getFunctionStatus().get();
-        } catch (Exception ex) {
-            return false;
-        }
-        if (!status.getRunning()) {
-            if (status.getFailureException() != null && !status.getFailureException().isEmpty()) {
-                deathException = new Exception(status.getFailureException());
-            }
-            return false;
-        }
         return true;
     }
 

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeSpawner.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeSpawner.java
@@ -72,6 +72,8 @@ public class RuntimeSpawner implements AutoCloseable {
                     if (!runtime.isAlive()) {
                         log.error("Function Container is dead with exception", runtime.getDeathException());
                         log.error("Restarting...");
+                        // Just for the sake of sanity, just destroy the runtime
+                        runtime.stop();
                         runtimeDeathException = runtime.getDeathException();
                         runtime.start();
                         numRestarts++;


### PR DESCRIPTION
### Motivation

Don't let Thread Runtime eat uncaught exceptions. Rather just log them within instance runnable and terminate the thread.

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
