### PR TITLE
Store data block header length in index and block header

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/DataBlockHeader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/DataBlockHeader.java
@@ -36,7 +36,7 @@ public interface DataBlockHeader {
     /**
      * Get the length of the block in bytes, including the header.
      */
-    int getBlockLength();
+    long getBlockLength();
 
     /**
      * Get the message entry Id for the first message that stored in this data block.
@@ -46,7 +46,7 @@ public interface DataBlockHeader {
     /**
      * Get the size of this DataBlockHeader.
      */
-    int getHeaderSize();
+    long getHeaderLength();
 
     /**
      * Get the content of the data block header as InputStream.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/OffloadIndexBlock.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/OffloadIndexBlock.java
@@ -60,10 +60,15 @@ public interface OffloadIndexBlock extends Closeable {
      */
     LedgerMetadata getLedgerMetadata();
 
-    /*
+    /**
      * Get the total size of the data object.
      */
     long getDataObjectLength();
+
+    /**
+     * Get the length of the header in the blocks in the data object.
+     */
+    long getDataBlockHeaderLength();
 
     /**
      * An input stream which knows the size of the stream upfront.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/OffloadIndexBlockBuilder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/OffloadIndexBlockBuilder.java
@@ -58,6 +58,12 @@ public interface OffloadIndexBlockBuilder {
     OffloadIndexBlockBuilder withDataObjectLength(long dataObjectLength);
 
     /**
+     * Specify the length of the block headers in the data object.
+     * @param dataHeaderLength the length of the headers
+     */
+    OffloadIndexBlockBuilder withDataBlockHeaderLength(long dataHeaderLength);
+
+    /**
      * Finalize the immutable OffloadIndexBlock
      */
     OffloadIndexBlock build();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/S3ManagedLedgerOffloader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/S3ManagedLedgerOffloader.java
@@ -115,7 +115,8 @@ public class S3ManagedLedgerOffloader implements LedgerOffloader {
         CompletableFuture<Void> promise = new CompletableFuture<>();
         scheduler.chooseThread(readHandle.getId()).submit(() -> {
             OffloadIndexBlockBuilder indexBuilder = OffloadIndexBlockBuilder.create()
-                .withLedgerMetadata(readHandle.getLedgerMetadata());
+                .withLedgerMetadata(readHandle.getLedgerMetadata())
+                .withDataBlockHeaderLength(BlockAwareSegmentInputStreamImpl.getHeaderSize());
             String dataBlockKey = dataBlockOffloadKey(readHandle.getId(), uuid);
             String indexBlockKey = indexBlockOffloadKey(readHandle.getId(), uuid);
             InitiateMultipartUploadRequest dataBlockReq = new InitiateMultipartUploadRequest(bucket, dataBlockKey, new ObjectMetadata());

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/impl/BlockAwareSegmentInputStreamImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/impl/BlockAwareSegmentInputStreamImpl.java
@@ -205,6 +205,10 @@ public class BlockAwareSegmentInputStreamImpl extends BlockAwareSegmentInputStre
         return dataBlockFullOffset - DataBlockHeaderImpl.getDataStartOffset() - ENTRY_HEADER_SIZE * blockEntryCount;
     }
 
+    public static long getHeaderSize() {
+        return DataBlockHeaderImpl.getDataStartOffset();
+    }
+
     // Calculate the block size after uploaded `entryBytesAlreadyWritten` bytes
     public static int calculateBlockSize(int maxBlockSize, ReadHandle readHandle,
                                          long firstEntryToWrite, long entryBytesAlreadyWritten) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/impl/OffloadIndexBlockBuilderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/impl/OffloadIndexBlockBuilderImpl.java
@@ -35,6 +35,7 @@ public class OffloadIndexBlockBuilderImpl implements OffloadIndexBlockBuilder {
 
     private LedgerMetadata ledgerMetadata;
     private long dataObjectLength;
+    private long dataHeaderLength;
     private List<OffloadIndexEntryImpl> entries;
     private int lastBlockSize;
 
@@ -49,6 +50,12 @@ public class OffloadIndexBlockBuilderImpl implements OffloadIndexBlockBuilder {
     }
 
     @Override
+    public OffloadIndexBlockBuilder withDataBlockHeaderLength(long dataHeaderLength) {
+        this.dataHeaderLength = dataHeaderLength;
+        return this;
+    }
+
+    @Override
     public OffloadIndexBlockBuilder withLedgerMetadata(LedgerMetadata metadata) {
         this.ledgerMetadata = metadata;
         return this;
@@ -56,6 +63,8 @@ public class OffloadIndexBlockBuilderImpl implements OffloadIndexBlockBuilder {
 
     @Override
     public OffloadIndexBlockBuilder addBlock(long firstEntryId, int partId, int blockSize) {
+        checkState(dataHeaderLength > 0);
+
         // we should added one by one.
         long offset;
         if (firstEntryId == 0) {
@@ -67,7 +76,7 @@ public class OffloadIndexBlockBuilderImpl implements OffloadIndexBlockBuilder {
         }
         lastBlockSize = blockSize;
 
-        this.entries.add(OffloadIndexEntryImpl.of(firstEntryId, partId, offset));
+        this.entries.add(OffloadIndexEntryImpl.of(firstEntryId, partId, offset, dataHeaderLength));
         return this;
     }
 
@@ -81,7 +90,8 @@ public class OffloadIndexBlockBuilderImpl implements OffloadIndexBlockBuilder {
         checkState(ledgerMetadata != null);
         checkState(!entries.isEmpty());
         checkState(dataObjectLength > 0);
-        return OffloadIndexBlockImpl.get(ledgerMetadata, dataObjectLength, entries);
+        checkState(dataHeaderLength > 0);
+        return OffloadIndexBlockImpl.get(ledgerMetadata, dataObjectLength, dataHeaderLength, entries);
     }
 
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/impl/OffloadIndexEntryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/s3offload/impl/OffloadIndexEntryImpl.java
@@ -26,15 +26,14 @@ import org.apache.pulsar.broker.s3offload.OffloadIndexEntry;
  *
  */
 public class OffloadIndexEntryImpl implements OffloadIndexEntry {
-    public static OffloadIndexEntryImpl of(long entryId, int partId, long offset) {
-        return new OffloadIndexEntryImpl(entryId, partId, offset);
+    public static OffloadIndexEntryImpl of(long entryId, int partId, long offset, long blockHeaderSize) {
+        return new OffloadIndexEntryImpl(entryId, partId, offset, blockHeaderSize);
     }
 
     private final long entryId;
-
     private final int partId;
-
     private final long offset;
+    private final long blockHeaderSize;
 
     @Override
     public long getEntryId() {
@@ -50,13 +49,14 @@ public class OffloadIndexEntryImpl implements OffloadIndexEntry {
     }
     @Override
     public long getDataOffset() {
-        return offset + DataBlockHeaderImpl.getDataStartOffset();
+        return offset + blockHeaderSize;
     }
 
-    public OffloadIndexEntryImpl(long entryId, int partId, long offset) {
+    private OffloadIndexEntryImpl(long entryId, int partId, long offset, long blockHeaderSize) {
         this.entryId = entryId;
         this.partId = partId;
         this.offset = offset;
+        this.blockHeaderSize = blockHeaderSize;
     }
 }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/s3offload/impl/DataBlockHeaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/s3offload/impl/DataBlockHeaderTest.java
@@ -23,6 +23,7 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import java.io.ByteArrayInputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import lombok.extern.slf4j.Slf4j;
@@ -34,22 +35,22 @@ public class DataBlockHeaderTest {
 
     @Test
     public void dataBlockHeaderImplTest() throws Exception {
-        int headerLength = 1024 * 1024;
+        int blockLength = 1024 * 1024;
         long firstEntryId = 3333L;
 
-        DataBlockHeaderImpl dataBlockHeader = DataBlockHeaderImpl.of(headerLength,
+        DataBlockHeaderImpl dataBlockHeader = DataBlockHeaderImpl.of(blockLength,
             firstEntryId);
 
         // verify get methods
         assertEquals(dataBlockHeader.getBlockMagicWord(), DataBlockHeaderImpl.MAGIC_WORD);
-        assertEquals(dataBlockHeader.getBlockLength(), headerLength);
+        assertEquals(dataBlockHeader.getBlockLength(), blockLength);
         assertEquals(dataBlockHeader.getFirstEntryId(), firstEntryId);
 
         // verify toStream and fromStream
         InputStream stream = dataBlockHeader.toStream();
         stream.mark(0);
         DataBlockHeader rebuild = DataBlockHeaderImpl.fromStream(stream);
-        assertEquals(rebuild.getBlockLength(), headerLength);
+        assertEquals(rebuild.getBlockLength(), blockLength);
         assertEquals(rebuild.getFirstEntryId(), firstEntryId);
         // verify InputStream reach end
         assertEquals(stream.read(), -1);
@@ -72,8 +73,8 @@ public class DataBlockHeaderTest {
                 new ByteArrayInputStream(streamContent, 0, DataBlockHeaderImpl.getDataStartOffset() - 1)) {
             DataBlockHeader rebuild3 = DataBlockHeaderImpl.fromStream(stream3);
             fail("Should throw EOFException");
-        } catch (Exception e) {
-            assertTrue(e instanceof java.io.EOFException);
+        } catch (EOFException e) {
+            // expected
         }
 
         stream.close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/s3offload/impl/OffloadIndexTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/s3offload/impl/OffloadIndexTest.java
@@ -47,17 +47,19 @@ public class OffloadIndexTest {
     @Test
     public void offloadIndexEntryImplTest() {
         // verify OffloadIndexEntryImpl builder
-        OffloadIndexEntryImpl entry1 = OffloadIndexEntryImpl.of(0, 2, 0);
-        OffloadIndexEntryImpl entry2 = OffloadIndexEntryImpl.of(100, 3, 1234);
+        OffloadIndexEntryImpl entry1 = OffloadIndexEntryImpl.of(0, 2, 0, 20);
+        OffloadIndexEntryImpl entry2 = OffloadIndexEntryImpl.of(100, 3, 1234, 20);
 
         // verify OffloadIndexEntryImpl get
         assertEquals(entry1.getEntryId(), 0L);
         assertEquals(entry1.getPartId(), 2);
         assertEquals(entry1.getOffset(), 0L);
+        assertEquals(entry1.getDataOffset(), 20L);
 
         assertEquals(entry2.getEntryId(), 100L);
         assertEquals(entry2.getPartId(), 3);
         assertEquals(entry2.getOffset(), 1234L);
+        assertEquals(entry2.getDataOffset(), 1254L);
     }
 
 
@@ -108,7 +110,7 @@ public class OffloadIndexTest {
         LedgerMetadata metadata = createLedgerMetadata();
         log.debug("created metadata: {}", metadata.toString());
 
-        blockBuilder.withLedgerMetadata(metadata).withDataObjectLength(1);
+        blockBuilder.withLedgerMetadata(metadata).withDataObjectLength(1).withDataBlockHeaderLength(23455);
 
         blockBuilder.addBlock(0, 2, 64 * 1024 * 1024);
         blockBuilder.addBlock(1000, 3, 64 * 1024 * 1024);
@@ -162,6 +164,7 @@ public class OffloadIndexTest {
         int magic = wrapper.readInt();
         int indexBlockLength = wrapper.readInt();
         long dataObjectLength = wrapper.readLong();
+        long dataHeaderLength = wrapper.readLong();
         int segmentMetadataLength = wrapper.readInt();
         int indexEntryCount = wrapper.readInt();
 
@@ -170,25 +173,32 @@ public class OffloadIndexTest {
         assertEquals(indexBlockLength, readoutLen);
         assertEquals(indexEntryCount, 3);
         assertEquals(dataObjectLength, 1);
+        assertEquals(dataHeaderLength, 23455);
 
         wrapper.readBytes(segmentMetadataLength);
         log.debug("magic: {}, blockLength: {}, metadataLength: {}, indexCount: {}",
             magic, indexBlockLength, segmentMetadataLength, indexEntryCount);
 
         // verify entry
-        OffloadIndexEntry e1 = OffloadIndexEntryImpl.of(wrapper.readLong(), wrapper.readInt(), wrapper.readLong());
-        OffloadIndexEntry e2 = OffloadIndexEntryImpl.of(wrapper.readLong(), wrapper.readInt(), wrapper.readLong());
-        OffloadIndexEntry e3 = OffloadIndexEntryImpl.of(wrapper.readLong(), wrapper.readInt(), wrapper.readLong());;
+        OffloadIndexEntry e1 = OffloadIndexEntryImpl.of(wrapper.readLong(), wrapper.readInt(),
+                                                        wrapper.readLong(), dataHeaderLength);
+        OffloadIndexEntry e2 = OffloadIndexEntryImpl.of(wrapper.readLong(), wrapper.readInt(),
+                                                        wrapper.readLong(), dataHeaderLength);
+        OffloadIndexEntry e3 = OffloadIndexEntryImpl.of(wrapper.readLong(), wrapper.readInt(),
+                                                        wrapper.readLong(), dataHeaderLength);;
 
         assertEquals(e1.getEntryId(),entry1.getEntryId());
         assertEquals(e1.getPartId(), entry1.getPartId());
         assertEquals(e1.getOffset(), entry1.getOffset());
+        assertEquals(e1.getDataOffset(), entry1.getDataOffset());
         assertEquals(e2.getEntryId(), entry2.getEntryId());
         assertEquals(e2.getPartId(), entry2.getPartId());
         assertEquals(e2.getOffset(), entry2.getOffset());
+        assertEquals(e2.getDataOffset(), entry2.getDataOffset());
         assertEquals(e3.getEntryId(), entry3.getEntryId());
         assertEquals(e3.getPartId(), entry3.getPartId());
         assertEquals(e3.getOffset(), entry3.getOffset());
+        assertEquals(e3.getDataOffset(), entry3.getDataOffset());
         wrapper.release();
 
         // verify build OffloadIndexBlock from InputStream


### PR DESCRIPTION
In the case of the index, if we store the block header length in the
index, we can change the length in future without having to break
compatibility.

In the case of the block header itself, storing the header length in
the block, allows reading of the data object without having to make
assumptions about the size of the header.

Master Issue: #1511
