### PR TITLE
Add `messageId` query param for WS Reader doc

### DIFF
--- a/site/docs/latest/clients/WebSocket.md
+++ b/site/docs/latest/clients/WebSocket.md
@@ -207,6 +207,7 @@ Key | Type | Required? | Explanation
 :---|:-----|:----------|:-----------
 `readerName` | string | no | Reader name
 `receiverQueueSize` | int | no | Size of the consumer receive queue (default: 1000)
+`messageId` | int or enum | no | Message ID to start from, `earliest` or `latest` (default: `latest`)
 
 ##### Receiving messages
 


### PR DESCRIPTION
### Motivation

The `messageId` param was missing from the docs.

### Modifications

Add one line to the docs.

### Result

Better docs.