### PR TITLE
Use consistent naming for cluster envvar in integ test

### DIFF
--- a/tests/docker-images/latest-version-image/scripts/init-cluster.sh
+++ b/tests/docker-images/latest-version-image/scripts/init-cluster.sh
@@ -20,7 +20,7 @@
 
 set -x
 
-ZNODE="/initialized"
+ZNODE="/initialized-$clusterName"
 
 bin/watch-znode.py -z $zkServers -p / -w
 
@@ -28,7 +28,7 @@ bin/watch-znode.py -z $zkServers -p $ZNODE -e
 if [ $? != 0 ]; then
     echo Initializing cluster
     bin/apply-config-from-env.py conf/bookkeeper.conf &&
-        bin/pulsar initialize-cluster-metadata --cluster $cluster --zookeeper $zkServers \
+        bin/pulsar initialize-cluster-metadata --cluster $clusterName --zookeeper $zkServers \
                    --configuration-store $configurationStore --web-service-url http://$pulsarNode:8080/ \
                    --broker-service-url pulsar://$pulsarNode:6650/ &&
         bin/watch-znode.py -z $zkServers -p $ZNODE -c

--- a/tests/docker-images/latest-version-image/scripts/run-bookie.sh
+++ b/tests/docker-images/latest-version-image/scripts/run-bookie.sh
@@ -25,6 +25,6 @@ if [ -z "$NO_AUTOSTART" ]; then
     sed -i 's/autostart=.*/autostart=true/' /etc/supervisord/conf.d/bookie.conf
 fi
 
-bin/watch-znode.py -z $zkServers -p /initialized -w
+bin/watch-znode.py -z $zkServers -p /initialized-$clusterName -w
 exec /usr/bin/supervisord -c /etc/supervisord.conf
 

--- a/tests/docker-images/latest-version-image/scripts/run-broker.sh
+++ b/tests/docker-images/latest-version-image/scripts/run-broker.sh
@@ -25,6 +25,6 @@ if [ -z "$NO_AUTOSTART" ]; then
     sed -i 's/autostart=.*/autostart=true/' /etc/supervisord/conf.d/broker.conf
 fi
 
-bin/watch-znode.py -z $zookeeperServers -p /initialized -w
+bin/watch-znode.py -z $zookeeperServers -p /initialized-$clusterName -w
 exec /usr/bin/supervisord -c /etc/supervisord.conf
 

--- a/tests/docker-images/latest-version-image/scripts/run-proxy.sh
+++ b/tests/docker-images/latest-version-image/scripts/run-proxy.sh
@@ -25,6 +25,6 @@ if [ -z "$NO_AUTOSTART" ]; then
     sed -i 's/autostart=.*/autostart=true/' /etc/supervisord/conf.d/proxy.conf
 fi
 
-bin/watch-znode.py -z $zookeeperServers -p /initialized -w
+bin/watch-znode.py -z $zookeeperServers -p /initialized-$clusterName -w
 exec /usr/bin/supervisord -c /etc/supervisord.conf
 

--- a/tests/integration-tests-topologies/src/main/resources/cube-definitions/single-cluster-2-bookie-1-broker-unstarted-with-s3.yaml
+++ b/tests/integration-tests-topologies/src/main/resources/cube-definitions/single-cluster-2-bookie-1-broker-unstarted-with-s3.yaml
@@ -58,7 +58,7 @@ init*:
   await:
     strategy: org.apache.pulsar.tests.NoopAwaitStrategy
   env:
-    - cluster=test
+    - clusterName=test
     - zkServers=zookeeper
     - configurationStore=configuration-store:2184
     - pulsarNode=pulsar-broker1
@@ -76,6 +76,7 @@ bookkeeper1*:
   await:
     strategy: org.apache.pulsar.tests.NoopAwaitStrategy
   env:
+    - clusterName=test
     - zkServers=zookeeper
     - useHostNameAsBookieID=true
   labels:
