### PR TITLE
Renamed Schema.IDENTITY into Schema.BYTES

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
@@ -103,7 +103,7 @@ public class RawReaderImpl implements RawReader {
         RawConsumerImpl(PulsarClientImpl client, ConsumerConfigurationData<byte[]> conf,
                 CompletableFuture<Consumer<byte[]>> consumerFuture) {
             super(client, conf.getSingleTopic(), conf, client.externalExecutorProvider().getExecutor(), -1,
-                    consumerFuture, SubscriptionMode.Durable, MessageId.earliest, Schema.IDENTITY);
+                    consumerFuture, SubscriptionMode.Durable, MessageId.earliest, Schema.BYTES);
             incomingRawMessages = new GrowableArrayBlockingQueue<>();
             pendingRawReceives = new ConcurrentLinkedQueue<>();
         }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -851,7 +851,7 @@ public class TopicsImpl extends BaseResource implements Topics, PersistentTopics
                 }
             }
 
-            return Collections.singletonList(new MessageImpl<byte[]>(msgId, properties, data, Schema.IDENTITY));
+            return Collections.singletonList(new MessageImpl<byte[]>(msgId, properties, data, Schema.BYTES));
         } finally {
             if (stream != null) {
                 stream.close();
@@ -876,7 +876,7 @@ public class TopicsImpl extends BaseResource implements Topics, PersistentTopics
                         properties.put(entry.getKey(), entry.getValue());
                     }
                 }
-                ret.add(new MessageImpl<>(batchMsgId, properties, singleMessagePayload, Schema.IDENTITY));
+                ret.add(new MessageImpl<>(batchMsgId, properties, singleMessagePayload, Schema.BYTES));
             } catch (Exception ex) {
                 log.error("Exception occured while trying to get BatchMsgId: {}", batchMsgId, ex);
             }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/MessageBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/MessageBuilder.java
@@ -44,7 +44,7 @@ public interface MessageBuilder<T> {
     }
 
     static MessageBuilder<byte[]> create() {
-        return create(Schema.IDENTITY);
+        return create(Schema.BYTES);
     }
 
     /**

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/Schema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/Schema.java
@@ -18,7 +18,8 @@
  */
 package org.apache.pulsar.client.api;
 
-import org.apache.pulsar.client.api.schemas.StringSchema;
+import org.apache.pulsar.client.impl.schema.BytesSchema;
+import org.apache.pulsar.client.impl.schema.StringSchema;
 import org.apache.pulsar.common.schema.SchemaInfo;
 
 /**
@@ -51,22 +52,10 @@ public interface Schema<T> {
      */
     SchemaInfo getSchemaInfo();
 
