### PR TITLE
Upgrade RocksDb to 5.13.1

### DIFF
--- a/all/src/assemble/LICENSE.bin.txt
+++ b/all/src/assemble/LICENSE.bin.txt
@@ -398,7 +398,7 @@ The Apache Software License, Version 2.0
     - org.eclipse.jetty.websocket-websocket-server-9.3.11.v20160721.jar
     - org.eclipse.jetty.websocket-websocket-servlet-9.3.11.v20160721.jar
  * SnakeYaml -- org.yaml-snakeyaml-1.15.jar
- * RocksDB - org.rocksdb-rocksdbjni-5.8.6.jar
+ * RocksDB - org.rocksdb-rocksdbjni-5.13.1.jar
  * HttpClient
     - org.apache.httpcomponents-httpclient-4.5.5.jar
     - org.apache.httpcomponents-httpcore-4.4.9.jar

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@ flexible messaging model and an intuitive client API.</description>
     <athenz.version>1.7.17</athenz.version>
     <prometheus.version>0.0.23</prometheus.version>
     <aspectj.version>1.8.9</aspectj.version>
-    <rocksdb.version>5.8.6</rocksdb.version>
+    <rocksdb.version>5.13.1</rocksdb.version>
     <slf4j.version>1.7.25</slf4j.version>
     <log4j2.version>2.10.0</log4j2.version>
     <bouncycastle.version>1.55</bouncycastle.version>


### PR DESCRIPTION
### Motivation

5.13.1 contains a fix for the long outstanding bug with rocksdb deleteRange operation that leaves empty SST and makes it crash on startup with a failed assertion.

Fixes #674 #1049 