### PR TITLE
Link internal C++ authentication plugins inside client library

### DIFF
--- a/pulsar-client-cpp/include/pulsar/Authentication.h
+++ b/pulsar-client-cpp/include/pulsar/Authentication.h
@@ -68,9 +68,23 @@ class Authentication {
     friend class ClientConfiguration;
 };
 
+/**
+ * AuthFactory is used to create instances of Authentication class when
+ * configuring a Client instance. It loads the authentication from an
+ * external plugin.
+ *
+ * To use authentication methods that are internally supported, you should
+ * use `AuthTls::create("my-cert.pem", "my-private.key")` or similar.
+ */
 class AuthFactory {
    public:
     static AuthenticationPtr Disabled();
+
+    /**
+     * Create
+     * @param dynamicLibPath
+     * @return
+     */
     static AuthenticationPtr create(const std::string& dynamicLibPath);
     static AuthenticationPtr create(const std::string& dynamicLibPath, const std::string& authParamsString);
     static AuthenticationPtr create(const std::string& dynamicLibPath, ParamMap& params);
@@ -80,8 +94,39 @@ class AuthFactory {
     static std::vector<void*> loadedLibrariesHandles_;
     static void release_handles();
 };
+
+/**
+ * TLS implementation of Pulsar client authentication
+ */
+class AuthTls : public Authentication {
+   public:
+    AuthTls(AuthenticationDataPtr&);
+    ~AuthTls();
+    static AuthenticationPtr create(const std::string& certificatePath, const std::string& privateKeyPath);
+    const std::string getAuthMethodName() const;
+    Result getAuthData(AuthenticationDataPtr& authDataTls) const;
+
+   private:
+    AuthenticationDataPtr authDataTls_;
+};
+
+/**
+ * Athenz implementation of Pulsar client authentication
+ */
+class AuthAthenz : public Authentication {
+   public:
+    AuthAthenz(AuthenticationDataPtr&);
+    ~AuthAthenz();
+    static AuthenticationPtr create(ParamMap& params);
+    static AuthenticationPtr create(const std::string& authParamsString);
+    const std::string getAuthMethodName() const;
+    Result getAuthData(AuthenticationDataPtr& authDataAthenz) const;
+
+   private:
+    AuthenticationDataPtr authDataAthenz_;
+};
+
 }  // namespace pulsar
-// namespace pulsar
 
 #pragma GCC visibility pop
 

--- a/pulsar-client-cpp/lib/CMakeLists.txt
+++ b/pulsar-client-cpp/lib/CMakeLists.txt
@@ -42,7 +42,8 @@ endif(NOT LIBRARY_VERSION)
 set_target_properties(pulsarStatic PROPERTIES OUTPUT_NAME ${LIB_NAME} VERSION ${LIBRARY_VERSION})
 set_target_properties(pulsarShared PROPERTIES OUTPUT_NAME ${LIB_NAME} VERSION ${LIBRARY_VERSION})
 
-target_link_libraries(pulsarStatic ${COMMON_LIBS})
-target_link_libraries(pulsarShared ${COMMON_LIBS})
-
 add_subdirectory(auth)
+
+target_link_libraries(pulsarStatic ${COMMON_LIBS} authTls authAthenz ztsClientStatic)
+target_link_libraries(pulsarShared ${COMMON_LIBS} authTls authAthenz ztsClientStatic)
+

--- a/pulsar-client-cpp/lib/auth/AuthAthenz.cc
+++ b/pulsar-client-cpp/lib/auth/AuthAthenz.cc
@@ -100,8 +100,4 @@ extern "C" Authentication* create(const std::string& authParamsString) {
     return new AuthAthenz(authDataAthenz);
 }
 
-extern "C" Authentication* createFromMap(ParamMap& params) {
-    AuthenticationDataPtr authDataAthenz = AuthenticationDataPtr(new AuthDataAthenz(params));
-    return new AuthAthenz(authDataAthenz);
-}
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/auth/AuthAthenz.h
+++ b/pulsar-client-cpp/lib/auth/AuthAthenz.h
@@ -21,8 +21,6 @@
 
 #include <pulsar/Authentication.h>
 #include <lib/auth/athenz/ZTSClient.h>
-#include <lib/LogUtils.h>
-#include <iostream>
 #include <string>
 
 namespace pulsar {
@@ -40,17 +38,5 @@ class AuthDataAthenz : public AuthenticationDataProvider {
     boost::shared_ptr<ZTSClient> ztsClient_;
 };
 
-class AuthAthenz : public Authentication {
-   public:
-    AuthAthenz(AuthenticationDataPtr&);
-    ~AuthAthenz();
-    static AuthenticationPtr create(ParamMap& params);
-    static AuthenticationPtr create(const std::string& authParamsString);
-    const std::string getAuthMethodName() const;
-    Result getAuthData(AuthenticationDataPtr& authDataAthenz) const;
-
-   private:
-    AuthenticationDataPtr authDataAthenz_;
-};
 }  // namespace pulsar
 #endif /* PULSAR_AUTH_ATHENZ_H_ */

