### PR TITLE
Move isConnected method into each interface class

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/Consumer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/Consumer.java
@@ -283,4 +283,9 @@ public interface Consumer<T> extends Closeable {
      * @return a future to track the completion of the seek operation
      */
     CompletableFuture<Void> seekAsync(MessageId messageId);
+
+    /**
+     * @return Whether the consumer is connected to the broker
+     */
+    boolean isConnected();
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/Producer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/Producer.java
@@ -192,4 +192,9 @@ public interface Producer<T> extends Closeable {
      * @return a future that can used to track when the producer has been closed
      */
     CompletableFuture<Void> closeAsync();
+
+    /**
+     * @return Whether the producer is connected to the broker
+     */
+    boolean isConnected();
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/Reader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/Reader.java
@@ -73,4 +73,9 @@ public interface Reader<T> extends Closeable {
      * Asynchronously Check if there is message that has been published successfully to the broker in the topic.
      */
     CompletableFuture<Boolean> hasMessageAvailableAsync();
+
+    /**
+     * @return Whether the reader is connected to the broker
+     */
+    boolean isConnected();
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -317,8 +317,6 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
         return null;
     }
 
-    abstract public boolean isConnected();
-
     abstract public int getAvailablePermits();
 
     abstract public int numMessagesInQueue();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBase.java
@@ -118,8 +118,6 @@ public abstract class ProducerBase<T> extends HandlerState implements Producer<T
     @Override
     abstract public CompletableFuture<Void> closeAsync();
 
-    abstract public boolean isConnected();
-
     @Override
     public String getTopic() {
         return topic;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
@@ -148,4 +148,8 @@ public class ReaderImpl<T> implements Reader<T> {
         return consumer.hasMessageAvailableAsync();
     }
 
+    @Override
+    public boolean isConnected() {
+        return consumer.isConnected();
+    }
 }


### PR DESCRIPTION
### Motivation

We want to check connection status with a broker on an application side.

### Modifications

Move isConnected method into each interface class.

### Result

We can check connection status on an application side without casting to impl class.