### PR TITLE
Fixed dasboard docker pom.xml version to 2.1.0-SNAPSHOT

### DIFF
--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.pulsar</groupId>
     <artifactId>docker-images</artifactId>
-    <version>2.0.0-incubating-SNAPSHOT</version>
+    <version>2.1.0-incubating-SNAPSHOT</version>
     <relativePath>../docker</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
### Motivation

CI build on master branch is failing because of discrepancy between the versions in the pom.xml file

```
[INFO] Scanning for projects...
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[FATAL] Non-resolvable parent POM for org.apache.pulsar:dashboard-docker-image:[unknown-version]: Could not find artifact org.apache.pulsar:docker-images:pom:2.0.0-incubating-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 23, column 11
```