--- a/pulsar-client-cpp/lib/auth/AuthTls.cc
+++ b/pulsar-client-cpp/lib/auth/AuthTls.cc
@@ -19,16 +19,16 @@
 #include <lib/auth/AuthTls.h>
 
 namespace pulsar {
-AuthDataTls::AuthDataTls(ParamMap& params) {
-    tlsCertificates_ = params["tlsCertFile"];
-    tlsPrivateKey_ = params["tlsKeyFile"];
+AuthDataTls::AuthDataTls(const std::string& certificatePath, const std::string& privateKeyPath) {
+    tlsCertificate_ = certificatePath;
+    tlsPrivateKey_ = privateKeyPath;
 }
 
 AuthDataTls::~AuthDataTls() {}
 
 bool AuthDataTls::hasDataForTls() { return true; }
 
-std::string AuthDataTls::getTlsCertificates() { return tlsCertificates_; }
+std::string AuthDataTls::getTlsCertificates() { return tlsCertificate_; }
 
 std::string AuthDataTls::getTlsPrivateKey() { return tlsPrivateKey_; }
 
@@ -36,8 +36,9 @@ AuthTls::AuthTls(AuthenticationDataPtr& authDataTls) { authDataTls_ = authDataTl
 
 AuthTls::~AuthTls() {}
 
-AuthenticationPtr AuthTls::create(ParamMap& params) {
-    AuthenticationDataPtr authDataTls = AuthenticationDataPtr(new AuthDataTls(params));
+AuthenticationPtr AuthTls::create(const std::string& certificatePath, const std::string& privateKeyPath) {
+    AuthenticationDataPtr authDataTls =
+        AuthenticationDataPtr(new AuthDataTls(certificatePath, privateKeyPath));
     return AuthenticationPtr(new AuthTls(authDataTls));
 }
 
@@ -48,8 +49,4 @@ Result AuthTls::getAuthData(AuthenticationDataPtr& authDataContent) const {
     return ResultOk;
 }
 
-extern "C" Authentication* createFromMap(ParamMap& params) {
-    AuthenticationDataPtr authDataTls = AuthenticationDataPtr(new AuthDataTls(params));
-    return new AuthTls(authDataTls);
-}
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/auth/AuthTls.h
+++ b/pulsar-client-cpp/lib/auth/AuthTls.h
@@ -16,39 +16,26 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#ifndef PULSAR_AUTH_TLS_H_
-#define PULSAR_AUTH_TLS_H_
+
+#pragma once
 
 #include <pulsar/Authentication.h>
-#include <lib/LogUtils.h>
-#include <iostream>
 #include <string>
 
 namespace pulsar {
 
 class AuthDataTls : public AuthenticationDataProvider {
    public:
-    AuthDataTls(ParamMap& params);
+    AuthDataTls(const std::string& certificatePath, const std::string& privateKeyPath);
     ~AuthDataTls();
+
     bool hasDataForTls();
     std::string getTlsCertificates();
     std::string getTlsPrivateKey();
 
    private:
-    std::string tlsCertificates_;
+    std::string tlsCertificate_;
     std::string tlsPrivateKey_;
 };
 
-class AuthTls : public Authentication {
-   public:
-    AuthTls(AuthenticationDataPtr&);
-    ~AuthTls();
-    static AuthenticationPtr create(ParamMap& params);
-    const std::string getAuthMethodName() const;
-    Result getAuthData(AuthenticationDataPtr& authDataTls) const;
-
-   private:
-    AuthenticationDataPtr authDataTls_;
-};
 }  // namespace pulsar
-#endif /* PULSAR_AUTH_TLS_H_ */

--- a/pulsar-client-cpp/lib/auth/CMakeLists.txt
+++ b/pulsar-client-cpp/lib/auth/CMakeLists.txt
@@ -17,12 +17,7 @@
 # under the License.
 #
 
-add_library(authTls MODULE AuthTls.cc)
-target_link_libraries(authTls ${CLIENT_LIBS})
-set_target_properties(authTls PROPERTIES OUTPUT_NAME authtls)
-
-add_library(authAthenz MODULE AuthAthenz.cc)
-target_link_libraries(authAthenz ${CLIENT_LIBS} ztsClient)
-set_target_properties(authAthenz PROPERTIES OUTPUT_NAME authathenz)
+add_library(authTls STATIC AuthTls.cc)
+add_library(authAthenz STATIC AuthAthenz.cc)
 
 add_subdirectory(athenz)

--- a/pulsar-client-cpp/lib/auth/athenz/CMakeLists.txt
+++ b/pulsar-client-cpp/lib/auth/athenz/CMakeLists.txt
@@ -17,5 +17,4 @@
 # under the License.
 #
 
-add_library(ztsClient SHARED ZTSClient.cc)
-target_link_libraries(ztsClient ${CLIENT_LIBS})
+add_library(ztsClientStatic STATIC ZTSClient.cc)

--- a/pulsar-client-cpp/python/CMakeLists.txt
+++ b/pulsar-client-cpp/python/CMakeLists.txt
@@ -30,9 +30,11 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS} -undefined dynamic_lookup")
 endif()
 
+set(PYTHON_WRAPPER_LIBS ${Boost_PYTHON_LIBRARY} ${Boost_PYTHON3_LIBRARY} authTls authAthenz)
+
 if (APPLE)
-    target_link_libraries(_pulsar -Wl,-all_load pulsarStatic ${Boost_PYTHON_LIBRARY} ${Boost_PYTHON3_LIBRARY})
+    target_link_libraries(_pulsar -Wl,-all_load pulsarStatic ${PYTHON_WRAPPER_LIBS})
 else ()
     set (CMAKE_SHARED_LINKER_FLAGS " -static-libgcc  -static-libstdc++")
-    target_link_libraries(_pulsar pulsarStatic ${Boost_PYTHON_LIBRARY} ${Boost_PYTHON3_LIBRARY})
+    target_link_libraries(_pulsar pulsarStatic ${PYTHON_WRAPPER_LIBS})
 endif ()

--- a/pulsar-client-cpp/tests/AuthPluginTest.cc
+++ b/pulsar-client-cpp/tests/AuthPluginTest.cc
@@ -42,28 +42,24 @@ static void sendCallBackTls(Result r, const Message& msg) {
     LOG_DEBUG("Received publish acknowledgement for " << msg.getDataAsString());
 }
 
-TEST(AuthPluginTest, testCreate) {
-    pulsar::AuthenticationDataPtr data;
+TEST(AuthPluginTest, testTls) {
+    ClientConfiguration config = ClientConfiguration();
+    config.setUseTls(true);
+    config.setTlsTrustCertsFilePath("../../pulsar-broker/src/test/resources/authentication/tls/cacert.pem");
+    config.setTlsAllowInsecureConnection(false);
+    AuthenticationPtr auth =
+        pulsar::AuthTls::create("../../pulsar-broker/src/test/resources/authentication/tls/client-cert.pem",
+                                "../pulsar-broker/src/test/resources/authentication/tls/client-key.pem");
 
-    pulsar::AuthenticationPtr auth = pulsar::AuthFactory::create("../lib/auth/libauthtls.so");
     ASSERT_TRUE(auth != NULL);
     ASSERT_EQ(auth->getAuthMethodName(), "tls");
+
+    pulsar::AuthenticationDataPtr data;
     ASSERT_EQ(auth->getAuthData(data), pulsar::ResultOk);
     ASSERT_EQ(data->getCommandData(), "none");
     ASSERT_EQ(data->hasDataForTls(), true);
     ASSERT_EQ(auth.use_count(), 1);
-}
 
-TEST(AuthPluginTest, testTls) {
-    ClientConfiguration config = ClientConfiguration();
-    config.setUseTls(true);
-    std::string certfile = "../../pulsar-broker/src/test/resources/authentication/tls/cacert.pem";
-    std::string params =
-        "tlsCertFile:../../pulsar-broker/src/test/resources/authentication/tls/client-cert.pem,tlsKeyFile:../"
-        "../pulsar-broker/src/test/resources/authentication/tls/client-key.pem";
-    config.setTlsTrustCertsFilePath(certfile);
-    config.setTlsAllowInsecureConnection(false);
-    AuthenticationPtr auth = pulsar::AuthFactory::create("../lib/auth/libauthtls.so", params);
     config.setAuth(auth);
     Client client(lookupUrlTls, config);
 
@@ -164,7 +160,7 @@ TEST(AuthPluginTest, testAthenz) {
         "privateKey": "file:../../pulsar-broker/src/test/resources/authentication/tls/client-key.pem",
         "ztsUrl": "http://localhost:9999"
     })";
-    pulsar::AuthenticationPtr auth = pulsar::AuthFactory::create("../lib/auth/libauthathenz.so", params);
+    pulsar::AuthenticationPtr auth = pulsar::AuthAthenz::create(params);
     ASSERT_EQ(auth->getAuthMethodName(), "athenz");
     ASSERT_EQ(auth->getAuthData(data), pulsar::ResultOk);
     ASSERT_EQ(data->hasDataForHttp(), true);


### PR DESCRIPTION
### Motivation

It is quite complicated to enable authentication in client library from Python or Golang wrappers. The primary reason for this is that authentication is based on plugins which are compiled as `.so` library and loaded at runtime. 

While this is convenient for extensibility, having the internally supplied authentication supplied as plugins complicates the distribution of wrappers based on C++ client lib. 

In Python, the library is distributed as a "wheel" file that contains both the Python code and a library that contains Pulsar C++ client library, Python bindings and all the dependencies for Pulsar client, statically linked, in order to have a self-contained file that will work on any system with no external dependencies. 

In Go, we link against `libpulsar.so` (that will need to be installed in the system through either Homebrew, RPM or DEB packages), but having to also include `tls.so` and have users figure out where that file is doesn't make for a good experiences.

### Modifications

 * Include TLS and Athenz authentication in `libpulsar.so`, accessible from code. Eg: 
```cpp
pulsar::AuthTls::create("my-cert.pem", "my-private.key");
```
 * Plugin system for loading external custom authentication schemes is still available.
### Result

 * We can have self-contained wrapper binaries with language native way to configure authentication.
