### PR TITLE
[functions] Dont shade log4j2 in java runtime instance

### DIFF
--- a/pulsar-functions/runtime-all/pom.xml
+++ b/pulsar-functions/runtime-all/pom.xml
@@ -207,10 +207,12 @@
                   <pattern>jersey</pattern>
                   <shadedPattern>org.apache.pulsar.functions.runtime.shaded.jersey</shadedPattern>
                 </relocation>
+                <!-- DONT ever shade log4j, otherwise logging won't work anymore in running functions in process mode
                 <relocation>
                   <pattern>org.apache.logging</pattern>
                   <shadedPattern>org.apache.pulsar.functions.runtime.shaded.org.apache.logging</shadedPattern>
                 </relocation>
+                -->
                 <relocation>
                   <pattern>javassist</pattern>
                   <shadedPattern>org.apache.pulsar.functions.runtime.shaded.javassist</shadedPattern>


### PR DESCRIPTION
*Motivation*

 #1849 shade the dependencies in java instance uber jar. However it
 shades the log4j2, which causes functions running in process mode
 can't output any logging messages.

*Solution*

Don't shade log4j2 in java runtime instance
