### PR TITLE
Simplify PushSource

### DIFF
--- a/pulsar-io/core/src/main/java/org/apache/pulsar/io/core/PushSource.java
+++ b/pulsar-io/core/src/main/java/org/apache/pulsar/io/core/PushSource.java
@@ -41,16 +41,6 @@ public abstract class PushSource<T> implements Source<T> {
 
     public PushSource() {
         this.queue = new LinkedBlockingQueue<>(this.getQueueLength());
-        this.setConsumer(new Consumer<Record<T>>() {
-            @Override
-            public void accept(Record<T> record) {
-                try {
-                    queue.put(record);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-        });
     }
 
     @Override
@@ -71,7 +61,13 @@ public abstract class PushSource<T> implements Source<T> {
      * to pass messages whenever there is data to be pushed to Pulsar.
      * @param consumer
      */
-    abstract public void setConsumer(Consumer<Record<T>> consumer);
+    public void consume(Record<T> record) {
+        try {
+            queue.put(record);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     /**
      * Get length of the queue that records are push onto

--- a/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaSource.java
+++ b/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaSource.java
@@ -48,8 +48,6 @@ public abstract class KafkaSource<V> extends PushSource<V> {
     private KafkaSourceConfig kafkaSourceConfig;
     Thread runnerThread;
 
-    private java.util.function.Consumer<Record<V>> consumeFunction;
-
     @Override
     public void open(Map<String, Object> config) throws Exception {
         kafkaSourceConfig = KafkaSourceConfig.load(config);
@@ -76,11 +74,6 @@ public abstract class KafkaSource<V> extends PushSource<V> {
 
         this.start();
 
-    }
-
-    @Override
-    public void setConsumer(java.util.function.Consumer<Record<V>> consumerFunction) {
-        this.consumeFunction = consumerFunction;
     }
 
     @Override
@@ -112,7 +105,7 @@ public abstract class KafkaSource<V> extends PushSource<V> {
                 for (ConsumerRecord<byte[], byte[]> consumerRecord : consumerRecords) {
                     LOG.debug("Record received from kafka, key: {}. value: {}", consumerRecord.key(), consumerRecord.value());
                     KafkaRecord<V> record = new KafkaRecord<>(consumerRecord, extractValue(consumerRecord));
-                    consumeFunction.accept(record);
+                    consume(record);
                     futures[index] = record.getCompletableFuture();
                     index++;
                 }

--- a/pulsar-io/twitter/src/main/java/org/apache/pulsar/io/twitter/TwitterFireHose.java
+++ b/pulsar-io/twitter/src/main/java/org/apache/pulsar/io/twitter/TwitterFireHose.java
@@ -50,7 +50,6 @@ public class TwitterFireHose extends PushSource<String> {
 
     // ----- Runtime fields
     private Object waitObject;
-    private Consumer<Record<String>> consumeFunction;
 
     @Override
     public void open(Map<String, Object> config) throws IOException {
@@ -63,11 +62,6 @@ public class TwitterFireHose extends PushSource<String> {
         }
         waitObject = new Object();
         startThread(hoseConfig);
-    }
-
-    @Override
-    public void setConsumer(Consumer<Record<String>> consumeFunction) {
-        this.consumeFunction = consumeFunction;
     }
 
     @Override
@@ -125,7 +119,7 @@ public class TwitterFireHose extends PushSource<String> {
                             // We don't really care if the record succeeds or not.
                             // However might be in the future to count failures
                             // TODO:- Figure out the metrics story for connectors
-                            consumeFunction.accept(new TwitterRecord(line));
+                            consume(new TwitterRecord(line));
                         } catch (Exception e) {
                             LOG.error("Exception thrown");
                         }


### PR DESCRIPTION
### Motivation

Currently implementing push source requires users implement an additional interface called setConsumer and then using that consumer in their loop. This pr just exposes a consume method from the pushSource abstract class that derived functions can make use of.

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
