### PR TITLE
Fix grpc version conflicts in pulsar binary distribution

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -118,6 +118,12 @@
       <groupId>org.apache.pulsar</groupId>
       <artifactId>pulsar-functions-worker</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.grpc</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- runtime-all -->
@@ -127,6 +133,18 @@
       <version>${project.version}</version>
       <!-- make sure the api examples are compiled before assembly -->
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.grpc</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- grpc -->
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-all</artifactId>
     </dependency>
   </dependencies>
 

--- a/all/src/assemble/bin.xml
+++ b/all/src/assemble/bin.xml
@@ -105,18 +105,20 @@
 
       <excludes>
         <!-- All these dependencies are already included in netty-all -->
+        <exclude>io.netty:netty-buffer</exclude>
         <exclude>io.netty:netty-common</exclude>
+        <exclude>io.netty:netty-codec</exclude>
+        <exclude>io.netty:netty-codec-dns</exclude>
+        <exclude>io.netty:netty-codec-http</exclude>
+        <exclude>io.netty:netty-codec-http2</exclude>
+        <exclude>io.netty:netty-codec-socks</exclude>
+        <exclude>io.netty:netty-handler</exclude>
+        <exclude>io.netty:netty-handler-proxy</exclude>
         <exclude>io.netty:netty-resolver</exclude>
         <exclude>io.netty:netty-resolver-dns</exclude>
-        <exclude>io.netty:netty-codec-dns</exclude>
-        <exclude>io.netty:netty-transport-native-unix-common</exclude>
-        <exclude>io.netty:netty-buffer</exclude>
-        <exclude>io.netty:netty-codec-http</exclude>
-        <exclude>io.netty:netty-codec</exclude>
         <exclude>io.netty:netty-transport</exclude>
-        <exclude>io.netty:netty-handler</exclude>
         <exclude>io.netty:netty-transport-native-epoll</exclude>
-        <exclude>io.netty:netty-codec-http</exclude>
+        <exclude>io.netty:netty-transport-native-unix-common</exclude>
 
         <!-- Already included in pulsar-zookeeper instrumented jar -->
         <exclude>org.apache.zookeeper:zookeeper</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -719,6 +719,18 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-core</artifactId>
