### PR TITLE
Provide meaningful error message in "pulsar-admin topics lookup"

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -573,7 +573,7 @@ public abstract class PulsarWebResource {
                 Policies policies = policiesResult.get();
                 if (policies.replication_clusters.isEmpty()) {
                     String msg = String.format(
-                            "Global namespace does not have any clusters configured : local_cluster=%s ns=%s",
+                            "Namespace does not have any clusters configured : local_cluster=%s ns=%s",
                             localCluster, namespace.toString());
                     log.warn(msg);
                     validationFuture.completeExceptionally(new RestException(Status.PRECONDITION_FAILED, msg));
@@ -586,7 +586,7 @@ public abstract class PulsarWebResource {
                         return;
                     }
                     String msg = String.format(
-                            "Global namespace missing local cluster name in replication list : local_cluster=%s ns=%s repl_clusters=%s",
+                            "Namespace missing local cluster name in clusters list: local_cluster=%s ns=%s clusters=%s",
                             localCluster, namespace.toString(), policies.replication_clusters);
 
                     log.warn(msg);

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/LookupImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/LookupImpl.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.client.admin.internal;
 
-import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.client.WebTarget;
 
 import org.apache.pulsar.client.admin.Lookup;
@@ -38,14 +37,6 @@ public class LookupImpl extends BaseResource implements Lookup {
         v2lookup = web.path("/lookup/v2");
     }
 
-    private PulsarAdminException getLookupApiException(WebTarget target, Exception e) {
-        if (e instanceof ClientErrorException) {
-            return new PulsarAdminException((ClientErrorException) e, e.getMessage() + " at " + target.getUri());
-        } else {
-            return getApiException(e);
-        }
-    }
-
     @Override
     public String lookupTopic(String topic) throws PulsarAdminException {
         TopicName topicName = TopicName.get(topic);
@@ -55,7 +46,7 @@ public class LookupImpl extends BaseResource implements Lookup {
         try {
             return doTopicLookup(target);
         } catch (Exception e) {
-            throw getLookupApiException(target, e);
+            throw getApiException(e);
         }
     }
 
@@ -68,7 +59,7 @@ public class LookupImpl extends BaseResource implements Lookup {
         try {
             return request(target).get(String.class);
         } catch (Exception e) {
-            throw getLookupApiException(target, e);
+            throw getApiException(e);
         }
     }
 


### PR DESCRIPTION
### Motivation

Unlike all other admin API calls from CLI tool `pulsar-admin`, the calls on `admin.lookups()` are not extracting and attaching to the exception message the "reason" that the broker is providing in the response.

Fixes #1411