### PR TITLE
Fix Prometheus metrics provider package name

### DIFF
--- a/deployment/dcos/PulsarGroups.json
+++ b/deployment/dcos/PulsarGroups.json
@@ -86,7 +86,7 @@
             "// Notice": "add PULSAR_MEM, PULSAR_GC, according to your environment.",
             "zkServers":  "master.mesos:2181",
             "ledgerManagerType": "hierarchical",
-            "statsProviderClass": "org.apache.bookkeeper.stats.PrometheusMetricsProvider",
+            "statsProviderClass": "org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider",
             "journalDirectory": "/bookkeeper/data/journal",
             "ledgerDirectories": "/bookkeeper/data/ledgers",
             "indexDirectories": "/bookkeeper/data/index"
@@ -348,4 +348,3 @@
     }
   ]
 }
-

--- a/deployment/kubernetes/aws/bookkeeper.yaml
+++ b/deployment/kubernetes/aws/bookkeeper.yaml
@@ -60,7 +60,7 @@ data:
   dbStorage_rocksDB_blockCacheSize: "4294967296"
   journalMaxSizeMB: "2048"
   zkServers: zk-0.zookeeper,zk-1.zookeeper,zk-2.zookeeper
-  statsProviderClass: org.apache.bookkeeper.stats.PrometheusMetricsProvider
+  statsProviderClass: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
   useHostNameAsBookieID: "true"
 ---
 apiVersion: apps/v1beta1

--- a/deployment/kubernetes/generic/bookie.yaml
+++ b/deployment/kubernetes/generic/bookie.yaml
@@ -27,7 +27,7 @@ data:
     dbStorage_writeCacheMaxSizeMb: "256" # Write cache size (direct memory)
     dbStorage_readAheadCacheMaxSizeMb: "256" # Read cache size (direct memory)
     zkServers: zk-0.zookeeper,zk-1.zookeeper,zk-2.zookeeper
-    statsProviderClass: org.apache.bookkeeper.stats.PrometheusMetricsProvider
+    statsProviderClass: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
 ---
 
 ## BookKeeper servers need to access the local disks and the pods

--- a/deployment/kubernetes/google-kubernetes-engine/bookie.yaml
+++ b/deployment/kubernetes/google-kubernetes-engine/bookie.yaml
@@ -49,7 +49,7 @@ data:
   dbStorage_writeCacheMaxSizeMb: "1024"
   dbStorage_readAheadCacheMaxSizeMb: "1024"
   zkServers: zk-0.zookeeper,zk-1.zookeeper,zk-2.zookeeper
-  statsProviderClass: org.apache.bookkeeper.stats.PrometheusMetricsProvider
+  statsProviderClass: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
   useHostNameAsBookieID: "true"
 ---
 apiVersion: apps/v1beta1
@@ -109,7 +109,7 @@ spec:
               hostPort: 3181
               name: client
           envFrom:
-            - configMapRef: 
+            - configMapRef:
                 name: bookie-config
           volumeMounts:
             - name: journal-disk

--- a/deployment/terraform-ansible/templates/bookkeeper.conf
+++ b/deployment/terraform-ansible/templates/bookkeeper.conf
@@ -317,7 +317,7 @@ writeBufferSizeBytes=65536
 useHostNameAsBookieID=false
 
 # Stats Provider Class
-statsProviderClass=org.apache.bookkeeper.stats.PrometheusMetricsProvider
+statsProviderClass=org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
 # Default port for Prometheus metrics exporter
 prometheusStatsHttpPort=8000
 

--- a/site/_data/config/bookkeeper.yaml
+++ b/site/_data/config/bookkeeper.yaml
@@ -198,7 +198,7 @@ configs:
   description: |
     Whether the bookie should use its hostname to register with the coordination service (e.g.: zookeeper service). When `false`, bookie will use its ipaddress for the registration.
 - name: statsProviderClass
-  default: org.apache.bookkeeper.stats.PrometheusMetricsProvider
+  default: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
 - name: prometheusStatsHttpPort
   default: 8000
 - name: dbStorage_writeCacheMaxSizeMb


### PR DESCRIPTION
### Motivation

In BookKeeper 4.7, the package name for Prometheus metrics provider was changed to include `prometheus`. While we have already the right package name in `conf/bookkeeper.conf`, in Kubernetes spec files, we still had the old package name.