### PR TITLE
Add compaction threshold policy

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -630,6 +630,10 @@ public class PersistentSubscription implements Subscription {
         return expiryMonitor.getMessageExpiryRate();
     }
 
+    public long estimateBacklogSize() {
+        return cursor.getEstimatedSizeSinceMarkDeletePosition();
+    }
+
     public SubscriptionStats getStats() {
         SubscriptionStats subStats = new SubscriptionStats();
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/Policies.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/Policies.java
@@ -57,6 +57,8 @@ public class Policies {
     public int max_consumers_per_topic = 0;
     public int max_consumers_per_subscription = 0;
 
+    public long compaction_threshold = 0;
+
     @Override
     public boolean equals(Object obj) {
         if (obj instanceof Policies) {
@@ -75,7 +77,8 @@ public class Policies {
                     && Objects.equals(antiAffinityGroup, other.antiAffinityGroup)
                     && max_producers_per_topic == other.max_producers_per_topic
                     && max_consumers_per_topic == other.max_consumers_per_topic
-                    && max_consumers_per_subscription == other.max_consumers_per_subscription;
+                    && max_consumers_per_subscription == other.max_consumers_per_subscription
+                    && compaction_threshold == other.compaction_threshold;
         }
 
         return false;
@@ -105,6 +108,7 @@ public class Policies {
                 .add("subscription_auth_mode", subscription_auth_mode)
                 .add("max_producers_per_topic", max_producers_per_topic)
                 .add("max_consumers_per_topic", max_consumers_per_topic)
-                .add("max_consumers_per_subscription", max_consumers_per_topic).toString();
+                .add("max_consumers_per_subscription", max_consumers_per_topic)
+                .add("compaction_threshold", compaction_threshold).toString();
     }
 }


### PR DESCRIPTION
Policy is number of bytes at which compaction should be triggered for
a topic.

This patch contains the policy itself, and the check. Subsequent patches
will include the monitor and rest api.
