### PR TITLE
Move s3 unit tests into correct package

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/s3offload/impl/BlockAwareSegmentInputStreamTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/s3offload/impl/BlockAwareSegmentInputStreamTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.s3offload;
+package org.apache.pulsar.broker.s3offload.impl;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
@@ -44,8 +44,6 @@ import org.apache.bookkeeper.client.api.LedgerEntry;
 import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.pulsar.broker.s3offload.DataBlockHeader;
-import org.apache.pulsar.broker.s3offload.impl.BlockAwareSegmentInputStreamImpl;
-import org.apache.pulsar.broker.s3offload.impl.DataBlockHeaderImpl;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/s3offload/impl/DataBlockHeaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/s3offload/impl/DataBlockHeaderTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.s3offload;
+package org.apache.pulsar.broker.s3offload.impl;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.broker.s3offload.DataBlockHeader;
-import org.apache.pulsar.broker.s3offload.impl.DataBlockHeaderImpl;
 import org.testng.annotations.Test;
 
 @Slf4j

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/s3offload/impl/OffloadIndexTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/s3offload/impl/OffloadIndexTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.s3offload;
+package org.apache.pulsar.broker.s3offload.impl;
 
 import static com.google.common.base.Charsets.UTF_8;
 import static org.testng.Assert.assertEquals;
@@ -39,8 +39,6 @@ import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.pulsar.broker.s3offload.OffloadIndexBlock;
 import org.apache.pulsar.broker.s3offload.OffloadIndexBlockBuilder;
 import org.apache.pulsar.broker.s3offload.OffloadIndexEntry;
-import org.apache.pulsar.broker.s3offload.impl.OffloadIndexBlockImpl;
-import org.apache.pulsar.broker.s3offload.impl.OffloadIndexEntryImpl;
 import org.testng.annotations.Test;
 
 @Slf4j


### PR DESCRIPTION
Unit tests should be in the same package as the units they are testing
so that they can reach into internals without having to expose those
internals to the world.

Master issue: #1511
