### PR TITLE
All user supplied arguments have to be properly typed

### DIFF
--- a/pulsar-functions/instance/src/main/python/contextimpl.py
+++ b/pulsar-functions/instance/src/main/python/contextimpl.py
@@ -121,6 +121,9 @@ class ContextImpl(pulsar.Context):
     return self.publish(topic_name, message, "serde.IdentitySerDe")
 
   def publish(self, topic_name, message, serde_class_name):
+    # Just make sure that user supplied values are properly typed
+    topic_name = str(topic_name)
+    serde_class_name = str(serde_class_name)
     if topic_name not in self.publish_producers:
       self.publish_producers[topic_name] = self.pulsar_client.create_producer(
         topic_name,


### PR DESCRIPTION
### Motivation

This is to avoid any kind of exceptions while using python pulsar libraries which expect variables to be typed string

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
