### PR TITLE
Corrected release name 2.0.0-incubating -> 2.0.0-rc1-incubating

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -26,7 +26,7 @@ baseurl: /
 destination: ../generated-site/content
 
 preview_version_id: 20180426.125800-32
-current_version: 2.0.0-incubating
+current_version: 2.0.0-rc1-incubating
 python_latest: 2.0.0
 archived_releases:
   - 1.22.0-incubating


### PR DESCRIPTION
### Motivation

Use correct version name or the download links won't be correct