### PR TITLE
Cpp client: add getLastMessageId and hasMessageAvailable in consmer and reader

### DIFF
--- a/pulsar-client-cpp/include/pulsar/MessageId.h
+++ b/pulsar-client-cpp/include/pulsar/MessageId.h
@@ -33,6 +33,7 @@ class MessageId {
    public:
     MessageId& operator=(const MessageId&);
     MessageId();
+    MessageId(int32_t partition, int64_t ledgerId, int64_t entryId, int32_t batchIndex);
 
     /**
      * MessageId representing the "earliest" or "oldest available" message stored in the topic
@@ -75,7 +76,6 @@ class MessageId {
     friend class PulsarWrapper;
     friend class PulsarFriend;
 
-    explicit MessageId(int32_t partition, int64_t ledgerId, int64_t entryId, int32_t batchIndex);
     friend std::ostream& operator<<(std::ostream& s, const MessageId& messageId);
 
     int64_t ledgerId() const;

--- a/pulsar-client-cpp/include/pulsar/MessageId.h
+++ b/pulsar-client-cpp/include/pulsar/MessageId.h
@@ -33,7 +33,7 @@ class MessageId {
    public:
     MessageId& operator=(const MessageId&);
     MessageId();
-    MessageId(int32_t partition, int64_t ledgerId, int64_t entryId, int32_t batchIndex);
+    explicit MessageId(int32_t partition, int64_t ledgerId, int64_t entryId, int32_t batchIndex);
 
     /**
      * MessageId representing the "earliest" or "oldest available" message stored in the topic

--- a/pulsar-client-cpp/include/pulsar/Reader.h
+++ b/pulsar-client-cpp/include/pulsar/Reader.h
@@ -29,6 +29,8 @@ class PulsarWrapper;
 class PulsarFriend;
 class ReaderImpl;
 
+typedef boost::function<void(Result result, bool hasMessageAvailable)> HasMessageAvailableCallback;
+
 /**
  * A Reader can be used to scan through all the messages currently available in a topic.
  */
@@ -70,6 +72,10 @@ class Reader {
     Result close();
 
     void closeAsync(ResultCallback callback);
+
+    void hasMessageAvailableAsync(HasMessageAvailableCallback callback);
+
+    Result hasMessageAvailable(bool& hasMessageAvailable);
 
    private:
     typedef boost::shared_ptr<ReaderImpl> ReaderImplPtr;

--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -960,6 +960,7 @@ void ClientConnection::handleIncomingCommand() {
 
                         getLastMessageIdPromise.setValue(messageId);
                     } else {
+                        lock.unlock();
                         LOG_WARN(
                             "getLastMessageIdResponse command - Received unknown request id from server: "
                             << getLastMessageIdResponse.request_id());
@@ -1261,6 +1262,7 @@ Future<Result, MessageId> ClientConnection::newGetLastMessageId(uint64_t consume
         lock.unlock();
         LOG_ERROR(cnxString_ << " Client is not connected to the broker");
         promise.setFailed(ResultNotConnected);
+        return promise.getFuture();
     }
 
     pendingGetLastMessageIdRequests_.insert(std::make_pair(requestId, promise));

--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -857,6 +857,20 @@ void ClientConnection::handleIncomingCommand() {
                     } else {
                         lock.unlock();
                     }
+
+                    Lock lock2(mutex_);
+                    PendingGetLastMessageIdRequestsMap::iterator it2 =
+                        pendingGetLastMessageIdRequests_.find(error.request_id());
+                    if (it2 != pendingGetLastMessageIdRequests_.end()) {
+                        Promise<Result, MessageId> getLastMessageIdPromise = it2->second;
+                        pendingGetLastMessageIdRequests_.erase(it2);
+                        lock2.unlock();
+
+                        getLastMessageIdPromise.setFailed(getResult(error.error()));
+                    } else {
+                        lock2.unlock();
+                    }
+
                     break;
                 }
 
@@ -925,6 +939,34 @@ void ClientConnection::handleIncomingCommand() {
                     LOG_DEBUG(cnxString_ << "Received notification about active consumer changes");
                     // ignore this message for now.
                     // TODO: @link{https://github.com/apache/incubator-pulsar/issues/1240}
+                    break;
+                }
+
+                case BaseCommand::GET_LAST_MESSAGE_ID_RESPONSE: {
+                    const CommandGetLastMessageIdResponse& getLastMessageIdResponse =
+                        incomingCmd_.getlastmessageidresponse();
+                    LOG_DEBUG(cnxString_ << "Received getLastMessageIdResponse from server. req_id: "
+                                         << getLastMessageIdResponse.request_id());
+
+                    Lock lock(mutex_);
+                    PendingGetLastMessageIdRequestsMap::iterator it =
+                        pendingGetLastMessageIdRequests_.find(getLastMessageIdResponse.request_id());
+
+                    if (it != pendingGetLastMessageIdRequests_.end()) {
+                        Promise<Result, MessageId> getLastMessageIdPromise = it->second;
+                        pendingGetLastMessageIdRequests_.erase(it);
+                        lock.unlock();
+
+                        MessageIdData messageIdData = getLastMessageIdResponse.last_message_id();
+                        MessageId messageId = MessageId(messageIdData.partition(), messageIdData.ledgerid(),
+                                                        messageIdData.entryid(), messageIdData.batch_index());
+
+                        getLastMessageIdPromise.setValue(messageId);
+                    } else {
+                        LOG_WARN(
+                            "getLastMessageIdResponse command - Received unknown request id from server: "
+                            << getLastMessageIdResponse.request_id());
+                    }
                     break;
                 }
 
@@ -1214,4 +1256,20 @@ int ClientConnection::getServerProtocolVersion() const { return serverProtocolVe
 Commands::ChecksumType ClientConnection::getChecksumType() const {
     return getServerProtocolVersion() >= proto::v6 ? Commands::Crc32c : Commands::None;
 }
+
+Future<Result, MessageId> ClientConnection::newGetLastMessageId(uint64_t consumerId, uint64_t requestId) {
+    Lock lock(mutex_);
+    Promise<Result, MessageId> promise;
+    if (isClosed()) {
+        lock.unlock();
+        LOG_ERROR(cnxString_ << " Client is not connected to the broker");
+        promise.setFailed(ResultNotConnected);
+    }
+
+    pendingGetLastMessageIdRequests_.insert(std::make_pair(requestId, promise));
+    lock.unlock();
+    sendCommand(Commands::newGetLastMessageId(consumerId, requestId));
+    return promise.getFuture();
+}
+
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/ClientConnection.h
+++ b/pulsar-client-cpp/lib/ClientConnection.h
@@ -81,7 +81,7 @@ class ClientConnection : public boost::enable_shared_from_this<ClientConnection>
 
    public:
     typedef boost::shared_ptr<boost::asio::ip::tcp::socket> SocketPtr;
-    typedef boost::shared_ptr<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>> TlsSocketPtr;
+    typedef boost::shared_ptr<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&> > TlsSocketPtr;
     typedef boost::shared_ptr<ClientConnection> ConnectionPtr;
     typedef boost::function<void(const boost::system::error_code&, ConnectionPtr)> ConnectionListener;
     typedef std::vector<ConnectionListener>::iterator ListenerIterator;
@@ -264,10 +264,10 @@ class ClientConnection : public boost::enable_shared_from_this<ClientConnection>
     typedef std::map<long, ConsumerImplWeakPtr> ConsumersMap;
     ConsumersMap consumers_;
 
-    typedef std::map<uint64_t, Promise<Result, BrokerConsumerStatsImpl>> PendingConsumerStatsMap;
+    typedef std::map<uint64_t, Promise<Result, BrokerConsumerStatsImpl> > PendingConsumerStatsMap;
     PendingConsumerStatsMap pendingConsumerStatsMap_;
 
-    typedef std::map<long, Promise<Result, MessageId>> PendingGetLastMessageIdRequestsMap;
+    typedef std::map<long, Promise<Result, MessageId> > PendingGetLastMessageIdRequestsMap;
     PendingGetLastMessageIdRequestsMap pendingGetLastMessageIdRequests_;
 
     boost::mutex mutex_;

--- a/pulsar-client-cpp/lib/ClientConnection.h
+++ b/pulsar-client-cpp/lib/ClientConnection.h
@@ -81,7 +81,7 @@ class ClientConnection : public boost::enable_shared_from_this<ClientConnection>
 
    public:
     typedef boost::shared_ptr<boost::asio::ip::tcp::socket> SocketPtr;
-    typedef boost::shared_ptr<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&> > TlsSocketPtr;
+    typedef boost::shared_ptr<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>> TlsSocketPtr;
     typedef boost::shared_ptr<ClientConnection> ConnectionPtr;
     typedef boost::function<void(const boost::system::error_code&, ConnectionPtr)> ConnectionListener;
     typedef std::vector<ConnectionListener>::iterator ListenerIterator;
@@ -141,6 +141,8 @@ class ClientConnection : public boost::enable_shared_from_this<ClientConnection>
     Commands::ChecksumType getChecksumType() const;
 
     Future<Result, BrokerConsumerStatsImpl> newConsumerStats(uint64_t consumerId, uint64_t requestId);
+
+    Future<Result, MessageId> newGetLastMessageId(uint64_t consumerId, uint64_t requestId);
 
    private:
     struct PendingRequestData {
@@ -262,8 +264,11 @@ class ClientConnection : public boost::enable_shared_from_this<ClientConnection>
     typedef std::map<long, ConsumerImplWeakPtr> ConsumersMap;
     ConsumersMap consumers_;
 
-    typedef std::map<uint64_t, Promise<Result, BrokerConsumerStatsImpl> > PendingConsumerStatsMap;
+    typedef std::map<uint64_t, Promise<Result, BrokerConsumerStatsImpl>> PendingConsumerStatsMap;
     PendingConsumerStatsMap pendingConsumerStatsMap_;
+
+    typedef std::map<long, Promise<Result, MessageId>> PendingGetLastMessageIdRequestsMap;
+    PendingGetLastMessageIdRequestsMap pendingGetLastMessageIdRequests_;
 
     boost::mutex mutex_;
     typedef boost::unique_lock<boost::mutex> Lock;

--- a/pulsar-client-cpp/lib/Commands.cc
+++ b/pulsar-client-cpp/lib/Commands.cc
@@ -312,6 +312,18 @@ SharedBuffer Commands::newSeek(uint64_t consumerId, uint64_t requestId, const Me
     return writeMessageWithSize(cmd);
 }
 
+SharedBuffer Commands::newGetLastMessageId(uint64_t consumerId, uint64_t requestId) {
+    BaseCommand cmd;
+    cmd.set_type(BaseCommand::GET_LAST_MESSAGE_ID);
+
+    CommandGetLastMessageId* getLastMessageId = cmd.mutable_getlastmessageid();
+    getLastMessageId->set_consumer_id(consumerId);
+    getLastMessageId->set_request_id(requestId);
+    const SharedBuffer buffer = writeMessageWithSize(cmd);
+    cmd.clear_getlastmessageid();
+    return buffer;
+}
+
 std::string Commands::messageType(BaseCommand_Type type) {
     switch (type) {
         case BaseCommand::CONNECT:
@@ -397,6 +409,12 @@ std::string Commands::messageType(BaseCommand_Type type) {
             break;
         case BaseCommand::ACTIVE_CONSUMER_CHANGE:
             return "ACTIVE_CONSUMER_CHANGE";
+            break;
+        case BaseCommand::GET_LAST_MESSAGE_ID:
+            return "GET_LAST_MESSAGE_ID";
+            break;
+        case BaseCommand::GET_LAST_MESSAGE_ID_RESPONSE:
+            return "GET_LAST_MESSAGE_ID_RESPONSE";
             break;
     };
 }

--- a/pulsar-client-cpp/lib/Commands.h
+++ b/pulsar-client-cpp/lib/Commands.h
@@ -111,6 +111,7 @@ class Commands {
     static SharedBuffer newConsumerStats(uint64_t consumerId, uint64_t requestId);
 
     static SharedBuffer newSeek(uint64_t consumerId, uint64_t requestId, const MessageId& messageId);
+    static SharedBuffer newGetLastMessageId(uint64_t consumerId, uint64_t requestId);
 
    private:
     Commands();

--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -58,7 +58,8 @@ ConsumerImpl::ConsumerImpl(const ClientImplPtr client, const std::string& topic,
       brokerConsumerStats_(),
       consumerStatsBasePtr_(),
       msgCrypto_(),
-      readCompacted_(conf.isReadCompacted()) {
+      readCompacted_(conf.isReadCompacted()),
+      lastMessageInBroker_(Optional<MessageId>::of(MessageId())) {
     std::stringstream consumerStrStream;
     consumerStrStream << "[" << topic_ << ", " << subscription_ << ", " << consumerId_ << "] ";
     consumerStr_ = consumerStrStream.str();
@@ -924,16 +925,23 @@ void ConsumerImpl::seekAsync(const MessageId& msgId, ResultCallback callback) {
 bool ConsumerImpl::isReadCompacted() { return readCompacted_; }
 
 void ConsumerImpl::hasMessageAvailableAsync(HasMessageAvailableCallback callback) {
-    if (this->lastMessageIdAvailable()) {
+    MessageId lastDequed = this->lastMessageIdDequed();
+    MessageId lastInBroker = this->lastMessageIdInBroker();
+    if (lastInBroker > lastDequed && lastInBroker.entryId() != -1) {
         callback(ResultOk, true);
         return;
     }
 
-    BrokerGetLastMessageIdCallback callback1 = [this, callback](Result result, MessageId messageId) {
-        if (this->lastMessageIdAvailable()) {
-            callback(ResultOk, true);
+    BrokerGetLastMessageIdCallback callback1 = [this, lastDequed, callback](Result result,
+                                                                            MessageId messageId) {
+        if (result == ResultOk) {
+            if (messageId > lastDequed && messageId.entryId() != -1) {
+                callback(ResultOk, true);
+            } else {
+                callback(ResultOk, false);
+            }
         } else {
-            callback(ResultOk, false);
+            callback(result, false);
         }
     };
 
@@ -942,9 +950,14 @@ void ConsumerImpl::hasMessageAvailableAsync(HasMessageAvailableCallback callback
 
 void ConsumerImpl::brokerGetLastMessageIdListener(Result res, MessageId messageId,
                                                   BrokerGetLastMessageIdCallback callback) {
-    if (!callback.empty()) {
+    Lock lock(mutex_);
+    if (messageId > lastMessageIdInBroker()) {
         lastMessageInBroker_ = Optional<MessageId>::of(messageId);
+        lock.unlock();
         callback(res, messageId);
+    } else {
+        lock.unlock();
+        callback(res, lastMessageIdInBroker());
     }
 }
 
@@ -971,17 +984,15 @@ void ConsumerImpl::getLastMessageIdAsync(BrokerGetLastMessageIdCallback callback
             cnx->newGetLastMessageId(consumerId_, requestId)
                 .addListener(boost::bind(&ConsumerImpl::brokerGetLastMessageIdListener, shared_from_this(),
                                          _1, _2, callback));
-            return;
         } else {
             LOG_ERROR(getName() << " Operation not supported since server protobuf version "
                                 << cnx->getServerProtocolVersion() << " is older than proto::v12");
             callback(ResultUnsupportedVersionError, MessageId());
-            return;
         }
+    } else {
+        LOG_ERROR(getName() << " Client Connection not ready for Consumer");
+        callback(ResultNotConnected, MessageId());
     }
-
-    LOG_ERROR(getName() << " Client Connection not ready for Consumer");
-    callback(ResultNotConnected, MessageId());
 }
 
 } /* namespace pulsar */

--- a/pulsar-client-cpp/lib/ConsumerImpl.h
+++ b/pulsar-client-cpp/lib/ConsumerImpl.h
@@ -176,12 +176,12 @@ class ConsumerImpl : public ConsumerImplBase,
     void brokerGetLastMessageIdListener(Result res, MessageId messageId,
                                         BrokerGetLastMessageIdCallback callback);
 
-    inline bool lastMessageIdAvailable() {
-        MessageId lastDequeued = lastDequedMessage_.is_present() ? lastDequedMessage_.value() : MessageId();
-        MessageId lastMessageInBroker =
-            lastMessageInBroker_.is_present() ? lastMessageInBroker_.value() : MessageId();
+    MessageId lastMessageIdDequed() {
+        return lastDequedMessage_.is_present() ? lastDequedMessage_.value() : MessageId();
+    }
 
-        return (lastMessageInBroker > lastDequeued && lastMessageInBroker.entryId() != -1);
+    MessageId lastMessageIdInBroker() {
+        return lastMessageInBroker_.is_present() ? lastMessageInBroker_.value() : MessageId();
     }
 
     friend class PulsarFriend;

--- a/pulsar-client-cpp/lib/ConsumerImpl.h
+++ b/pulsar-client-cpp/lib/ConsumerImpl.h
@@ -53,6 +53,8 @@ class BatchAcknowledgementTracker;
 typedef boost::shared_ptr<ConsumerImpl> ConsumerImplPtr;
 typedef boost::weak_ptr<ConsumerImpl> ConsumerImplWeakPtr;
 typedef boost::shared_ptr<MessageCrypto> MessageCryptoPtr;
+typedef boost::function<void(Result result, MessageId messageId)> BrokerGetLastMessageIdCallback;
+typedef boost::function<void(Result result, bool hasMessageAvailable)> HasMessageAvailableCallback;
 
 enum ConsumerTopicType
 {
@@ -105,6 +107,8 @@ class ConsumerImpl : public ConsumerImplBase,
     void handleSeek(Result result, ResultCallback callback);
     virtual void seekAsync(const MessageId& msgId, ResultCallback callback);
     virtual bool isReadCompacted();
+    virtual void hasMessageAvailableAsync(HasMessageAvailableCallback callback);
+    virtual void getLastMessageIdAsync(BrokerGetLastMessageIdCallback callback);
 
    protected:
     void connectionOpened(const ClientConnectionPtr& cnx);
@@ -167,6 +171,18 @@ class ConsumerImpl : public ConsumerImplBase,
 
     MessageCryptoPtr msgCrypto_;
     const bool readCompacted_;
+
+    Optional<MessageId> lastMessageInBroker_;
+    void brokerGetLastMessageIdListener(Result res, MessageId messageId,
+                                        BrokerGetLastMessageIdCallback callback);
+
+    inline bool lastMessageIdAvailable() {
+        MessageId lastDequeued = lastDequedMessage_.is_present() ? lastDequedMessage_.value() : MessageId();
+        MessageId lastMessageInBroker =
+            lastMessageInBroker_.is_present() ? lastMessageInBroker_.value() : MessageId();
+
+        return (lastMessageInBroker > lastDequeued && lastMessageInBroker.entryId() != -1);
+    }
 
     friend class PulsarFriend;
 };

--- a/pulsar-client-cpp/lib/Reader.cc
+++ b/pulsar-client-cpp/lib/Reader.cc
@@ -66,4 +66,25 @@ void Reader::closeAsync(ResultCallback callback) {
 
     impl_->closeAsync(callback);
 }
+
+void Reader::hasMessageAvailableAsync(HasMessageAvailableCallback callback) {
+    if (!impl_) {
+        callback(ResultConsumerNotInitialized, false);
+        return;
+    }
+
+    impl_->hasMessageAvailableAsync(callback);
+}
+
+Result Reader::hasMessageAvailable(bool& hasMessageAvailable) {
+    if (!impl_) {
+        return ResultConsumerNotInitialized;
+    }
+
+    Promise<Result, bool> promise;
+
+    impl_->hasMessageAvailableAsync(WaitForCallbackValue<bool>(promise));
+    return promise.getFuture().get(hasMessageAvailable);
+}
+
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/ReaderImpl.cc
+++ b/pulsar-client-cpp/lib/ReaderImpl.cc
@@ -97,4 +97,9 @@ void ReaderImpl::acknowledgeIfNecessary(Result result, const Message& msg) {
 }
 
 void ReaderImpl::closeAsync(ResultCallback callback) { consumer_->closeAsync(callback); }
+
+void ReaderImpl::hasMessageAvailableAsync(HasMessageAvailableCallback callback) {
+    consumer_->hasMessageAvailableAsync(callback);
+}
+
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/ReaderImpl.h
+++ b/pulsar-client-cpp/lib/ReaderImpl.h
@@ -49,6 +49,8 @@ class ReaderImpl : public boost::enable_shared_from_this<ReaderImpl> {
 
     ConsumerImplPtr getConsumer();
 
+    void hasMessageAvailableAsync(HasMessageAvailableCallback callback);
+
    private:
     void handleConsumerCreated(Result result, ConsumerImplBaseWeakPtr consumer);
 


### PR DESCRIPTION
In PR #1066, we have getLastMessageId and hasMessageAvailable to identify when the reader has reached the last published entry on the topic, in java client.
This is the support for cpp client.