### PR TITLE
Add Commons Logging bridge to broker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -389,6 +389,12 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jcl-over-slf4j</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
         <version>${log4j2.version}</version>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -204,6 +204,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>


### PR DESCRIPTION
The AWS SDK, which we use for S3 offload uses commons logging as its
logging API. For slf4j to be able to pick up this logs, we need to use
the jcl-over-slf4j bridge. This patch adds the bridge as a dependency
for the broker.

Master Issue: #1511
