### PR TITLE
S3Offload datablock magic word should be negative

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/impl/DataBlockHeaderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/impl/DataBlockHeaderImpl.java
@@ -35,7 +35,7 @@ import org.apache.pulsar.broker.s3offload.DataBlockHeader;
 public class DataBlockHeaderImpl implements DataBlockHeader {
     // Magic Word for data block.
     // It is a sequence of bytes used to identify the start of a block.
-    private static final int MAGIC_WORD = 0xFBDBABCB;
+    static final int MAGIC_WORD = 0xFBDBABCB;
     // This is bigger than header size. Leaving some place for alignment and future enhancement.
     // Payload use this as the start offset.
     private static final int HEADER_MAX_SIZE = 128;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/impl/DataBlockHeaderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/impl/DataBlockHeaderImpl.java
@@ -35,7 +35,7 @@ import org.apache.pulsar.broker.s3offload.DataBlockHeader;
 public class DataBlockHeaderImpl implements DataBlockHeader {
     // Magic Word for data block.
     // It is a sequence of bytes used to identify the start of a block.
-    private static final int MAGIC_WORD = 0xDBDBDBDB;
+    private static final int MAGIC_WORD = 0xFBDBABCB;
     // This is bigger than header size. Leaving some place for alignment and future enhancement.
     // Payload use this as the start offset.
     private static final int HEADER_MAX_SIZE = 128;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/s3offload/impl/DataBlockHeaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/s3offload/impl/DataBlockHeaderTest.java
@@ -41,7 +41,7 @@ public class DataBlockHeaderTest {
             firstEntryId);
 
         // verify get methods
-        assertEquals(dataBlockHeader.getBlockMagicWord(), 0xDBDBDBDB);
+        assertEquals(dataBlockHeader.getBlockMagicWord(), DataBlockHeaderImpl.MAGIC_WORD);
         assertEquals(dataBlockHeader.getBlockLength(), headerLength);
         assertEquals(dataBlockHeader.getFirstEntryId(), firstEntryId);
 


### PR DESCRIPTION
When reading in a bunch of blocks, we need to know when we've hit the
next block or padding. To identify padding, we just check if the read
in value is negative. Hitting the magic word for a new block should do
the same.

Master Issue: #1511
