### PR TITLE
Fix exception in offload index block for consistency

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/impl/OffloadIndexBlockImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/impl/OffloadIndexBlockImpl.java
@@ -302,8 +302,8 @@ public class OffloadIndexBlockImpl implements OffloadIndexBlock {
         DataInputStream dis = new DataInputStream(stream);
         int magic = dis.readInt();
         if (magic != this.INDEX_MAGIC_WORD) {
-            throw new IOException("Invalid MagicWord. read: " + Integer.toHexString(magic)
-                + " expected: 0x" + Integer.toHexString(INDEX_MAGIC_WORD));
+            throw new IOException(String.format("Invalid MagicWord. read: 0x%x  expected: 0x%x",
+                                                magic, INDEX_MAGIC_WORD));
         }
         int indexBlockLength = dis.readInt();
         int segmentMetadataLength = dis.readInt();


### PR DESCRIPTION
One number was being printed with 0x, the other wasn't. Added 0x for
both, and changed it to use String.format() to avoid string
concatenation.

Master Issue: #1511
