### PR TITLE
Remove "global" from returned clusters list

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/AdminResource.java
@@ -40,6 +40,7 @@ import org.apache.pulsar.broker.cache.LocalZooKeeperCacheService;
 import org.apache.pulsar.broker.web.PulsarWebResource;
 import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.naming.Constants;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.NamespaceBundleFactory;
 import org.apache.pulsar.common.naming.NamespaceBundles;
@@ -334,7 +335,11 @@ public abstract class AdminResource extends PulsarWebResource {
 
     protected Set<String> clusters() {
         try {
-            return pulsar().getConfigurationCache().clustersListCache().get();
+            Set<String> clusters = pulsar().getConfigurationCache().clustersListCache().get();
+
+            // Remove "global" cluster from returned list
+            clusters.remove(Constants.GLOBAL_CLUSTER);
+            return clusters;
         } catch (Exception e) {
             throw new RestException(e);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest2.java
@@ -869,4 +869,10 @@ public class AdminApiTest2 extends MockedPulsarServiceBaseTest {
         } catch (PulsarAdminException.NotFoundException e) {// expected
         }
     }
+
+    @Test
+    public void clustersList() throws PulsarAdminException {
+        final String cluster = pulsar.getConfiguration().getClusterName();
+        assertEquals(admin.clusters().getClusters(), Lists.newArrayList(cluster));
+    }
 }


### PR DESCRIPTION
### Motivation

`global` clusters is still returned in the clusters list command. Since this was an artificial placeholder, which is not even needed anymore, we should prune it from the clusters list, to avoid confusion.