### PR TITLE
Upgrade Lombok to 1.18.0 to work with JDK 10

### DIFF
--- a/all/src/assemble/LICENSE.bin.txt
+++ b/all/src/assemble/LICENSE.bin.txt
@@ -432,7 +432,7 @@ MIT License
     - org.slf4j-jul-to-slf4j-1.7.25.jar
     - org.slf4j-slf4j-api-1.7.25.jar
     - org.slf4j-jcl-over-slf4j-1.7.25.jar
- * Lombok -- org.projectlombok-lombok-1.16.20.jar  -- licenses/LICENSE-Lombok.txt
+ * Lombok -- org.projectlombok-lombok-1.18.0.jar  -- licenses/LICENSE-Lombok.txt
 
 Protocol Buffers License
  * Protocol Buffers

--- a/pom.xml
+++ b/pom.xml
@@ -388,7 +388,7 @@ flexible messaging model and an intuitive client API.</description>
         <artifactId>commons-configuration</artifactId>
         <version>1.6</version>
       </dependency>
-      
+
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
@@ -821,7 +821,7 @@ flexible messaging model and an intuitive client API.</description>
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.16.20</version>
+      <version>1.18.0</version>
       <scope>provided</scope>
     </dependency>
 


### PR DESCRIPTION
### Motivation

Upgrade Lombok to 1.18.0 to work with JDK 10

Fixes #1435 