### PR TITLE
Improve logging when we fail to bind on server ports

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -287,8 +287,14 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
         ServiceConfiguration serviceConfig = pulsar.getConfiguration();
 
         bootstrap.childHandler(new PulsarChannelInitializer(this, serviceConfig, false));
+
         // Bind and start to accept incoming connections.
-        bootstrap.bind(new InetSocketAddress(pulsar.getBindAddress(), port)).sync();
+        InetSocketAddress addr = new InetSocketAddress(pulsar.getBindAddress(), port);
+        try {
+            bootstrap.bind(addr).sync();
+        } catch (Exception e) {
+            throw new IOException("Failed to bind Pulsar broker on " + addr, e);
+        }
         log.info("Started Pulsar Broker service on port {}", port);
 
         if (serviceConfig.isTlsEnabled()) {

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyService.java
@@ -24,6 +24,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicReference;
@@ -113,7 +114,11 @@ public class ProxyService implements Closeable {
 
         bootstrap.childHandler(new ServiceChannelInitializer(this, proxyConfig, false));
         // Bind and start to accept incoming connections.
-        bootstrap.bind(proxyConfig.getServicePort()).sync();
+        try {
+            bootstrap.bind(proxyConfig.getServicePort()).sync();
+        } catch (Exception e) {
+            throw new IOException("Failed to bind Pulsar Proxy on port " + proxyConfig.getServicePort(), e);
+        }
         LOG.info("Started Pulsar Proxy at {}", serviceUrl);
 
         if (proxyConfig.isTlsEnabledInProxy()) {
@@ -175,7 +180,7 @@ public class ProxyService implements Closeable {
     public Semaphore getLookupRequestSemaphore() {
         return lookupRequestSemaphore.get();
     }
-    
+
     public EventLoopGroup getWorkerGroup() {
         return workerGroup;
     }

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/WebServer.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/WebServer.java
@@ -18,8 +18,15 @@
  */
 package org.apache.pulsar.proxy.server;
 
+import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
+import com.google.common.collect.Lists;
+
+import io.netty.util.concurrent.DefaultThreadFactory;
+
+import java.io.IOException;
 import java.net.URI;
 import java.security.GeneralSecurityException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.TimeZone;
@@ -29,6 +36,7 @@ import java.util.concurrent.Executors;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.common.util.SecurityUtility;
+import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
@@ -45,11 +53,6 @@ import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
-import com.google.common.collect.Lists;
-
-import io.netty.util.concurrent.DefaultThreadFactory;
 
 /**
  * Manages web-service startup/stop on jetty server.
@@ -78,7 +81,7 @@ public class WebServer {
                         config.isTlsAllowInsecureConnection(),
                         config.getTlsTrustCertsFilePath(),
                         config.getTlsCertificateFilePath(),
-                        config.getTlsKeyFilePath(), 
+                        config.getTlsKeyFilePath(),
                         config.getTlsRequireTrustedClientCertOnConnect());
                 ServerConnector tlsConnector = new ServerConnector(server, 1, 1, sslCtxFactory);
                 tlsConnector.setPort(config.getWebServicePortTls());
@@ -124,7 +127,7 @@ public class WebServer {
         context.setAttribute(attribute, attributeValue);
         handlers.add(context);
     }
-    
+
     public int getExternalServicePort() {
         return externalServicePort;
     }
@@ -146,7 +149,17 @@ public class WebServer {
         handlerCollection.setHandlers(new Handler[] { contexts, new DefaultHandler(), requestLogHandler });
         server.setHandler(handlerCollection);
 
-        server.start();
+        try {
+            server.start();
+        } catch (Exception e) {
+            List<Integer> ports = new ArrayList<>();
+            for (Connector c : server.getConnectors()) {
+                if (c instanceof ServerConnector) {
+                    ports.add(((ServerConnector) c).getPort());
+                }
+            }
+            throw new IOException("Failed to start HTTP server on ports " + ports, e);
+        }
 
         log.info("Server started at end point {}", getServiceUri());
     }


### PR DESCRIPTION
### Motivation

Ensure that in most cases we print the IP/port we're trying to bind to when there is a bind exception.