### PR TITLE
Allow to configure TLS hostname verification in PulsarAdmin

### DIFF
--- a/conf/client.conf
+++ b/conf/client.conf
@@ -17,11 +17,12 @@
 # under the License.
 #
 
-# Pulsar Client configuration
+# Pulsar Client and pulsar-admin configuration
 webServiceUrl=http://localhost:8080/
 brokerServiceUrl=pulsar://localhost:6650/
 #authPlugin=
 #authParams=
 #useTls=
-#tlsAllowInsecureConnection
+tlsAllowInsecureConnection=false
+tlsEnableHostnameVerification=false
 #tlsTrustCertsFilePath

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TlsProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/TlsProducerConsumerTest.java
@@ -19,11 +19,17 @@
 package org.apache.pulsar.client.api;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.impl.auth.AuthenticationTls;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class TlsProducerConsumerTest extends TlsProducerConsumerBase {
@@ -80,10 +86,8 @@ public class TlsProducerConsumerTest extends TlsProducerConsumerBase {
         // Test 1 - Using TLS on binary protocol without sending certs - expect failure
         internalSetUpForClient(false, "pulsar+ssl://localhost:" + BROKER_PORT_TLS);
         try {
-            ConsumerConfiguration conf = new ConsumerConfiguration();
-            conf.setSubscriptionType(SubscriptionType.Exclusive);
-            Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic1",
-                    "my-subscriber-name", conf);
+            pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/my-topic1")
+                    .subscriptionName("my-subscriber-name").subscriptionType(SubscriptionType.Exclusive).subscribe();
             Assert.fail("Server should have failed the TLS handshake since client didn't .");
         } catch (Exception ex) {
             // OK
@@ -92,10 +96,8 @@ public class TlsProducerConsumerTest extends TlsProducerConsumerBase {
         // Test 2 - Using TLS on binary protocol - sending certs
         internalSetUpForClient(true, "pulsar+ssl://localhost:" + BROKER_PORT_TLS);
         try {
-            ConsumerConfiguration conf = new ConsumerConfiguration();
-            conf.setSubscriptionType(SubscriptionType.Exclusive);
-            Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic1",
-                    "my-subscriber-name", conf);
+            pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/my-topic1")
+                    .subscriptionName("my-subscriber-name").subscriptionType(SubscriptionType.Exclusive).subscribe();
         } catch (Exception ex) {
             Assert.fail("Should not fail since certs are sent.");
         }
@@ -112,10 +114,8 @@ public class TlsProducerConsumerTest extends TlsProducerConsumerBase {
         // Test 1 - Using TLS on https without sending certs - expect failure
         internalSetUpForClient(false, "https://localhost:" + BROKER_WEBSERVICE_PORT_TLS);
         try {
-            ConsumerConfiguration conf = new ConsumerConfiguration();
-            conf.setSubscriptionType(SubscriptionType.Exclusive);
-            Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic1",
-                    "my-subscriber-name", conf);
+            pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/my-topic1")
+                    .subscriptionName("my-subscriber-name").subscriptionType(SubscriptionType.Exclusive).subscribe();
             Assert.fail("Server should have failed the TLS handshake since client didn't .");
         } catch (Exception ex) {
             // OK
@@ -124,12 +124,38 @@ public class TlsProducerConsumerTest extends TlsProducerConsumerBase {
         // Test 2 - Using TLS on https - sending certs
         internalSetUpForClient(true, "https://localhost:" + BROKER_WEBSERVICE_PORT_TLS);
         try {
-            ConsumerConfiguration conf = new ConsumerConfiguration();
-            conf.setSubscriptionType(SubscriptionType.Exclusive);
-            Consumer consumer = pulsarClient.subscribe("persistent://my-property/use/my-ns/my-topic1",
-                    "my-subscriber-name", conf);
+            pulsarClient.newConsumer().topic("persistent://my-property/use/my-ns/my-topic1")
+                    .subscriptionName("my-subscriber-name").subscriptionType(SubscriptionType.Exclusive).subscribe();
         } catch (Exception ex) {
             Assert.fail("Should not fail since certs are sent.");
+        }
+    }
+
+    @DataProvider(name = "hostnameVerification")
+    public Object[][] hostnameVerificationCodecProvider() {
+        return new Object[][] { { Boolean.TRUE }, { Boolean.FALSE } };
+    }
+
+    @Test(dataProvider = "hostnameVerification")
+    public void testTlsHostVerificationAdminClient(boolean hostnameVerificationEnabled) throws Exception {
+        Map<String, String> authParams = new HashMap<>();
+        authParams.put("tlsCertFile", TLS_CLIENT_CERT_FILE_PATH);
+        authParams.put("tlsKeyFile", TLS_CLIENT_KEY_FILE_PATH);
+        PulsarAdmin adminClient = PulsarAdmin.builder().serviceHttpUrl("https://127.0.0.1:" + BROKER_WEBSERVICE_PORT_TLS)
+                .tlsTrustCertsFilePath(TLS_TRUST_CERT_FILE_PATH).allowTlsInsecureConnection(false)
+                .authentication(AuthenticationTls.class.getName(), authParams)
+                .enableTlsHostnameVerification(hostnameVerificationEnabled).build();
+
+        try {
+            adminClient.tenants().getTenants();
+            if (hostnameVerificationEnabled) {
+                Assert.fail("Admin call should be failed due to hostnameVerification enabled");
+            }
+        } catch (PulsarAdminException e) {
+            if (!hostnameVerificationEnabled) {
+                e.printStackTrace();
+                Assert.fail("Admin call should have succeeded because hostnameverification is disabled");
+            }
         }
     }
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PulsarAdmin.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PulsarAdmin.java
@@ -30,6 +30,8 @@ import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.conn.ssl.DefaultHostnameVerifier;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.pulsar.client.admin.internal.BrokerStatsImpl;
 import org.apache.pulsar.client.admin.internal.BrokersImpl;
 import org.apache.pulsar.client.admin.internal.ClustersImpl;
@@ -147,6 +149,12 @@ public class PulsarAdmin implements Closeable {
                 }
 
                 clientBuilder.sslContext(sslCtx);
+                if (clientConfigData.isTlsHostnameVerificationEnable()) {
+                    clientBuilder.hostnameVerifier(new DefaultHostnameVerifier());
+                } else {
+                    // Disable hostname verification
+                    clientBuilder.hostnameVerifier(NoopHostnameVerifier.INSTANCE);
+                }
             } catch (Exception e) {
                 try {
                     if (auth != null) {

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PulsarAdminBuilder.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PulsarAdminBuilder.java
@@ -159,4 +159,14 @@ public interface PulsarAdminBuilder {
      */
     PulsarAdminBuilder allowTlsInsecureConnection(boolean allowTlsInsecureConnection);
 
+    /**
+     * It allows to validate hostname verification when client connects to broker over TLS. It validates incoming x509
+     * certificate and matches provided hostname(CN/SAN) with expected broker's host name. It follows RFC 2818, 3.1.
+     * Server Identity hostname verification.
+     *
+     * @see <a href="https://tools.ietf.org/html/rfc2818">rfc2818</a>
+     *
+     * @param enableTlsHostnameVerification
+     */
+    PulsarAdminBuilder enableTlsHostnameVerification(boolean enableTlsHostnameVerification);
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/PulsarAdminBuilderImpl.java
@@ -87,4 +87,10 @@ public class PulsarAdminBuilderImpl implements PulsarAdminBuilder {
         conf.setTlsAllowInsecureConnection(allowTlsInsecureConnection);
         return this;
     }
+
+    @Override
+    public PulsarAdminBuilder enableTlsHostnameVerification(boolean enableTlsHostnameVerification) {
+        conf.setTlsHostnameVerificationEnable(enableTlsHostnameVerification);
+        return this;
+    }
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
@@ -46,6 +46,13 @@ public class PulsarAdminTool {
     @Parameter(names = { "--auth-params" }, description = "Authentication parameters, e.g., \"key1:val1,key2:val2\".")
     String authParams = null;
 
+    @Parameter(names = { "--tls-allow-insecure" }, description = "Allow TLS insecure connection")
+    Boolean tlsAllowInsecureConnection;
+
+
+    @Parameter(names = { "--tls-enable-hostname-verification" }, description = "Enalbe TLS common name verification")
+    Boolean tlsEnableHostnameVerification;
+
     @Parameter(names = { "-h", "--help", }, help = true, description = "Show this help.")
     boolean help;
 
@@ -56,10 +63,16 @@ public class PulsarAdminTool {
                 : properties.getProperty("serviceUrl");
         authPluginClassName = properties.getProperty("authPlugin");
         authParams = properties.getProperty("authParams");
-        boolean tlsAllowInsecureConnection = Boolean.parseBoolean(properties.getProperty("tlsAllowInsecureConnection"));
+        boolean tlsAllowInsecureConnection = this.tlsAllowInsecureConnection != null ? this.tlsAllowInsecureConnection
+                : Boolean.parseBoolean(properties.getProperty("tlsAllowInsecureConnection", "false"));
+
+        boolean tlsEnableHostnameVerification = this.tlsEnableHostnameVerification != null
+                ? this.tlsEnableHostnameVerification
+                : Boolean.parseBoolean(properties.getProperty("tlsEnableHostnameVerification", "false"));
         String tlsTrustCertsFilePath = properties.getProperty("tlsTrustCertsFilePath");
 
         adminBuilder = PulsarAdmin.builder().allowTlsInsecureConnection(tlsAllowInsecureConnection)
+                .enableTlsHostnameVerification(tlsEnableHostnameVerification)
                 .tlsTrustCertsFilePath(tlsTrustCertsFilePath);
 
         jcommander = new JCommander();

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/PulsarClientTool.java
@@ -53,6 +53,7 @@ public class PulsarClientTool {
 
     boolean useTls = false;
     boolean tlsAllowInsecureConnection = false;
+    boolean tlsEnableHostnameVerification = false;
     String tlsTrustCertsFilePath = null;
 
     JCommander commandParser;
@@ -69,7 +70,10 @@ public class PulsarClientTool {
         this.authPluginClassName = properties.getProperty("authPlugin");
         this.authParams = properties.getProperty("authParams");
         this.useTls = Boolean.parseBoolean(properties.getProperty("useTls"));
-        this.tlsAllowInsecureConnection = Boolean.parseBoolean(properties.getProperty("tlsAllowInsecureConnection"));
+        this.tlsAllowInsecureConnection = Boolean
+                .parseBoolean(properties.getProperty("tlsAllowInsecureConnection", "false"));
+        this.tlsEnableHostnameVerification = Boolean
+                .parseBoolean(properties.getProperty("tlsEnableHostnameVerification", "false"));
         this.tlsTrustCertsFilePath = properties.getProperty("tlsTrustCertsFilePath");
 
         produceCommand = new CmdProduce();


### PR DESCRIPTION
### Motivation

Unlike Pulsar client configuration builder where it's possible to either enable or disable the TLS hostname verifcation of the CommonName to match with broker address, on `PulsarAdmin` it's not possible to configure it.

The default in Jersey client is to have that enabled, and with a verifier that doesn't properly expand wildcards in the CN string.

### Modifications
 * Added `enableTlsHostnameVerification()` in `PulsarAdminBuilder`
 * Added option in `pulsar-admin` tool to configure verification in `client.conf` or through CLI arguments