### PR TITLE
Don't set Pulsar Memory if variable is already set

### DIFF
--- a/conf/pulsar_tools_env.sh
+++ b/conf/pulsar_tools_env.sh
@@ -42,7 +42,9 @@
 # PULSAR_GLOBAL_ZK_CONF=
 
 # Extra options to be passed to the jvm
-PULSAR_MEM=" -Xmx256m -XX:MaxDirectMemorySize=256m"
+if [ -z "$PULSAR_MEM" ]; then
+    PULSAR_MEM=" -Xmx256m -XX:MaxDirectMemorySize=256m"
+fi
 
 # Garbage collection options
 PULSAR_GC=" -client "

--- a/conf/pulsar_tools_env.sh
+++ b/conf/pulsar_tools_env.sh
@@ -42,9 +42,7 @@
 # PULSAR_GLOBAL_ZK_CONF=
 
 # Extra options to be passed to the jvm
-if [ -z "$PULSAR_MEM" ]; then
-    PULSAR_MEM=" -Xmx256m -XX:MaxDirectMemorySize=256m"
-fi
+PULSAR_MEM=${PULSAR_MEM:-"-Xmx256m -XX:MaxDirectMemorySize=256m"}
 
 # Garbage collection options
 PULSAR_GC=" -client "


### PR DESCRIPTION
### Motivation
This allows users to be able to increase memory for certain admin commands by overriding PULSAR_MEM in their command line.

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
