### PR TITLE
Support non persistent topics in C++ client

### DIFF
--- a/pulsar-client-cpp/lib/TopicName.cc
+++ b/pulsar-client-cpp/lib/TopicName.cc
@@ -161,7 +161,7 @@ bool TopicName::operator==(const TopicName& other) {
 
 bool TopicName::validate() {
     // check domain matches to "persistent", in future check "memory" when server is ready
-    if (domain_.compare("persistent") != 0) {
+    if (domain_.compare("persistent") != 0 && domain_.compare("non-persistent") != 0) {
         return false;
     }
     // cluster_ can be empty

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -253,11 +253,11 @@ TEST(BasicEndToEndTest, testNonPersistentTopic) {
     Client client(lookupUrl);
     Producer producer;
     Result result = client.createProducer(topicName, producer);
-    ASSERT_EQ(ResultInvalidTopicName, result);
+    ASSERT_EQ(ResultOk, result);
 
     Consumer consumer;
     result = client.subscribe(topicName, "my-sub-name", consumer);
-    ASSERT_EQ(ResultInvalidTopicName, result);
+    ASSERT_EQ(ResultOk, result);
 }
 
 TEST(BasicEndToEndTest, testSingleClientMultipleSubscriptions) {

--- a/pulsar-client-cpp/tests/TopicNameTest.cc
+++ b/pulsar-client-cpp/tests/TopicNameTest.cc
@@ -78,6 +78,16 @@ TEST(TopicNameTest, testTopicNameV2) {
     ASSERT_EQ(TopicName::getEncodedName("short-topic"), tn1->getLocalName());
 }
 
+TEST(TopicNameTest, testNonPersistentTopicNameV2) {
+    // v2 topic names doesn't have "cluster"
+    boost::shared_ptr<TopicName> tn1 = TopicName::get("non-persistent://tenant/namespace/short-topic");
+    ASSERT_EQ("tenant", tn1->getProperty());
+    ASSERT_EQ("", tn1->getCluster());
+    ASSERT_EQ("namespace", tn1->getNamespacePortion());
+    ASSERT_EQ("non-persistent", tn1->getDomain());
+    ASSERT_EQ(TopicName::getEncodedName("short-topic"), tn1->getLocalName());
+}
+
 TEST(TopicNameTest, testTopicNameWithSlashes) {
     // Compare getters and setters
     boost::shared_ptr<TopicName> topicName =


### PR DESCRIPTION
### Motivation

C++ topic name validation is rejecting `non-persistent` topics.