### PR TITLE
Encode zk-path for function-pkg

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/Utils.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/Utils.java
@@ -100,19 +100,18 @@ public final class Utils {
                                          String destPkgPath)
             throws IOException {
 
-        String encodedDestPkgPath = Codec.encode(destPkgPath);
         // if the dest directory does not exist, create it.
-        if (dlogNamespace.logExists(encodedDestPkgPath)) {
+        if (dlogNamespace.logExists(destPkgPath)) {
             // if the destination file exists, write a log message
             log.info(String.format("Target function file already exists at '%s'. Overwriting it now",
-                    encodedDestPkgPath));
-            dlogNamespace.deleteLog(encodedDestPkgPath);
+                    destPkgPath));
+            dlogNamespace.deleteLog(destPkgPath);
         }
         // copy the topology package to target working directory
         log.info(String.format("Uploading function package to '%s'",
                 destPkgPath));
 
-        try (DistributedLogManager dlm = dlogNamespace.openLog(encodedDestPkgPath)) {
+        try (DistributedLogManager dlm = dlogNamespace.openLog(destPkgPath)) {
             try (AppendOnlyStreamWriter writer = dlm.getAppendOnlyStreamWriter()){
 
                 try (OutputStream out = new DLOutputStream(dlm, writer)) {
@@ -130,8 +129,7 @@ public final class Utils {
     public static void downloadFromBookkeeper(Namespace namespace,
                                                  OutputStream outputStream,
                                                  String packagePath) throws IOException {
-        String decodedDestPkgPath = Codec.decode(packagePath);
-        DistributedLogManager dlm = namespace.openLog(decodedDestPkgPath);
+        DistributedLogManager dlm = namespace.openLog(packagePath);
         try (InputStream in = new DLInputStream(dlm)) {
             int read = 0;
             byte[] bytes = new byte[1024];

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2ResourceTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2ResourceTest.java
@@ -113,8 +113,9 @@ public class FunctionApiV2ResourceTest {
     public void setup() {
         this.mockedManager = mock(FunctionMetaDataManager.class);
         this.mockedInputStream = mock(InputStream.class);
-        this.mockedFormData = mock(FormDataContentDisposition.class);
         this.mockedNamespace = mock(Namespace.class);
+        this.mockedFormData = mock(FormDataContentDisposition.class);
+        when(mockedFormData.getFileName()).thenReturn("test");
 
         this.mockedWorkerService = mock(WorkerService.class);
         when(mockedWorkerService.getFunctionMetaDataManager()).thenReturn(mockedManager);


### PR DESCRIPTION
### Motivation

Right now, functions stores function-pkg with zk-path based on function name which could have escape character and it can fail zk-node creation and consequently function uploading. 

### Modifications

Encode zk path before creating function same as broker does for managed-ledger creation.

### Result

It will prevent function creation if function name has escape character.
