### PR TITLE
Make SchemaSerializationException an unchecked exception

### DIFF
--- a/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/producer/PulsarKafkaProducer.java
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka/src/main/java/org/apache/kafka/clients/producer/PulsarKafkaProducer.java
@@ -240,15 +240,13 @@ public class PulsarKafkaProducer<K, V> implements Producer<K, V> {
         if (record.key() != null) {
             builder.key(getKey(record.topic(), record.key()));
         }
+
         if (record.timestamp() != null) {
             builder.eventTime(record.timestamp());
         }
+
         byte[] value = valueSerializer.serialize(record.topic(), record.value());
-        try {
-            builder.value(value);
-        } catch (SchemaSerializationException e) {
-            throw new RuntimeException(e);
-        }
+        builder.value(value);
         return value.length;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/MessageBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/MessageBuilder.java
@@ -60,7 +60,7 @@ public interface MessageBuilder<T> {
      * @param value
      *            the domain object
      */
-    MessageBuilder<T> setValue(T value) throws SchemaSerializationException;
+    MessageBuilder<T> setValue(T value);
 
     /**
      * Set the content of the message

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/Schema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/Schema.java
@@ -35,7 +35,7 @@ public interface Schema<T> {
      * @throws SchemaSerializationException
      *             if the serialization fails
      */
-    byte[] encode(T message) throws SchemaSerializationException;
+    byte[] encode(T message);
 
     /**
      * Decode a byte array into an object using the schema definition and deserializer implementation

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/SchemaSerializationException.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/SchemaSerializationException.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.client.api;
 
-public class SchemaSerializationException extends PulsarClientException {
+public class SchemaSerializationException extends RuntimeException {
     public SchemaSerializationException(Throwable cause) {
         super(cause);
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/TypedMessageBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/TypedMessageBuilder.java
@@ -95,7 +95,7 @@ public interface TypedMessageBuilder<T> extends Serializable {
      * @param value
      *            the domain object
      */
-    TypedMessageBuilder<T> value(T value) throws SchemaSerializationException;
+    TypedMessageBuilder<T> value(T value);
 
     /**
      * Sets a new property on a message.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageBuilderImpl.java
@@ -20,6 +20,8 @@ package org.apache.pulsar.client.impl;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.common.base.Preconditions;
+
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
@@ -27,11 +29,8 @@ import java.util.Map;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageBuilder;
 import org.apache.pulsar.client.api.Schema;
-import org.apache.pulsar.client.api.SchemaSerializationException;
 import org.apache.pulsar.common.api.proto.PulsarApi.KeyValue;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
-
-import com.google.common.base.Preconditions;
 
 public class MessageBuilderImpl<T> implements MessageBuilder<T> {
     private static final ByteBuffer EMPTY_CONTENT = ByteBuffer.allocate(0);
@@ -49,7 +48,7 @@ public class MessageBuilderImpl<T> implements MessageBuilder<T> {
     }
 
     @Override
-    public MessageBuilder<T> setValue(T value) throws SchemaSerializationException {
+    public MessageBuilder<T> setValue(T value) {
         return setContent(schema.encode(value));
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TypedMessageBuilderImpl.java
@@ -28,11 +28,9 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.client.api.MessageBuilder;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
-import org.apache.pulsar.client.api.SchemaSerializationException;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
 import org.apache.pulsar.common.api.proto.PulsarApi.KeyValue;
 import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
@@ -68,7 +66,7 @@ public class TypedMessageBuilderImpl<T> implements TypedMessageBuilder<T> {
     }
 
     @Override
-    public TypedMessageBuilder<T> value(T value) throws SchemaSerializationException {
+    public TypedMessageBuilder<T> value(T value) {
         this.content = ByteBuffer.wrap(schema.encode(value));
         return this;
     }


### PR DESCRIPTION
### Motivation

Since the exception when serializing is only thrown when there is a severe misconfiguration in the Schema implementation, we can avoid having the application to forcefully handle that exception.