### PR TITLE
Cpp client: add seek support in consumer for cpp client

### DIFF
--- a/pulsar-client-cpp/include/pulsar/Consumer.h
+++ b/pulsar-client-cpp/include/pulsar/Consumer.h
@@ -211,6 +211,30 @@ class Consumer {
      */
     void getBrokerConsumerStatsAsync(BrokerConsumerStatsCallback callback);
 
+    /**
+     * Reset the subscription associated with this consumer to a specific message id.
+     * The message id can either be a specific message or represent the first or last messages in the topic.
+     *
+     * Note: this operation can only be done on non-partitioned topics. For these, one can rather perform the
+     * seek() on the individual partitions.
+     *
+     * @param messageId
+     *            the message id where to reposition the subscription
+     */
+    Result seek(const MessageId& msgId);
+
+    /**
+     * Asynchronously reset the subscription associated with this consumer to a specific message id.
+     * The message id can either be a specific message or represent the first or last messages in the topic.
+     *
+     * Note: this operation can only be done on non-partitioned topics. For these, one can rather perform the
+     * seek() on the individual partitions.
+     *
+     * @param messageId
+     *            the message id where to reposition the subscription
+     */
+    virtual void seekAsync(const MessageId& msgId, ResultCallback callback);
+
    private:
     typedef boost::shared_ptr<ConsumerImplBase> ConsumerImplBasePtr;
     ConsumerImplBasePtr impl_;

--- a/pulsar-client-cpp/include/pulsar/c/consumer.h
+++ b/pulsar-client-cpp/include/pulsar/c/consumer.h
@@ -192,6 +192,11 @@ pulsar_result resume_message_listener(pulsar_consumer_t *consumer);
  */
 void pulsar_consumer_redeliver_unacknowledged_messages(pulsar_consumer_t *consumer);
 
+void pulsar_consumer_seek_async(pulsar_consumer_t *consumer, pulsar_message_id_t *messageId,
+                                pulsar_result_callback callback, void *ctx);
+
+pulsar_result pulsar_consumer_seek(pulsar_consumer_t *consumer, pulsar_message_id_t *messageId);
+
 #pragma GCC visibility pop
 
 #ifdef __cplusplus

--- a/pulsar-client-cpp/lib/Commands.cc
+++ b/pulsar-client-cpp/lib/Commands.cc
@@ -298,6 +298,19 @@ SharedBuffer Commands::newRedeliverUnacknowledgedMessages(uint64_t consumerId) {
     return writeMessageWithSize(cmd);
 }
 
+SharedBuffer Commands::newSeek(uint64_t consumerId, uint64_t requestId, const MessageId& messageId) {
+    BaseCommand cmd;
+    cmd.set_type(BaseCommand::SEEK);
+    CommandSeek* commandSeek = cmd.mutable_seek();
+    commandSeek->set_consumer_id(consumerId);
+    commandSeek->set_request_id(requestId);
+
+    MessageIdData& messageIdData = *commandSeek->mutable_message_id();
+    messageIdData.set_ledgerid(messageId.ledgerId());
+    messageIdData.set_entryid(messageId.entryId());
+    return writeMessageWithSize(cmd);
+}
+
 std::string Commands::messageType(BaseCommand_Type type) {
     switch (type) {
         case BaseCommand::CONNECT:

--- a/pulsar-client-cpp/lib/Commands.h
+++ b/pulsar-client-cpp/lib/Commands.h
@@ -109,6 +109,8 @@ class Commands {
 
     static SharedBuffer newConsumerStats(uint64_t consumerId, uint64_t requestId);
 
+    static SharedBuffer newSeek(uint64_t consumerId, uint64_t requestId, const MessageId& messageId);
+
    private:
     Commands();
 

--- a/pulsar-client-cpp/lib/Consumer.cc
+++ b/pulsar-client-cpp/lib/Consumer.cc
@@ -189,4 +189,25 @@ void Consumer::getBrokerConsumerStatsAsync(BrokerConsumerStatsCallback callback)
     }
     impl_->getBrokerConsumerStatsAsync(callback);
 }
+
+void Consumer::seekAsync(const MessageId& msgId, ResultCallback callback) {
+    if (!impl_) {
+        callback(ResultConsumerNotInitialized);
+        return;
+    }
+    impl_->seekAsync(msgId, callback);
+}
+
+Result Consumer::seek(const MessageId& msgId) {
+    if (!impl_) {
+        return ResultConsumerNotInitialized;
+    }
+
+    Promise<bool, Result> promise;
+    impl_->seekAsync(msgId, WaitForCallback(promise));
+    Result result;
+    promise.getFuture().get(result);
+    return result;
+}
+
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -879,4 +879,45 @@ void ConsumerImpl::brokerConsumerStatsListener(Result res, BrokerConsumerStatsIm
     }
 }
 
+void ConsumerImpl::handleSeek(Result result, ResultCallback callback) {
+    if (result == ResultOk) {
+        Lock lock(mutex_);
+        LOG_INFO(getName() << "Seek successfully");
+    } else {
+        LOG_ERROR(getName() << "Failed to seek: " << strResult(result));
+    }
+    callback(result);
+}
+
+void ConsumerImpl::seekAsync(const MessageId& msgId, ResultCallback callback) {
+    Lock lock(mutex_);
+    if (state_ == Closed || state_ == Closing) {
+        lock.unlock();
+        LOG_ERROR(getName() << "Client connection already closed.");
+        if (!callback.empty()) {
+            callback(ResultAlreadyClosed);
+        }
+        return;
+    }
+    lock.unlock();
+
+    ClientConnectionPtr cnx = getCnx().lock();
+    if (cnx) {
+        ClientImplPtr client = client_.lock();
+        uint64_t requestId = client->newRequestId();
+        LOG_DEBUG(getName() << " Sending seek Command for Consumer - " << getConsumerId() << ", requestId - "
+                            << requestId);
+        Future<Result, ResponseData> future =
+            cnx->sendRequestWithId(Commands::newSeek(consumerId_, requestId, msgId), requestId);
+
+        if (!callback.empty()) {
+            future.addListener(boost::bind(&ConsumerImpl::handleSeek, shared_from_this(), _1, callback));
+        }
+        return;
+    }
+
+    LOG_ERROR(getName() << " Client Connection not ready for Consumer");
+    callback(ResultNotConnected);
+}
+
 } /* namespace pulsar */

