### PR TITLE
Fixed mem leak when acknowledging while disconnected from broker

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -479,13 +479,13 @@ public class ConsumerImpl extends ConsumerBase {
     private CompletableFuture<Void> sendAcknowledge(MessageId messageId, AckType ackType,
                                                     Map<String,Long> properties) {
         MessageIdImpl msgId = (MessageIdImpl) messageId;
-        final ByteBuf cmd = Commands.newAck(consumerId, msgId.getLedgerId(), msgId.getEntryId(),
-                                            ackType, null, properties);
 
         // There's no actual response from ack messages
         final CompletableFuture<Void> ackFuture = new CompletableFuture<Void>();
 
         if (isConnected()) {
+            final ByteBuf cmd = Commands.newAck(consumerId, msgId.getLedgerId(), msgId.getEntryId(),
+                    ackType, null, properties);
             cnx().ctx().writeAndFlush(cmd).addListener(new GenericFutureListener<Future<Void>>() {
                 @Override
                 public void operationComplete(Future<Void> future) throws Exception {


### PR DESCRIPTION
### Motivation

ByteBuf for ack command is not released if we don't have a connection to send the acknowledgemt to.

This is an issue only in 1.22, not in 2.0 code which is already handling acks in a different way and doesn't suffer from this problem.