### PR TITLE
Fix build with boost >= 1.66

### DIFF
--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -141,7 +141,7 @@ ClientConnection::ClientConnection(const std::string& logicalAddress, const std:
         using namespace boost::filesystem;
 
 #if BOOST_VERSION >= 105400
-        boost::asio::ssl::context ctx(executor_->io_service_, boost::asio::ssl::context::tlsv12_client);
+        boost::asio::ssl::context ctx(boost::asio::ssl::context::tlsv12_client);
 #else
         boost::asio::ssl::context ctx(executor_->io_service_, boost::asio::ssl::context::tlsv1_client);
 #endif


### PR DESCRIPTION
### Motivation

The SSL context object constructor taking an `io_service` was already deprecated in boost 1.54 and it has been removed in boost 1.66.

Ref: https://github.com/boostorg/asio/blob/boost-1.54.0/include/boost/asio/ssl/context.hpp#L62

### Modifications

Use non-deprecated constructor.
