### PR TITLE
PIP-17:  fix index entry offset error in OffloadIndexBlock

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/impl/OffloadIndexBlockBuilderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/impl/OffloadIndexBlockBuilderImpl.java
@@ -35,6 +35,7 @@ public class OffloadIndexBlockBuilderImpl implements OffloadIndexBlockBuilder {
 
     private LedgerMetadata ledgerMetadata;
     private List<OffloadIndexEntryImpl> entries;
+    private int lastBlockSize;
 
     public OffloadIndexBlockBuilderImpl() {
         this.entries = Lists.newArrayList();
@@ -50,13 +51,14 @@ public class OffloadIndexBlockBuilderImpl implements OffloadIndexBlockBuilder {
     public OffloadIndexBlockBuilder addBlock(long firstEntryId, int partId, int blockSize) {
         // we should added one by one.
         long offset;
-        if(firstEntryId == 0) {
+        if (firstEntryId == 0) {
             checkState(entries.size() == 0);
             offset = 0;
         } else {
             checkState(entries.size() > 0);
-            offset = entries.get(entries.size() - 1).getOffset() + blockSize;
+            offset = entries.get(entries.size() - 1).getOffset() + lastBlockSize;
         }
+        lastBlockSize = blockSize;
 
         this.entries.add(OffloadIndexEntryImpl.of(firstEntryId, partId, offset));
         return this;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/impl/OffloadIndexBlockImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/impl/OffloadIndexBlockImpl.java
@@ -96,7 +96,7 @@ public class OffloadIndexBlockImpl implements OffloadIndexBlock {
 
     @Override
     public OffloadIndexEntry getIndexEntryForEntry(long messageEntryId) throws IOException {
-        if(messageEntryId > segmentMetadata.getLastEntryId()) {
+        if (messageEntryId > segmentMetadata.getLastEntryId()) {
             log.warn("Try to get entry: {}, which beyond lastEntryId {}, return null",
                 messageEntryId, segmentMetadata.getLastEntryId());
             throw new IndexOutOfBoundsException("Entry index: " + messageEntryId +
@@ -302,7 +302,8 @@ public class OffloadIndexBlockImpl implements OffloadIndexBlock {
         DataInputStream dis = new DataInputStream(stream);
         int magic = dis.readInt();
         if (magic != this.INDEX_MAGIC_WORD) {
-            throw new IOException("Invalid MagicWord. read: " + magic + " expected: " + INDEX_MAGIC_WORD);
+            throw new IOException("Invalid MagicWord. read: " + Integer.toHexString(magic)
+                + " expected: 0x" + Integer.toHexString(INDEX_MAGIC_WORD));
         }
         int indexBlockLength = dis.readInt();
         int segmentMetadataLength = dis.readInt();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/s3offload/impl/OffloadIndexTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/s3offload/impl/OffloadIndexTest.java
@@ -110,7 +110,7 @@ public class OffloadIndexTest {
 
         blockBuilder.withMetadata(metadata);
 
-        blockBuilder.addBlock(0, 2, 0);
+        blockBuilder.addBlock(0, 2, 64 * 1024 * 1024);
         blockBuilder.addBlock(1000, 3, 64 * 1024 * 1024);
         blockBuilder.addBlock(2000, 4, 64 * 1024 * 1024);
         OffloadIndexBlock indexBlock = blockBuilder.build();


### PR DESCRIPTION
### Motivation

In OffloadIndexBlock, we will calculate and keep the offset in S3 Object for each data block.
The offset should be based on the blockSize of last data block, instead of current data block.

### Modifications

- change OffloadIndexBlockBuilderImpl and OffloadIndexTest to fix the issue.
Describe the modifications you've done.

### Result

issue fixed.

Master issue #1511 