### PR TITLE
BlockAwareSegmentInputStreamImpl shouldn't use LedgerEntry#getLength

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/impl/BlockAwareSegmentInputStreamImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/impl/BlockAwareSegmentInputStreamImpl.java
@@ -122,14 +122,15 @@ public class BlockAwareSegmentInputStreamImpl extends BlockAwareSegmentInputStre
             Iterator<LedgerEntry> iterator = ledgerEntriesOnce.iterator();
             while (iterator.hasNext()) {
                 LedgerEntry entry = iterator.next();
-                int entryLength = (int) entry.getLength();
+                ByteBuf buf = entry.getEntryBuffer().retain();
+                int entryLength = buf.readableBytes();
                 long entryId = entry.getEntryId();
 
                 CompositeByteBuf entryBuf = PooledByteBufAllocator.DEFAULT.compositeBuffer(2);
                 ByteBuf entryHeaderBuf = PooledByteBufAllocator.DEFAULT.buffer(ENTRY_HEADER_SIZE, ENTRY_HEADER_SIZE);
 
                 entryHeaderBuf.writeInt(entryLength).writeLong(entryId);
-                entryBuf.addComponents(true, entryHeaderBuf, entry.getEntryBuffer().retain());
+                entryBuf.addComponents(true, entryHeaderBuf, buf);
 
                 entries.add(entryBuf);
             }


### PR DESCRIPTION
LedgerEntry#getLength() returns the length of the ledger up to and
including the length of the entry, not the length of the entry as you
would expected (and the documentation states). So we shouldn't use it
when serializing the entry, because what we need is the length of the
entry.

This patch changes BlockAwareSegmentInputStreamImpl to use the
readable bytes of the bytebuf instead.

Master Issue: #1511
