### PR TITLE
Provide a vagrant file to launch a linux vm for running integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ deployment/terraform-ansible/aws/.terraform/
 deployment/terraform-ansible/aws/.terraform.tfstate.lock.info
 deployment/terraform-ansible/aws/terraform.tfstate
 deployment/terraform-ansible/aws/terraform.tfstate.backup
+
+# Vagrant
+**/.vagrant

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,53 @@
+## Apache Pulsar Dev Tools
+
+### Running Integration Tests on macOS
+
+Currently all the integration tests are docker based and written using arquillian framework. 
+Due to the networking issues, the integration tests can only be run on linux environment.
+For people who is using macOS as their development environment, you can use [Vagrant](https://www.vagrantup.com)
+to launch a linux virtual machine and run the integration tests there.
+
+1. [Download and Install](https://www.vagrantup.com/downloads.html) Vagrant.
+
+2. Provision and launch the dev vm.
+
+   ```shell
+   $ cd ${PULSAR_HOME}/dev
+   
+   # provision the vm
+   $ vagrant up
+   ```
+
+3. The dev vm will try to mount your current pulsar workspace to be under `/pulsar` in the vm. You might
+   potentially hit following errors due to fail to install VirtualBox Guest additions.
+
+   ```
+   /sbin/mount.vboxsf: mounting failed with the error: No such device
+   ```
+
+   If that happens, follow the below instructions:
+
+   ```
+   # ssh to the dev vm
+   $ vagrant ssh
+
+   [vagrant@bogon pulsar]$ sudo yum update -y
+   [vagrant@bogon pulsar]$ exit  
+
+   # reload the vm
+   $ vagrant reload
+   ```
+
+4. Now, you will have a pulsar dev vm ready for running integration tests.
+
+   ```shell
+   $ vagrant ssh
+
+   # once you are in the pulsar dev vm, you can launch docker.
+   [vagrant@bogon pulsar]$ sudo systemctl start docker
+
+   # your pulsar workspace will be mount under /pulsar
+   [vagrant@bogon pulsar]$ cd /pulsar
+
+   # you can build and test using maven commands
+   ```

--- a/dev/Vagrantfile
+++ b/dev/Vagrantfile
@@ -1,0 +1,87 @@
+#/**
+# * Licensed to the Apache Software Foundation (ASF) under one
+# * or more contributor license agreements.  See the NOTICE file
+# * distributed with this work for additional information
+# * regarding copyright ownership.  The ASF licenses this file
+# * to you under the Apache License, Version 2.0 (the
+# * "License"); you may not use this file except in compliance
+# * with the License.  You may obtain a copy of the License at
+# *
+# *     http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# */
+
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "centos/7"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder "..", "/pulsar"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "virtualbox" do |vb|
+    vb.name   = "pulsar_dev_vm"
+    vb.memory = "4096"
+  end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", inline: <<-SHELL
+    yum update -y
+    yum install -y kernel-devel
+    yum install -y kernel-headers
+    yum install -y wget vim java-1.8.0-openjdk-devel maven docker gcc-c++
+  SHELL
+end


### PR DESCRIPTION
*Motivation*

Currently all pulsar's integration tests and bc tests are docker based and written
using arquillian framework. Due to the way how pulsar integration tests were written,
we can *ONLY* run integration tests in a linux environment. It is inconvinient to people
who is using macOS as the development environment.

*Solution*

This PR is providing a Vagrantfile to lanuch a dev vm that contains all the tools required
for running integration tests and bc tests. So people can actually debug and test integration
tests locally using a linux vm.
