### PR TITLE
Remove usage() call on ParameterException

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBase.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBase.java
@@ -63,7 +63,6 @@ public abstract class CmdBase {
             } catch (ParameterException e) {
                 System.err.println(e.getMessage());
                 System.err.println();
-                jcommander.usage();
                 return false;
             } catch (ConnectException e) {
                 System.err.println(e.getMessage());


### PR DESCRIPTION
As it stands, the `pulsar-admin` tool (in particular the `functions` command) provides full usage output whenever a `ParameterException` is thrown. The issue is that the exception message is buried by the usage printout (which is inappropriate in this case anyway).