### PR TITLE
Create shared library that only exports API symbols

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -41,6 +41,11 @@ endif(NOT CXX_STANDARD)
 
 set(CMAKE_CXX_FLAGS " -msse4.2 -mpclmul -Wno-deprecated-declarations ${CXX_STANDARD} ${CMAKE_CXX_FLAGS}")
 
+if (!APPLE)
+    # Hide all non-exported symbols to avoid conflicts
+    set(CMAKE_CXX_FLAGS " -fvisibility=hidden -Wl,--exclude-libs,ALL ${CMAKE_CXX_FLAGS}")
+endif ()
+
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 set(PROTOBUF_LIBRARIES $ENV{PROTOBUF_LIBRARIES})

--- a/pulsar-client-cpp/include/pulsar/DeprecatedException.h
+++ b/pulsar-client-cpp/include/pulsar/DeprecatedException.h
@@ -22,6 +22,8 @@
 #include <stdexcept>
 #include <string>
 
+#pragma GCC visibility push(default)
+
 namespace pulsar {
 class DeprecatedException : public std::runtime_error {
    public:
@@ -31,5 +33,7 @@ class DeprecatedException : public std::runtime_error {
     static const std::string message_prefix;
 };
 }  // namespace pulsar
+
+#pragma GCC visibility pop
 
 #endif  // DEPRECATED_EXCEPTION_HPP_

--- a/pulsar-client-cpp/include/pulsar/TopicMetadata.h
+++ b/pulsar-client-cpp/include/pulsar/TopicMetadata.h
@@ -19,6 +19,8 @@
 #ifndef TOPIC_METADATA_HPP_
 #define TOPIC_METADATA_HPP_
 
+#pragma GCC visibility push(default)
+
 namespace pulsar {
 /**
  * Metadata of a topic that can be used for message routing.
@@ -28,5 +30,7 @@ class TopicMetadata {
     virtual int getNumPartitions() const = 0;
 };
 }  // namespace pulsar
+
+#pragma GCC visibility pop
 
 #endif /* TOPIC_METADATA_HPP_ */

--- a/pulsar-client-cpp/include/pulsar/c/authentication.h
+++ b/pulsar-client-cpp/include/pulsar/c/authentication.h
@@ -23,12 +23,16 @@
 extern "C" {
 #endif
 
+#pragma GCC visibility push(default)
+
 typedef struct _pulsar_authentication pulsar_authentication_t;
 
 pulsar_authentication_t *pulsar_authentication_create(const char *dynamicLibPath,
                                                       const char *authParamsString);
 
 void pulsar_authentication_free(pulsar_authentication_t *authentication);
+
+#pragma GCC visibility pop
 
 #ifdef __cplusplus
 }

--- a/pulsar-client-cpp/include/pulsar/c/client.h
+++ b/pulsar-client-cpp/include/pulsar/c/client.h
@@ -34,6 +34,8 @@
 extern "C" {
 #endif
 
+#pragma GCC visibility push(default)
+
 typedef struct _pulsar_client pulsar_client_t;
 typedef struct _pulsar_producer pulsar_producer_t;
 
@@ -127,6 +129,8 @@ pulsar_result pulsar_client_close(pulsar_client_t *client);
 void pulsar_client_close_async(pulsar_client_t *client, pulsar_close_callback callback, void *ctx);
 
 void pulsar_client_free(pulsar_client_t *client);
+
+#pragma GCC visibility pop
 
 #ifdef __cplusplus
 }

--- a/pulsar-client-cpp/include/pulsar/c/client_configuration.h
+++ b/pulsar-client-cpp/include/pulsar/c/client_configuration.h
@@ -23,6 +23,8 @@
 extern "C" {
 #endif
 
+#pragma GCC visibility push(default)
+
 typedef struct _pulsar_client_configuration pulsar_client_configuration_t;
 typedef struct _pulsar_authentication pulsar_authentication_t;
 
@@ -138,6 +140,8 @@ void pulsar_client_configuration_set_stats_interval_in_seconds(pulsar_client_con
  */
 const unsigned int pulsar_client_configuration_get_stats_interval_in_seconds(
     pulsar_client_configuration_t *conf);
+
+#pragma GCC visibility pop
 
 #ifdef __cplusplus
 }

--- a/pulsar-client-cpp/include/pulsar/c/consumer.h
+++ b/pulsar-client-cpp/include/pulsar/c/consumer.h
@@ -27,6 +27,8 @@ extern "C" {
 
 #include <stdint.h>
 
+#pragma GCC visibility push(default)
+
 typedef struct _pulsar_consumer pulsar_consumer_t;
 
 typedef void (*pulsar_result_callback)(pulsar_result, void *);
@@ -189,6 +191,8 @@ pulsar_result resume_message_listener(pulsar_consumer_t *consumer);
  * breaks, the messages are redelivered after reconnect.
  */
 void pulsar_consumer_redeliver_unacknowledged_messages(pulsar_consumer_t *consumer);
+
+#pragma GCC visibility pop
 
 #ifdef __cplusplus
 }

--- a/pulsar-client-cpp/include/pulsar/c/consumer_configuration.h
+++ b/pulsar-client-cpp/include/pulsar/c/consumer_configuration.h
@@ -22,6 +22,8 @@
 extern "C" {
 #endif
 
+#pragma GCC visibility push(default)
+
 typedef struct _pulsar_consumer_configuration pulsar_consumer_configuration_t;
 
 typedef enum {
@@ -158,6 +160,8 @@ int pulsar_consumer_is_encryption_enabled(pulsar_consumer_configuration_t *consu
 // ConsumerConfiguration&
 // setCryptoFailureAction(ConsumerCryptoFailureAction
 // action);
+
+#pragma GCC visibility pop
 
 #ifdef __cplusplus
 }

--- a/pulsar-client-cpp/include/pulsar/c/message.h
+++ b/pulsar-client-cpp/include/pulsar/c/message.h
@@ -26,6 +26,8 @@ extern "C" {
 #include <stddef.h>
 #include <stdint.h>
 
+#pragma GCC visibility push(default)
+
 typedef struct _pulsar_message pulsar_message_t;
 typedef struct _pulsar_message_id pulsar_message_id_t;
 
@@ -162,6 +164,8 @@ uint64_t pulsar_message_get_publish_timestamp(pulsar_message_t *message);
  * Get the event timestamp associated with this message. It is set by the client producer.
  */
 uint64_t pulsar_message_get_event_timestamp(pulsar_message_t *message);
+
+#pragma GCC visibility pop
 
 #ifdef __cplusplus
 }

--- a/pulsar-client-cpp/include/pulsar/c/message_id.h
+++ b/pulsar-client-cpp/include/pulsar/c/message_id.h
@@ -26,6 +26,8 @@ extern "C" {
 #include <stddef.h>
 #include <stdint.h>
 
+#pragma GCC visibility push(default)
+
 typedef struct _pulsar_message_id pulsar_message_id_t;
 
 /**
@@ -51,6 +53,8 @@ pulsar_message_id_t *pulsar_message_id_deserialize(const void *buffer, uint32_t 
 char *pulsar_message_id_str(pulsar_message_id_t *messageId);
 
 void pulsar_message_id_free(pulsar_message_id_t *messageId);
+
+#pragma GCC visibility pop
 
 #ifdef __cplusplus
 }

--- a/pulsar-client-cpp/include/pulsar/c/message_router.h
+++ b/pulsar-client-cpp/include/pulsar/c/message_router.h
@@ -25,12 +25,16 @@
 extern "C" {
 #endif
 
+#pragma GCC visibility push(default)
+
 typedef struct _pulsar_topic_metadata pulsar_topic_metadata_t;
 
 typedef int (*pulsar_message_router)(pulsar_message_t *msg, pulsar_topic_metadata_t *topicMetadata,
                                      void *ctx);
 
 int pulsar_topic_metadata_get_num_partitions(pulsar_topic_metadata_t *topicMetadata);
+
+#pragma GCC visibility pop
 
 #ifdef __cplusplus
 }

--- a/pulsar-client-cpp/include/pulsar/c/producer.h
+++ b/pulsar-client-cpp/include/pulsar/c/producer.h
@@ -28,6 +28,8 @@ extern "C" {
 
 #include <stdint.h>
 
+#pragma GCC visibility push(default)
+
 typedef struct _pulsar_producer pulsar_producer_t;
 
 typedef void (*pulsar_send_callback)(pulsar_result, pulsar_message_t *msg, void *ctx);
@@ -113,6 +115,8 @@ pulsar_result pulsar_producer_close(pulsar_producer_t *producer);
 void pulsar_producer_close_async(pulsar_producer_t *producer, pulsar_close_callback callback, void *ctx);
 
 void pulsar_producer_free(pulsar_producer_t *producer);
+
+#pragma GCC visibility pop
 
 #ifdef __cplusplus
 }

--- a/pulsar-client-cpp/include/pulsar/c/producer_configuration.h
+++ b/pulsar-client-cpp/include/pulsar/c/producer_configuration.h
@@ -27,6 +27,8 @@
 extern "C" {
 #endif
 
+#pragma GCC visibility push(default)
+
 typedef enum {
     pulsar_UseSinglePartition,
     pulsar_RoundRobinDistribution,
@@ -141,6 +143,8 @@ unsigned long pulsar_producer_configuration_get_batching_max_publish_delay_ms(
 // std::set <std::string> &getEncryptionKeys();
 // int isEncryptionEnabled() const;
 // ProducerConfiguration &addEncryptionKey(std::string key);
+
+#pragma GCC visibility pop
 
 #ifdef __cplusplus
 }

--- a/pulsar-client-cpp/include/pulsar/c/reader.h
+++ b/pulsar-client-cpp/include/pulsar/c/reader.h
@@ -25,6 +25,8 @@
 extern "C" {
 #endif
 
+#pragma GCC visibility push(default)
+
 typedef struct _pulsar_reader pulsar_reader_t;
 
 typedef void (*pulsar_result_callback)(pulsar_result, void *);
@@ -63,6 +65,8 @@ pulsar_result pulsar_reader_close(pulsar_reader_t *reader);
 void pulsar_reader_close_async(pulsar_reader_t *reader, pulsar_result_callback callback, void *ctx);
 
 void pulsar_reader_free(pulsar_reader_t *reader);
+
+#pragma GCC visibility pop
 
 #ifdef __cplusplus
 }

--- a/pulsar-client-cpp/include/pulsar/c/reader_configuration.h
+++ b/pulsar-client-cpp/include/pulsar/c/reader_configuration.h
@@ -23,6 +23,8 @@
 extern "C" {
 #endif
 
+#pragma GCC visibility push(default)
+
 typedef struct _pulsar_reader_configuration pulsar_reader_configuration_t;
 
 typedef void (*pulsar_reader_listener)(pulsar_reader_t *reader, pulsar_message_t *msg, void *ctx);
@@ -76,6 +78,8 @@ void pulsar_reader_configuration_set_subscription_role_prefix(pulsar_reader_conf
 
 const char *pulsar_reader_configuration_get_subscription_role_prefix(
     pulsar_reader_configuration_t *configuration);
+
+#pragma GCC visibility pop
 
 #ifdef __cplusplus
 }

--- a/pulsar-client-cpp/include/pulsar/c/result.h
+++ b/pulsar-client-cpp/include/pulsar/c/result.h
@@ -23,6 +23,8 @@
 extern "C" {
 #endif
 
+#pragma GCC visibility push(default)
+
 typedef enum {
     pulsar_result_Ok,  /// Operation successful
 
@@ -75,6 +77,8 @@ typedef enum {
 
 // Return string representation of result code
 const char *pulsar_result_str(pulsar_result result);
+
+#pragma GCC visibility pop
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Motivation

Pass the `-fvisibility=hidden -Wl,--exclude-libs,ALL` flags to the linker when creating `libpulsar.so`. That will ensure we hide all symbols that are not part of Pulsar API.

API symbols are explicitely whitelisted with the `#pragma GCC visibility push(default)` and `#pragma GCC visibility pop` directives.

This is critical especially, when compiling a static `libpulsar.so` (that contains all the other dependencies like boost, log4cxx, protobuf, etc..) to avoid conflicts in case an application uses different versions of the same library.

This was already done before open sourcing C++ client lib, though the flags got dropped when the conversion to CMake happened long time back.