### PR TITLE
Fix C++ MurmurHash3 algorithm

### DIFF
--- a/pulsar-client-cpp/lib/Murmur3_32Hash.cc
+++ b/pulsar-client-cpp/lib/Murmur3_32Hash.cc
@@ -70,14 +70,15 @@ uint32_t Murmur3_32Hash::makeHash(const void *key, const int64_t len) {
         h1 = mixH1(h1, k1);
     }
 
+    const uint8_t *tail = reinterpret_cast<const uint8_t *>(data + nblocks * MACRO_CHUNK_SIZE);
     uint32_t k1 = 0;
     switch (len - nblocks * MACRO_CHUNK_SIZE) {
         case 3:
-            k1 ^= static_cast<uint32_t>(blocks[2]) << 16;
+            k1 ^= static_cast<uint32_t>(tail[2]) << 16;
         case 2:
-            k1 ^= static_cast<uint32_t>(blocks[1]) << 8;
+            k1 ^= static_cast<uint32_t>(tail[1]) << 8;
         case 1:
-            k1 ^= static_cast<uint32_t>(blocks[0]);
+            k1 ^= static_cast<uint32_t>(tail[0]);
     };
 
     h1 ^= mixK1(k1);

--- a/pulsar-client-cpp/tests/HashTest.cc
+++ b/pulsar-client-cpp/tests/HashTest.cc
@@ -58,10 +58,18 @@ TEST(HashTest, testJavaStringHash) {
 
 TEST(HashTest, testMurmur3_32Hash) {
     Murmur3_32Hash hash;
+    std::string k1 = "k1";
+    std::string k2 = "k2";
     std::string key1 = "key1";
     std::string key2 = "key2";
+    std::string key01 = "key01";
+    std::string key02 = "key02";
 
     // Same value as Java client
+    ASSERT_EQ(2110152746, hash.makeHash(k1));
+    ASSERT_EQ(1479966664, hash.makeHash(k2));
     ASSERT_EQ(462881061, hash.makeHash(key1));
     ASSERT_EQ(1936800180, hash.makeHash(key2));
+    ASSERT_EQ(39696932, hash.makeHash(key01));
+    ASSERT_EQ(751761803, hash.makeHash(key02));
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/HashTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/HashTest.java
@@ -43,7 +43,11 @@ public class HashTest {
         Hash h = Murmur3_32Hash.getInstance();
 
         // Same value as C++ client
+        assertEquals(2110152746, h.makeHash("k1"));
+        assertEquals(1479966664, h.makeHash("k2"));
         assertEquals(462881061, h.makeHash("key1"));
         assertEquals(1936800180, h.makeHash("key2"));
+        assertEquals(39696932, h.makeHash("key01"));
+        assertEquals(751761803, h.makeHash("key02"));
     }
 }


### PR DESCRIPTION
### Motivation

I noticed that messages with the same key might be routed to different partitions when MurmurHash3 was selected as a hashing scheme in the C++ client library.
This is because there is a mistake in C++ implementation of MurmurHash3.

### Modifications

Fixed `Murmur3_32Hash.cc` by reference to the following SMHasher code.
https://github.com/aappleby/smhasher/blob/61a0530f28277f2e850bfc39600ce61d02b518de/src/MurmurHash3.cpp#L94-L146

### Result

The same key generates the same hash, and messages with the same key are routed to the same partition.