+        <version>${grpc.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-protobuf-lite</artifactId>
+        <version>${grpc.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
         <version>${gson.version}</version>


### PR DESCRIPTION
*Motivation*

There are multiple grpc versions dropped in pulsar binary distribution. It seems that maven
doesn't handle transitive dependencies well on assembly plugin.

```
io.grpc-grpc-all-1.12.0.jar
io.grpc-grpc-auth-1.5.0.jar
io.grpc-grpc-context-1.5.0.jar
io.grpc-grpc-core-1.5.0.jar
io.grpc-grpc-netty-1.5.0.jar
io.grpc-grpc-okhttp-1.5.0.jar
io.grpc-grpc-protobuf-1.5.0.jar
io.grpc-grpc-protobuf-lite-1.5.0.jar
io.grpc-grpc-protobuf-nano-1.5.0.jar
io.grpc-grpc-stub-1.5.0.jar
io.grpc-grpc-testing-1.12.0.jar
```

*Changes*

- Exclude transitive grpc dependencies from functions modules.
- Pin versions for some grpc modules
- Exclude netty dependencies that are already included in `netty-all` module.

*Result*

```
com.amazonaws-aws-java-sdk-core-1.11.297.jar                                  org.apache.commons-commons-lang3-3.4.jar
com.amazonaws-aws-java-sdk-kms-1.11.297.jar                                   org.apache.distributedlog-distributedlog-common-4.7.0.jar
com.amazonaws-aws-java-sdk-s3-1.11.297.jar                                    org.apache.distributedlog-distributedlog-core-4.7.0.jar
com.amazonaws-jmespath-java-1.11.297.jar                                      org.apache.distributedlog-distributedlog-protocol-4.7.0.jar
com.beust-jcommander-1.48.jar                                                 org.apache.httpcomponents-httpclient-4.5.5.jar
com.carrotsearch-hppc-0.7.3.jar                                               org.apache.httpcomponents-httpcore-4.4.9.jar
com.ea.agentloader-ea-agent-loader-1.0.2.jar                                  org.apache.logging.log4j-log4j-api-2.10.0.jar
com.fasterxml.jackson.core-jackson-annotations-2.8.4.jar                      org.apache.logging.log4j-log4j-core-2.10.0.jar
com.fasterxml.jackson.core-jackson-core-2.8.4.jar                             org.apache.logging.log4j-log4j-slf4j-impl-2.10.0.jar
com.fasterxml.jackson.core-jackson-databind-2.8.4.jar                         org.apache.logging.log4j-log4j-web-2.10.0.jar
com.fasterxml.jackson.dataformat-jackson-dataformat-cbor-2.6.7.jar            org.apache.pulsar-managed-ledger-2.1.0-incubating-SNAPSHOT.jar
com.fasterxml.jackson.dataformat-jackson-dataformat-yaml-2.8.4.jar            org.apache.pulsar-protobuf-shaded-2.1.0-incubating-SNAPSHOT.jar
com.fasterxml.jackson.datatype-jackson-datatype-joda-2.8.4.jar                org.apache.pulsar-pulsar-broker-2.1.0-incubating-SNAPSHOT.jar
com.fasterxml.jackson.jaxrs-jackson-jaxrs-base-2.8.4.jar                      org.apache.pulsar-pulsar-broker-common-2.1.0-incubating-SNAPSHOT.jar
com.fasterxml.jackson.jaxrs-jackson-jaxrs-json-provider-2.8.4.jar             org.apache.pulsar-pulsar-client-admin-original-2.1.0-incubating-SNAPSHOT.jar
com.fasterxml.jackson.module-jackson-module-jaxb-annotations-2.8.4.jar        org.apache.pulsar-pulsar-client-original-2.1.0-incubating-SNAPSHOT.jar
com.fasterxml.jackson.module-jackson-module-jsonSchema-2.9.0.jar              org.apache.pulsar-pulsar-client-tools-2.1.0-incubating-SNAPSHOT.jar
com.github.ben-manes.caffeine-caffeine-2.3.3.jar                              org.apache.pulsar-pulsar-common-2.1.0-incubating-SNAPSHOT.jar
com.github.zafarkhaja-java-semver-0.9.0.jar                                   org.apache.pulsar-pulsar-discovery-service-2.1.0-incubating-SNAPSHOT.jar
com.google.api.grpc-proto-google-common-protos-0.1.9.jar                      org.apache.pulsar-pulsar-functions-api-2.1.0-incubating-SNAPSHOT.jar
com.google.auth-google-auth-library-credentials-0.4.0.jar                     org.apache.pulsar-pulsar-functions-api-examples-2.1.0-incubating-SNAPSHOT.jar
com.google.code.findbugs-jsr305-3.0.2.jar                                     org.apache.pulsar-pulsar-functions-instance-2.1.0-incubating-SNAPSHOT.jar
com.google.code.gson-gson-2.8.2.jar                                           org.apache.pulsar-pulsar-functions-metrics-2.1.0-incubating-SNAPSHOT.jar
com.google.errorprone-error_prone_annotations-2.1.2.jar                       org.apache.pulsar-pulsar-functions-proto-2.1.0-incubating-SNAPSHOT.jar
com.google.errorprone-javac-9-dev-r3297-1-shaded.jar                          org.apache.pulsar-pulsar-functions-runtime-2.1.0-incubating-SNAPSHOT.jar
com.google.googlejavaformat-google-java-format-1.2.jar                        org.apache.pulsar-pulsar-functions-runtime-all-2.1.0-incubating-SNAPSHOT.jar
com.google.guava-guava-21.0.jar                                               org.apache.pulsar-pulsar-functions-utils-2.1.0-incubating-SNAPSHOT.jar
com.google.instrumentation-instrumentation-api-0.4.3.jar                      org.apache.pulsar-pulsar-functions-worker-2.1.0-incubating-SNAPSHOT.jar
com.google.protobuf-protobuf-java-3.5.1.jar                                   org.apache.pulsar-pulsar-io-core-2.1.0-incubating-SNAPSHOT.jar
com.google.protobuf-protobuf-java-util-3.3.1.jar                              org.apache.pulsar-pulsar-proxy-2.1.0-incubating-SNAPSHOT.jar
com.google.protobuf.nano-protobuf-javanano-3.0.0-alpha-5.jar                  org.apache.pulsar-pulsar-testclient-2.1.0-incubating-SNAPSHOT.jar
com.squareup.okhttp-okhttp-2.5.0.jar                                          org.apache.pulsar-pulsar-websocket-2.1.0-incubating-SNAPSHOT.jar
com.squareup.okio-okio-1.6.0.jar                                              org.apache.pulsar-pulsar-zookeeper-2.1.0-incubating-SNAPSHOT.jar
com.typesafe.netty-netty-reactive-streams-2.0.0.jar                           org.apache.pulsar-pulsar-zookeeper-utils-2.1.0-incubating-SNAPSHOT.jar
com.wordnik-swagger-annotations-1.5.3-M1.jar                                  org.apache.yetus-audience-annotations-0.5.0.jar
com.yahoo.datasketches-memory-0.8.3.jar                                       org.aspectj-aspectjrt-1.8.9.jar
com.yahoo.datasketches-sketches-core-0.8.3.jar                                org.aspectj-aspectjweaver-1.8.9.jar
commons-beanutils-commons-beanutils-1.7.0.jar                                 org.asynchttpclient-async-http-client-2.1.0-alpha26.jar
commons-beanutils-commons-beanutils-core-1.8.0.jar                            org.asynchttpclient-async-http-client-netty-utils-2.1.0-alpha26.jar
commons-cli-commons-cli-1.2.jar                                               org.bouncycastle-bcpkix-jdk15on-1.55.jar
commons-codec-commons-codec-1.10.jar                                          org.bouncycastle-bcprov-jdk15on-1.55.jar
commons-collections-commons-collections-3.2.1.jar                             org.eclipse.jetty-jetty-client-9.3.11.v20160721.jar
commons-configuration-commons-configuration-1.6.jar                           org.eclipse.jetty-jetty-continuation-9.3.11.v20160721.jar
commons-digester-commons-digester-1.8.jar                                     org.eclipse.jetty-jetty-http-9.3.11.v20160721.jar
commons-io-commons-io-2.5.jar                                                 org.eclipse.jetty-jetty-io-9.3.11.v20160721.jar
commons-lang-commons-lang-2.6.jar                                             org.eclipse.jetty-jetty-proxy-9.3.11.v20160721.jar
commons-logging-commons-logging-1.1.1.jar                                     org.eclipse.jetty-jetty-security-9.3.11.v20160721.jar
io.grpc-grpc-all-1.12.0.jar                                                   org.eclipse.jetty-jetty-server-9.3.11.v20160721.jar
io.grpc-grpc-auth-1.12.0.jar                                                  org.eclipse.jetty-jetty-servlet-9.3.11.v20160721.jar
io.grpc-grpc-context-1.12.0.jar                                               org.eclipse.jetty-jetty-servlets-9.3.11.v20160721.jar
io.grpc-grpc-core-1.12.0.jar                                                  org.eclipse.jetty-jetty-util-9.3.11.v20160721.jar
io.grpc-grpc-netty-1.12.0.jar                                                 org.eclipse.jetty.websocket-javax-websocket-client-impl-9.3.11.v20160721.jar
io.grpc-grpc-okhttp-1.12.0.jar                                                org.eclipse.jetty.websocket-websocket-api-9.3.11.v20160721.jar
io.grpc-grpc-protobuf-1.12.0.jar                                              org.eclipse.jetty.websocket-websocket-client-9.3.11.v20160721.jar
io.grpc-grpc-protobuf-lite-1.12.0.jar                                         org.eclipse.jetty.websocket-websocket-common-9.3.11.v20160721.jar
io.grpc-grpc-protobuf-nano-1.12.0.jar                                         org.eclipse.jetty.websocket-websocket-server-9.3.11.v20160721.jar
io.grpc-grpc-stub-1.12.0.jar                                                  org.eclipse.jetty.websocket-websocket-servlet-9.3.11.v20160721.jar
io.grpc-grpc-testing-1.12.0.jar                                               org.glassfish.hk2-hk2-api-2.5.0-b30.jar
io.netty-netty-3.10.1.Final.jar                                               org.glassfish.hk2-hk2-locator-2.5.0-b30.jar
io.netty-netty-all-4.1.22.Final.jar                                           org.glassfish.hk2-hk2-utils-2.5.0-b30.jar
io.netty-netty-tcnative-boringssl-static-2.0.7.Final.jar                      org.glassfish.hk2-osgi-resource-locator-1.0.1.jar
io.opencensus-opencensus-api-0.11.0.jar                                       org.glassfish.hk2.external-aopalliance-repackaged-2.5.0-b30.jar
io.opencensus-opencensus-contrib-grpc-metrics-0.11.0.jar                      org.glassfish.hk2.external-javax.inject-2.5.0-b30.jar
io.prometheus-simpleclient-0.0.23.jar                                         org.glassfish.jersey.bundles.repackaged-jersey-guava-2.25.jar
io.prometheus-simpleclient_common-0.0.23.jar                                  org.glassfish.jersey.containers-jersey-container-servlet-2.25.jar
io.prometheus-simpleclient_hotspot-0.0.23.jar                                 org.glassfish.jersey.containers-jersey-container-servlet-core-2.25.jar
io.prometheus-simpleclient_servlet-0.0.23.jar                                 org.glassfish.jersey.core-jersey-client-2.25.jar
io.swagger-swagger-annotations-1.5.3.jar                                      org.glassfish.jersey.core-jersey-common-2.25.jar
io.swagger-swagger-core-1.5.3.jar                                             org.glassfish.jersey.core-jersey-server-2.25.jar
io.swagger-swagger-models-1.5.3.jar                                           org.glassfish.jersey.ext-jersey-entity-filtering-2.25.jar
javax.annotation-javax.annotation-api-1.2.jar                                 org.glassfish.jersey.media-jersey-media-jaxb-2.25.jar
javax.servlet-javax.servlet-api-3.1.0.jar                                     org.glassfish.jersey.media-jersey-media-json-jackson-2.25.jar
javax.validation-validation-api-1.1.0.Final.jar                               org.glassfish.jersey.media-jersey-media-multipart-2.25.jar
javax.websocket-javax.websocket-api-1.0.jar                                   org.hamcrest-hamcrest-core-1.1.jar
javax.ws.rs-javax.ws.rs-api-2.1.jar                                           org.hdrhistogram-HdrHistogram-2.1.9.jar
joda-time-joda-time-2.8.1.jar                                                 org.inferred-freebuilder-1.12.3.jar
log4j-log4j-1.2.17.jar                                                        org.javassist-javassist-3.21.0-GA.jar
net.java.dev.jna-jna-4.2.0.jar                                                org.jboss-jboss-common-core-2.2.17.GA.jar
net.jodah-typetools-0.5.0.jar                                                 org.jboss-jboss-reflect-2.2.1.SP1.jar
net.jpountz.lz4-lz4-1.3.0.jar                                                 org.jboss.logging-jboss-logging-spi-2.2.0.CR1.jar
org.apache.bookkeeper-bookkeeper-common-4.7.0.jar                             org.jvnet.mimepull-mimepull-1.9.6.jar
org.apache.bookkeeper-bookkeeper-proto-4.7.0.jar                              org.projectlombok-lombok-1.16.20.jar
org.apache.bookkeeper-bookkeeper-server-4.7.0.jar                             org.reactivestreams-reactive-streams-1.0.0.jar
org.apache.bookkeeper-circe-checksum-4.7.0.jar                                org.rocksdb-rocksdbjni-5.8.6.jar
org.apache.bookkeeper-stream-storage-java-client-4.7.0.jar                    org.slf4j-jcl-over-slf4j-1.7.25.jar
org.apache.bookkeeper.http-http-server-4.7.0.jar                              org.slf4j-jul-to-slf4j-1.7.25.jar
org.apache.bookkeeper.stats-bookkeeper-stats-api-4.7.0.jar                    org.slf4j-slf4j-api-1.7.25.jar
org.apache.bookkeeper.stats-prometheus-metrics-provider-4.7.0.jar             org.yaml-snakeyaml-1.15.jar
org.apache.commons-commons-collections4-4.1.jar                               software.amazon.ion-ion-java-1.0.2.jar
```

