### PR TITLE
Ability to disable test retries from commandline

### DIFF
--- a/buildtools/src/main/java/org/apache/pulsar/tests/RetryAnalyzer.java
+++ b/buildtools/src/main/java/org/apache/pulsar/tests/RetryAnalyzer.java
@@ -26,7 +26,7 @@ public class RetryAnalyzer implements IRetryAnalyzer {
     private int count = 0;
 
     // Only try again once
-    private static final int MAX_RETRIES = 1;
+    private static final int MAX_RETRIES = Integer.valueOf(System.getProperty("testRetryCount", "1"));
 
     @Override
     public boolean retry(ITestResult result) {

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,7 @@ flexible messaging model and an intuitive client API.</description>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
     <testRealAWS>false</testRealAWS>
+    <testRetryCount>1</testRetryCount>
 
     <bookkeeper.version>4.7.0</bookkeeper.version>
     <zookeeper.version>3.4.10</zookeeper.version>
@@ -836,6 +837,10 @@ flexible messaging model and an intuitive client API.</description>
             <property>
               <name>testRealAWS</name>
               <value>${testRealAWS}</value>
+            </property>
+            <property>
+              <name>testRetryCount</name>
+              <value>${testRetryCount}</value>
             </property>
             <property>
               <name>listener</name>


### PR DESCRIPTION
Sometimes it's useful to be able to disable retries when testing
sometime, for example, if you want to find flakes, or you have a test
that's failing and you want to dig into why. This patch adds a
commandline flag, testRetryCount, which can be passed to maven to
disable retries.

```
mvn test -Dtest=SomeTest -DtestRetryCount=0
```
