### PR TITLE
Update topic names

### DIFF
--- a/site/docs/latest/adaptors/KafkaWrapper.md
+++ b/site/docs/latest/adaptors/KafkaWrapper.md
@@ -24,18 +24,11 @@ tags: [apache, kafka, wrapper]
 
 -->
 
-Pulsar provides an easy option for applications that are currently written using the
-[Apache Kafka](http://kafka.apache.org) Java client API.
-
-
+Pulsar provides an easy option for applications that are currently written using the [Apache Kafka](http://kafka.apache.org) Java client API.
 
 ## Using the Pulsar Kafka compatibility wrapper
 
-In an existing application, change the regular Kafka client dependency and replace it with
-the Pulsar Kafka wrapper:
-
-
-Remove:
+In an existing application, change the regular Kafka client dependency and replace it with the Pulsar Kafka wrapper. Remove:
 
 ```xml
 <dependency>
@@ -45,7 +38,7 @@ Remove:
 </dependency>
 ```
 
-Include dependency for Pulsar Kafka wrapper:
+Then include this dependency for the Pulsar Kafka wrapper:
 
 ```xml
 <dependency>
@@ -81,7 +74,7 @@ instead of `org.apache.kafka.clients.producer.KafkaProducer` and `org.apache.kaf
 
 ```java
 // Topic needs to be a regular Pulsar topic
-String topic = "persistent://sample/standalone/ns/my-topic";
+String topic = "persistent://public/default/my-topic";
 
 Properties props = new Properties();
 // Point to a Pulsar service
@@ -103,7 +96,7 @@ producer.close();
 ## Consumer example
 
 ```java
-String topic = "persistent://sample/standalone/ns/my-topic";
+String topic = "persistent://public/default/my-topic";
 
 Properties props = new Properties();
 // Point to a Pulsar service

--- a/site/docs/latest/adaptors/PulsarSpark.md
+++ b/site/docs/latest/adaptors/PulsarSpark.md
@@ -71,7 +71,7 @@ JavaStreamingContext jssc = new JavaStreamingContext(conf, Durations.seconds(5))
 ClientConfiguration clientConf = new ClientConfiguration();
 ConsumerConfiguration consConf = new ConsumerConfiguration();
 String url = "pulsar://localhost:6650/";
-String topic = "persistent://sample/standalone/ns1/topic1";
+String topic = "persistent://public/default/topic1";
 String subs = "sub1";
 
 JavaReceiverInputDStream<byte[]> msgs = jssc

--- a/site/docs/latest/admin-api/namespaces.md
+++ b/site/docs/latest/admin-api/namespaces.md
@@ -35,21 +35,21 @@ Namespaces can be managed via:
 
 ### Create
 
-You can create new namespaces under a given {% popover property %} and within a Pulsar {% popover cluster %}.
+You can create new namespaces under a given {% popover tenant %}.
 
 #### pulsar-admin
 
 Use the [`create`](../../reference/CliTools#pulsar-admin-namespaces-create) subcommand and specify the namespace by name:
 
 ```shell
-$ pulsar-admin namespaces create test-property/cl1/ns1
+$ pulsar-admin namespaces create test-tenant/test-namespace
 ```
 
 #### REST API
 
-{% endpoint PUT /admin/namespaces/:property/:cluster/:namespace %}
+{% endpoint PUT /admin/namespaces/:tenant/:cluster/:namespace %}
 
-[More info](../../reference/RestApi#/admin/namespaces/:property/:cluster/:namespace)
+[More info](../../reference/RestApi#/admin/namespaces/:tenant/:cluster/:namespace)
 
 #### Java
 
@@ -66,7 +66,7 @@ You can fetch the current policies associated with a namespace at any time.
 Use the [`policies`](../../reference/CliTools#pulsar-admin-namespaces-policies) subcommand and specify the namespace:
 
 ```shell
-$ pulsar-admin namespaces policies test-property/cl1/ns1
+$ pulsar-admin namespaces policies test-tenant/test-namespace
 {
   "auth_policies": {
     "namespace_auth": {},
@@ -92,9 +92,9 @@ $ pulsar-admin namespaces policies test-property/cl1/ns1
 
 #### REST API
 
-{% endpoint GET /admin/namespaces/:property/:cluster/:namespace %}
+{% endpoint GET /admin/namespaces/:tenant/:cluster/:namespace %}
 
-[More info](../../reference/RestApi#/admin/namespaces/:property/:cluster/:namespace)
+[More info](../../reference/RestApi#/admin/namespaces/:tenant/:cluster/:namespace)
 
 #### Java
 
@@ -102,30 +102,30 @@ $ pulsar-admin namespaces policies test-property/cl1/ns1
 admin.namespaces().getPolicies(namespace);
 ```
 
-### List namespaces within a property
+### List namespaces within a tenant
 
-You can list all namespaces within a given Pulsar {% popover property %}.
+You can list all namespaces within a given Pulsar {% popover tenant %}.
 
 #### pulsar-admin
 
-Use the [`list`](../../reference/CliTools#pulsar-admin-namespaces-list) subcommand and specify the property:
+Use the [`list`](../../reference/CliTools#pulsar-admin-namespaces-list) subcommand and specify the tenant:
 
 ```shell
-$ pulsar-admin namespaces list test-property
-test-property/cl1/ns1
-test-property/cl2/ns2
+$ pulsar-admin namespaces list test-tenant
+test-tenant/ns1
+test-tenant/ns2
 ```
 
 #### REST API
 
-{% endpoint GET /admin/namespaces/:property %}
+{% endpoint GET /admin/namespaces/:tenant %}
 
-[More info](../../reference/RestApi#/admin/namespaces/:property)
+[More info](../../reference/RestApi#/admin/namespaces/:tenant)
 
 #### Java
 
 ```java
-admin.namespaces().getNamespaces(property);
+admin.namespaces().getNamespaces(tenant);
 ```
 
 ### List namespaces within a cluster
@@ -137,40 +137,40 @@ You can list all namespaces within a given Pulsar {% popover cluster %}.
 Use the [`list-cluster`](../../reference/CliTools#pulsar-admin-namespaces-list-cluster) subcommand and specify the cluster:
 
 ```shell
-$ pulsar-admin namespaces list-cluster test-property/cl1
-test-property/cl1/ns1
-test-property/cl1/ns1
+$ pulsar-admin namespaces list-cluster test-tenant/cl1
+test-tenant/ns1
+test-tenant/ns2
 ```
 
 #### REST API
 
-{% endpoint GET /admin/namespaces/:property/:cluster %}
+{% endpoint GET /admin/namespaces/:tenant/:cluster %}
 
-[More info](../../reference/RestApi#/admin/namespaces/:property/:cluster)
+[More info](../../reference/RestApi#/admin/namespaces/:tenant/:cluster)
 
 #### Java
 
 ```java
-admin.namespaces().getNamespaces(property, cluster);
+admin.namespaces().getNamespaces(tenant);
 ```
 
 ### Delete
 
-You can delete existing namespaces from a property/cluster.
+You can delete existing namespaces from a tenant.
 
 #### pulsar-admin
 
 Use the [`delete`](../../reference/CliTools#pulsar-admin-namespaces-delete) subcommand and specify the namespace:
 
 ```shell
-$ pulsar-admin namespaces delete test-property/cl1/ns1
+$ pulsar-admin namespaces delete test-tenant/ns1
 ```
 
 #### REST
 
-{% endpoint DELETE /admin/namespaces/:property/:cluster/:namespace %}
+{% endpoint DELETE /admin/namespaces/:tenant/:cluster/:namespace %}
 
-[More info](../../reference/RestApi#/admin/namespaces/:property/:cluster/:namespace)
+[More info](../../reference/RestApi#/admin/namespaces/:tenant/:cluster/:namespace)
 
 #### Java
 
@@ -181,35 +181,35 @@ admin.namespaces().deleteNamespace(namespace);
 
 #### set replication cluster
 
-It sets replication clusters for a namespace, so Pulsar can internally replicate publish message from one colo to another colo. However, in order to set replication clusters, your namespace has to be global such as: *test-property/**global**/ns1.* It means cluster-name has to be *“global”*  
+It sets replication clusters for a namespace, so Pulsar can internally replicate publish message from one colo to another colo.
 
 ###### CLI
 
 ```
-$ pulsar-admin namespaces set-clusters test-property/cl1/ns1 \
-  --clusters cl2
+$ pulsar-admin namespaces set-clusters test-tenant/ns1 \
+  --clusters cl1
 ```
 
 ###### REST
 
 ```
-{% endpoint POST /admin/namespaces/:property/:cluster/:namespace/replication %}
+{% endpoint POST /admin/namespaces/:tenant/:namespace/replication %}
 ```
 
 ###### Java
 
 ```java
-admin.namespaces().setNamespaceReplicationClusters(namespace, clusters)
-```    
+admin.namespaces().setNamespaceReplicationClusters(namespace, clusters);
+```
 
 #### get replication cluster
 
-It gives a list of replication clusters for a given namespace.  
+It gives a list of replication clusters for a given namespace.
 
 ###### CLI
 
 ```
-$ pulsar-admin namespaces get-clusters test-property/cl1/ns1
+$ pulsar-admin namespaces get-clusters test-tenant/cl1/ns1
 ```
 
 ```
@@ -219,7 +219,7 @@ cl2
 ###### REST
 
 ```
-GET /admin/namespaces/{property}/{cluster}/{namespace}/replication
+GET /admin/namespaces/{tenant}/{namespace}/replication
 ```
 
 ###### Java
@@ -243,7 +243,7 @@ Backlog quota helps broker to restrict bandwidth/storage of a namespace once it 
 ###### CLI
 
 ```
-$ pulsar-admin namespaces set-backlog-quota --limit 10 --policy producer_request_hold test-property/cl1/ns1
+$ pulsar-admin namespaces set-backlog-quota --limit 10 --policy producer_request_hold test-tenant/ns1
 ```
 
 ```
@@ -253,7 +253,7 @@ N/A
 ###### REST
 
 ```
-POST /admin/namespaces/{property}/{cluster}/{namespace}/backlogQuota
+POST /admin/namespaces/{tenant}/{namespace}/backlogQuota
 ```
 
 ###### Java
@@ -264,43 +264,43 @@ admin.namespaces().setBacklogQuota(namespace, new BacklogQuota(limit, policy))
 
 #### get backlog quota policies
 
-It shows a configured backlog quota for a given namespace.  
+It shows a configured backlog quota for a given namespace.
 
 ###### CLI
 
 ```
-$ pulsar-admin namespaces get-backlog-quotas test-property/cl1/ns1
+$ pulsar-admin namespaces get-backlog-quotas test-tenant/ns1
 ```
 
 ```json
 {
-    "destination_storage": {
-        "limit": 10,
-        "policy": "producer_request_hold"
-    }
+  "destination_storage": {
+    "limit": 10,
+    "policy": "producer_request_hold"
+  }
 }          
 ```
 
 ###### REST
 
 ```
-GET /admin/namespaces/{property}/{cluster}/{namespace}/backlogQuotaMap
+GET /admin/namespaces/{tenant}/{namespace}/backlogQuotaMap
 ```
 
 ###### Java
 
 ```java
-admin.namespaces().getBacklogQuotaMap(namespace)
+admin.namespaces().getBacklogQuotaMap(namespace);
 ```
 
-#### remove backlog quota policies  
+#### remove backlog quota policies
 
 It removes backlog quota policies for a given namespace  
 
 ###### CLI
 
 ```
-$ pulsar-admin namespaces remove-backlog-quota test-property/cl1/ns1
+$ pulsar-admin namespaces remove-backlog-quota test-tenant/ns1
 ```
 
 ```
@@ -310,7 +310,7 @@ N/A
 ###### REST
 
 ```
-DELETE /admin/namespaces/{property}/{cluster}/{namespace}/backlogQuota
+DELETE /admin/namespaces/{tenant}/{namespace}/backlogQuota
 ```
 
 ###### Java
@@ -334,7 +334,7 @@ Persistence policies allow to configure persistency-level for all topic messages
 ###### CLI
 
 ```
-$ pulsar-admin namespaces set-persistence --bookkeeper-ack-quorum 2 --bookkeeper-ensemble 3 --bookkeeper-write-quorum 2 --ml-mark-delete-max-rate 0 test-property/cl1/ns1
+$ pulsar-admin namespaces set-persistence --bookkeeper-ack-quorum 2 --bookkeeper-ensemble 3 --bookkeeper-write-quorum 2 --ml-mark-delete-max-rate 0 test-tenant/ns1
 ```
 
 ```
@@ -344,7 +344,7 @@ N/A
 ###### REST
 
 ```
-POST /admin/persistent/{property}/{cluster}/{namespace}/persistence
+POST /admin/persistent/{tenant}/{namespace}/persistence
 ```
 
 ###### Java
@@ -361,7 +361,7 @@ It shows configured persistence policies of a given namespace.
 ###### CLI
 
 ```
-$ pulsar-admin namespaces get-persistence test-property/cl1/ns1
+$ pulsar-admin namespaces get-persistence test-tenant/ns1
 ```
 
 ```json
@@ -376,7 +376,7 @@ $ pulsar-admin namespaces get-persistence test-property/cl1/ns1
 ###### REST
 
 ```
-GET /admin/namespaces/{property}/{cluster}/{namespace}/persistence
+GET /admin/namespaces/{tenant}/{namespace}/persistence
 ```
 
 ###### Java
@@ -393,7 +393,7 @@ Namespace bundle is a virtual group of topics which belong to same namespace. If
 ###### CLI
 
 ```
-$ pulsar-admin namespaces unload --bundle 0x00000000_0xffffffff test-property/pstg-gq1/ns1
+$ pulsar-admin namespaces unload --bundle 0x00000000_0xffffffff test-tenant/ns1
 ```
 
 ```
@@ -403,7 +403,7 @@ N/A
 ###### REST
 
 ```
-PUT /admin/namespaces/{property}/{cluster}/{namespace}/unload
+PUT /admin/namespaces/{tenant}/{namespace}/unload
 ```
 
 ###### Java
@@ -415,12 +415,12 @@ admin.namespaces().unloadNamespaceBundle(namespace, bundle)
 
 #### set message-ttl
 
-It configures message’s time to live (in seconds) duration.  
+It configures message’s time to live (in seconds) duration.
 
 ###### CLI
 
 ```
-$ pulsar-admin namespaces set-message-ttl --messageTTL 100 test-property/cl1/ns1
+$ pulsar-admin namespaces set-message-ttl --messageTTL 100 test-tenant/ns1
 ```
 
 ```
@@ -430,7 +430,7 @@ N/A
 ###### REST
 
 ```
-POST /admin/namespaces/{property}/{cluster}/{namespace}/messageTTL
+POST /admin/namespaces/{tenant}/{namespace}/messageTTL
 ```
 
 ###### Java
@@ -441,12 +441,12 @@ admin.namespaces().setNamespaceMessageTTL(namespace, messageTTL)
 
 #### get message-ttl
 
-It gives a message ttl of configured namespace.  
+It gives a message ttl of configured namespace.
 
 ###### CLI
 
 ```
-$ pulsar-admin namespaces get-message-ttl test-property/cl1/ns1
+$ pulsar-admin namespaces get-message-ttl test-tenant/ns1
 ```
 
 ```
@@ -457,7 +457,7 @@ $ pulsar-admin namespaces get-message-ttl test-property/cl1/ns1
 ###### REST
 
 ```
-GET /admin/namespaces/{property}/{cluster}/{namespace}/messageTTL
+GET /admin/namespaces/{tenant}/{namespace}/messageTTL
 ```
 
 ###### Java
@@ -474,7 +474,7 @@ Each namespace bundle can contain multiple topics and each bundle can be served 
 ###### CLI
 
 ```
-$ pulsar-admin namespaces split-bundle --bundle 0x00000000_0xffffffff test-property/cl1/ns1
+$ pulsar-admin namespaces split-bundle --bundle 0x00000000_0xffffffff test-tenant/ns1
 ```
 
 ```
@@ -484,7 +484,7 @@ N/A
 ###### REST
 
 ```
-PUT /admin/namespaces/{property}/{cluster}/{namespace}/{bundle}/split
+PUT /admin/namespaces/{tenant}/{namespace}/{bundle}/split
 ```
 
 ###### Java
@@ -501,7 +501,7 @@ It clears all message backlog for all the topics those belong to specific namesp
 ###### CLI
 
 ```
-$ pulsar-admin namespaces clear-backlog --sub my-subscription test-property/pstg-gq1/ns1
+$ pulsar-admin namespaces clear-backlog --sub my-subscription test-tenant/ns1
 ```
 
 ```
@@ -511,7 +511,7 @@ N/A
 ###### REST
 
 ```
-POST /admin/namespaces/{property}/{cluster}/{namespace}/clearBacklog
+POST /admin/namespaces/{tenant}/{namespace}/clearBacklog
 ```
 
 ###### Java
@@ -528,7 +528,7 @@ It clears all message backlog for all the topics those belong to specific Namesp
 ###### CLI
 
 ```
-$ pulsar-admin namespaces clear-backlog  --bundle 0x00000000_0xffffffff  --sub my-subscription test-property/pstg-gq1/ns1
+$ pulsar-admin namespaces clear-backlog  --bundle 0x00000000_0xffffffff  --sub my-subscription test-tenant/ns1
 ```
 
 ```
@@ -538,7 +538,7 @@ N/A
 ###### REST
 
 ```
-POST /admin/namespaces/{property}/{cluster}/{namespace}/{bundle}/clearBacklog
+POST /admin/namespaces/{tenant}/{namespace}/{bundle}/clearBacklog
 ```
 
 ###### Java
@@ -550,12 +550,12 @@ admin.namespaces().clearNamespaceBundleBacklogForSubscription(namespace, bundle,
 
 #### set retention
 
-Each namespace contains multiple topics and each topic’s retention size (storage size) should not exceed to a specific threshold or it should be stored till certain time duration. This command helps to configure retention size and time of topics in a given namespace.  
+Each namespace contains multiple topics and each topic’s retention size (storage size) should not exceed to a specific threshold or it should be stored till certain time duration. This command helps to configure retention size and time of topics in a given namespace.
 
 ###### CLI
 
 ```
-$ pulsar-admin set-retention --size 10 --time 100 test-property/cl1/ns1
+$ pulsar-admin set-retention --size 10 --time 100 test-tenant/ns1
 ```
 
 ```
@@ -565,7 +565,7 @@ N/A
 ###### REST
 
 ```
-POST /admin/namespaces/{property}/{cluster}/{namespace}/retention
+POST /admin/namespaces/{tenant}/{namespace}/retention
 ```
 
 ###### Java
@@ -577,25 +577,25 @@ admin.namespaces().setRetention(namespace, new RetentionPolicies(retentionTimeIn
 
 #### get retention
 
-It shows retention information of a given namespace.  
+It shows retention information of a given namespace.
 
 ###### CLI
 
 ```
-$ pulsar-admin namespaces get-retention test-property/cl1/ns1
+$ pulsar-admin namespaces get-retention test-tenant/ns1
 ```
 
 ```json
 {
-    "retentionTimeInMinutes": 10,
-    "retentionSizeInMB": 100
+  "retentionTimeInMinutes": 10,
+  "retentionSizeInMB": 100
 }
 ```
 
 ###### REST
 
 ```
-GET /admin/namespaces/{property}/{cluster}/{namespace}/retention
+GET /admin/namespaces/{tenant}/{namespace}/retention
 ```
 
 ###### Java
@@ -614,13 +614,16 @@ disables the throttling.
 ###### CLI
 
 ```
-$ pulsar-admin namespaces set-dispatch-rate test-property/cl1/ns1 --msg-dispatch-rate 1000 --byte-dispatch-rate 1048576 --dispatch-rate-period 1
+$ pulsar-admin namespaces set-dispatch-rate test-tenant/ns1 \
+  --msg-dispatch-rate 1000 \
+  --byte-dispatch-rate 1048576 \
+  --dispatch-rate-period 1
 ```
 
 ###### REST
 
 ```
-POST /admin/namespaces/{property}/{cluster}/{namespace}/dispatchRate
+POST /admin/namespaces/{tenant}/{namespace}/dispatchRate
 ```
 
 ###### Java
@@ -636,7 +639,7 @@ It shows configured message-rate for the namespace (topics under this namespace 
 ###### CLI
 
 ```
-$ pulsar-admin namespaces get-dispatch-rate test-property/cl1/ns1
+$ pulsar-admin namespaces get-dispatch-rate test-tenant/ns1
 ```
 
 ```json
@@ -650,7 +653,7 @@ $ pulsar-admin namespaces get-dispatch-rate test-property/cl1/ns1
 ###### REST
 
 ```
-GET /admin/namespaces/{property}/{cluster}/{namespace}/dispatchRate
+GET /admin/namespaces/{tenant}/{namespace}/dispatchRate
 ```
 
 ###### Java
@@ -675,7 +678,7 @@ Use the [`unload`](../../reference/CliTools#pulsar-admin-namespaces-unload) subc
 ##### Example
 
 ```shell
-$ pulsar-admin namespaces unload my-prop/my-cluster/my-ns
+$ pulsar-admin namespaces unload my-tenant/my-ns
 ```
 
 #### REST API

--- a/site/docs/latest/admin-api/non-persistent-topics.md
+++ b/site/docs/latest/admin-api/non-persistent-topics.md
@@ -29,7 +29,7 @@ persisting messages.
 
 In all of the instructions and commands below, the topic name structure is:
 
-`non-persistent://property/cluster/namespace/topic`
+{% include topic.html ten="tenant" n="namespace" t="topic" %}
 
 ## Non-persistent topics resources
 
@@ -136,18 +136,18 @@ Topic stats can be fetched using [`stats`](../../reference/CliTools#stats) comma
 
 ```shell
 $ pulsar-admin non-persistent stats \
-  non-persistent://test-property/cl1/ns1/tp1 \
+  non-persistent://test-tenant/ns1/tp1 \
 ```
 
 #### REST API
 
-{% endpoint GET /admin/non-persistent/:property/:cluster/:namespace/:destination/stats %}
+{% endpoint GET /admin/non-persistent/:tenant/:namespace/:destination/stats %}
 
 
 #### Java
 
 ```java
-String destination = "non-persistent://my-property/my-cluster-my-namespace/my-topic";
+String destination = "non-persistent://my-tenant/my-namespace/my-topic";
 admin.nonPersistentTopics().getStats(destination);
 ```
 
@@ -161,7 +161,7 @@ Topic internal-stats can be fetched using [`stats-internal`](../../reference/Cli
 
 ```shell
 $ pulsar-admin non-persistent stats-internal \
-  non-persistent://test-property/cl1/ns1/tp1 \
+  non-persistent://test-tenant/ns1/tp1 \
 
 {
   "entriesAddedCounter" : 48834,
@@ -182,13 +182,13 @@ $ pulsar-admin non-persistent stats-internal \
 
 #### REST API
 
-{% endpoint GET /admin/non-persistent/:property/:cluster/:namespace/:destination/internalStats %}
+{% endpoint GET /admin/non-persistent/:tenant/:namespace/:destination/internalStats %}
 
 
 #### Java
 
 ```java
-String destination = "non-persistent://my-property/my-cluster-my-namespace/my-topic";
+String destination = "non-persistent://my-tenant/my-namespace/my-topic";
 admin.nonPersistentTopics().getInternalStats(destination);
 ```
 
@@ -200,18 +200,18 @@ Partitioned topics in Pulsar must be explicitly created. When creating a new par
 
 ```shell
 $ bin/pulsar-admin non-persistent create-partitioned-topic \
-  non-persistent://my-property/my-cluster-my-namespace/my-topic \
+  non-persistent://my-tenant/my-namespace/my-topic \
   --partitions 4
 ```
 
 #### REST API
 
-{% endpoint PUT /admin/non-persistent/:property/:cluster/:namespace/:destination/partitions %}
+{% endpoint PUT /admin/non-persistent/:tenant/:namespace/:destination/partitions %}
 
 #### Java
 
 ```java
-String topicName = "non-persistent://my-property/my-cluster-my-namespace/my-topic";
+String topicName = "non-persistent://my-tenant/my-namespace/my-topic";
 int numPartitions = 4;
 admin.nonPersistentTopics().createPartitionedTopic(topicName, numPartitions);
 ```
@@ -228,7 +228,7 @@ Field | Meaning
 
 ```shell
 $ pulsar-admin non-persistent get-partitioned-topic-metadata \
-  non-persistent://my-property/my-cluster-my-namespace/my-topic
+  non-persistent://my-tenant/my-namespace/my-topic
 {
   "partitions": 4
 }
@@ -236,13 +236,13 @@ $ pulsar-admin non-persistent get-partitioned-topic-metadata \
 
 #### REST API
 
-{% endpoint GET /admin/non-persistent/:property/:cluster:/:namespace/:destination/partitions %}
+{% endpoint GET /admin/non-persistent/:tenant/:namespace/:destination/partitions %}
 
 
 #### Java
 
 ```java
-String topicName = "non-persistent://my-property/my-cluster-my-namespace/my-topic";
+String topicName = "non-persistent://my-tenant/my-namespace/my-topic";
 admin.nonPersistentTopics().getPartitionedTopicMetadata(topicName);
 ```
 
@@ -256,18 +256,18 @@ Topic can be unloaded using [`unload`](../../reference/CliTools#unload) command.
 
 ```shell
 $ pulsar-admin non-persistent unload \
-  non-persistent://test-property/cl1/ns1/tp1 \
+  non-persistent://test-tenant/ns1/tp1 \
 ```
 
 #### REST API
 
-{% endpoint PUT /admin/non-persistent/:property/:cluster/:namespace/:destination/unload %}
+{% endpoint PUT /admin/non-persistent/:tenant/:namespace/:destination/unload %}
 
-[More info](../../reference/RestApi#/admin/non-persistent/:property/:cluster/:namespace/:destination/unload)
+[More info](../../reference/RestApi#/admin/non-persistent/:tenant/:namespace/:destination/unload)
 
 #### Java
 
 ```java
-String destination = "non-persistent://my-property/my-cluster-my-namespace/my-topic";
+String destination = "non-persistent://my-tenantmy-namespace/my-topic";
 admin.nonPersistentTopics().unload(destination);
 ```

--- a/site/docs/latest/admin-api/persistent-topics.md
+++ b/site/docs/latest/admin-api/persistent-topics.md
@@ -41,20 +41,19 @@ List of topics can be fetched using [`list`](../../reference/CliTools#list) comm
 
 ```shell
 $ pulsar-admin persistent list \
-  my-property/my-cluster/my-namespace \
-  my-topic
+  my-tenant/my-namespace
 ```
 
 #### REST API
 
-{% endpoint GET /admin/persistent/:property/:cluster/:namespace %}
+{% endpoint GET /admin/persistent/:tenant/:namespace %}
 
-[More info](../../reference/RestApi#/admin/persistent/:property/:cluster/:namespace)
+[More info](../../reference/RestApi#/admin/persistent/:tenant/:namespace)
 
 #### Java
 
 ```java
-String namespace = "my-property/my-cluster-my-namespace";
+String namespace = "my-tenant/my-namespace";
 admin.persistentTopics().getList(namespace);
 ```
 
@@ -69,20 +68,20 @@ Permission can be granted using [`grant-permission`](../../reference/CliTools#gr
 ```shell
 $ pulsar-admin persistent grant-permission \
   --actions produce,consume --role application1 \
-  persistent://test-property/cl1/ns1/tp1 \
+  persistent://test-tenant/ns1/tp1 \
 
 ```
 
 #### REST API
 
-{% endpoint POST /admin/namespaces/:property/:cluster/:namespace/permissions/:role %}
+{% endpoint POST /admin/namespaces/:tenant/:namespace/permissions/:role %}
 
-[More info](../../reference/RestApi#/admin/namespaces/:property/:cluster/:namespace/permissions/:role)
+[More info](../../reference/RestApi#/admin/namespaces/:tenant/:namespace/permissions/:role)
 
 #### Java
 
 ```java
-String destination = "persistent://my-property/my-cluster-my-namespace/my-topic";
+String destination = "persistent://my-tenant/my-namespace/my-topic";
 String role = "test-role";
 Set<AuthAction> actions  = Sets.newHashSet(AuthAction.produce, AuthAction.consume);
 admin.persistentTopics().grantPermission(destination, role, actions);
@@ -98,7 +97,7 @@ TODO: admin
 
 ```shell
 $ pulsar-admin persistent permissions \
-  persistent://test-property/cl1/ns1/tp1 \
+  persistent://test-tenant/ns1/tp1 \
 
 {
     "application1": [
@@ -110,14 +109,14 @@ $ pulsar-admin persistent permissions \
 
 #### REST API
 
-{% endpoint GET /admin/namespaces/:property/:cluster/:namespace/permissions %}
+{% endpoint GET /admin/namespaces/:tenant/:namespace/permissions %}
 
-[More info](../../reference/RestApi#/admin/namespaces/:property/:cluster/:namespace/permissions)
+[More info](../../reference/RestApi#/admin/namespaces/:tenant:namespace/permissions)
 
 #### Java
 
 ```java
-String destination = "persistent://my-property/my-cluster-my-namespace/my-topic";
+String destination = "persistent://my-tenant/my-namespace/my-topic";
 admin.persistentTopics().getPermissions(destination);
 ```
 
@@ -132,26 +131,26 @@ Permission can be revoked using [`revoke-permission`](../../reference/CliTools#r
 ```shell
 $ pulsar-admin persistent revoke-permission \
   --role application1 \
-  persistent://test-property/cl1/ns1/tp1 \
+  persistent://test-tenant/ns1/tp1 \
 
 {
-    "application1": [
-        "consume",
-        "produce"
-    ]
+  "application1": [
+    "consume",
+    "produce"
+  ]
 }
 ```
 
 #### REST API
 
-{% endpoint DELETE /admin/namespaces/:property/:cluster/:namespace/permissions/:role %}
+{% endpoint DELETE /admin/namespaces/:tenant:namespace/permissions/:role %}
 
-[More info](../../reference/RestApi#/admin/namespaces/:property/:cluster/:namespace/permissions/:role)
+[More info](../../reference/RestApi#/admin/namespaces/:tenant/:namespace/permissions/:role)
 
 #### Java
 
 ```java
-String destination = "persistent://my-property/my-cluster-my-namespace/my-topic";
+String destination = "persistent://my-tenant/my-namespace/my-topic";
 String role = "test-role";
 admin.persistentTopics().revokePermissions(destination, role);
 ```
@@ -166,19 +165,19 @@ Topic can be deleted using [`delete`](../../reference/CliTools#delete) command.
 
 ```shell
 $ pulsar-admin persistent delete \
-  persistent://test-property/cl1/ns1/tp1 \
+  persistent://test-tenant/ns1/tp1 \
 ```
 
 #### REST API
 
-{% endpoint DELETE /admin/persistent/:property/:cluster/:namespace/:destination %}
+{% endpoint DELETE /admin/persistent/:tenant/:namespace/:destination %}
 
-[More info](../../reference/RestApi#/admin/persistent/:property/:cluster/:namespace/:destination)
+[More info](../../reference/RestApi#/admin/persistent/:tenant/:namespace/:destination)
 
 #### Java
 
 ```java
-String destination = "persistent://my-property/my-cluster-my-namespace/my-topic";
+String destination = "persistent://my-tenant/my-namespace/my-topic";
 admin.persistentTopics().delete(destination);
 ```
 
@@ -192,19 +191,19 @@ Topic can be unloaded using [`unload`](../../reference/CliTools#unload) command.
 
 ```shell
 $ pulsar-admin persistent unload \
-  persistent://test-property/cl1/ns1/tp1 \
+  persistent://test-tenant/ns1/tp1 \
 ```
 
 #### REST API
 
-{% endpoint PUT /admin/persistent/:property/:cluster/:namespace/:destination/unload %}
+{% endpoint PUT /admin/persistent/:tenant/:namespace/:destination/unload %}
 
-[More info](../../reference/RestApi#/admin/persistent/:property/:cluster/:namespace/:destination/unload)
+[More info](../../reference/RestApi#/admin/persistent/:tenant/:namespace/:destination/unload)
 
 #### Java
 
 ```java
-String destination = "persistent://my-property/my-cluster-my-namespace/my-topic";
+String destination = "persistent://my-tenant/my-namespace/my-topic";
 admin.persistentTopics().unload(destination);
 ```
 
@@ -303,19 +302,19 @@ Topic stats can be fetched using [`stats`](../../reference/CliTools#stats) comma
 
 ```shell
 $ pulsar-admin persistent stats \
-  persistent://test-property/cl1/ns1/tp1 \
+  persistent://test-tenant/ns1/tp1 \
 ```
 
 #### REST API
 
-{% endpoint GET /admin/persistent/:property/:cluster/:namespace/:destination/stats %}
+{% endpoint GET /admin/persistent/:tenant/:namespace/:destination/stats %}
 
-[More info](../../reference/RestApi#/admin/persistent/:property/:cluster/:namespace/:destination/stats)
+[More info](../../reference/RestApi#/admin/persistent/:tenant:namespace/:destination/stats)
 
 #### Java
 
 ```java
-String destination = "persistent://my-property/my-cluster-my-namespace/my-topic";
+String destination = "persistent://my-tenant/my-namespace/my-topic";
 admin.persistentTopics().getStats(destination);
 ```
 
@@ -413,19 +412,19 @@ Topic internal-stats can be fetched using [`stats-internal`](../../reference/Cli
 
 ```shell
 $ pulsar-admin persistent stats-internal \
-  persistent://test-property/cl1/ns1/tp1 \
+  persistent://test-tenant/ns1/tp1 \
 ```
 
 #### REST API
 
-{% endpoint GET /admin/persistent/:property/:cluster/:namespace/:destination/internalStats %}
+{% endpoint GET /admin/persistent/:tenant/:namespace/:destination/internalStats %}
 
-[More info](../../reference/RestApi#/admin/persistent/:property/:cluster/:namespace/:destination/internalStats)
+[More info](../../reference/RestApi#/admin/persistent/:tenant/:namespace/:destination/internalStats)
 
 #### Java
 
 ```java
-String destination = "persistent://my-property/my-cluster-my-namespace/my-topic";
+String destination = "persistent://my-tenant/my-namespace/my-topic";
 admin.persistentTopics().getInternalStats(destination);
 ```
 
@@ -439,23 +438,23 @@ It peeks N messages for a specific subscription of a given topic.
 ```shell
 $ pulsar-admin persistent peek-messages \
   --count 10 --subscription my-subscription \
-  persistent://test-property/cl1/ns1/tp1 \
+  persistent://test-tenant/ns1/tp1 \
 
-Message ID: 315674752:0  
+Message ID: 315674752:0
 Properties:  {  "X-Pulsar-publish-time" : "2015-07-13 17:40:28.451"  }
 msg-payload
 ```
 
 #### REST API
 
-{% endpoint GET /admin/persistent/:property/:cluster/:namespace/:destination/subscription/:subName/position/:messagePosition %}
+{% endpoint GET /admin/persistent/:tenant/:namespace/:destination/subscription/:subName/position/:messagePosition %}
 
-[More info](../../reference/RestApi#/admin/persistent/:property/:cluster/:namespace/:destination/subscription/:subName/position/:messagePosition)
+[More info](../../reference/RestApi#/admin/persistent/:tenant/:namespace/:destination/subscription/:subName/position/:messagePosition)
 
 #### Java
 
 ```java
-String destination = "persistent://my-property/my-cluster-my-namespace/my-topic";
+String destination = "persistent://my-tenant/my-namespace/my-topic";
 String subName = "my-subscription";
 int numMessages = 1;
 admin.persistentTopics().peekMessages(destination, subName, numMessages);
@@ -471,19 +470,19 @@ It skips N messages for a specific subscription of a given topic.
 ```shell
 $ pulsar-admin persistent skip \
   --count 10 --subscription my-subscription \
-  persistent://test-property/cl1/ns1/tp1 \
+  persistent://test-tenant/ns1/tp1 \
 ```
 
 #### REST API
 
-{% endpoint POST /admin/persistent/:property/:cluster/:namespace/:destination/subscription/:subName/skip/:numMessages %}
+{% endpoint POST /admin/persistent/:tenant/:namespace/:destination/subscription/:subName/skip/:numMessages %}
 
-[More info](../../reference/RestApi#/admin/persistent/:property/:cluster/:namespace/:destination/subscription/:subName/skip/:numMessages)
+[More info](../../reference/RestApi#/admin/persistent/:tenant/:namespace/:destination/subscription/:subName/skip/:numMessages)
 
 #### Java
 
 ```java
-String destination = "persistent://my-property/my-cluster-my-namespace/my-topic";
+String destination = "persistent://my-tenant/my-namespace/my-topic";
 String subName = "my-subscription";
 int numMessages = 1;
 admin.persistentTopics().skipMessages(destination, subName, numMessages);
@@ -499,19 +498,19 @@ It skips all old messages for a specific subscription of a given topic.
 ```shell
 $ pulsar-admin persistent skip-all \
   --subscription my-subscription \
-  persistent://test-property/cl1/ns1/tp1 \
+  persistent://test-tenant/ns1/tp1 \
 ```
 
 #### REST API
 
-{% endpoint POST /admin/persistent/:property/:cluster/:namespace/:destination/subscription/:subName/skip_all %}
+{% endpoint POST /admin/persistent/:tenant/:namespace/:destination/subscription/:subName/skip_all %}
 
-[More info](../../reference/RestApi#/admin/persistent/:property/:cluster/:namespace/:destination/subscription/:subName/skip_all)
+[More info](../../reference/RestApi#/admin/persistent/:tenant/:namespace/:destination/subscription/:subName/skip_all)
 
 #### Java
 
 ```java
-String destination = "persistent://my-property/my-cluster-my-namespace/my-topic";
+String destination = "persistent://my-tenant/my-namespace/my-topic";
 String subName = "my-subscription";
 admin.persistentTopics().skipAllMessages(destination, subName);
 ```
@@ -526,19 +525,19 @@ It resets a subscription’s cursor position back to the position which was reco
 ```shell
 $ pulsar-admin persistent reset-cursor \
   --subscription my-subscription --time 10 \
-  persistent://test-property/cl1/ns1/tp1 \
+  persistent://test-tenant/ns1/tp1 \
 ```
 
 #### REST API
 
-{% endpoint POST /admin/persistent/:property/:cluster/:namespace/:destination/subscription/:subName/resetcursor/:timestamp %}
+{% endpoint POST /admin/persistent/:tenant/:namespace/:destination/subscription/:subName/resetcursor/:timestamp %}
 
-[More info](../../reference/RestApi#/admin/persistent/:property/:cluster/:namespace/:destination/subscription/:subName/resetcursor/:timestamp)
+[More info](../../reference/RestApi#/admin/persistent/:tenant/:namespace/:destination/subscription/:subName/resetcursor/:timestamp)
 
 #### Java
 
 ```java
-String destination = "persistent://my-property/my-cluster-my-namespace/my-topic";
+String destination = "persistent://my-tenant/my-namespace/my-topic";
 String subName = "my-subscription";
 long timestamp = 2342343L;
 admin.persistentTopics().skipAllMessages(destination, subName, timestamp);
@@ -553,19 +552,19 @@ It locates broker url which is serving the given topic.
 
 ```shell
 $ pulsar-admin persistent lookup \
-  persistent://test-property/cl1/ns1/tp1 \
+  persistent://test-tenant/ns1/tp1 \
 
  "pulsar://broker1.org.com:4480"
 ```
 
 #### REST API
 
-{% endpoint GET /lookup/v2/destination/persistent/:property/:cluster/:namespace/:destination %}
+{% endpoint GET /lookup/v2/destination/persistent/:tenant:namespace/:destination %}
 
 #### Java
 
 ```java
-String destination = "persistent://my-property/my-cluster-my-namespace/my-topic";
+String destination = "persistent://my-tenant/my-namespace/my-topic";
 admin.lookup().lookupDestination(destination);
 ```
 
@@ -578,19 +577,19 @@ It gives range of the bundle which contains given topic
 
 ```shell
 $ pulsar-admin persistent bundle-range \
-  persistent://test-property/cl1/ns1/tp1 \
+  persistent://test-tenant/ns1/tp1 \
 
  "0x00000000_0xffffffff"
 ```
 
 #### REST API
 
-{% endpoint GET /lookup/v2/destination/:destination_domain/:property/:cluster/:namespace/:destination/bundle %}
+{% endpoint GET /lookup/v2/destination/:destination_domain/:tenant/:namespace/:destination/bundle %}
 
 #### Java
 
 ```java
-String destination = "persistent://my-property/my-cluster-my-namespace/my-topic";
+String destination = "persistent://my-tenant/my-namespace/my-topic";
 admin.lookup().getBundleRange(destination);
 ```
 
@@ -603,21 +602,21 @@ It shows all subscription names for a given topic.
 
 ```shell
 $ pulsar-admin persistent subscriptions \
-  persistent://test-property/cl1/ns1/tp1 \
+  persistent://test-tenant/ns1/tp1 \
 
  my-subscription
 ```
 
 #### REST API
 
-{% endpoint GET /admin/persistent/:property/:cluster/:namespace/:destination/subscriptions %}
+{% endpoint GET /admin/persistent/:tenant/:namespace/:destination/subscriptions %}
 
-[More info](../../reference/RestApi#/admin/persistent/:property/:cluster/:namespace/:destination/subscriptions)
+[More info](../../reference/RestApi#/admin/persistent/:tenant/:namespace/:destination/subscriptions)
 
 #### Java
 
 ```java
-String destination = "persistent://my-property/my-cluster-my-namespace/my-topic";
+String destination = "persistent://my-tenant/my-namespace/my-topic";
 admin.persistentTopics().getSubscriptions(destination);
 ```
 
@@ -631,19 +630,19 @@ It can also help to unsubscribe a subscription which is no more processing furth
 ```shell
 $ pulsar-admin persistent unsubscribe \
   --subscription my-subscription \
-  persistent://test-property/cl1/ns1/tp1 \
+  persistent://test-tenant/ns1/tp1 \
 ```
 
 #### REST API
 
-{% endpoint POST /admin/namespaces/:property/:cluster/:namespace/unsubscribe/:subscription %}
+{% endpoint POST /admin/namespaces/:tenant/:namespace/unsubscribe/:subscription %}
 
-[More info](../../reference/RestApi#/admin/namespaces/:property/:cluster/:namespace/unsubscribe/:subscription)
+[More info](../../reference/RestApi#/admin/namespaces/:tenant/:namespace/unsubscribe/:subscription)
 
 #### Java
 
 ```java
-String destination = "persistent://my-property/my-cluster-my-namespace/my-topic";
+String destination = "persistent://my-tenant/my-namespace/my-topic";
 String subscriptionName = "my-subscription";
 admin.persistentTopics().deleteSubscription(destination, subscriptionName);
 ```

--- a/site/docs/latest/clients/Cpp.md
+++ b/site/docs/latest/clients/Cpp.md
@@ -123,7 +123,7 @@ $ make
 Client client("pulsar://localhost:6650");
 
 Consumer consumer;
-Result result = client.subscribe("persistent://sample/standalone/ns1/my-topic", "my-subscribtion-name", consumer);
+Result result = client.subscribe("persistent://public/default/my-topic", "my-subscribtion-name", consumer);
 if (result != ResultOk) {
     LOG_ERROR("Failed to subscribe: " << result);
     return -1;
@@ -148,7 +148,7 @@ client.close();
 Client client("pulsar://localhost:6650");
 
 Producer producer;
-Result result = client.createProducer("persistent://sample/standalone/ns1/my-topic", producer);
+Result result = client.createProducer("persistent://public/default/my-topic", producer);
 if (result != ResultOk) {
     LOG_ERROR("Error creating producer: " << result);
     return -1;

--- a/site/docs/latest/clients/Java.md
+++ b/site/docs/latest/clients/Java.md
@@ -96,7 +96,7 @@ In addition to client-level configuration, you can also apply [producer](#config
 In Pulsar, {% popover producers %} write {% popover messages %} to {% popover topics %}. Once you've instantiated a {% javadoc PulsarClient client org.apache.pulsar.client.api.PulsarClient %} object (as in the section [above](#client-configuration)), you can create a {% javadoc Producer client org.apache.pulsar.client.api.Producer %} for a specific Pulsar {% popover topic %}.
 
 ```java
-String topic = "persistent://sample/standalone/ns1/my-topic";
+String topic = "persistent://public/default/my-topic";
 
 Producer producer<byte[]> = client.newProducer()
         .topic(topic)
@@ -252,13 +252,13 @@ ConsumerBuilder consumerBuilder = pulsarClient.newConsumer()
         .subscriptionName(subscription);
 
 // Subscribe to all topics in a namespace
-Pattern allTopicsInNamespace = Pattern.compile("persistent://sample/standalone/ns1/.*");
+Pattern allTopicsInNamespace = Pattern.compile("persistent://public/default/.*");
 Consumer allTopicsConsumer = consumerBuilder
         .topicsPattern(allTopicsInNamespace)
         .subscribe();
 
 // Subscribe to a subsets of topics in a namespace, based on regex
-Pattern someTopicsInNamespace = Pattern.compile("persistent://sample/standalone/ns1/foo.*");
+Pattern someTopicsInNamespace = Pattern.compile("persistent://public/default/foo.*");
 Consumer allTopicsConsumer = consumerBuilder
         .topicsPattern(someTopicsInNamespace)
         .subscribe();
@@ -268,9 +268,9 @@ You can also subscribe to an explicit list of topics (across namespaces if you w
 
 ```java
 List<String> topics = Arrays.asList(
-        "persistent://sample/standalone/ns1/topic-1",
-        "persistent://sample/standalone/ns2/topic-2",
-        "persistent://sample/standalone/ns3/topic-3"
+        "persistent://public/default/topic-1",
+        "persistent://public/default/topic-2",
+        "persistent://public/default/topic-3"
 );
 
 Consumer multiTopicConsumer = consumerBuilder
@@ -280,9 +280,9 @@ Consumer multiTopicConsumer = consumerBuilder
 // Alternatively:
 Consumer multiTopicConsumer = consumerBuilder
         .topics(
-            "persistent://sample/standalone/ns1/topic-1",
-            "persistent://sample/standalone/ns2/topic-2",
-            "persistent://sample/standalone/ns3/topic-3"
+            "persistent://public/default/topic-1",
+            "persistent://public/default/topic-2",
+            "persistent://public/default/topic-3"
         )
         .subscribe();
 ```
@@ -290,7 +290,7 @@ Consumer multiTopicConsumer = consumerBuilder
 You can also subscribe to multiple topics asynchronously using the `subscribeAsync` method rather than the synchronous `subscribe` method. Here's an example:
 
 ```java
-Pattern allTopicsInNamespace = Pattern.compile("persistent://sample/standalone/ns1/.*");
+Pattern allTopicsInNamespace = Pattern.compile("persistent://public/default.*");
 consumerBuilder
         .topics(topics)
         .subscribeAsync()
@@ -474,4 +474,3 @@ The `privateKey` parameter supports the following three pattern formats:
 * `file:///path/to/file`
 * `file:/path/to/file`
 * `data:application/x-pem-file;base64,<base64-encoded value>`' %}
-

--- a/site/docs/latest/clients/WebSocket.md
+++ b/site/docs/latest/clients/WebSocket.md
@@ -77,9 +77,9 @@ All exchanges via the WebSocket API use JSON.
 
 ### Producer endpoint
 
-The producer endpoint requires you to specify a {% popover property %}, {% popover cluster %}, {% popover namespace %}, and {% popover topic %} in the URL:
+The producer endpoint requires you to specify a {% popover tenant %}, {% popover namespace %}, and {% popover topic %} in the URL:
 
-{% endpoint ws://broker-service-url:8080/ws/producer/persistent/:property/:cluster/:namespace/:topic %}
+{% endpoint ws://broker-service-url:8080/ws/producer/persistent/:tenant/:namespace/:topic %}
 
 ##### Query param
 
@@ -144,9 +144,9 @@ Key | Type | Required? | Explanation
 
 ### Consumer endpoint
 
-The consumer endpoint requires you to specify a {% popover property %}, {% popover cluster %}, {% popover namespace %}, and {% popover topic %}, as well as a {% popover subscription %}, in the URL:
+The consumer endpoint requires you to specify a {% popover tenant %}, {% popover namespace %}, and {% popover topic %}, as well as a {% popover subscription %}, in the URL:
 
-{% endpoint ws://broker-service-url:8080/ws/consumer/persistent/:property/:cluster/:namespace/:topic/:subscription %}
+{% endpoint ws://broker-service-url:8080/ws/consumer/persistent/:tenant/:namespace/:topic/:subscription %}
 
 ##### Query param
 
@@ -197,9 +197,9 @@ Key | Type | Required? | Explanation
 
 ### Reader endpoint
 
-The reader endpoint requires you to specify a {% popover property %}, {% popover cluster %}, {% popover namespace %}, and {% popover topic %} in the URL:
+The reader endpoint requires you to specify a {% popover tenant %}, {% popover namespace %}, and {% popover topic %} in the URL:
 
-{% endpoint ws://broker-service-url:8080/ws/reader/persistent/:property/:cluster/:namespace/:topic %}
+{% endpoint ws://broker-service-url:8080/ws/reader/persistent/:tenant/:namespace/:topic %}
 
 ##### Query param
 
@@ -286,7 +286,7 @@ Here's an example Python {% popover producer %} that sends a simple message to a
 ```python
 import websocket, base64, json
 
-TOPIC = 'ws://localhost:8080/ws/producer/persistent/sample/standalone/ns1/my-topic'
+TOPIC = 'ws://localhost:8080/ws/producer/persistent/public/default/my-topic'
 
 ws = websocket.create_connection(TOPIC)
 
@@ -315,7 +315,7 @@ Here's an example Python {% popover consumer %} that listens on a Pulsar {% popo
 ```python
 import websocket, base64, json
 
-TOPIC = 'ws://localhost:8080/ws/consumer/persistent/sample/standalone/ns1/my-topic/my-sub'
+TOPIC = 'ws://localhost:8080/ws/consumer/persistent/public/default/my-topic/my-sub'
 
 ws = websocket.create_connection(TOPIC)
 
@@ -338,7 +338,7 @@ Here's an example Python reader that listens on a Pulsar {% popover topic %} and
 ```python
 import websocket, base64, json
 
-TOPIC = 'ws://localhost:8080/ws/reader/persistent/sample/standalone/ns1/my-topic'
+TOPIC = 'ws://localhost:8080/ws/reader/persistent/public/default/my-topic'
 
 ws = websocket.create_connection(TOPIC)
 
@@ -368,7 +368,7 @@ Here's an example Node.js {% popover producer %} that sends a simple message to 
 
 ```javascript
 var WebSocket = require('ws'),
-    topic = "ws://localhost:8080/ws/producer/persistent/my-property/us-west/my-ns/my-topic1",
+    topic = "ws://localhost:8080/ws/producer/persistent/my-tenant/my-ns/my-topic1",
     ws = new WebSocket(topic);
 
 var message = {
@@ -396,7 +396,7 @@ Here's an example Node.js {% popover consumer %} that listens on the same topic 
 
 ```javascript
 var WebSocket = require('ws'),
-    topic = "ws://localhost:8080/ws/consumer/persistent/my-property/us-west/my-ns/my-topic1/my-sub",
+    topic = "ws://localhost:8080/ws/consumer/persistent/my-tenant/my-ns/my-topic1/my-sub",
     ws = new WebSocket(topic);
 
 ws.on('message', function(message) {
@@ -410,7 +410,7 @@ ws.on('message', function(message) {
 #### NodeJS reader
 ```javascript
 var WebSocket = require('ws'),
-    topic = "ws://localhost:8080/ws/reader/persistent/my-property/us-west/my-ns/my-topic1",
+    topic = "ws://localhost:8080/ws/reader/persistent/my-tenant/my-ns/my-topic1",
     ws = new WebSocket(topic);
 
 ws.on('message', function(message) {

--- a/site/docs/latest/cookbooks/message-deduplication.md
+++ b/site/docs/latest/cookbooks/message-deduplication.md
@@ -42,7 +42,7 @@ You can enable message deduplication on specific namespaces, regardless of the t
 
 ```bash
 $ bin/pulsar-admin namespaces set-deduplication \
-  persistent://sample/standalone/ns1/topic-1 \
+  persistent://public/default/topic-1 \
   --enable # or just -e
 ```
 
@@ -52,7 +52,7 @@ You can disable message deduplication on a specific namespace using the same met
 
 ```bash
 $ bin/pulsar-admin namespaces set-deduplication \
-  persistent://sample/standalone/ns1/topic-1 \
+  persistent://public/default/topic-1 \
   --disable # or just -d
 ```
 
@@ -79,7 +79,7 @@ PulsarClient pulsarClient = PulsarClient.builder()
         .build();
 Producer producer = pulsarClient.newProducer()
         .producerName("producer-1")
-        .topic("persistent://sample/standalone/ns1/topic-1")
+        .topic("persistent://public/default/topic-1")
         .sendTimeout(0, TimeUnit.SECONDS)
         .create();
 ```
@@ -93,7 +93,7 @@ import pulsar
 
 client = pulsar.Client("pulsar://localhost:6650")
 producer = client.create_producer(
-    "persistent://sample/standalone/ns1/topic-1",
+    "persistent://public/default/topic-1",
     producer_name="producer-1",
     send_timeout_millis=0)
 ```
@@ -106,7 +106,7 @@ To enable message deduplication on a [C++ producer](../../clients/Cpp#producer),
 #include <pulsar/Client.h>
 
 std::string serviceUrl = "pulsar://localhost:6650";
-std::string topic = "persistent://prop/unit/ns1/topic-1";
+std::string topic = "persistent://some-tenant/ns1/topic-1";
 std::string producerName = "producer-1";
 
 Client client(serviceUrl);
@@ -117,5 +117,5 @@ producerConfig.setProducerName(producerName);
 
 Producer producer;
 
-Result result = client.createProducer("persistent://sample/standalone/ns1/my-topic", producerConfig, producer);
+Result result = client.createProducer(topic, producerConfig, producer);
 ```

--- a/site/docs/latest/cookbooks/message-queue.md
+++ b/site/docs/latest/cookbooks/message-queue.md
@@ -53,7 +53,7 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.SubscriptionType;
 
 String SERVICE_URL = "pulsar://localhost:6650";
-String TOPIC = "persistent://sample/standalone/ns1/mq-topic-1";
+String TOPIC = "persistent://public/default/mq-topic-1";
 String subscription = "sub-1";
 
 PulsarClient client = PulsarClient.builder()
@@ -77,7 +77,7 @@ Here's an example Python consumer configuration that uses a shared subscription:
 from pulsar import Client, ConsumerType
 
 SERVICE_URL = "pulsar://localhost:6650"
-TOPIC = "persistent://sample/standalone/ns1/mq-topic-1"
+TOPIC = "persistent://public/default/mq-topic-1"
 SUBSCRIPTION = "sub-1"
 
 client = Client(SERVICE_URL)
@@ -97,7 +97,7 @@ Here's an example C++ consumer configuration that uses a shared subscription:
 #include <pulsar/Client.h>
 
 std::string serviceUrl = "pulsar://localhost:6650";
-std::string topic = "persistent://sample/standalone/ns1/mq-topic-1";
+std::string topic = "persistent://public/defaultmq-topic-1";
 std::string subscription = "sub-1";
 
 Client client(serviceUrl);
@@ -109,5 +109,5 @@ consumerConfig.setReceiverQueueSize(10);
 
 Consumer consumer;
 
-Result result = client.subscribe("persistent://sample/standalone/ns1/my-topic", subscription, consumerConfig, consumer);
+Result result = client.subscribe("persistent://public/default/my-topic", subscription, consumerConfig, consumer);
 ```

--- a/site/docs/latest/cookbooks/non-persistent-messaging.md
+++ b/site/docs/latest/cookbooks/non-persistent-messaging.md
@@ -42,7 +42,7 @@ title: Non-persistent messaging
 In order to use non-persistent topics, you only need to differentiate them by name when interacting with them. This [`pulsar-client produce`](../../CliTools#pulsar-client-produce) command, for example, would produce one message on a non-persistent topic in a {% popover standalone %} cluster:
 
 ```bash
-$ bin/pulsar-client produce non-persistent://sample/standalone/ns1/example-np-topic \
+$ bin/pulsar-client produce non-persistent://public/default/example-np-topic \
   --num-produce 1 \
   --messages "This message will be stored only in memory"
 ```

--- a/site/docs/latest/deployment/aws-cluster.md
+++ b/site/docs/latest/deployment/aws-cluster.md
@@ -176,7 +176,7 @@ Once in the shell, run the following:
 >>> import pulsar
 >>> client = pulsar.Client('pulsar://pulsar-elb-1800761694.us-west-2.elb.amazonaws.com:6650')
 # Make sure to use your connection URL
->>> producer = client.create_producer('persistent://sample/local/ns1/test-topic')
+>>> producer = client.create_producer('persistent://public/default/test-topic')
 >>> producer.send('Hello world')
 >>> client.close()
 ```

--- a/site/docs/latest/deployment/cluster.md
+++ b/site/docs/latest/deployment/cluster.md
@@ -243,7 +243,7 @@ Once you've done that, you can publish a message to Pulsar topic:
 
 ```bash
 $ bin/pulsar-client produce \
-  persistent://sample/pulsar-cluster-1/ns1/test \
+  persistent://public/default/test \
   -n 1 \
   -m "Hello, Pulsar"
 ```

--- a/site/docs/latest/functions/api.md
+++ b/site/docs/latest/functions/api.md
@@ -47,8 +47,8 @@ Deploying Pulsar Functions is handled by the [`pulsar-admin`](../../reference/Cl
 $ bin/pulsar-admin functions localrun \
   --py sanitizer.py \          # The Python file with the function's code
   --className sanitizer \      # The class or function holding the processing logic
-  --tenant sample \            # The function's tenant (derived from the topic name by default)
-  --namespace ns1 \            # The function's namespace (derived from the topic name by default)
+  --tenant public \            # The function's tenant (derived from the topic name by default)
+  --namespace default \        # The function's namespace (derived from the topic name by default)
   --name sanitizer-function \  # The name of the function (the class name by default)
   --inputs dirty-strings-in \  # The input topic(s) for the function
   --output clean-strings-out \ # The output topic for the function
@@ -417,11 +417,11 @@ If you want your function to produce logs, you need to specify a log topic when 
 $ bin/pulsar-admin functions create \
   --jar my-functions.jar \
   --className my.package.LoggingFunction \
-  --logTopic persistent://sample/standalone/ns1/logging-function-logs \
+  --logTopic persistent://public/default/logging-function-logs \
   # Other function configs
 ```
 
-Now, all logs produced by the `LoggingFunction` above can be accessed via the `persistent://sample/standalone/ns1/logging-function-logs` topic.
+Now, all logs produced by the `LoggingFunction` above can be accessed via the `persistent://public/default/logging-function-logs` topic.
 
 ### Java user config
 
@@ -577,8 +577,8 @@ Pulsar Functions use [SerDe](#serde) when publishing data to and consuming data 
 
 ```bash
 $ bin/pulsar-admin functions create \
-  --tenant sample \
-  --namespace ns1 \
+  --tenant public \
+  --namespace default \
   --name my_function \
   --py my_function.py \
   --className my_function.MyFunction \

--- a/site/docs/latest/functions/deployment.md
+++ b/site/docs/latest/functions/deployment.md
@@ -69,8 +69,8 @@ If you run a Pulsar Function in **local run** mode, it will run on the machine f
 $ bin/pulsar-admin functions localrun \
   --py myfunc.py \
   --className myfunc.SomeFunction \
-  --inputs persistent://sample/standalone/ns1/input-1 \
-  --output persistent://sample/standalone/ns1/output-1
+  --inputs persistent://public/default/input-1 \
+  --output persistent://public/default/output-1
 ```
 
 By default, the function will connect to a Pulsar cluster running on the same machine, via a local {% popover broker %} service URL of `pulsar://localhost:6650`. If you'd like to use local run mode to run a function but connect it to a non-local Pulsar cluster, you can specify a different broker URL using the `--brokerServiceUrl` flag. Here's an example:
@@ -89,8 +89,8 @@ When you run a Pulsar Function in **cluster mode**, the function code will be up
 $ bin/pulsar-admin functions create \
   --py myfunc.py \
   --className myfunc.SomeFunction \
-  --inputs persistent://sample/standalone/ns1/input-1 \
-  --output persistent://sample/standalone/ns1/output-1
+  --inputs persistent://public/default/input-1 \
+  --output persistent://public/default/output-1
 ```
 
 ### Updating cluster mode functions {#updating}
@@ -101,8 +101,8 @@ You can use the [`update`](../../CliTools#pulsar-admin-functions-update) command
 $ bin/pulsar-admin functions update \
   --py myfunc.py \
   --className myfunc.SomeFunction \
-  --inputs persistent://sample/standalone/ns1/new-input-topic \
-  --output persistent://sample/standalone/ns1/new-output-topic
+  --inputs persistent://public/default/new-input-topic \
+  --output persistent://public/default/new-output-topic
 ```
 
 ### Parallelism
@@ -131,8 +131,8 @@ If you're specifying a function's configuration via YAML, use the `parallelism` 
 # function-config.yaml
 parallelism: 3
 inputs:
-- persistent://sample/standalone/ns1/input-1
-output: persistent://sample/standalone/ns1/output-1
+- persistent://public/default/input-1
+output: persistent://public/default/output-1
 # other parameters
 ```
 
@@ -161,19 +161,19 @@ Let's run that function in [local run mode](../deployment#local-run):
 
 ```bash
 $ bin/pulsar-admin functions create \
-  --tenant sample \
-  --namespace ns1 \
+  --tenant public \
+  --namespace default \
   --name myfunc \
   --py myfunc.py \
   --className myfunc \
-  --inputs persistent://sample/standalone/ns1/in \
-  --output persistent://sample/standalone/ns1/out
+  --inputs persistent://public/default/in \
+  --output persistent://public/default/out
 ```
 
 Now let's make a consumer listen on the output topic for messages coming from the `myfunc` function using the [`pulsar-client consume`](../../CliTools#pulsar-client-consume) command:
 
 ```bash
-$ bin/pulsar-client consume persistent://sample/standalone/ns1/out \
+$ bin/pulsar-client consume persistent://public/default/out \
   --subscription-name my-subscription
   --num-messages 0 # Listen indefinitely
 ```
@@ -182,8 +182,8 @@ Now let's trigger that function:
 
 ```bash
 $ bin/pulsar-admin functions trigger \
-  --tenant sample \
-  --namespace ns1 \
+  --tenant public \
+  --namespace default \
   --name myfunc \
   --triggerValue "hello world"
 ```

--- a/site/docs/latest/functions/overview.md
+++ b/site/docs/latest/functions/overview.md
@@ -98,11 +98,11 @@ public class WordCountFunction implements Function<String, Void> {
 $ bin/pulsar-admin functions create \
   --jar target/my-jar-with-dependencies.jar \
   --className org.example.functions.WordCountFunction \
-  --tenant sample \
-  --namespace ns1 \
+  --tenant public \
+  --namespace default \
   --name word-count \
-  --inputs persistent://sample/standalone/ns1/sentences \
-  --output persistent://sample/standalone/ns1/count
+  --inputs persistent://public/default/sentences \
+  --output persistent://public/default/count
 ```
 
 ### Content-based routing example {#content}
@@ -120,8 +120,8 @@ from pulsar import Function
 
 class RoutingFunction(Function):
     def __init__(self):
-        self.fruits_topic = "persistent://sample/standalone/ns1/fruits"
-        self.vegetables_topic = "persistent://sample/standalone/ns1/vegetables"
+        self.fruits_topic = "persistent://public/default/fruits"
+        self.vegetables_topic = "persistent://public/default/vegetables"
 
     def is_fruit(item):
         return item in ["apple", "orange", "pear", "other fruits..."]
@@ -145,8 +145,8 @@ Pulsar Functions are managed using the [`pulsar-admin`](../../reference/CliTools
 
 ```bash
 $ bin/pulsar-functions localrun \
-  --inputs persistent://sample/standalone/ns1/test_src \
-  --output persistent://sample/standalone/ns1/test_result \
+  --inputs persistent://public/default/test_src \
+  --output persistent://public/default/test_result \
   --jar examples/api-examples.jar \
   --className org.apache.pulsar.functions.api.examples.ExclamationFunction
 ```
@@ -177,13 +177,13 @@ And here's an example `my-function.yaml` file:
 
 ```yaml
 name: my-function
-tenant: sample
-namespace: ns1
+tenant: public
+namespace: default
 jar: ./target/my-functions.jar
 className: org.example.pulsar.functions.MyFunction
 inputs:
-- persistent://sample/standalone/ns1/test_src
-output: persistent://sample/standalone/ns1/test_result
+- persistent://public/default/test_src
+output: persistent://public/default/test_result
 ```
 
 You can also mix and match configuration methods by specifying some function attributes via the CLI and others via YAML configuration.
@@ -275,8 +275,8 @@ If you run a Pulsar Function in **local run** mode, it will run on the machine f
 $ bin/pulsar-admin functions localrun \
   --py myfunc.py \
   --className myfunc.SomeFunction \
-  --inputs persistent://sample/standalone/ns1/input-1 \
-  --output persistent://sample/standalone/ns1/output-1
+  --inputs persistent://public/default/input-1 \
+  --output persistent://public/default/output-1
 ```
 
 By default, the function will connect to a Pulsar cluster running on the same machine, via a local {% popover broker %} service URL of `pulsar://localhost:6650`. If you'd like to use local run mode to run a function but connect it to a non-local Pulsar cluster, you can specify a different broker URL using the `--brokerServiceUrl` flag. Here's an example:
@@ -295,8 +295,8 @@ When you run a Pulsar Function in **cluster mode**, the function code will be up
 $ bin/pulsar-admin functions create \
   --py myfunc.py \
   --className myfunc.SomeFunction \
-  --inputs persistent://sample/standalone/ns1/input-1 \
-  --output persistent://sample/standalone/ns1/output-1
+  --inputs persistent://public/default/input-1 \
+  --output persistent://public/default/output-1
 ```
 
 This command will upload `myfunc.py` to Pulsar, which will use the code to start one [or more](#parallelism) instances of the function.
@@ -310,8 +310,8 @@ This command, for example, would create and run a function with a parallelism of
 ```bash
 $ bin/pulsar-admin functions create \
   --name parallel-fun \
-  --tenant sample \
-  --namespace ns1 \
+  --tenant public \
+  --namespace default \
   --py func.py \
   --className func.ParallelFunction \
   --parallelism 5
@@ -319,12 +319,12 @@ $ bin/pulsar-admin functions create \
 
 ### Logging
 
-Pulsar Functions created using the [Pulsar Functions SDK(#sdk) can send logs to a log topic that you specify as part of the function's configuration. The function created using the command below, for example, would produce all logs on the `persistent://sample/standalone/ns1/my-func-1-log` topic:
+Pulsar Functions created using the [Pulsar Functions SDK(#sdk) can send logs to a log topic that you specify as part of the function's configuration. The function created using the command below, for example, would produce all logs on the `persistent://public/default/my-func-1-log` topic:
 
 ```bash
 $ bin/pulsar-admin functions create \
   --name my-func-1 \
-  --logTopic persistent://sample/standalone/ns1/my-func-1-log \
+  --logTopic persistent://public/default/my-func-1-log \
   # Other configs
 ```
 
@@ -387,8 +387,8 @@ If that function were running in a Pulsar cluster, it could be triggered like th
 
 ```bash
 $ bin/pulsar-admin functions trigger \
-  --tenant sample \
-  --namespace ns1 \
+  --tenant public \
+  --namespace default \
   --name reverse-func \
   --triggerValue "snoitcnuf raslup ot emoclew"
 ```

--- a/site/docs/latest/functions/quickstart.md
+++ b/site/docs/latest/functions/quickstart.md
@@ -24,7 +24,7 @@ $ bin/pulsar standalone \
   --advertised-address 127.0.0.1
 ```
 
-When running Pulsar in standalone mode, the `sample` {% popover tenant %} and `ns1` {% popover namespace %} will be created automatically for you. That tenant and namespace will be used throughout this tutorial.
+When running Pulsar in standalone mode, the `public` {% popover tenant %} and `default` {% popover namespace %} will be created automatically for you. That tenant and namespace will be used throughout this tutorial.
 
 ## Run a Pulsar Function in local run mode {#local-run-mode}
 
@@ -49,8 +49,8 @@ A JAR file containing this and several other functions (written in Java) is incl
 $ bin/pulsar-admin functions localrun \
   --jar examples/api-examples.jar \
   --className org.apache.pulsar.functions.api.examples.ExclamationFunction \
-  --inputs persistent://sample/standalone/ns1/exclamation-input \
-  --output persistent://sample/standalone/ns1/exclamation-output \
+  --inputs persistent://public/default/exclamation-input \
+  --output persistent://public/default/exclamation-output \
   --name exclamation
 ```
 
@@ -65,7 +65,7 @@ In the example above, a single topic was specified using the `--inputs` flag. Yo
 We can open up another shell and use the [`pulsar-client`](../../reference/CliTools#pulsar-client) tool to listen for messages on the output topic:
 
 ```bash
-$ bin/pulsar-client consume persistent://sample/standalone/ns1/exclamation-output \
+$ bin/pulsar-client consume persistent://public/default/exclamation-output \
   --subscription-name my-subscription \
   --num-messages 0
 ```
@@ -75,7 +75,7 @@ $ bin/pulsar-client consume persistent://sample/standalone/ns1/exclamation-outpu
 With a listener up and running, we can open up another shell and produce a message on the input topic that we specified:
 
 ```bash
-$ bin/pulsar-client produce persistent://sample/standalone/ns1/exclamation-input \
+$ bin/pulsar-client produce persistent://public/default/exclamation-input \
   --num-produce 1 \
   --messages "Hello world"
 ```
@@ -91,8 +91,8 @@ Success! As you can see, the message has been successfully processed by the excl
 
 Here's what happened:
 
-* The `Hello world` message that we published to the input {% popover topic %} (`persistent://sample/standalone/ns1/exclamation-input`) was passed to the exclamation function that we ran on our machine
-* The exclamation function processed the message (providing a result of `Hello world!`) and published the result to the output topic (`persistent://sample/standalone/ns1/exclamation-output`).
+* The `Hello world` message that we published to the input {% popover topic %} (`persistent://public/default/exclamation-input`) was passed to the exclamation function that we ran on our machine
+* The exclamation function processed the message (providing a result of `Hello world!`) and published the result to the output topic (`persistent://public/default/exclamation-output`).
 * If our exclamation function *hadn't* been running, Pulsar would have durably stored the message data published to the input topic in [Apache BookKeeper](https://bookkeeper.apache.org) until a {% popover consumer %} consumed and {% popover acknowledged %} the message
 
 ## Run a Pulsar Function in cluster mode {#cluster-mode}
@@ -105,10 +105,8 @@ This command, for example, would deploy the same exclamation function we ran loc
 $ bin/pulsar-admin functions create \
   --jar examples/api-examples.jar \
   --className org.apache.pulsar.functions.api.examples.ExclamationFunction \
-  --inputs persistent://sample/standalone/ns1/exclamation-input \
-  --output persistent://sample/standalone/ns1/exclamation-output \
-  --tenant sample \
-  --namespace ns1 \
+  --inputs persistent://public/default/exclamation-input \
+  --output persistent://public/default/exclamation-output \
   --name exclamation
 ```
 
@@ -116,16 +114,16 @@ You should see `Created successfully` in the output. Now, let's see a list of fu
 
 ```bash
 $ bin/pulsar-admin functions list \
-  --tenant sample \
-  --namespace ns1
+  --tenant public \
+  --namespace default
 ```
 
 We should see just the `exclamation` function listed there. We can also check the status of our deployed function using the `getstatus` command:
 
 ```bash
 $ bin/pulsar-admin functions getstatus \
-  --tenant sample \
-  --namespace ns1 \
+  --tenant public \
+  --namespace default \
   --name exclamation
 ```
 
@@ -146,8 +144,8 @@ As we can see, (a) the instance is currently running and (b) there is one instan
 
 ```bash
 $ bin/pulsar-admin functions get \
-  --tenant sample \
-  --namespace ns1 \
+  --tenant public \
+  --namespace default \
   --name exclamation
 ```
 
@@ -155,14 +153,14 @@ You should see this JSON output:
 
 ```json
 {
-  "tenant": "sample",
-  "namespace": "ns1",
+  "tenant": "public",
+  "namespace": "default",
   "name": "exclamation",
   "className": "org.apache.pulsar.functions.api.examples.ExclamationFunction",
-  "output": "persistent://sample/standalone/ns1/exclamation-output",
+  "output": "persistent://public/default/exclamation-output",
   "autoAck": true,
   "inputs": [
-    "persistent://sample/standalone/ns1/exclamation-input"
+    "persistent://public/default/exclamation-input"
   ],
   "parallelism": 1
 }
@@ -174,10 +172,10 @@ As we can see, the parallelism of the function is 1, meaning that only one insta
 $ bin/pulsar-admin functions update \
   --jar examples/api-examples.jar \
   --className org.apache.pulsar.functions.api.examples.ExclamationFunction \
-  --inputs persistent://sample/standalone/ns1/exclamation-input \
-  --output persistent://sample/standalone/ns1/exclamation-output \
-  --tenant sample \
-  --namespace ns1 \
+  --inputs persistent://public/default/exclamation-input \
+  --output persistent://public/default/exclamation-output \
+  --tenant public \
+  --namespace default \
   --name exclamation \
   --parallelism 3
 ```
@@ -186,14 +184,14 @@ You should see `Updated successfully` in the output. If you run the `get` comman
 
 ```json
 {
-  "tenant": "sample",
-  "namespace": "ns1",
+  "tenant": "public",
+  "namespace": "default",
   "name": "exclamation",
   "className": "org.apache.pulsar.functions.api.examples.ExclamationFunction",
-  "output": "persistent://sample/standalone/ns1/exclamation-output",
+  "output": "persistent://public/default/exclamation-output",
   "autoAck": true,
   "inputs": [
-    "persistent://sample/standalone/ns1/exclamation-input"
+    "persistent://public/default/exclamation-input"
   ],
   "parallelism": 3
 }
@@ -203,8 +201,8 @@ Finally, we can shut down our running function using the `delete` command:
 
 ```bash
 $ bin/pulsar-admin functions delete \
-  --tenant sample \
-  --namespace ns1 \
+  --tenant public \
+  --namespace default \
   --name exclamation
 ```
 
@@ -241,10 +239,10 @@ Here, the `process` method defines the processing logic of the Pulsar Function. 
 $ bin/pulsar-admin functions create \
   --py reverse.py \
   --className reverse \
-  --inputs persistent://sample/standalone/ns1/backwards \
-  --output persistent://sample/standalone/ns1/forwards \
-  --tenant sample \
-  --namespace ns1 \
+  --inputs persistent://public/default/backwards \
+  --output persistent://public/default/forwards \
+  --tenant public \
+  --namespace default \
   --name reverse
 ```
 
@@ -253,8 +251,8 @@ If you see `Created successfully`, the function is ready to accept incoming mess
 ```bash
 $ bin/pulsar-admin functions trigger \
   --name reverse \
-  --tenant sample \
-  --namespace ns1 \
+  --tenant public \
+  --namespace default \
   --triggerValue "sdrawrof won si tub sdrawkcab saw gnirts sihT"
 ```
 

--- a/site/docs/latest/getting-started/ConceptsAndArchitecture.md
+++ b/site/docs/latest/getting-started/ConceptsAndArchitecture.md
@@ -151,9 +151,9 @@ In the diagram above, Consumer-C-1 is the master consumer while Consumer-C-2 wou
 
 ### Multi-topic subscriptions
 
-When a {% popover consumer %} subscribes to a Pulsar {% popover topic %}, by default it subscribes to one specific topic, such as `persistent://sample/ns1/standalone/my-topic`. As of Pulsar version 1.23.0-incubating, however, Pulsar consumers can simultaneously subscribe to multiple topics. You can define a list of topics in two ways:
+When a {% popover consumer %} subscribes to a Pulsar {% popover topic %}, by default it subscribes to one specific topic, such as `persistent://public/default/my-topic`. As of Pulsar version 1.23.0-incubating, however, Pulsar consumers can simultaneously subscribe to multiple topics. You can define a list of topics in two ways:
 
-* On the basis of a [**reg**ular **ex**pression](https://en.wikipedia.org/wiki/Regular_expression) (regex), for example `persistent://sample/standalone/ns1/finance-.*`
+* On the basis of a [**reg**ular **ex**pression](https://en.wikipedia.org/wiki/Regular_expression) (regex), for example `persistent://public/default/finance-.*`
 * By explicitly defining a list of topics
 
 {% include admonition.html type="info" content="When subscribing to multiple topics by regex, all topics must be in the same [namespace](#namespaces)." %}
@@ -174,11 +174,11 @@ import org.apache.pulsar.client.api.PulsarClient;
 PulsarClient pulsarClient = // Instantiate Pulsar client object
 
 // Subscribe to all topics in a namespace
-Pattern allTopicsInNamespace = Pattern.compile("persistent://sample/standalone/ns1/.*");
+Pattern allTopicsInNamespace = Pattern.compile("persistent://public/default/.*");
 Consumer allTopicsConsumer = pulsarClient.subscribe(allTopicsInNamespace, "subscription-1");
 
 // Subscribe to a subsets of topics in a namespace, based on regex
-Pattern someTopicsInNamespace = Pattern.compile("persistent://sample/standalone/ns1/foo.*");
+Pattern someTopicsInNamespace = Pattern.compile("persistent://public/default/foo.*");
 Consumer someTopicsConsumer = pulsarClient.subscribe(someTopicsInNamespace, "subscription-1");
 ```
 
@@ -214,7 +214,7 @@ Here's an example [Java consumer](../../clients/Java#consumer) for a non-persist
 
 ```java
 PulsarClient client = PulsarClient.create("pulsar://localhost:6650");
-String npTopic = "non-persistent://sample/standalone/ns1/my-topic";
+String npTopic = "non-persistent://public/default/my-topic";
 String subscriptionName = "my-subscription-name";
 
 Consumer consumer = client.subscribe(npTopic, subscriptionName);
@@ -225,20 +225,6 @@ Here's an example [Java producer](../../clients/Java#producer) for the same non-
 ```java
 Producer producer = client.createProducer(npTopic);
 ```
-
-#### Broker configuration
-
-Sometimes, there would be a need to configure few dedicated brokers in a cluster, to just serve non-persistent topics.
-
-Broker configuration for enabling broker to own only configured type of topics  
-
-```
-# It disables broker to load persistent topics
-enablePersistentTopics=false
-# It enables broker to load non-persistent topics
-enableNonPersistentTopics=true
-```
-
 
 ## Architecture overview
 
@@ -506,7 +492,7 @@ import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Reader;
 
-String topic = "persistent://sample/standalone/ns1/reader-api-test";
+String topic = "persistent://public/default/reader-api-test";
 MessageId id = MessageId.earliest;
 
 // Create a reader on a topic and for a specific message (and onward)

--- a/site/docs/latest/getting-started/LocalCluster.md
+++ b/site/docs/latest/getting-started/LocalCluster.md
@@ -52,11 +52,11 @@ If Pulsar has been successfully started, you should see `INFO`-level log message
 ```
 
 {% include admonition.html type="success" title='Automatically created namespace' content='
-When you start a local standalone cluster, Pulsar will automatically create a `sample/standalone/ns1` [namespace](../ConceptsAndArchitecture#namespace) that you can use for development purposes. All Pulsar topics are managed within namespaces. For more info, see [Topics](../ConceptsAndArchitecture#topics).' %}
+When you start a local standalone cluster, Pulsar will automatically create a `public/default` [namespace](../ConceptsAndArchitecture#namespace) that you can use for development purposes. All Pulsar topics are managed within namespaces. For more info, see [Topics](../ConceptsAndArchitecture#topics).' %}
 
 ## Testing your cluster setup
 
-Pulsar provides a CLI tool called [`pulsar-client`](../../reference/CliTools#pulsar-client) that enables you to do things like send messages to a Pulsar {% popover topic %} in a running cluster. This command will send a simple message saying `hello-pulsar` to the `persistent://sample/standalone/ns1/my-topic` topic:
+Pulsar provides a CLI tool called [`pulsar-client`](../../reference/CliTools#pulsar-client) that enables you to do things like send messages to a Pulsar {% popover topic %} in a running cluster. This command will send a simple message saying `hello-pulsar` to the `my-topic` topic:
 
 ```bash
 $ bin/pulsar-client produce my-topic \

--- a/site/docs/latest/getting-started/docker.md
+++ b/site/docs/latest/getting-started/docker.md
@@ -63,7 +63,7 @@ If Pulsar has been successfully started, you should see `INFO`-level log message
 ```
 
 {% include admonition.html type="success" title='Automatically created namespace' content='
-When you start a local standalone cluster, Pulsar will automatically create a `sample/standalone/ns1`
+When you start a local standalone cluster, Pulsar will automatically create a `public/default`
 namespace that you can use for development purposes. All Pulsar topics are managed within namespaces.
 For more info, see [Topics](../ConceptsAndArchitecture#Topics).' %}
 


### PR DESCRIPTION
This PR updates all example topic names in the docs to use the new system (default tenant and namespace, no cluster component, etc.)