### PR TITLE
Exclude grpc dependencies in binary distribution

### DIFF
--- a/all/src/assemble/bin.xml
+++ b/all/src/assemble/bin.xml
@@ -111,6 +111,9 @@
         <!-- Already included in pulsar-zookeeper instrumented jar -->
         <exclude>org.apache.zookeeper:zookeeper</exclude>
 
+        <!-- Already shaded in runtime-shaded jar -->
+        <exclude>io.grpc:*</exclude>
+
         <!-- Explicitely remove JUnit which is getting pulled in even
              though it's set to the scope 'test' -->
         <exclude>junit:junit</exclude>


### PR DESCRIPTION
*Motivation*

Gprc is used by functions as control plane. The dependencies were shaded in `pulsar-functions-runtime`. However the assembly plugin still
includes those dependencies in the binary distribution. It causes the conflicts between protobuf versions.

*Solution*

Exclude grpc dependencies in binary distribution.

