### PR TITLE
Add tenant and namespace getters to Python context

### DIFF
--- a/pulsar-client-cpp/python/functions/context.py
+++ b/pulsar-client-cpp/python/functions/context.py
@@ -50,9 +50,18 @@ class Context(object):
     pass
 
   @abstractmethod
-  def get_topic_name(self):
+  def get_input_topic_name(self):
     """Returns the topic name of the message that we are processing"""
     pass
+  
+  @abstractmethod
+  def get_function_tenant(self):
+    """Returns the tenant of the message that's being processed"""
+    pass
+
+  @abstractmethod
+  def get_function_namespace(self):
+    """Returns the namespace of the message that's being processed"""
 
   @abstractmethod
   def get_function_name(self):
@@ -106,15 +115,15 @@ class Context(object):
 
   @abstractmethod
   def get_output_topic(self):
-    '''Returns the output topic of function'''
+    """Returns the output topic of function"""
     pass
 
   @abstractmethod
   def get_output_serde_class_name(self):
-    '''return output Serde class'''
+    """return output Serde class"""
     pass
 
   @abstractmethod
   def ack(self, msgid, topic):
-    '''ack this message id'''
+    """ack this message id"""
     pass

--- a/pulsar-client-cpp/python/functions/context.py
+++ b/pulsar-client-cpp/python/functions/context.py
@@ -50,7 +50,7 @@ class Context(object):
     pass
 
   @abstractmethod
-  def get_input_topic_name(self):
+  def get_current_message_topic_name(self):
     """Returns the topic name of the message that we are processing"""
     pass
   

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/Context.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/Context.java
@@ -40,10 +40,10 @@ public interface Context {
     byte[] getMessageId();
 
     /**
-     * The topic that this message belongs to
-     * @return The topic name
+     * The input topic that this message belongs to
+     * @return The input topic name
      */
-    String getTopicName();
+    String getInputTopicName();
 
     /**
      * Get a list of all input topics

--- a/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/Context.java
+++ b/pulsar-functions/api-java/src/main/java/org/apache/pulsar/functions/api/Context.java
@@ -40,10 +40,10 @@ public interface Context {
     byte[] getMessageId();
 
     /**
-     * The input topic that this message belongs to
+     * The input topic that the message currently being processed belongs to
      * @return The input topic name
      */
-    String getInputTopicName();
+    String getCurrentMessageTopicName();
 
     /**
      * Get a list of all input topics

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
@@ -122,7 +122,7 @@ class ContextImpl implements Context {
     }
 
     @Override
-    public String getInputTopicName() {
+    public String getCurrentMessageTopicName() {
         return currentTopicName;
     }
 

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
@@ -122,7 +122,7 @@ class ContextImpl implements Context {
     }
 
     @Override
-    public String getTopicName() {
+    public String getInputTopicName() {
         return currentTopicName;
     }
 

--- a/pulsar-functions/instance/src/main/python/contextimpl.py
+++ b/pulsar-functions/instance/src/main/python/contextimpl.py
@@ -57,23 +57,29 @@ class ContextImpl(pulsar.Context):
     self.publish_producers = {}
     self.publish_serializers = {}
     self.current_message_id = None
-    self.current_topic_name = None
+    self.current_input_topic_name = None
     self.current_start_time = None
 
   # Called on a per message basis to set the context for the current message
   def set_current_message_context(self, msgid, topic):
     self.current_message_id = msgid
-    self.current_topic_name = topic
+    self.current_input_topic_name = topic
     self.current_start_time = time.time()
 
   def get_message_id(self):
     return self.current_message_id
 
-  def get_topic_name(self):
+  def get_input_topic_name(self):
     return self.current_topic_name
 
   def get_function_name(self):
-    return self.instance_config.function_config.name
+    return self.instance_config.function_details.name
+
+  def get_function_tenant(self):
+    return self.instance_config.function_details.tenant
+
+  def get_function_namespace(self):
+    return self.instance_config.function_details.namespace
 
   def get_function_id(self):
     return self.instance_config.function_id

--- a/pulsar-functions/instance/src/main/python/contextimpl.py
+++ b/pulsar-functions/instance/src/main/python/contextimpl.py
@@ -69,7 +69,7 @@ class ContextImpl(pulsar.Context):
   def get_message_id(self):
     return self.current_message_id
 
-  def get_input_topic_name(self):
+  def get_current_message_topic_name(self):
     return self.current_topic_name
 
   def get_function_name(self):


### PR DESCRIPTION
This PR supplies some missing getters for the Python context object (to achieve parity with the Java Pulsar Functions SDK).