### PR TITLE
Allow ability to specify resources to functions

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -63,6 +63,7 @@ import org.apache.pulsar.functions.shaded.io.netty.buffer.Unpooled;
 import org.apache.pulsar.functions.shaded.proto.Function.SinkSpec;
 import org.apache.pulsar.functions.shaded.proto.Function.SourceSpec;
 import org.apache.pulsar.functions.shaded.proto.Function.FunctionDetails;
+import org.apache.pulsar.functions.shaded.proto.Function.Resources;
 import org.apache.pulsar.functions.shaded.proto.Function.SubscriptionType;
 import org.apache.pulsar.functions.shaded.proto.Function.ProcessingGuarantees;
 import org.apache.pulsar.functions.utils.FunctionDetailsUtils;
@@ -219,6 +220,12 @@ public class CmdFunctions extends CmdBase {
         protected String userConfigString;
         @Parameter(names = "--parallelism", description = "The function's parallelism factor (i.e. the number of function instances to run)")
         protected String parallelism;
+        @Parameter(names = "--cpu", description = "The cpu that need to be allocated per function instance(applicable only to docker runtime)")
+        protected Double cpu;
+        @Parameter(names = "--ram", description = "The ram in bytes that need to be allocated per function instance(applicable only to process/docker runtime)")
+        protected Long ram;
+        @Parameter(names = "--disk", description = "The disk in bytes that need to be allocated per function instance(applicable only to docker runtime)")
+        protected Long disk;
 
         protected FunctionConfig functionConfig;
         protected String userCodeFile;
@@ -315,6 +322,23 @@ public class CmdFunctions extends CmdBase {
                 }
                 functionConfig.setParallelism(num);
             }
+
+            if (cpu != null) {
+                if (cpu <= 0) {
+                    throw new IllegalArgumentException("The cpu allocation for the function must be positive");
+                }
+            }
+            if (ram != null) {
+                if (ram <= 0) {
+                    throw new IllegalArgumentException("The ram allocation for the function must be positive");
+                }
+            }
+            if (disk != null) {
+                if (disk <= 0) {
+                    throw new IllegalArgumentException("The disk allocation for the function must be positive");
+                }
+            }
+            functionConfig.setResources(new org.apache.pulsar.functions.utils.Resources(cpu, ram, disk));
 
             if (functionConfig.getSubscriptionType() != null
                     && functionConfig.getSubscriptionType() != FunctionConfig.SubscriptionType.FAILOVER
@@ -616,6 +640,19 @@ public class CmdFunctions extends CmdBase {
             }
             functionDetailsBuilder.setAutoAck(functionConfig.isAutoAck());
             functionDetailsBuilder.setParallelism(functionConfig.getParallelism());
+            if (functionConfig.getResources() != null) {
+                Resources.Builder bldr = Resources.newBuilder();
+                if (functionConfig.getResources().getCpu() != null) {
+                    bldr.setCpu(functionConfig.getResources().getCpu());
+                }
+                if (functionConfig.getResources().getRam() != null) {
+                    bldr.setRam(functionConfig.getResources().getRam());
+                }
+                if (functionConfig.getResources().getDisk() != null) {
+                    bldr.setDisk(functionConfig.getResources().getDisk());
+                }
+                functionDetailsBuilder.setResources(bldr.build());
+            }
             return functionDetailsBuilder.build();
         }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -323,21 +323,9 @@ public class CmdFunctions extends CmdBase {
                 functionConfig.setParallelism(num);
             }
 
