### PR TITLE
Fix flaky test with s3 backend

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/S3ManagedLedgerOffloader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/S3ManagedLedgerOffloader.java
@@ -172,8 +172,12 @@ public class S3ManagedLedgerOffloader implements LedgerOffloader {
                     .withUploadId(dataBlockRes.getUploadId())
                     .withPartETags(etags));
             } catch (Throwable t) {
-                s3client.abortMultipartUpload(
-                    new AbortMultipartUploadRequest(bucket, dataBlockKey, dataBlockRes.getUploadId()));
+                try {
+                    s3client.abortMultipartUpload(
+                        new AbortMultipartUploadRequest(bucket, dataBlockKey, dataBlockRes.getUploadId()));
+                } catch (Throwable throwable) {
+                    log.error("Failed abortMultipartUpload ", throwable);
+                }
                 promise.completeExceptionally(t);
                 return;
             }
@@ -191,7 +195,11 @@ public class S3ManagedLedgerOffloader implements LedgerOffloader {
                     metadata));
                 promise.complete(null);
             } catch (Throwable t) {
-                s3client.deleteObject(bucket, dataBlockKey);
+                try {
+                    s3client.deleteObject(bucket, dataBlockKey);
+                } catch (Throwable throwable) {
+                    log.error("Failed deleteObject ", throwable);
+                }
                 promise.completeExceptionally(t);
                 return;
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/S3ManagedLedgerOffloader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/S3ManagedLedgerOffloader.java
@@ -172,9 +172,9 @@ public class S3ManagedLedgerOffloader implements LedgerOffloader {
                     .withUploadId(dataBlockRes.getUploadId())
                     .withPartETags(etags));
             } catch (Throwable t) {
-                promise.completeExceptionally(t);
                 s3client.abortMultipartUpload(
                     new AbortMultipartUploadRequest(bucket, dataBlockKey, dataBlockRes.getUploadId()));
+                promise.completeExceptionally(t);
                 return;
             }
 
@@ -191,8 +191,8 @@ public class S3ManagedLedgerOffloader implements LedgerOffloader {
                     metadata));
                 promise.complete(null);
             } catch (Throwable t) {
-                promise.completeExceptionally(t);
                 s3client.deleteObject(bucket, dataBlockKey);
+                promise.completeExceptionally(t);
                 return;
             }
         });

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/S3ManagedLedgerOffloader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/S3ManagedLedgerOffloader.java
@@ -176,8 +176,8 @@ public class S3ManagedLedgerOffloader implements LedgerOffloader {
                     s3client.abortMultipartUpload(
                         new AbortMultipartUploadRequest(bucket, dataBlockKey, dataBlockRes.getUploadId()));
                 } catch (Throwable throwable) {
-                    log.error("Failed abortMultipartUpload in bucket - {} with key - {}.",
-                        bucket, dataBlockKey, throwable);
+                    log.error("Failed abortMultipartUpload in bucket - {} with key - {}, uploadId - {}.",
+                        bucket, dataBlockKey, dataBlockRes.getUploadId(), throwable);
                 }
                 promise.completeExceptionally(t);
                 return;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/S3ManagedLedgerOffloader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/S3ManagedLedgerOffloader.java
@@ -176,7 +176,8 @@ public class S3ManagedLedgerOffloader implements LedgerOffloader {
                     s3client.abortMultipartUpload(
                         new AbortMultipartUploadRequest(bucket, dataBlockKey, dataBlockRes.getUploadId()));
                 } catch (Throwable throwable) {
-                    log.error("Failed abortMultipartUpload ", throwable);
+                    log.error("Failed abortMultipartUpload in bucket - {} with key - {}.",
+                        bucket, dataBlockKey, throwable);
                 }
                 promise.completeExceptionally(t);
                 return;
@@ -198,7 +199,8 @@ public class S3ManagedLedgerOffloader implements LedgerOffloader {
                 try {
                     s3client.deleteObject(bucket, dataBlockKey);
                 } catch (Throwable throwable) {
-                    log.error("Failed deleteObject ", throwable);
+                    log.error("Failed deleteObject in bucket - {} with key - {}.",
+                        bucket, dataBlockKey, throwable);
                 }
                 promise.completeExceptionally(t);
                 return;


### PR DESCRIPTION
There is a flaky test in s3 backend, which reported:
```
expected [false] but found [true]
org.apache.pulsar.broker.s3offload.S3ManagedLedgerOffloaderTest.testOffloadFailPutIndexBlock(S3ManagedLedgerOffloaderTest.java:304)
...
```
The reason for it is future completed before error handling. This change put future complete behind.

After the change, all tests of s3 should pass.

Master issue #1511 