### PR TITLE
Log4j2.yaml configures loggers incorrectly

### DIFF
--- a/conf/log4j2.yaml
+++ b/conf/log4j2.yaml
@@ -156,20 +156,6 @@ Configuration:
 
   Loggers:
 
-    Logger:
-      name: org.apache.bookkeeper
-      level: "${sys:bk.log.level}"
-      additivity: false
-      AppenderRef:
-        - ref: BkRollingFile
-
-    Logger:
-      name: org.apache.distributedlog
-      level: "${sys:bk.log.level}"
-      additivity: false
-      AppenderRef:
-        - ref: BkRollingFile
-  
     # Default root logger configuration
     Root:
       level: info
@@ -177,17 +163,29 @@ Configuration:
       AppenderRef:
         - ref: "${sys:pulsar.log.appender}"
           level: "${sys:pulsar.log.level}"
+
+    Logger:
+      - name: org.apache.bookkeeper
+        level: "${sys:bk.log.level}"
+        additivity: false
+        AppenderRef:
+          - ref: BkRollingFile
+
+      - name: org.apache.distributedlog
+        level: "${sys:bk.log.level}"
+        additivity: false
+        AppenderRef:
+          - ref: BkRollingFile
     
     # Logger to inject filter script
-#    Logger:
-#      name: org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl
-#      level: debug
-#      additivity: false
-#      AppenderRef:
-#        ref: "${sys:pulsar.log.appender}"
-#        ScriptFilter:
-#          onMatch: ACCEPT
-#          onMisMatch: DENY
-#          ScriptRef:
-#            ref: filter.js
+#     - name: org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl
+#       level: debug
+#       additivity: false
+#       AppenderRef:
+#         ref: "${sys:pulsar.log.appender}"
+#         ScriptFilter:
+#           onMatch: ACCEPT
+#           onMisMatch: DENY
+#           ScriptRef:
+#             ref: filter.js
         


### PR DESCRIPTION
log4j2.yaml has a list of loggers. However, this is not a yaml list,
but a yaml map, so the configuration only picks up the last one.

This patch changes the loggers to a yaml list.
