### PR TITLE
Increase watch-znode.py connection timeout

### DIFF
--- a/docker/pulsar/scripts/watch-znode.py
+++ b/docker/pulsar/scripts/watch-znode.py
@@ -18,8 +18,10 @@
 # under the License.
 #
 
-import sys, getopt, time
+import sys, getopt, time, logging
 from kazoo.client import KazooClient
+
+logging.getLogger('kazoo.client').addHandler(logging.StreamHandler())
 
 def usage():
     print >> sys.stderr, "\n%s -z <zookeeper> -p <path> [-w|-c|-e]" % (sys.argv[0])
@@ -77,7 +79,7 @@ if (not watch and not create and not exists):
     usage()
     sys.exit(5)
 
-zk = KazooClient(hosts=zookeeper)
+zk = KazooClient(hosts=zookeeper, timeout=3600)
 zk.start()
 
 if create:

--- a/docker/pulsar/scripts/watch-znode.py
+++ b/docker/pulsar/scripts/watch-znode.py
@@ -80,7 +80,7 @@ if (not watch and not create and not exists):
     usage()
     sys.exit(5)
 
-zk = KazooClient(hosts=zookeeper, timeout=3600, connection_retry=KazooRetry(max_tries=-1))
+zk = KazooClient(hosts=zookeeper, timeout=1, connection_retry=KazooRetry(max_tries=-1))
 zk.start()
 
 if create:

--- a/docker/pulsar/scripts/watch-znode.py
+++ b/docker/pulsar/scripts/watch-znode.py
@@ -20,6 +20,7 @@
 
 import sys, getopt, time, logging
 from kazoo.client import KazooClient
+from kazoo.retry import KazooRetry
 
 logging.getLogger('kazoo.client').addHandler(logging.StreamHandler())
 
@@ -79,7 +80,7 @@ if (not watch and not create and not exists):
     usage()
     sys.exit(5)
 
-zk = KazooClient(hosts=zookeeper, timeout=3600)
+zk = KazooClient(hosts=zookeeper, timeout=3600, connection_retry=KazooRetry(max_tries=-1))
 zk.start()
 
 if create:


### PR DESCRIPTION
watch-znode is used in integration tests to ensure that initialization
has occurred before booting brokers and proxies. By default kazoo uses
a 10 second connection timeout. However, on occasion zookeeper could
take longer than 10 seconds to come up depending on the order that
containers are started and the load on the machine.

This patch increases the connect timeout to a very high value (1h). If
zookeeper doesn't come up within the hour, the test will fail in other
places, and the containers will be torn down.
