### PR TITLE
Fixed message routing mode in Py client

### DIFF
--- a/pulsar-client-cpp/python/pulsar/__init__.py
+++ b/pulsar-client-cpp/python/pulsar/__init__.py
@@ -282,7 +282,8 @@ class Client:
                         batching_enabled=False,
                         batching_max_messages=1000,
                         batching_max_allowed_size_in_bytes=128*1024,
-                        batching_max_publish_delay_ms=10
+                        batching_max_publish_delay_ms=10,
+                        message_routing_mode=PartitionsRoutingMode.RoundRobinDistribution
                         ):
         """
         Create a new producer on a given topic.
@@ -317,7 +318,8 @@ class Client:
         * `block_if_queue_full`: Set whether `send_async` operations should
           block when the outgoing message queue is full.
         * `message_routing_mode`:
-          Set the message routing mode for the partitioned producer.
+          Set the message routing mode for the partitioned producer. Default is `PartitionsRoutingMode.RoundRobinDistribution`,
+          other option is `PartitionsRoutingMode.UseSinglePartition`
         """
         _check_type(str, topic, 'topic')
         _check_type_or_none(str, producer_name, 'producer_name')
@@ -340,6 +342,7 @@ class Client:
         conf.batching_max_messages(batching_max_messages)
         conf.batching_max_allowed_size_in_bytes(batching_max_allowed_size_in_bytes)
         conf.batching_max_publish_delay_ms(batching_max_publish_delay_ms)
+        conf.partitions_routing_mode(message_routing_mode)
         if producer_name:
             conf.producer_name(producer_name)
         if initial_sequence_id:

--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -22,7 +22,7 @@
 from unittest import TestCase, main
 import time
 from pulsar import Client, MessageId, \
-            CompressionType, ConsumerType
+            CompressionType, ConsumerType, PartitionsRoutingMode
 
 from _pulsar import ProducerConfiguration, ConsumerConfiguration
 
@@ -323,6 +323,13 @@ class PulsarTest(TestCase):
         except:
             # Exception is expected
             pass
+
+    def test_producer_routing_mode(self):
+        client = Client(self.serviceUrl)
+        producer = client.create_producer('my-python-test-producer',
+                                          message_routing_mode=PartitionsRoutingMode.UseSinglePartition)
+        producer.send(b'test')
+        client.close()
 
     def test_message_argument_errors(self):
         client = Client(self.serviceUrl)


### PR DESCRIPTION
### Motivation

It's not currently possible to configure message routing mode from Python API.