-            if (cpu != null) {
-                if (cpu <= 0) {
-                    throw new IllegalArgumentException("The cpu allocation for the function must be positive");
-                }
-            }
-            if (ram != null) {
-                if (ram <= 0) {
-                    throw new IllegalArgumentException("The ram allocation for the function must be positive");
-                }
-            }
-            if (disk != null) {
-                if (disk <= 0) {
-                    throw new IllegalArgumentException("The disk allocation for the function must be positive");
-                }
-            }
+            com.google.common.base.Preconditions.checkArgument(cpu == null || cpu > 0, "The cpu allocation for the function must be positive");
+            com.google.common.base.Preconditions.checkArgument(ram == null || ram > 0, "The ram allocation for the function must be positive");
+            com.google.common.base.Preconditions.checkArgument(disk == null || disk > 0, "The disk allocation for the function must be positive");
             functionConfig.setResources(new org.apache.pulsar.functions.utils.Resources(cpu, ram, disk));
 
             if (functionConfig.getSubscriptionType() != null

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -220,7 +220,7 @@ public class CmdFunctions extends CmdBase {
         protected String userConfigString;
         @Parameter(names = "--parallelism", description = "The function's parallelism factor (i.e. the number of function instances to run)")
         protected String parallelism;
-        @Parameter(names = "--cpu", description = "The cpu that need to be allocated per function instance(applicable only to docker runtime)")
+        @Parameter(names = "--cpu", description = "The cpu in cores that need to be allocated per function instance(applicable only to docker runtime)")
         protected Double cpu;
         @Parameter(names = "--ram", description = "The ram in bytes that need to be allocated per function instance(applicable only to process/docker runtime)")
         protected Long ram;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
@@ -134,7 +134,7 @@ public class CmdSinks extends CmdBase {
         @Parameter(names = "--sinkConfigFile", description = "The path to a YAML config file specifying the "
                 + "sink's configuration")
         protected String sinkConfigFile;
-        @Parameter(names = "--cpu", description = "The cpu that need to be allocated per function instance(applicable only to docker runtime)")
+        @Parameter(names = "--cpu", description = "The cpu in cores that need to be allocated per function instance(applicable only to docker runtime)")
         protected Double cpu;
         @Parameter(names = "--ram", description = "The ram in bytes that need to be allocated per function instance(applicable only to process/docker runtime)")
         protected Long ram;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
@@ -34,6 +34,7 @@ import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.functions.api.utils.IdentityFunction;
 import org.apache.pulsar.functions.shaded.proto.Function;
 import org.apache.pulsar.functions.shaded.proto.Function.FunctionDetails;
+import org.apache.pulsar.functions.shaded.proto.Function.Resources;
 import org.apache.pulsar.functions.shaded.proto.Function.ProcessingGuarantees;
 import org.apache.pulsar.functions.shaded.proto.Function.SinkSpec;
 import org.apache.pulsar.functions.shaded.proto.Function.SourceSpec;
@@ -133,6 +134,12 @@ public class CmdSinks extends CmdBase {
         @Parameter(names = "--sinkConfigFile", description = "The path to a YAML config file specifying the "
                 + "sink's configuration")
         protected String sinkConfigFile;
+        @Parameter(names = "--cpu", description = "The cpu that need to be allocated per function instance(applicable only to docker runtime)")
+        protected Double cpu;
+        @Parameter(names = "--ram", description = "The ram in bytes that need to be allocated per function instance(applicable only to process/docker runtime)")
+        protected Long ram;
+        @Parameter(names = "--disk", description = "The disk in bytes that need to be allocated per function instance(applicable only to docker runtime)")
+        protected Long disk;
 
         protected SinkConfig sinkConfig;
 
@@ -199,6 +206,23 @@ public class CmdSinks extends CmdBase {
             if (null == jarFile) {
                 throw new IllegalArgumentException("Connector JAR not specfied");
             }
+
+            if (cpu != null) {
+                if (cpu <= 0) {
+                    throw new IllegalArgumentException("The cpu allocation for the source must be positive");
+                }
+            }
+            if (ram != null) {
+                if (ram <= 0) {
+                    throw new IllegalArgumentException("The ram allocation for the source must be positive");
+                }
+            }
+            if (disk != null) {
+                if (disk <= 0) {
+                    throw new IllegalArgumentException("The disk allocation for the source must be positive");
+                }
+            }
+            sinkConfig.setResources(new org.apache.pulsar.functions.utils.Resources(cpu, ram, disk));
         }
 
         @Override
@@ -282,6 +306,20 @@ public class CmdSinks extends CmdBase {
             sinkSpecBuilder.setConfigs(new Gson().toJson(sinkConfig.getConfigs()));
             sinkSpecBuilder.setTypeClassName(typeArg.getName());
             functionDetailsBuilder.setSink(sinkSpecBuilder);
+
+            if (sinkConfig.getResources() != null) {
+                Resources.Builder bldr = Resources.newBuilder();
+                if (sinkConfig.getResources().getCpu() != null) {
+                    bldr.setCpu(sinkConfig.getResources().getCpu());
+                }
+                if (sinkConfig.getResources().getRam() != null) {
+                    bldr.setRam(sinkConfig.getResources().getRam());
+                }
+                if (sinkConfig.getResources().getDisk() != null) {
+                    bldr.setDisk(sinkConfig.getResources().getDisk());
+                }
+                functionDetailsBuilder.setResources(bldr.build());
+            }
             return functionDetailsBuilder.build();
         }
     }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
@@ -209,21 +209,9 @@ public class CmdSinks extends CmdBase {
                 throw new IllegalArgumentException("Connector JAR not specfied");
             }
 
-            if (cpu != null) {
-                if (cpu <= 0) {
-                    throw new IllegalArgumentException("The cpu allocation for the source must be positive");
-                }
-            }
-            if (ram != null) {
-                if (ram <= 0) {
-                    throw new IllegalArgumentException("The ram allocation for the source must be positive");
-                }
-            }
-            if (disk != null) {
-                if (disk <= 0) {
-                    throw new IllegalArgumentException("The disk allocation for the source must be positive");
-                }
-            }
+            com.google.common.base.Preconditions.checkArgument(cpu == null || cpu > 0, "The cpu allocation for the sink must be positive");
+            com.google.common.base.Preconditions.checkArgument(ram == null || ram > 0, "The ram allocation for the sink must be positive");
+            com.google.common.base.Preconditions.checkArgument(disk == null || disk > 0, "The disk allocation for the sink must be positive");
             sinkConfig.setResources(new org.apache.pulsar.functions.utils.Resources(cpu, ram, disk));
 
             if (null != sinkConfigString) {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
@@ -134,7 +134,7 @@ public class CmdSources extends CmdBase {
         @Parameter(names = "--sourceConfigFile", description = "The path to a YAML config file specifying the "
                 + "source's configuration")
         protected String sourceConfigFile;
-        @Parameter(names = "--cpu", description = "The cpu that need to be allocated per function instance(applicable only to docker runtime)")
+        @Parameter(names = "--cpu", description = "The cpu in cores that need to be allocated per function instance(applicable only to docker runtime)")
         protected Double cpu;
         @Parameter(names = "--ram", description = "The ram in bytes that need to be allocated per function instance(applicable only to process/docker runtime)")
         protected Long ram;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
@@ -194,21 +194,9 @@ public class CmdSources extends CmdBase {
                 throw new IllegalArgumentException("Connector JAR not specfied");
             }
 
-            if (cpu != null) {
-                if (cpu <= 0) {
-                    throw new IllegalArgumentException("The cpu allocation for the source must be positive");
-                }
-            }
-            if (ram != null) {
-                if (ram <= 0) {
-                    throw new IllegalArgumentException("The ram allocation for the source must be positive");
-                }
-            }
-            if (disk != null) {
-                if (disk <= 0) {
-                    throw new IllegalArgumentException("The disk allocation for the source must be positive");
-                }
-            }
+            com.google.common.base.Preconditions.checkArgument(cpu == null || cpu > 0, "The cpu allocation for the source must be positive");
+            com.google.common.base.Preconditions.checkArgument(ram == null || ram > 0, "The ram allocation for the source must be positive");
+            com.google.common.base.Preconditions.checkArgument(disk == null || disk > 0, "The disk allocation for the source must be positive");
             sourceConfig.setResources(new org.apache.pulsar.functions.utils.Resources(cpu, ram, disk));
 
             if (null != sourceConfigString) {

--- a/pulsar-functions/proto/src/main/proto/Function.proto
+++ b/pulsar-functions/proto/src/main/proto/Function.proto
@@ -34,6 +34,12 @@ enum SubscriptionType {
     FAILOVER = 1;
 }
 
+message Resources {
+    double cpu = 1;
+    int64 ram = 2;
+    int64 disk = 3;
+}
+
 message FunctionDetails {
     enum Runtime {
         JAVA = 0;
@@ -51,6 +57,7 @@ message FunctionDetails {
     int32 parallelism = 10;
     SourceSpec source = 11;
     SinkSpec sink = 12;
+    Resources resources = 13;
 }
 
 message SourceSpec {

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntime.java
@@ -81,15 +81,15 @@ class ProcessRuntime implements Runtime {
             args.add("-Dlog4j.configurationFile=java_instance_log4j2.yml");
             args.add("-Dpulsar.log.dir=" + logDirectory);
             args.add("-Dpulsar.log.file=" + instanceConfig.getFunctionDetails().getName());
-            args.add(JavaInstanceMain.class.getName());
-            args.add("--jar");
-            args.add(codeFile);
             if (instanceConfig.getFunctionDetails().getResources() != null) {
                 Function.Resources resources = instanceConfig.getFunctionDetails().getResources();
                 if (resources.getRam() != 0) {
-                    args.add("--Xmx" + String.valueOf(resources.getRam()));
+                    args.add("-Xmx" + String.valueOf(resources.getRam()));
                 }
             }
+            args.add(JavaInstanceMain.class.getName());
+            args.add("--jar");
+            args.add(codeFile);
         } else if (instanceConfig.getFunctionDetails().getRuntime() == Function.FunctionDetails.Runtime.PYTHON) {
             args.add("python");
             args.add(instanceFile);

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntime.java
@@ -84,6 +84,12 @@ class ProcessRuntime implements Runtime {
             args.add(JavaInstanceMain.class.getName());
             args.add("--jar");
             args.add(codeFile);
+            if (instanceConfig.getFunctionDetails().getResources() != null) {
+                Function.Resources resources = instanceConfig.getFunctionDetails().getResources();
+                if (resources.getRam() != 0) {
+                    args.add("--Xmx" + String.valueOf(resources.getRam()));
+                }
+            }
         } else if (instanceConfig.getFunctionDetails().getRuntime() == Function.FunctionDetails.Runtime.PYTHON) {
             args.add("python");
             args.add(instanceFile);
@@ -93,6 +99,7 @@ class ProcessRuntime implements Runtime {
             args.add(logDirectory);
             args.add("--logging_file");
             args.add(instanceConfig.getFunctionDetails().getName());
+            // TODO:- Find a platform independent way of controlling memory for a python application
         }
         args.add("--instance_id");
         args.add(instanceConfig.getInstanceId());

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfig.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfig.java
@@ -79,5 +79,6 @@ public class FunctionConfig {
     private Runtime runtime;
     private boolean autoAck;
     private int parallelism;
+    private Resources resources;
     private String fqfn;
 }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Resources.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Resources.java
@@ -18,11 +18,7 @@
  */
 package org.apache.pulsar.functions.utils;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -32,15 +28,9 @@ import java.util.Map;
 @Data
 @EqualsAndHashCode
 @ToString
-public class SourceConfig {
-    private String tenant;
-    private String namespace;
-    private String name;
-    private String className;
-    private String topicName;
-    private String serdeClassName;
-    private Map<String, Object> configs = new HashMap<>();
-    private int parallelism = 1;
-    private FunctionConfig.ProcessingGuarantees processingGuarantees;
-    private Resources resources;
+@AllArgsConstructor
+public class Resources {
+    private Double cpu;
+    private Long ram;
+    private Long disk;
 }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfig.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfig.java
@@ -41,4 +41,5 @@ public class SinkConfig {
     private Map<String, String> configs = new HashMap<>();
     private int parallelism = 1;
     private FunctionConfig.ProcessingGuarantees processingGuarantees;
+    private Resources resources;
 }


### PR DESCRIPTION
### Motivation

This pr allows cpu/ram/disk resources to be specified for each function instance. Depending on the type of runtimes, we can enforce some or all of these resource constraints. This will allow functions to be run in a bounded resource manner

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
