### PR TITLE
Remove duplicated dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -434,13 +434,6 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-api</artifactId>
-        <type>test-jar</type>
-        <version>${log4j2.version}</version>
-      </dependency>
-
-      <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>2.5</version>


### PR DESCRIPTION
### Motivation

When running `docker/build.sh`, Maven lets out the following warning:
```
[WARNING] Some problems were encountered while building the effective model for org.apache.pulsar:docker-images:pom:2.1.0-incubating-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.apache.logging.log4j:log4j-api:test-jar -> duplicate declaration of version ${log4j2.version} @ org.apache.pulsar:pulsar:2.1.0-incubating-SNAPSHOT, /path/to/incubator-pulsar/pom.xml, line 436, column 19
```

### Modifications

Remove one repetition of the duplicated dependency `org.apache.logging.log4j:log4j-api:test-jar` from `pom.xml`.

### Result

Maven warning disappears.