### PR TITLE
Print periodic status of instances in localrun

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -60,7 +60,6 @@ import org.apache.pulsar.functions.runtime.RuntimeSpawner;
 import org.apache.pulsar.functions.shaded.io.netty.buffer.ByteBuf;
 import org.apache.pulsar.functions.shaded.io.netty.buffer.ByteBufUtil;
 import org.apache.pulsar.functions.shaded.io.netty.buffer.Unpooled;
-import org.apache.pulsar.functions.shaded.proto.InstanceCommunication.FunctionStatus;
 import org.apache.pulsar.functions.shaded.proto.Function.SinkSpec;
 import org.apache.pulsar.functions.shaded.proto.Function.SourceSpec;
 import org.apache.pulsar.functions.shaded.proto.Function.FunctionDetails;
@@ -657,15 +656,15 @@ public class CmdFunctions extends CmdBase {
                 statusCheckTimer.scheduleAtFixedRate(new TimerTask() {
                     @Override
                     public void run() {
-                        CompletableFuture<FunctionStatus>[] futures = new CompletableFuture[spawners.size()];
+                        CompletableFuture<String>[] futures = new CompletableFuture[spawners.size()];
                         int index = 0;
                         for (RuntimeSpawner spawner : spawners) {
-                            futures[index++] = spawner.getFunctionStatus();
+                            futures[index++] = spawner.getFunctionStatusAsJson();
                         }
                         try {
                             CompletableFuture.allOf(futures).get(5, TimeUnit.SECONDS);
                             for (index = 0; index < futures.length; ++index) {
-                                String json = Utils.printJson(futures[index].get());
+                                String json = futures[index].get();
                                 Gson gson = new GsonBuilder().setPrettyPrinting().create();
                                 log.info(gson.toJson(new JsonParser().parse(json)));
                             }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -673,6 +673,11 @@ public class CmdFunctions extends CmdBase {
                         }
                     }
                 }, 30000, 30000);
+                Runtime.getRuntime().addShutdownHook(new Thread() {
+                    public void run() {
+                        statusCheckTimer.cancel();
+                    }
+                });
                 for (RuntimeSpawner spawner : spawners) {
                     spawner.join();
                     log.info("RuntimeSpawner quit because of {}", spawner.getRuntime().getDeathException());

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeSpawner.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeSpawner.java
@@ -23,6 +23,7 @@
  */
 package org.apache.pulsar.functions.runtime;
 
+import java.io.IOException;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.CompletableFuture;
@@ -31,6 +32,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.functions.instance.InstanceConfig;
 import org.apache.pulsar.functions.proto.InstanceCommunication.FunctionStatus;
+import org.apache.pulsar.functions.utils.Utils;
 
 @Slf4j
 public class RuntimeSpawner implements AutoCloseable {
@@ -97,6 +99,16 @@ public class RuntimeSpawner implements AutoCloseable {
                builder.setFailureException(runtimeDeathException.getMessage());
            }
            return builder.build();
+        });
+    }
+
+    public CompletableFuture<String> getFunctionStatusAsJson() {
+        return this.getFunctionStatus().thenApply(msg -> {
+            try {
+                return Utils.printJson(msg);
+            } catch (IOException e) {
+                throw new RuntimeException("Exception parsing getstatus", e);
+            }
         });
     }
 


### PR DESCRIPTION
### Motivation

Currently localrun does not provide any information to the user about the status of the locally executing functions. This pr makes it print the status of each running instance every so often.

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
