### PR TITLE
S3ManagedLedgerOffloader should require region or endpoint

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/S3ManagedLedgerOffloader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/S3ManagedLedgerOffloader.java
@@ -68,11 +68,13 @@ public class S3ManagedLedgerOffloader implements LedgerOffloader {
         int maxBlockSize = conf.getS3ManagedLedgerOffloadMaxBlockSizeInBytes();
         int readBufferSize = conf.getS3ManagedLedgerOffloadReadBufferSizeInBytes();
 
-        if (Strings.isNullOrEmpty(region)) {
-            throw new PulsarServerException("s3ManagedLedgerOffloadRegion cannot be empty is s3 offload enabled");
+        if (Strings.isNullOrEmpty(region) && Strings.isNullOrEmpty(endpoint)) {
+            throw new PulsarServerException(
+                    "Either s3ManagedLedgerOffloadRegion or s3ManagedLedgerOffloadServiceEndpoint must be set"
+                    + " if s3 offload enabled");
         }
         if (Strings.isNullOrEmpty(bucket)) {
-            throw new PulsarServerException("s3ManagedLedgerOffloadBucket cannot be empty is s3 offload enabled");
+            throw new PulsarServerException("s3ManagedLedgerOffloadBucket cannot be empty if s3 offload enabled");
         }
 
         AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard();


### PR DESCRIPTION
The S3 client requires one of the two, but never both. Previously we
were throwing an error if region was not specified, even though it's
not needed if endpoint is.

Master Issue: #1511