@@ -92,6 +93,7 @@ bookkeeper2*:
   await:
     strategy: org.apache.pulsar.tests.NoopAwaitStrategy
   env:
+    - clusterName=test
     - zkServers=zookeeper
     - useHostNameAsBookieID=true
   labels:

--- a/tests/integration-tests-topologies/src/main/resources/cube-definitions/single-cluster-3-bookie-2-broker-unstarted.yaml
+++ b/tests/integration-tests-topologies/src/main/resources/cube-definitions/single-cluster-3-bookie-2-broker-unstarted.yaml
@@ -58,7 +58,7 @@ init*:
   await:
     strategy: org.apache.pulsar.tests.NoopAwaitStrategy
   env:
-    - cluster=test
+    - clusterName=test
     - zkServers=zookeeper
     - configurationStore=configuration-store:2184
     - pulsarNode=pulsar-broker1
@@ -76,6 +76,7 @@ bookkeeper1*:
   await:
     strategy: org.apache.pulsar.tests.NoopAwaitStrategy
   env:
+    - clusterName=test
     - zkServers=zookeeper
     - useHostNameAsBookieID=true
   labels:
@@ -92,6 +93,7 @@ bookkeeper2*:
   await:
     strategy: org.apache.pulsar.tests.NoopAwaitStrategy
   env:
+    - clusterName=test
     - zkServers=zookeeper
     - useHostNameAsBookieID=true
   labels:
@@ -108,6 +110,7 @@ bookkeeper3*:
   await:
     strategy: org.apache.pulsar.tests.NoopAwaitStrategy
   env:
+    - clusterName=test
     - zkServers=zookeeper
     - useHostNameAsBookieID=true
   labels:
@@ -126,9 +129,9 @@ pulsar-broker1*:
   aliases:
     - pulsar-broker1
   env:
+    - clusterName=test
     - zookeeperServers=zookeeper
     - configurationStoreServers=configuration-store:2184
-    - clusterName=test
     - NO_AUTOSTART=true
   labels:
     cluster: test
@@ -146,9 +149,9 @@ pulsar-broker2*:
   aliases:
     - pulsar-broker2
   env:
+    - clusterName=test
     - zookeeperServers=zookeeper
     - configurationStoreServers=configuration-store:2184
-    - clusterName=test
     - NO_AUTOSTART=true
   labels:
     cluster: test
@@ -166,9 +169,9 @@ pulsar-proxy*:
   aliases:
     - pulsar-broker2
   env:
+    - clusterName=test
     - zookeeperServers=zookeeper
     - configurationStoreServers=configuration-store:2184
-    - clusterName=test
     - NO_AUTOSTART=true
   labels:
     cluster: test

--- a/tests/integration-tests-topologies/src/main/resources/cube-definitions/single-cluster-3-bookie-2-broker.yaml
+++ b/tests/integration-tests-topologies/src/main/resources/cube-definitions/single-cluster-3-bookie-2-broker.yaml
@@ -58,7 +58,7 @@ init*:
   await:
     strategy: org.apache.pulsar.tests.NoopAwaitStrategy
   env:
-    - cluster=test
+    - clusterName=test
     - zkServers=zookeeper
     - configurationStore=configuration-store:2184
     - pulsarNode=pulsar-broker1
@@ -78,6 +78,7 @@ bookkeeper1*:
   env:
     - zkServers=zookeeper
     - useHostNameAsBookieID=true
+    - clusterName=test
   labels:
     cluster: test
     service: bookie
@@ -110,6 +111,7 @@ bookkeeper3*:
   env:
     - zkServers=zookeeper
     - useHostNameAsBookieID=true
+    - clusterName=test
   labels:
     cluster: test
     service: bookie


### PR DESCRIPTION
Previously we were using cluster in some places, and clusterName in
others. Settles on clusterName, as that's what the config files
expects. Also changes the znode wait to be cluster specific.