-    Schema<byte[]> IDENTITY = new Schema<byte[]>() {
-        @Override
-        public byte[] encode(byte[] message) {
-            return message;
-        }
-
-        @Override
-        public byte[] decode(byte[] bytes) {
-            return bytes;
-        }
-
-        @Override
-        public SchemaInfo getSchemaInfo() {
-            return null;
-        }
-    };
+    /**
+     * Schema that doesn't perform any encoding on the message payloads. Accepts a byte array and it passes it through.
+     */
+    Schema<byte[]> BYTES = new BytesSchema();
 
     /**
      * Schema that can be used to encode/decode messages whose values are String. The payload is encoded with UTF-8.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -74,7 +74,7 @@ public class MessageImpl<T> extends MessageRecordImpl<T, MessageId> {
         msg.cnx = null;
         msg.payload = Unpooled.wrappedBuffer(payload);
         msg.properties = null;
-        msg.schema = Schema.IDENTITY;
+        msg.schema = Schema.BYTES;
         return msg;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -144,7 +144,7 @@ public class PulsarClientImpl implements PulsarClient {
 
     @Override
     public ProducerBuilder<byte[]> newProducer() {
-        return new ProducerBuilderImpl<>(this, Schema.IDENTITY);
+        return new ProducerBuilderImpl<>(this, Schema.BYTES);
     }
 
     @Override
@@ -154,7 +154,7 @@ public class PulsarClientImpl implements PulsarClient {
 
     @Override
     public ConsumerBuilder<byte[]> newConsumer() {
-        return new ConsumerBuilderImpl<>(this, Schema.IDENTITY);
+        return new ConsumerBuilderImpl<>(this, Schema.BYTES);
     }
 
     @Override
@@ -164,7 +164,7 @@ public class PulsarClientImpl implements PulsarClient {
 
     @Override
     public ReaderBuilder<byte[]> newReader() {
-        return new ReaderBuilderImpl<>(this, Schema.IDENTITY);
+        return new ReaderBuilderImpl<>(this, Schema.BYTES);
     }
 
     @Override
@@ -229,7 +229,7 @@ public class PulsarClientImpl implements PulsarClient {
     }
 
     public CompletableFuture<Producer<byte[]>> createProducerAsync(ProducerConfigurationData conf) {
-        return createProducerAsync(conf, Schema.IDENTITY);
+        return createProducerAsync(conf, Schema.BYTES);
     }
 
     public <T> CompletableFuture<Producer<T>> createProducerAsync(ProducerConfigurationData conf, Schema<T> schema) {
@@ -321,7 +321,7 @@ public class PulsarClientImpl implements PulsarClient {
     }
 
     public CompletableFuture<Consumer<byte[]>> subscribeAsync(ConsumerConfigurationData<byte[]> conf) {
-        return subscribeAsync(conf, Schema.IDENTITY);
+        return subscribeAsync(conf, Schema.BYTES);
     }
 
     public <T> CompletableFuture<Consumer<T>> subscribeAsync(ConsumerConfigurationData<T> conf, Schema<T> schema) {
@@ -417,7 +417,7 @@ public class PulsarClientImpl implements PulsarClient {
     }
 
     public CompletableFuture<Consumer<byte[]>> patternTopicSubscribeAsync(ConsumerConfigurationData<byte[]> conf) {
-        return patternTopicSubscribeAsync(conf, Schema.IDENTITY);
+        return patternTopicSubscribeAsync(conf, Schema.BYTES);
     }
 
     private <T> CompletableFuture<Consumer<T>> patternTopicSubscribeAsync(ConsumerConfigurationData<T> conf, Schema<T> schema) {
@@ -495,7 +495,7 @@ public class PulsarClientImpl implements PulsarClient {
     }
 
     public CompletableFuture<Reader<byte[]>> createReaderAsync(ReaderConfigurationData<byte[]> conf) {
-        return createReaderAsync(conf, Schema.IDENTITY);
+        return createReaderAsync(conf, Schema.BYTES);
     }
 
     public <T> CompletableFuture<Reader<T>> createReaderAsync(ReaderConfigurationData<T> conf, Schema<T> schema) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/BytesSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/BytesSchema.java
@@ -16,40 +16,24 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.client.api.schemas;
+package org.apache.pulsar.client.impl.schema;
 
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.schema.SchemaInfo;
-import org.apache.pulsar.common.schema.SchemaType;
 
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-
-public class StringSchema implements Schema<String> {
-    private final Charset charset;
-    private static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
-
-    public StringSchema() {
-        this.charset = DEFAULT_CHARSET;
+public class BytesSchema implements Schema<byte[]> {
+    @Override
+    public byte[] encode(byte[] message) {
+        return message;
     }
 
-    public StringSchema(Charset charset) {
-        this.charset = charset;
+    @Override
+    public byte[] decode(byte[] bytes) {
+        return bytes;
     }
 
-    public byte[] encode(String message) {
-        return message.getBytes(charset);
-    }
-
-    public String decode(byte[] bytes) {
-        return new String(bytes, charset);
-    }
-
+    @Override
     public SchemaInfo getSchemaInfo() {
-        SchemaInfo schemaInfo = new SchemaInfo();
-        schemaInfo.setName("String");
-        schemaInfo.setType(SchemaType.STRING);
-        schemaInfo.setSchema(new byte[0]);
-        return schemaInfo;
+        return null;
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/StringSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/StringSchema.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.schema;
+
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.schema.SchemaInfo;
+import org.apache.pulsar.common.schema.SchemaType;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+public class StringSchema implements Schema<String> {
+    private final Charset charset;
+    private static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
+
+    public StringSchema() {
+        this.charset = DEFAULT_CHARSET;
+    }
+
+    public StringSchema(Charset charset) {
+        this.charset = charset;
+    }
+
+    public byte[] encode(String message) {
+        return message.getBytes(charset);
+    }
+
+    public String decode(byte[] bytes) {
+        return new String(bytes, charset);
+    }
+
+    public SchemaInfo getSchemaInfo() {
+        SchemaInfo schemaInfo = new SchemaInfo();
+        schemaInfo.setName("String");
+        schemaInfo.setType(SchemaType.STRING);
+        schemaInfo.setSchema(new byte[0]);
+        return schemaInfo;
+    }
+}

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/schemas/DefaultSchemasTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/schemas/DefaultSchemasTest.java
@@ -25,7 +25,7 @@ import org.apache.pulsar.client.api.ProducerBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.ReaderBuilder;
-import org.apache.pulsar.client.api.schemas.StringSchema;
+import org.apache.pulsar.client.impl.schema.StringSchema;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;


### PR DESCRIPTION
### Motivation

`Schema.BYTES` seems to resonate more with people, so renaming before releasing it.