### PR TITLE
If tenant/namespace are not specified, infer public/default

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -125,11 +125,21 @@ public class CmdFunctions extends CmdBase {
      */
     @Getter
     abstract class NamespaceCommand extends BaseCommand {
-        @Parameter(names = "--tenant", description = "The function's tenant", required = true)
+        @Parameter(names = "--tenant", description = "The function's tenant")
         protected String tenant;
 
-        @Parameter(names = "--namespace", description = "The function's namespace", required = true)
+        @Parameter(names = "--namespace", description = "The function's namespace")
         protected String namespace;
+
+        @Override
+        public void processArguments() {
+            if (tenant == null) {
+                tenant = PUBLIC_TENANT;
+            }
+            if (namespace == null) {
+                namespace = DEFAULT_NAMESPACE;
+            }
+        }
     }
 
     /**
@@ -171,9 +181,15 @@ public class CmdFunctions extends CmdBase {
                 namespace = fqfnParts[1];
                 functionName = fqfnParts[2];
             } else {
-                if (null == tenant || null == namespace || null == functionName) {
+                if (tenant == null) {
+                    tenant = PUBLIC_TENANT;
+                }
+                if (namespace == null) {
+                    namespace = DEFAULT_NAMESPACE;
+                }
+                if (null == functionName) {
                     throw new RuntimeException(
-                            "You must specify a tenant, namespace, and name for the function or a Fully Qualified Function Name (FQFN)");
+                            "You must specify a name for the function or a Fully Qualified Function Name (FQFN)");
                 }
             }
         }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
@@ -358,9 +358,15 @@ public class CmdSinks extends CmdBase {
         @Override
         void processArguments() throws Exception {
             super.processArguments();
-            if (null == tenant || null == namespace || null == name) {
+            if (null == name) {
                 throw new RuntimeException(
-                        "You must specify a tenant, namespace, and name for the sink");
+                        "You must specify a name for the sink");
+            }
+            if (tenant == null) {
+                tenant = PUBLIC_TENANT;
+            }
+            if (namespace == null) {
+                namespace = DEFAULT_NAMESPACE;
             }
         }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
@@ -340,9 +340,15 @@ public class CmdSources extends CmdBase {
         @Override
         void processArguments() throws Exception {
             super.processArguments();
-            if (null == tenant || null == namespace || null == name) {
+            if (null == name) {
                 throw new RuntimeException(
-                        "You must specify a tenant, namespace, and name for the source");
+                        "You must specify a name for the source");
+            }
+            if (tenant == null) {
+                tenant = PUBLIC_TENANT;
+            }
+            if (namespace == null) {
+                namespace = DEFAULT_NAMESPACE;
             }
         }
 


### PR DESCRIPTION
### Motivation

For a bunch of functions/sources/sinks commands, if user does not specify tenant/namespace, we infer them to be public/default. This pr extends that to all functions/sources/sinks commands.

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
