### PR TITLE
Supervisord configurations shouldn't specify stderr logfile

### DIFF
--- a/tests/docker-images/latest-version-image/conf/proxy.conf
+++ b/tests/docker-images/latest-version-image/conf/proxy.conf
@@ -21,7 +21,6 @@
 autostart=false
 redirect_stderr=true
 stdout_logfile=/var/log/pulsar/proxy.log
-stderr_logfile=/var/log/pulsar/proxy-stderr.log
 directory=/pulsar
 environment=PULSAR_MEM=-Xms128M
 command=/pulsar/bin/pulsar proxy


### PR DESCRIPTION
As it already being redirected to stderr. Configuring both causes a
warning in the log.
