### PR TITLE
Move functions to use V2 style namespaces for internal data keeping

### DIFF
--- a/conf/functions_worker.yml
+++ b/conf/functions_worker.yml
@@ -23,7 +23,8 @@ workerPort: 6750
 functionMetadataTopicName: metadata
 functionMetadataSnapshotsTopicPath: snapshots
 clusterCoordinationTopicName: coordinate
-pulsarFunctionsNamespace: sample/standalone/functions
+pulsarFunctionsNamespace: public/functions
+pulsarFunctionsCluster: standalone
 pulsarServiceUrl: pulsar://localhost:6650
 pulsarWebServiceUrl: http://localhost:8080
 numFunctionPackageReplicas: 1

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -30,6 +30,7 @@ import io.netty.util.concurrent.DefaultThreadFactory;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -81,6 +82,7 @@ import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.Policies;
+import org.apache.pulsar.common.policies.data.RetentionPolicies;
 import org.apache.pulsar.common.policies.data.TenantInfo;
 import org.apache.pulsar.common.util.FutureUtil;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
@@ -852,7 +854,7 @@ public class PulsarService implements AutoCloseable {
                     .getWorkerConfig().getPulsarFunctionsNamespace();
             String[] a = functionWorkerService.get().getWorkerConfig().getPulsarFunctionsNamespace().split("/");
             String property = a[0];
-            String cluster = a[1];
+            String cluster = functionWorkerService.get().getWorkerConfig().getPulsarFunctionsCluster();
 
                 /*
                 multiple brokers may be trying to create the property, cluster, and namespace
@@ -904,6 +906,9 @@ public class PulsarService implements AutoCloseable {
             // create namespace for function worker service
             try {
                 Policies policies = new Policies();
+                policies.retention_policies = new RetentionPolicies(-1, -1);
+                policies.replication_clusters = new HashSet<>();
+                policies.replication_clusters.add(functionWorkerService.get().getWorkerConfig().getPulsarFunctionsCluster());
                 int defaultNumberOfBundles = this.getConfiguration().getDefaultNumberOfNamespaceBundles();
                 policies.bundles = getBundles(defaultNumberOfBundles);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -30,10 +30,7 @@ import io.netty.util.concurrent.DefaultThreadFactory;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -907,8 +904,7 @@ public class PulsarService implements AutoCloseable {
             try {
                 Policies policies = new Policies();
                 policies.retention_policies = new RetentionPolicies(-1, -1);
-                policies.replication_clusters = new HashSet<>();
-                policies.replication_clusters.add(functionWorkerService.get().getWorkerConfig().getPulsarFunctionsCluster());
+                policies.replication_clusters = Collections.singleton(functionWorkerService.get().getWorkerConfig().getPulsarFunctionsCluster());
                 int defaultNumberOfBundles = this.getConfiguration().getDefaultNumberOfNamespaceBundles();
                 policies.bundles = getBundles(defaultNumberOfBundles);
 

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/Worker.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/Worker.java
@@ -31,6 +31,7 @@ import org.apache.pulsar.functions.worker.rest.WorkerServer;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.net.URI;
+import java.util.HashSet;
 
 @Slf4j
 public class Worker extends AbstractService {
@@ -104,6 +105,8 @@ public class Worker extends AbstractService {
                     try {
                         Policies policies = new Policies();
                         policies.retention_policies = new RetentionPolicies(-1, -1);
+                        policies.replication_clusters = new HashSet<>();
+                        policies.replication_clusters.add(workerConfig.getPulsarFunctionsCluster());
                         admin.namespaces().createNamespace(workerConfig.getPulsarFunctionsNamespace(),
                                 policies);
                     } catch (PulsarAdminException e1) {

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -51,6 +51,7 @@ public class WorkerConfig implements Serializable {
     private String clusterCoordinationTopicName;
     private String functionMetadataSnapshotsTopicPath;
     private String pulsarFunctionsNamespace;
+    private String pulsarFunctionsCluster;
     private int numFunctionPackageReplicas;
     private String downloadDirectory;
     private long snapshotFreqMs;


### PR DESCRIPTION
### Motivation

In https://github.com/apache/incubator-pulsar/pull/1735 we moved to using apis for creating namespaces that are only applicable with V2 style namespaces. This pr moves the rest of the functions worker related code to use V2 style
### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
