### PR TITLE
Estimate the size of a managed ledger suffix from a position

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
@@ -529,6 +529,13 @@ public interface ManagedCursor {
     int getTotalNonContiguousDeletedMessagesRange();
 
     /**
+     * Returns the estimated size of the unacknowledged backlog for this cursor
+     *
+     * @return the estimated size from the mark delete position of the cursor
+     */
+    long getEstimatedSizeSinceMarkDeletePosition();
+
+    /**
      * Returns cursor throttle mark-delete rate.
      *
      * @return

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -661,6 +661,11 @@ public class ManagedCursorImpl implements ManagedCursor {
     }
 
     @Override
+    public long getEstimatedSizeSinceMarkDeletePosition() {
+        return ledger.estimateBacklogFromPosition(markDeletePosition);
+    }
+
+    @Override
     public long getNumberOfEntriesInBacklog() {
         if (log.isDebugEnabled()) {
             log.debug("[{}] Consumer {} cursor ml-entries: {} -- deleted-counter: {} other counters: mdPos {} rdPos {}",

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
@@ -278,6 +278,11 @@ public class ManagedCursorContainerTest {
         }
 
         @Override
+        public long getEstimatedSizeSinceMarkDeletePosition() {
+            return 0L;
+        }
+
+        @Override
         public void setThrottleMarkDelete(double throttleMarkDelete) {
         }
 


### PR DESCRIPTION
This patch adds the ability to estimate the size of a suffix of a
managed ledger by passing in a prefix. The size is an estimate. For
complete ledgers after the position, the size can be calculated
exactly, but for the first ledger, if it is partial, we can only get
an estimate without having to make an RPC. The estimate for this
ledger is based on the total size of that ledger and the number of
entries in that ledger.
