### PR TITLE
Check if javaInstance is created in the first place before invocing close

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -348,7 +348,9 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
     @Override
     public void close() {
         processor.close();
-        javaInstance.close();
+        if (null != javaInstance) {
+            javaInstance.close();
+        }
 
         // kill the state table
         if (null != stateTable) {


### PR DESCRIPTION

### Motivation

If there is an issue setting up javaInstance(like if class path is not found, etc), there is an exception thrown in setupJavaInstance, which triggers close, which causes npe. This pr fixes that
### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
