### PR TITLE
Added a bunch of concrete sources/sinks so that they are usable without having to write code

### DIFF
--- a/pulsar-io/aerospike/src/main/java/org/apache/pulsar/io/aerospike/AerospikeAbstractSink.java
+++ b/pulsar-io/aerospike/src/main/java/org/apache/pulsar/io/aerospike/AerospikeAbstractSink.java
@@ -45,9 +45,9 @@ import java.util.concurrent.LinkedBlockingDeque;
  * A Simple abstract class for Aerospike sink
  * Users need to implement extractKeyValue function to use this sink
  */
-public abstract class AerospikeSink<K, V> extends SimpleSink<byte[]> {
+public abstract class AerospikeAbstractSink<K, V> extends SimpleSink<byte[]> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(AerospikeSink.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AerospikeAbstractSink.class);
 
     // ----- Runtime fields
     private AerospikeSinkConfig aerospikeSinkConfig;

--- a/pulsar-io/aerospike/src/main/java/org/apache/pulsar/io/aerospike/AerospikeStringSink.java
+++ b/pulsar-io/aerospike/src/main/java/org/apache/pulsar/io/aerospike/AerospikeStringSink.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.io.aerospike;
+
+import org.apache.pulsar.common.util.KeyValue;
+
+/**
+ * Aerospike sink that treats incoming messages on the input topic as Strings
+ * and write identical key/value pairs.
+ */
+public class AerospikeStringSink extends AerospikeAbstractSink<String, String> {
+    @Override
+    public KeyValue<String, String> extractKeyValue(byte[] message) {
+        return new KeyValue<>(new String(message), new String(message));
+    }
+}

--- a/pulsar-io/cassandra/src/main/java/org/apache/pulsar/io/cassandra/CassandraAbstractSink.java
+++ b/pulsar-io/cassandra/src/main/java/org/apache/pulsar/io/cassandra/CassandraAbstractSink.java
@@ -39,9 +39,9 @@ import java.util.concurrent.CompletableFuture;
  * A Simple abstract class for Cassandra sink
  * Users need to implement extractKeyValue function to use this sink
  */
-public abstract class CassandraSink<K, V> extends SimpleSink<byte[]> {
+public abstract class CassandraAbstractSink<K, V> extends SimpleSink<byte[]> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(CassandraSink.class);
+    private static final Logger LOG = LoggerFactory.getLogger(CassandraAbstractSink.class);
 
     // ----- Runtime fields
     private Cluster cluster;

--- a/pulsar-io/cassandra/src/main/java/org/apache/pulsar/io/cassandra/CassandraStringSink.java
+++ b/pulsar-io/cassandra/src/main/java/org/apache/pulsar/io/cassandra/CassandraStringSink.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.io.cassandra;
+
+import org.apache.pulsar.common.util.KeyValue;
+
+/**
+ * Cassandra sink that treats incoming messages on the input topic as Strings
+ * and write identical key/value pairs.
+ */
+public class CassandraStringSink extends CassandraAbstractSink<String, String> {
+    @Override
+    public KeyValue<String, String> extractKeyValue(byte[] message) {
+        return new KeyValue<>(new String(message), new String(message));
+    }
+}

--- a/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaAbstractSink.java
+++ b/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaAbstractSink.java
@@ -39,9 +39,9 @@ import java.util.concurrent.Future;
  * A Simple abstract class for Kafka sink
  * Users need to implement extractKeyValue function to use this sink
  */
-public abstract class KafkaSink<K, V> extends SimpleSink<byte[]> {
+public abstract class KafkaAbstractSink<K, V> extends SimpleSink<byte[]> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(KafkaSink.class);
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaAbstractSink.class);
 
     private Producer<K, V> producer;
     private Properties props = new Properties();

--- a/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaAbstractSource.java
+++ b/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaAbstractSource.java
@@ -39,9 +39,9 @@ import java.util.concurrent.ExecutionException;
 /**
  * Simple Kafka Source to transfer messages from a Kafka topic
  */
-public abstract class KafkaSource<V> extends PushSource<V> {
+public abstract class KafkaAbstractSource<V> extends PushSource<V> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(KafkaSource.class);
+    private static final Logger LOG = LoggerFactory.getLogger(KafkaAbstractSource.class);
 
     private Consumer<byte[], byte[]> consumer;
     private Properties props;

--- a/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaStringSink.java
+++ b/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaStringSink.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.io.kafka;
+
+import org.apache.pulsar.common.util.KeyValue;
+
+/**
+ * Kafka sink that treats incoming messages on the input topic as Strings
+ * and write identical key/value pairs.
+ */
+public class KafkaStringSink extends KafkaAbstractSink<String, String> {
+    @Override
+    public KeyValue<String, String> extractKeyValue(byte[] message) {
+        return new KeyValue<>(new String(message), new String(message));
+    }
+}

--- a/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaStringSource.java
+++ b/pulsar-io/kafka/src/main/java/org/apache/pulsar/io/kafka/KafkaStringSource.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pulsar.io.kafka;
+
+import org.apache.kafka.clients.consumer.*;
+
+/**
+ * Simple Kafka Source that just transfers the value part of the kafka records
+ * as Strings
+ */
+public class KafkaStringSource extends KafkaAbstractSource<String> {
+    @Override
+    public String extractValue(ConsumerRecord<byte[], byte[]> record) {
+        return new String(record.value());
+    }
+}


### PR DESCRIPTION

### Motivation

Currently Kafka/Cassandra/Aerospike connectors are all abstract which means that to use them, one has to actually write a concrete class. This pr adds a bunch of concrete classes so that these classes are usable right away without having to write any code

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
