### PR TITLE
Ship git info in jar and print at boot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1039,6 +1039,30 @@ flexible messaging model and an intuitive client API.</description>
           </excludes>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>pl.project13.maven</groupId>
+        <artifactId>git-commit-id-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>git-info</id>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <useNativeGit>true</useNativeGit>
+          <prefix>git</prefix>
+          <verbose>true</verbose>
+          <generateGitPropertiesFile>true</generateGitPropertiesFile>
+          <generateGitPropertiesFilename>${project.build.outputDirectory}/${project.artifactId}-git.properties</generateGitPropertiesFilename>
+          <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
+          <format>properties</format>
+          <gitDescribe>
+            <skip>true</skip>
+          </gitDescribe>
+        </configuration>
+      </plugin>
     </plugins>
 
     <pluginManagement>
@@ -1110,6 +1134,11 @@ flexible messaging model and an intuitive client API.</description>
               </pluginExecutions>
             </lifecycleMappingMetadata>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>pl.project13.maven</groupId>
+          <artifactId>git-commit-id-plugin</artifactId>
+          <version>2.2.4</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -308,6 +308,13 @@ public class PulsarService implements AutoCloseable {
     public void start() throws PulsarServerException {
         mutex.lock();
 
+        LOG.info("Starting Pulsar Broker service; version: '{}'", ( brokerVersion != null ? brokerVersion : "unknown" )  );
+        LOG.info("Git Revision {}", PulsarBrokerVersionStringUtils.getGitSha());
+        LOG.info("Built by {} on {} at {}",
+                 PulsarBrokerVersionStringUtils.getBuildUser(),
+                 PulsarBrokerVersionStringUtils.getBuildHost(),
+                 PulsarBrokerVersionStringUtils.getBuildTime());
+
         try {
             if (state != State.Init) {
                 throw new PulsarServerException("Cannot start the service once it was stopped");
@@ -336,7 +343,6 @@ public class PulsarService implements AutoCloseable {
 
             this.offloader = createManagedLedgerOffloader(this.getConfiguration());
 
-            LOG.info("Starting Pulsar Broker service; version: '{}'", ( brokerVersion != null ? brokerVersion : "unknown" )  );
             brokerService.start();
 
             this.webService = new WebService(this);
@@ -420,8 +426,6 @@ public class PulsarService implements AutoCloseable {
             });
 
             leaderElectionService.start();
-
-            LOG.info("Starting Pulsar Broker service; version: '{}'", ( brokerVersion != null ? brokerVersion : "unknown" )  );
 
             webService.start();
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/utils/PulsarBrokerVersionStringUtils.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/utils/PulsarBrokerVersionStringUtils.java
@@ -31,6 +31,8 @@ public class PulsarBrokerVersionStringUtils {
     private static final Logger LOG = LoggerFactory.getLogger(PulsarBrokerVersionStringUtils.class);
 
     private static final String RESOURCE_NAME = "pulsar-broker-version.properties";
+    private static final String GIT_RESOURCE_NAME = "pulsar-broker-git.properties";
+
     private static final Pattern majorMinorPatchPattern = Pattern.compile("([1-9]+[0-9]*)\\.([1-9]+[0-9]*)\\.([1-9]+[0-9]*)(.*)");
 
     // If the version string does not contain a patch version, add one so the
@@ -100,5 +102,29 @@ public class PulsarBrokerVersionStringUtils {
 
     public static String getNormalizedVersionString() {
         return fixVersionString(getPropertyFromResource(RESOURCE_NAME, "version"));
+    }
+
+    public static String getGitSha() {
+        String commit = getPropertyFromResource(GIT_RESOURCE_NAME, "git.commit.id");
+        String dirtyString = getPropertyFromResource(GIT_RESOURCE_NAME, "git.dirty");
+        if (dirtyString == null || Boolean.valueOf(dirtyString)) {
+            return commit + "(dirty)";
+        } else {
+            return commit;
+        }
+    }
+
+    public static String getBuildUser() {
+        String email = getPropertyFromResource(GIT_RESOURCE_NAME, "git.build.user.email");
+        String name = getPropertyFromResource(GIT_RESOURCE_NAME, "git.build.user.name");
+        return String.format("%s <%s>", name, email);
+    }
+
+    public static String getBuildHost() {
+        return getPropertyFromResource(GIT_RESOURCE_NAME, "git.build.host");
+    }
+
+    public static String getBuildTime() {
+        return getPropertyFromResource(GIT_RESOURCE_NAME, "git.build.time");
     }
 }


### PR DESCRIPTION
We currently print the version at boot. However, there's no guarantee
that modifications haven't been made against that version without the
version string being bumped. The only why to be sure is to have the
git sha that the jar was built from.

This patch packages the git information into a properties file, which
is shipped in the jar. It requires git to be available on the PATH to
work. If not, the file is not generated, but the build does not fail.

The version printing on boot has been moved to the start of the
PulsarService#start() method, and now prints the version as before,
but also the git sha, the git user and email of the builder, the
machine it was built on and the time it was built.