--- a/pulsar-client-cpp/lib/ConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/ConsumerImpl.cc
@@ -881,7 +881,6 @@ void ConsumerImpl::brokerConsumerStatsListener(Result res, BrokerConsumerStatsIm
 
 void ConsumerImpl::handleSeek(Result result, ResultCallback callback) {
     if (result == ResultOk) {
-        Lock lock(mutex_);
         LOG_INFO(getName() << "Seek successfully");
     } else {
         LOG_ERROR(getName() << "Failed to seek: " << strResult(result));

--- a/pulsar-client-cpp/lib/ConsumerImpl.h
+++ b/pulsar-client-cpp/lib/ConsumerImpl.h
@@ -102,6 +102,8 @@ class ConsumerImpl : public ConsumerImplBase,
     virtual Result resumeMessageListener();
     virtual void redeliverUnacknowledgedMessages();
     virtual void getBrokerConsumerStatsAsync(BrokerConsumerStatsCallback callback);
+    void handleSeek(Result result, ResultCallback callback);
+    virtual void seekAsync(const MessageId& msgId, ResultCallback callback);
 
    protected:
     void connectionOpened(const ClientConnectionPtr& cnx);

--- a/pulsar-client-cpp/lib/ConsumerImplBase.h
+++ b/pulsar-client-cpp/lib/ConsumerImplBase.h
@@ -49,6 +49,7 @@ class ConsumerImplBase {
     virtual const std::string& getName() const = 0;
     virtual int getNumOfPrefetchedMessages() const = 0;
     virtual void getBrokerConsumerStatsAsync(BrokerConsumerStatsCallback callback) = 0;
+    virtual void seekAsync(const MessageId& msgId, ResultCallback callback) = 0;
 };
 }  // namespace pulsar
 #endif  // PULSAR_CONSUMER_IMPL_BASE_HEADER

--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.cc
@@ -407,4 +407,9 @@ void PartitionedConsumerImpl::handleGetConsumerStats(Result res, BrokerConsumerS
         callback(ResultOk, BrokerConsumerStats(statsPtr));
     }
 }
+
+void PartitionedConsumerImpl::seekAsync(const MessageId& msgId, ResultCallback callback) {
+    callback(ResultOperationNotSupported);
+}
+
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/PartitionedConsumerImpl.h
+++ b/pulsar-client-cpp/lib/PartitionedConsumerImpl.h
@@ -68,6 +68,7 @@ class PartitionedConsumerImpl : public ConsumerImplBase,
     virtual void getBrokerConsumerStatsAsync(BrokerConsumerStatsCallback callback);
     void handleGetConsumerStats(Result, BrokerConsumerStats, LatchPtr, PartitionedBrokerConsumerStatsPtr,
                                 size_t, BrokerConsumerStatsCallback);
+    virtual void seekAsync(const MessageId& msgId, ResultCallback callback);
 
    private:
     const ClientImplPtr client_;

--- a/pulsar-client-cpp/lib/c/c_Consumer.cc
+++ b/pulsar-client-cpp/lib/c/c_Consumer.cc
@@ -122,3 +122,13 @@ pulsar_result resume_message_listener(pulsar_consumer_t *consumer) {
 void pulsar_consumer_redeliver_unacknowledged_messages(pulsar_consumer_t *consumer) {
     return consumer->consumer.redeliverUnacknowledgedMessages();
 }
+
+void pulsar_consumer_seek_async(pulsar_consumer_t *consumer, pulsar_message_id_t *messageId,
+                                pulsar_result_callback callback, void *ctx) {
+    consumer->consumer.seekAsync(messageId->messageId,
+                                 boost::bind(handle_result_callback, _1, callback, ctx));
+}
+
+pulsar_result pulsar_consumer_seek(pulsar_consumer_t *consumer, pulsar_message_id_t *messageId) {
+    return (pulsar_result)consumer->consumer.seek(messageId->messageId);
+}


### PR DESCRIPTION
In PR #848, It introduced in seek for consumer. This is for c++ client.