### PR TITLE
Make supervisord wait a single command

### DIFF
--- a/tests/integration-tests-utils/src/main/java/org/apache/pulsar/tests/PulsarClusterUtils.java
+++ b/tests/integration-tests-utils/src/main/java/org/apache/pulsar/tests/PulsarClusterUtils.java
@@ -200,24 +200,9 @@ public class PulsarClusterUtils {
             .reduce(true, (accum, res) -> accum && res);
     }
 
-    public static boolean waitSupervisord(DockerClient docker, String containerId) {
-        int i = 50;
-        while (i > 0) {
-            try {
-                DockerUtils.runCommand(docker, containerId, "test", "-S", "/var/run/supervisor/supervisor.sock");
-                return true;
-            } catch (Exception e) {
-                // supervisord not running
-            }
-            try {
-                Thread.sleep(100);
-                i++;
-            } catch (InterruptedException ie) {
-                Thread.currentThread().interrupt();
-                break;
-            }
-        }
-        return false;
+    public static void waitSupervisord(DockerClient docker, String containerId) {
+        DockerUtils.runCommand(docker, containerId, "timeout", "60", "bash", "-c",
+                               "until test -S /var/run/supervisor/supervisor.sock; do sleep 0.1; done");
     }
 
     public static boolean startAllBrokers(DockerClient docker, String cluster) {


### PR DESCRIPTION
The integration tests wait for supervisord to be up before attempting
to start the brokers and proxies. Previously we were doing this by
checking for the existence of the supervisord socket
repeatedly. However, this spams the log.

This patch replaces the loop with a single bash command (a bash loop),
with the timeout built into the command.

Failure of the socket to appear also throws a exception (timeout
exits with 124), rather than returning a boolean which we were not
checking previously anyhow.
