### PR TITLE
Base class for S3 testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@ flexible messaging model and an intuitive client API.</description>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
+    <testRealAWS>false</testRealAWS>
 
     <bookkeeper.version>4.7.0</bookkeeper.version>
     <zookeeper.version>3.4.10</zookeeper.version>
@@ -839,6 +840,10 @@ flexible messaging model and an intuitive client API.</description>
           <redirectTestOutputToFile>${redirectTestOutputToFile}</redirectTestOutputToFile>
           <trimStackTrace>false</trimStackTrace>
           <properties>
+            <property>
+              <name>testRealAWS</name>
+              <value>${testRealAWS}</value>
+            </property>
             <property>
               <name>listener</name>
               <value>org.apache.pulsar.tests.PulsarTestListener,org.apache.pulsar.tests.AnnotationListener</value>

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/s3offload/S3TestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/s3offload/S3TestBase.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.s3offload;
+
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+import io.findify.s3mock.S3Mock;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.AfterMethod;
+
+public class S3TestBase {
+    final static String BUCKET = "pulsar-unittest";
+
+    S3Mock s3mock = null;
+    protected AmazonS3 s3client = null;
+    protected String s3endpoint = null;
+
+    @BeforeMethod
+    public void start() throws Exception {
+        s3mock = new S3Mock.Builder().withPort(0).withInMemoryBackend().build();
+        int port = s3mock.start().localAddress().getPort();
+        s3endpoint = "http://localhost:" + port;
+
+        if (Boolean.parseBoolean(System.getProperty("testRealAWS", "false"))) {
+            // To use this, ~/.aws must be configured with credentials and a default region
+            s3client = AmazonS3ClientBuilder.standard().build();
+        } else {
+            s3client = AmazonS3ClientBuilder.standard()
+                .withEndpointConfiguration(new EndpointConfiguration(s3endpoint, "foobar"))
+                .withPathStyleAccessEnabled(true).build();
+        }
+
+        if (!s3client.doesBucketExistV2(BUCKET)) {
+            s3client.createBucket(BUCKET);
+        }
+    }
+
+    @AfterMethod
+    public void stop() throws Exception {
+        if (s3mock != null) {
+            s3mock.shutdown();
+        }
+    }
+}


### PR DESCRIPTION
Moves the setting up of the mock and s3 client into a base class so
that it can be shared by multiple tests.

Includes a switch, that can be flipped with the system property
testRealAWS(i.e. -DtestRealAWS=true) to run the test against real AWS,
rather than the mock. This is disabled by default, but allows us to
validate that the mock is behaving the same way as S3 would. It
requires that credentials and a default region are specified in
~/.aws.

Master Issue: #1511
