### PR TITLE
Fixed race condition in consumer event listener

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherSingleActiveConsumer.java
@@ -38,7 +38,6 @@ import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.admin.AdminResource;
 import org.apache.pulsar.broker.service.AbstractDispatcherSingleActiveConsumer;
 import org.apache.pulsar.broker.service.Consumer;
-import org.apache.pulsar.broker.service.Consumer.SendMessageInfo;
 import org.apache.pulsar.broker.service.Dispatcher;
 import org.apache.pulsar.client.impl.Backoff;
 import org.apache.pulsar.common.api.proto.PulsarApi.CommandSubscribe.SubType;
@@ -199,6 +198,7 @@ public final class PersistentDispatcherSingleActiveConsumer extends AbstractDisp
             entries.forEach(Entry::release);
             cursor.rewind();
             if (currentConsumer != null) {
+                notifyActiveConsumerChanged(currentConsumer);
                 readMoreEntries(currentConsumer);
             }
         } else {
@@ -457,6 +457,9 @@ public final class PersistentDispatcherSingleActiveConsumer extends AbstractDisp
                     if (currentConsumer != null && !havePendingRead) {
                         if (log.isDebugEnabled()) {
                             log.debug("[{}-{}] Retrying read operation", name, c);
+                        }
+                        if (currentConsumer != c) {
+                            notifyActiveConsumerChanged(currentConsumer);
                         }
                         readMoreEntries(currentConsumer);
                     } else {


### PR DESCRIPTION
### Motivation

Fixes #1614 #1617 

The flaky test was actually because of a race condition in the dispatcher code. If there is a pending read when the consumer is switched, the actual switch happens after the read completes, but the dispatcher wouldn't trigger the notification at that point.

### Modifications

Ensure the active/inactive notification is sent after the read completes.