### PR TITLE
Add Client auth plugin and tls support for function to connect with broker

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
@@ -144,11 +144,8 @@ public class PulsarBrokerStarter {
                     workerConfig = WorkerConfig.load(starterArguments.fnWorkerConfigFile);
                 }
                 // worker talks to local broker
-                boolean isTls = workerConfig.isUseTls();
-                workerConfig.setPulsarServiceUrl(String.format("pulsar://127.0.0.1:%s",
-                        (isTls ? brokerConfig.getBrokerServicePortTls() : brokerConfig.getBrokerServicePort()), args));
-                workerConfig.setPulsarWebServiceUrl(String.format("%s://127.0.0.1:%s", (isTls ? "https" : "http"),
-                        (isTls ? brokerConfig.getWebServicePortTls() : brokerConfig.getWebServicePort())));
+                workerConfig.setPulsarServiceUrl("pulsar://127.0.0.1:" + brokerConfig.getBrokerServicePort());
+                workerConfig.setPulsarWebServiceUrl("http://127.0.0.1:" + brokerConfig.getWebServicePort());
                 String hostname = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(
                     brokerConfig.getAdvertisedAddress());
                 workerConfig.setWorkerHostname(hostname);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarBrokerStarter.java
@@ -144,8 +144,11 @@ public class PulsarBrokerStarter {
                     workerConfig = WorkerConfig.load(starterArguments.fnWorkerConfigFile);
                 }
                 // worker talks to local broker
-                workerConfig.setPulsarServiceUrl("pulsar://127.0.0.1:" + brokerConfig.getBrokerServicePort());
-                workerConfig.setPulsarWebServiceUrl("http://127.0.0.1:" + brokerConfig.getWebServicePort());
+                boolean isTls = workerConfig.isUseTls();
+                workerConfig.setPulsarServiceUrl(String.format("pulsar://127.0.0.1:%s",
+                        (isTls ? brokerConfig.getBrokerServicePortTls() : brokerConfig.getBrokerServicePort()), args));
+                workerConfig.setPulsarWebServiceUrl(String.format("%s://127.0.0.1:%s", (isTls ? "https" : "http"),
+                        (isTls ? brokerConfig.getWebServicePortTls() : brokerConfig.getWebServicePort())));
                 String hostname = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(
                     brokerConfig.getAdvertisedAddress());
                 workerConfig.setWorkerHostname(hostname);

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -656,14 +656,21 @@ public class CmdFunctions extends CmdBase {
 
         @Parameter(names = "--tls_allow_insecure", description = "Allow insecure tls connection\n")
         protected boolean tlsAllowInsecureConnection;
+        
+        @Parameter(names = "--hostname_verification_enabled", description = "Enable hostname verification")
+        protected boolean tlsHostNameVerificationEnabled;
+        
+        @Parameter(names = "--tls_trust_cert_path", description = "tls trust cert file path")
+        protected String tlsTrustCertFilePath;
 
         @Override
         void runCmd() throws Exception {
-            CmdFunctions.startLocalRun(convertProto2(functionConfig),
-                    functionConfig.getParallelism(), brokerServiceUrl,
+            CmdFunctions.startLocalRun(convertProto2(functionConfig), functionConfig.getParallelism(), brokerServiceUrl,
                     AuthenticationConfig.builder().clientAuthenticationPlugin(clientAuthPlugin)
                             .clientAuthenticationParameters(clientAuthParams).useTls(useTls)
-                            .tlsAllowInsecureConnection(tlsAllowInsecureConnection).build(),
+                            .tlsAllowInsecureConnection(tlsAllowInsecureConnection)
+                            .tlsHostnameVerificationEnable(tlsHostNameVerificationEnabled)
+                            .tlsTrustCertsFilePath(tlsTrustCertFilePath).build(),
                     userCodeFile, admin);
         }
     }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
@@ -29,6 +29,7 @@ import org.apache.pulsar.admin.cli.utils.CmdUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.internal.FunctionsImpl;
 import org.apache.pulsar.functions.api.utils.IdentityFunction;
+import org.apache.pulsar.functions.instance.AuthenticationConfig;
 import org.apache.pulsar.functions.proto.Function;
 import org.apache.pulsar.functions.proto.Function.FunctionDetails;
 import org.apache.pulsar.functions.proto.Function.Resources;
@@ -115,7 +116,11 @@ public class CmdSinks extends CmdBase {
         @Override
         void runCmd() throws Exception {
             CmdFunctions.startLocalRun(createSinkConfigProto2(sinkConfig), sinkConfig.getParallelism(),
-                    brokerServiceUrl, clientAuthPlugin, clientAuthParams, useTls, tlsAllowInsecureConnection, jarFile, admin);
+                    brokerServiceUrl,
+                    AuthenticationConfig.builder().clientAuthenticationPlugin(clientAuthPlugin)
+                            .clientAuthenticationParameters(clientAuthParams).useTls(useTls)
+                            .tlsAllowInsecureConnection(tlsAllowInsecureConnection).build(),
+                    jarFile, admin);
         }
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
@@ -99,11 +99,23 @@ public class CmdSinks extends CmdBase {
 
         @Parameter(names = "--brokerServiceUrl", description = "The URL for the Pulsar broker")
         protected String brokerServiceUrl;
+        
+        @Parameter(names = "--clientAuthPlugin", description = "Client authentication plugin using which function-process can connect to broker")
+        protected String clientAuthPlugin;
+        
+        @Parameter(names = "--clientAuthParams", description = "Client authentication param")
+        protected String clientAuthParams;
+        
+        @Parameter(names = "--use_tls", description = "Use tls connection\n")
+        protected boolean useTls;
+
+        @Parameter(names = "--tls_allow_insecure", description = "Allow insecure tls connection\n")
+        protected boolean tlsAllowInsecureConnection;
 
         @Override
         void runCmd() throws Exception {
-            CmdFunctions.startLocalRun(createSinkConfigProto2(sinkConfig),
-                    sinkConfig.getParallelism(), brokerServiceUrl, jarFile, admin);
+            CmdFunctions.startLocalRun(createSinkConfigProto2(sinkConfig), sinkConfig.getParallelism(),
+                    brokerServiceUrl, clientAuthPlugin, clientAuthParams, useTls, tlsAllowInsecureConnection, jarFile, admin);
         }
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
@@ -112,6 +112,12 @@ public class CmdSinks extends CmdBase {
 
         @Parameter(names = "--tls_allow_insecure", description = "Allow insecure tls connection\n")
         protected boolean tlsAllowInsecureConnection;
+        
+        @Parameter(names = "--hostname_verification_enabled", description = "Enable hostname verification")
+        protected boolean tlsHostNameVerificationEnabled;
+        
+        @Parameter(names = "--tls_trust_cert_path", description = "tls trust cert file path")
+        protected String tlsTrustCertFilePath;
 
         @Override
         void runCmd() throws Exception {
@@ -119,7 +125,9 @@ public class CmdSinks extends CmdBase {
                     brokerServiceUrl,
                     AuthenticationConfig.builder().clientAuthenticationPlugin(clientAuthPlugin)
                             .clientAuthenticationParameters(clientAuthParams).useTls(useTls)
-                            .tlsAllowInsecureConnection(tlsAllowInsecureConnection).build(),
+                            .tlsAllowInsecureConnection(tlsAllowInsecureConnection)
+                            .tlsHostnameVerificationEnable(tlsHostNameVerificationEnabled)
+                            .tlsTrustCertsFilePath(tlsTrustCertFilePath).build(),
                     jarFile, admin);
         }
     }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
@@ -108,6 +108,12 @@ public class CmdSources extends CmdBase {
 
         @Parameter(names = "--tls_allow_insecure", description = "Allow insecure tls connection\n")
         protected boolean tlsAllowInsecureConnection;
+        
+        @Parameter(names = "--hostname_verification_enabled", description = "Enable hostname verification")
+        protected boolean tlsHostNameVerificationEnabled;
+        
+        @Parameter(names = "--tls_trust_cert_path", description = "tls trust cert file path")
+        protected String tlsTrustCertFilePath;
 
         @Override
         void runCmd() throws Exception {
@@ -115,7 +121,9 @@ public class CmdSources extends CmdBase {
                     brokerServiceUrl,
                     AuthenticationConfig.builder().clientAuthenticationPlugin(clientAuthPlugin)
                             .clientAuthenticationParameters(clientAuthParams).useTls(useTls)
-                            .tlsAllowInsecureConnection(tlsAllowInsecureConnection).build(),
+                            .tlsAllowInsecureConnection(tlsAllowInsecureConnection)
+                            .tlsHostnameVerificationEnable(tlsHostNameVerificationEnabled)
+                            .tlsTrustCertsFilePath(tlsTrustCertFilePath).build(),
                     jarFile, admin);
         }
     }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
@@ -29,6 +29,7 @@ import org.apache.pulsar.admin.cli.utils.CmdUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.internal.FunctionsImpl;
 import org.apache.pulsar.functions.api.utils.IdentityFunction;
+import org.apache.pulsar.functions.instance.AuthenticationConfig;
 import org.apache.pulsar.functions.proto.Function.FunctionDetails;
 import org.apache.pulsar.functions.proto.Function.Resources;
 import org.apache.pulsar.functions.proto.Function.SinkSpec;
@@ -111,8 +112,11 @@ public class CmdSources extends CmdBase {
         @Override
         void runCmd() throws Exception {
             CmdFunctions.startLocalRun(createSourceConfigProto2(sourceConfig), sourceConfig.getParallelism(),
-                    brokerServiceUrl, clientAuthPlugin, clientAuthParams, useTls, tlsAllowInsecureConnection, jarFile,
-                    admin);
+                    brokerServiceUrl,
+                    AuthenticationConfig.builder().clientAuthenticationPlugin(clientAuthPlugin)
+                            .clientAuthenticationParameters(clientAuthParams).useTls(useTls)
+                            .tlsAllowInsecureConnection(tlsAllowInsecureConnection).build(),
+                    jarFile, admin);
         }
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
@@ -95,11 +95,24 @@ public class CmdSources extends CmdBase {
 
         @Parameter(names = "--brokerServiceUrl", description = "The URL for the Pulsar broker")
         protected String brokerServiceUrl;
+        
+        @Parameter(names = "--clientAuthPlugin", description = "Client authentication plugin using which function-process can connect to broker")
+        protected String clientAuthPlugin;
+        
+        @Parameter(names = "--clientAuthParams", description = "Client authentication param")
+        protected String clientAuthParams;
+        
+        @Parameter(names = "--use_tls", description = "Use tls connection\n")
+        protected boolean useTls;
+
+        @Parameter(names = "--tls_allow_insecure", description = "Allow insecure tls connection\n")
+        protected boolean tlsAllowInsecureConnection;
 
         @Override
         void runCmd() throws Exception {
-            CmdFunctions.startLocalRun(createSourceConfigProto2(sourceConfig),
-                    sourceConfig.getParallelism(), brokerServiceUrl, jarFile, admin);
+            CmdFunctions.startLocalRun(createSourceConfigProto2(sourceConfig), sourceConfig.getParallelism(),
+                    brokerServiceUrl, clientAuthPlugin, clientAuthParams, useTls, tlsAllowInsecureConnection, jarFile,
+                    admin);
         }
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -55,7 +55,7 @@ public class ClientConfigurationData implements Serializable, Cloneable {
     private int maxLookupRequest = 50000;
     private int maxNumberOfRejectedRequestPerConnection = 50;
     private int keepAliveIntervalSeconds = 30;
-
+    
     public ClientConfigurationData clone() {
         try {
             return (ClientConfigurationData) super.clone();

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/AuthenticationConfig.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/AuthenticationConfig.java
@@ -37,6 +37,8 @@ import lombok.ToString;
 public class AuthenticationConfig {
     private String clientAuthenticationPlugin;
     private String clientAuthenticationParameters;
+    private String tlsTrustCertsFilePath;
     private boolean useTls;
     private boolean tlsAllowInsecureConnection;
+    private boolean tlsHostnameVerificationEnable;
 }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/AuthenticationConfig.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/AuthenticationConfig.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.instance;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * Configuration to aggregate various authentication params.
+ */
+@Data
+@Getter
+@Setter
+@EqualsAndHashCode
+@ToString
+@Builder
+public class AuthenticationConfig {
+    private String clientAuthenticationPlugin;
+    private String clientAuthenticationParameters;
+    private boolean useTls;
+    private boolean tlsAllowInsecureConnection;
+}

--- a/pulsar-functions/instance/src/main/python/python_instance_main.py
+++ b/pulsar-functions/instance/src/main/python/python_instance_main.py
@@ -68,6 +68,8 @@ def main():
   parser.add_argument('--client_auth_params', required=False, help='Client authentication params')
   parser.add_argument('--use_tls', required=False, help='Use tls')
   parser.add_argument('--tls_allow_insecure_connection', required=False, help='Tls allow insecure connection')
+  parser.add_argument('--hostname_verification_enabled', required=False, help='Enable hostname verification')
+  parser.add_argument('--tls_trust_cert_path', required=False, help='Tls trust cert file path')
   parser.add_argument('--port', required=True, help='Instance Port', type=int)
   parser.add_argument('--max_buffered_tuples', required=True, help='Maximum number of Buffered tuples')
   parser.add_argument('--user_config', required=False, help='User Config')
@@ -132,13 +134,16 @@ def main():
   authentication = None
   use_tls = False
   tls_allow_insecure_connection = False
+  tls_trust_cert_path = None
   if args.client_auth_plugin and args.client_auth_params:
       authentication = pulsar.Authentication(args.client_auth_plugin, args.client_auth_params)
   if args.use_tls == "true":
     use_tls = True
   if args.tls_allow_insecure_connection == "true":
     tls_allow_insecure_connection = True
-  pulsar_client = pulsar.Client(args.pulsar_serviceurl, authentication, 30, 1, 1, 50000, None, use_tls, None, tls_allow_insecure_connection)
+  if args.tls_trust_cert_path:
+     tls_trust_cert_path =  args.tls_trust_cert_path
+  pulsar_client = pulsar.Client(args.pulsar_serviceurl, authentication, 30, 1, 1, 50000, None, use_tls, tls_trust_cert_path, tls_allow_insecure_connection)
   pyinstance = python_instance.PythonInstance(str(args.instance_id), str(args.function_id),
                                               str(args.function_version), function_details,
                                               int(args.max_buffered_tuples), str(args.py),

--- a/pulsar-functions/instance/src/main/python/python_instance_main.py
+++ b/pulsar-functions/instance/src/main/python/python_instance_main.py
@@ -30,6 +30,7 @@ import signal
 import time
 import json
 
+from pulsar import Authentication
 import pulsar
 
 import Function_pb2
@@ -63,6 +64,10 @@ def main():
   parser.add_argument('--function_version', required=True, help='Function Version')
   parser.add_argument('--processing_guarantees', required=True, help='Processing Guarantees')
   parser.add_argument('--pulsar_serviceurl', required=True, help='Pulsar Service Url')
+  parser.add_argument('--client_auth_plugin', required=False, help='Client authentication plugin')
+  parser.add_argument('--client_auth_params', required=False, help='Client authentication params')
+  parser.add_argument('--use_tls', required=False, help='Use tls')
+  parser.add_argument('--tls_allow_insecure_connection', required=False, help='Tls allow insecure connection')
   parser.add_argument('--port', required=True, help='Instance Port', type=int)
   parser.add_argument('--max_buffered_tuples', required=True, help='Maximum number of Buffered tuples')
   parser.add_argument('--user_config', required=False, help='User Config')
@@ -124,7 +129,16 @@ def main():
   if args.user_config != None and len(args.user_config) != 0:
     function_details.userConfig = args.user_config
 
-  pulsar_client = pulsar.Client(args.pulsar_serviceurl)
+  authentication = None
+  use_tls = False
+  tls_allow_insecure_connection = False
+  if args.client_auth_plugin and args.client_auth_params:
+      authentication = pulsar.Authentication(args.client_auth_plugin, args.client_auth_params)
+  if args.use_tls == "true":
+    use_tls = True
+  if args.tls_allow_insecure_connection == "true":
+    tls_allow_insecure_connection = True
+  pulsar_client = pulsar.Client(args.pulsar_serviceurl, authentication, 30, 1, 1, 50000, None, use_tls, None, tls_allow_insecure_connection)
   pyinstance = python_instance.PythonInstance(str(args.instance_id), str(args.function_id),
                                               str(args.function_version), function_details,
                                               int(args.max_buffered_tuples), str(args.py),

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceMain.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceMain.java
@@ -30,6 +30,8 @@ import io.grpc.stub.StreamObserver;
 import lombok.extern.slf4j.Slf4j;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import org.apache.pulsar.functions.instance.AuthenticationConfig;
 import org.apache.pulsar.functions.instance.InstanceConfig;
 import org.apache.pulsar.functions.proto.Function;
 import org.apache.pulsar.functions.proto.Function.ProcessingGuarantees;
@@ -219,14 +221,11 @@ public class JavaInstanceMain implements AutoCloseable {
         instanceConfig.setFunctionDetails(functionDetails);
         instanceConfig.setPort(port);
 
-        ThreadRuntimeFactory containerFactory = new ThreadRuntimeFactory(
-                "LocalRunnerThreadGroup",
-                pulsarServiceUrl,
+        ThreadRuntimeFactory containerFactory = new ThreadRuntimeFactory("LocalRunnerThreadGroup", pulsarServiceUrl,
                 stateStorageServiceUrl,
-                clientAuthenticationPlugin,
-                clientAuthenticationParameters,
-                useTls,
-                tlsAllowInsecureConnection);
+                AuthenticationConfig.builder().clientAuthenticationPlugin(clientAuthenticationPlugin)
+                        .clientAuthenticationParameters(clientAuthenticationParameters).useTls(useTls)
+                        .tlsAllowInsecureConnection(tlsAllowInsecureConnection).build());
         runtimeSpawner = new RuntimeSpawner(
                 instanceConfig,
                 jarFile,

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceMain.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceMain.java
@@ -82,7 +82,19 @@ public class JavaInstanceMain implements AutoCloseable {
 
     @Parameter(names = "--pulsar_serviceurl", description = "Pulsar Service Url\n", required = true)
     protected String pulsarServiceUrl;
-
+    
+    @Parameter(names = "--client_auth_plugin", description = "Client auth plugin name\n")
+    protected String clientAuthenticationPlugin;
+    
+    @Parameter(names = "--client_auth_params", description = "Client auth param\n")
+    protected String clientAuthenticationParameters;
+    
+    @Parameter(names = "--use_tls", description = "Use tls connection\n")
+    protected boolean useTls;
+    
+    @Parameter(names = "--tls_allow_insecure", description = "Allow insecure tls connection\n")
+    protected boolean tlsAllowInsecureConnection;
+    
     @Parameter(names = "--state_storage_serviceurl", description = "State Storage Service Url\n", required= false)
     protected String stateStorageServiceUrl;
 
@@ -210,7 +222,11 @@ public class JavaInstanceMain implements AutoCloseable {
         ThreadRuntimeFactory containerFactory = new ThreadRuntimeFactory(
                 "LocalRunnerThreadGroup",
                 pulsarServiceUrl,
-                stateStorageServiceUrl);
+                stateStorageServiceUrl,
+                clientAuthenticationPlugin,
+                clientAuthenticationParameters,
+                useTls,
+                tlsAllowInsecureConnection);
         runtimeSpawner = new RuntimeSpawner(
                 instanceConfig,
                 jarFile,

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceMain.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceMain.java
@@ -97,6 +97,12 @@ public class JavaInstanceMain implements AutoCloseable {
     @Parameter(names = "--tls_allow_insecure", description = "Allow insecure tls connection\n")
     protected boolean tlsAllowInsecureConnection;
     
+    @Parameter(names = "--hostname_verification_enabled", description = "Enable hostname verification")
+    protected boolean tlsHostNameVerificationEnabled;
+    
+    @Parameter(names = "--tls_trust_cert_path", description = "tls trust cert file path")
+    protected String tlsTrustCertFilePath;
+    
     @Parameter(names = "--state_storage_serviceurl", description = "State Storage Service Url\n", required= false)
     protected String stateStorageServiceUrl;
 
@@ -225,7 +231,9 @@ public class JavaInstanceMain implements AutoCloseable {
                 stateStorageServiceUrl,
                 AuthenticationConfig.builder().clientAuthenticationPlugin(clientAuthenticationPlugin)
                         .clientAuthenticationParameters(clientAuthenticationParameters).useTls(useTls)
-                        .tlsAllowInsecureConnection(tlsAllowInsecureConnection).build());
+                        .tlsAllowInsecureConnection(tlsAllowInsecureConnection)
+                        .tlsHostnameVerificationEnable(tlsHostNameVerificationEnabled)
+                        .tlsTrustCertsFilePath(tlsTrustCertFilePath).build());
         runtimeSpawner = new RuntimeSpawner(
                 instanceConfig,
                 jarFile,

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntime.java
@@ -32,6 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.functions.instance.AuthenticationConfig;
 import org.apache.pulsar.functions.instance.InstanceConfig;
 import org.apache.pulsar.functions.proto.Function;
 import org.apache.pulsar.functions.proto.InstanceCommunication;
@@ -69,14 +70,11 @@ class ProcessRuntime implements Runtime {
                    String logDirectory,
                    String codeFile,
                    String pulsarServiceUrl,
-                   String clientAuthenticationPlugin,
-                   String clientAuthenticationParameters,
-                   boolean useTls,
-                   boolean tlsAllowInsecureConnection) {
+                   AuthenticationConfig authConfig) {
         this.instanceConfig = instanceConfig;
         this.instancePort = instanceConfig.getPort();
         this.processArgs = composeArgs(instanceConfig, instanceFile, logDirectory, codeFile, pulsarServiceUrl,
-                clientAuthenticationPlugin, clientAuthenticationParameters, useTls, tlsAllowInsecureConnection);
+                authConfig);
     }
 
     private List<String> composeArgs(InstanceConfig instanceConfig,
@@ -84,10 +82,7 @@ class ProcessRuntime implements Runtime {
                                      String logDirectory,
                                      String codeFile,
                                      String pulsarServiceUrl,
-                                     String clientAuthenticationPlugin,
-                                     String clientAuthenticationParameters,
-                                     boolean useTls,
-                                     boolean TlsAllowInsecureConnection) {
+                                     AuthenticationConfig authConfig) {
         List<String> args = new LinkedList<>();
         if (instanceConfig.getFunctionDetails().getRuntime() == Function.FunctionDetails.Runtime.JAVA) {
             args.add("java");
@@ -146,16 +141,19 @@ class ProcessRuntime implements Runtime {
         args.add(String.valueOf(instanceConfig.getFunctionDetails().getProcessingGuarantees()));
         args.add("--pulsar_serviceurl");
         args.add(pulsarServiceUrl);
-        if(isNotBlank(clientAuthenticationPlugin) && isNotBlank(clientAuthenticationParameters)) {
-            args.add("--client_auth_plugin");
-            args.add(clientAuthenticationPlugin);
-            args.add("--client_auth_params");
-            args.add(clientAuthenticationParameters);
+        if (authConfig != null) {
+            if (isNotBlank(authConfig.getClientAuthenticationPlugin())
+                    && isNotBlank(authConfig.getClientAuthenticationParameters())) {
+                args.add("--client_auth_plugin");
+                args.add(authConfig.getClientAuthenticationPlugin());
+                args.add("--client_auth_params");
+                args.add(authConfig.getClientAuthenticationParameters());
+            }
+            args.add("--use_tls");
+            args.add(Boolean.toString(authConfig.isUseTls()));
+            args.add("--tls_allow_insecure");
         }
-        args.add("--use_tls");
-        args.add(Boolean.toString(useTls));
-        args.add("--tls_allow_insecure");
-        args.add(Boolean.toString(TlsAllowInsecureConnection));
+        args.add(Boolean.toString(authConfig.isTlsAllowInsecureConnection()));
         args.add("--max_buffered_tuples");
         args.add(String.valueOf(instanceConfig.getMaxBufferedTuples()));
         String userConfig = instanceConfig.getFunctionDetails().getUserConfig();

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntime.java
@@ -152,8 +152,14 @@ class ProcessRuntime implements Runtime {
             args.add("--use_tls");
             args.add(Boolean.toString(authConfig.isUseTls()));
             args.add("--tls_allow_insecure");
+            args.add(Boolean.toString(authConfig.isTlsAllowInsecureConnection()));
+            args.add("--hostname_verification_enabled");
+            args.add(Boolean.toString(authConfig.isTlsHostnameVerificationEnable()));
+            if(isNotBlank(authConfig.getTlsTrustCertsFilePath())) {
+                args.add("--tls_trust_cert_path");
+                args.add(authConfig.getTlsTrustCertsFilePath());
+            }
         }
-        args.add(Boolean.toString(authConfig.isTlsAllowInsecureConnection()));
         args.add("--max_buffered_tuples");
         args.add(String.valueOf(instanceConfig.getMaxBufferedTuples()));
         String userConfig = instanceConfig.getFunctionDetails().getUserConfig();

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntime.java
@@ -30,6 +30,8 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.functions.instance.InstanceConfig;
 import org.apache.pulsar.functions.proto.Function;
 import org.apache.pulsar.functions.proto.InstanceCommunication;
@@ -66,17 +68,26 @@ class ProcessRuntime implements Runtime {
                    String instanceFile,
                    String logDirectory,
                    String codeFile,
-                   String pulsarServiceUrl) {
+                   String pulsarServiceUrl,
+                   String clientAuthenticationPlugin,
+                   String clientAuthenticationParameters,
+                   boolean useTls,
+                   boolean tlsAllowInsecureConnection) {
         this.instanceConfig = instanceConfig;
         this.instancePort = instanceConfig.getPort();
-        this.processArgs = composeArgs(instanceConfig, instanceFile, logDirectory, codeFile, pulsarServiceUrl);
+        this.processArgs = composeArgs(instanceConfig, instanceFile, logDirectory, codeFile, pulsarServiceUrl,
+                clientAuthenticationPlugin, clientAuthenticationParameters, useTls, tlsAllowInsecureConnection);
     }
 
     private List<String> composeArgs(InstanceConfig instanceConfig,
                                      String instanceFile,
                                      String logDirectory,
                                      String codeFile,
-                                     String pulsarServiceUrl) {
+                                     String pulsarServiceUrl,
+                                     String clientAuthenticationPlugin,
+                                     String clientAuthenticationParameters,
+                                     boolean useTls,
+                                     boolean TlsAllowInsecureConnection) {
         List<String> args = new LinkedList<>();
         if (instanceConfig.getFunctionDetails().getRuntime() == Function.FunctionDetails.Runtime.JAVA) {
             args.add("java");
@@ -135,6 +146,16 @@ class ProcessRuntime implements Runtime {
         args.add(String.valueOf(instanceConfig.getFunctionDetails().getProcessingGuarantees()));
         args.add("--pulsar_serviceurl");
         args.add(pulsarServiceUrl);
+        if(isNotBlank(clientAuthenticationPlugin) && isNotBlank(clientAuthenticationParameters)) {
+            args.add("--client_auth_plugin");
+            args.add(clientAuthenticationPlugin);
+            args.add("--client_auth_params");
+            args.add(clientAuthenticationParameters);
+        }
+        args.add("--use_tls");
+        args.add(Boolean.toString(useTls));
+        args.add("--tls_allow_insecure");
+        args.add(Boolean.toString(TlsAllowInsecureConnection));
         args.add("--max_buffered_tuples");
         args.add(String.valueOf(instanceConfig.getMaxBufferedTuples()));
         String userConfig = instanceConfig.getFunctionDetails().getUserConfig();

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntimeFactory.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntimeFactory.java
@@ -32,17 +32,29 @@ import java.nio.file.Paths;
 public class ProcessRuntimeFactory implements RuntimeFactory {
 
     private String pulsarServiceUrl;
+    private String clientAuthenticationPlugin;
+    private String clientAuthenticationParameters;
+    private boolean useTls;
+    private boolean tlsAllowInsecureConnection;
     private String javaInstanceJarFile;
     private String pythonInstanceFile;
     private String logDirectory;
 
     @VisibleForTesting
     public ProcessRuntimeFactory(String pulsarServiceUrl,
+                                 String clientAuthenticationPlugin,
+                                 String clientAuthenticationParameters,
+                                 boolean useTls,
+                                 boolean allowInsecureConnection,
                                  String javaInstanceJarFile,
                                  String pythonInstanceFile,
                                  String logDirectory) {
 
         this.pulsarServiceUrl = pulsarServiceUrl;
+        this.clientAuthenticationPlugin = clientAuthenticationPlugin;
+        this.clientAuthenticationParameters = clientAuthenticationParameters;
+        this.useTls = useTls;
+        this.tlsAllowInsecureConnection = allowInsecureConnection;
         this.javaInstanceJarFile = javaInstanceJarFile;
         this.pythonInstanceFile = pythonInstanceFile;
         this.logDirectory = logDirectory;
@@ -100,7 +112,11 @@ public class ProcessRuntimeFactory implements RuntimeFactory {
             instanceFile,
             logDirectory,
             codeFile,
-            pulsarServiceUrl);
+            pulsarServiceUrl,
+            clientAuthenticationPlugin,
+            clientAuthenticationParameters,
+            useTls,
+            tlsAllowInsecureConnection);
     }
 
     @Override

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntimeFactory.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntimeFactory.java
@@ -21,6 +21,8 @@ package org.apache.pulsar.functions.runtime;
 
 import com.google.common.annotations.VisibleForTesting;
 import lombok.extern.slf4j.Slf4j;
+
+import org.apache.pulsar.functions.instance.AuthenticationConfig;
 import org.apache.pulsar.functions.instance.InstanceConfig;
 
 import java.nio.file.Paths;
@@ -32,29 +34,20 @@ import java.nio.file.Paths;
 public class ProcessRuntimeFactory implements RuntimeFactory {
 
     private String pulsarServiceUrl;
-    private String clientAuthenticationPlugin;
-    private String clientAuthenticationParameters;
-    private boolean useTls;
-    private boolean tlsAllowInsecureConnection;
+    private AuthenticationConfig authConfig;
     private String javaInstanceJarFile;
     private String pythonInstanceFile;
     private String logDirectory;
 
     @VisibleForTesting
     public ProcessRuntimeFactory(String pulsarServiceUrl,
-                                 String clientAuthenticationPlugin,
-                                 String clientAuthenticationParameters,
-                                 boolean useTls,
-                                 boolean allowInsecureConnection,
+                                 AuthenticationConfig authConfig,
                                  String javaInstanceJarFile,
                                  String pythonInstanceFile,
                                  String logDirectory) {
 
         this.pulsarServiceUrl = pulsarServiceUrl;
-        this.clientAuthenticationPlugin = clientAuthenticationPlugin;
-        this.clientAuthenticationParameters = clientAuthenticationParameters;
-        this.useTls = useTls;
-        this.tlsAllowInsecureConnection = allowInsecureConnection;
+        this.authConfig = authConfig;
         this.javaInstanceJarFile = javaInstanceJarFile;
         this.pythonInstanceFile = pythonInstanceFile;
         this.logDirectory = logDirectory;
@@ -113,10 +106,7 @@ public class ProcessRuntimeFactory implements RuntimeFactory {
             logDirectory,
             codeFile,
             pulsarServiceUrl,
-            clientAuthenticationPlugin,
-            clientAuthenticationParameters,
-            useTls,
-            tlsAllowInsecureConnection);
+            authConfig);
     }
 
     @Override

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ThreadRuntimeFactory.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ThreadRuntimeFactory.java
@@ -72,6 +72,8 @@ public class ThreadRuntimeFactory implements RuntimeFactory {
                 }
                 clientBuilder.enableTls(authConfig.isUseTls());
                 clientBuilder.allowTlsInsecureConnection(authConfig.isTlsAllowInsecureConnection());
+                clientBuilder.enableTlsHostnameVerification(authConfig.isTlsHostnameVerificationEnable());
+                clientBuilder.tlsTrustCertsFilePath(authConfig.getTlsTrustCertsFilePath());
             }
             return clientBuilder.build();
         }

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/ProcessRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/ProcessRuntimeTest.java
@@ -66,7 +66,7 @@ public class ProcessRuntimeTest {
         this.pulsarServiceUrl = "pulsar://localhost:6670";
         this.logDirectory = "Users/user/logs";
         this.factory = new ProcessRuntimeFactory(
-            pulsarServiceUrl, null, null, false, false, javaInstanceJarFile, pythonInstanceFile, logDirectory);
+            pulsarServiceUrl, null, javaInstanceJarFile, pythonInstanceFile, logDirectory);
     }
 
     @AfterMethod

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/ProcessRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/ProcessRuntimeTest.java
@@ -66,7 +66,7 @@ public class ProcessRuntimeTest {
         this.pulsarServiceUrl = "pulsar://localhost:6670";
         this.logDirectory = "Users/user/logs";
         this.factory = new ProcessRuntimeFactory(
-            pulsarServiceUrl, javaInstanceJarFile, pythonInstanceFile, logDirectory);
+            pulsarServiceUrl, null, null, false, false, javaInstanceJarFile, pythonInstanceFile, logDirectory);
     }
 
     @AfterMethod

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
@@ -93,9 +93,12 @@ public class FunctionRuntimeManager implements AutoCloseable{
 
         this.functionAssignmentTailer = new FunctionAssignmentTailer(this, reader);
 
-        AuthenticationConfig authConfig = AuthenticationConfig.builder().clientAuthenticationPlugin(workerConfig.getClientAuthenticationPlugin())
-        .clientAuthenticationParameters(workerConfig.getClientAuthenticationParameters()).useTls(workerConfig.isUseTls())
-        .tlsAllowInsecureConnection(workerConfig.isTlsAllowInsecureConnection()).build();
+        AuthenticationConfig authConfig = AuthenticationConfig.builder()
+                .clientAuthenticationPlugin(workerConfig.getClientAuthenticationPlugin())
+                .clientAuthenticationParameters(workerConfig.getClientAuthenticationParameters())
+                .tlsTrustCertsFilePath(workerConfig.getTlsTrustCertsFilePath())
+                .useTls(workerConfig.isUseTls()).tlsAllowInsecureConnection(workerConfig.isTlsAllowInsecureConnection())
+                .tlsHostnameVerificationEnable(workerConfig.isTlsHostnameVerificationEnable()).build();
         
         if (workerConfig.getThreadContainerFactory() != null) {
             this.runtimeFactory = new ThreadRuntimeFactory(

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
@@ -96,10 +96,18 @@ public class FunctionRuntimeManager implements AutoCloseable{
             this.runtimeFactory = new ThreadRuntimeFactory(
                     workerConfig.getThreadContainerFactory().getThreadGroupName(),
                     workerConfig.getPulsarServiceUrl(),
-                    workerConfig.getStateStorageServiceUrl());
+                    workerConfig.getStateStorageServiceUrl(),
+                    workerConfig.getClientAuthenticationPlugin(),
+                    workerConfig.getClientAuthenticationParameters(),
+                    workerConfig.isUseTls(),
+                    workerConfig.isTlsAllowInsecureConnection());
         } else if (workerConfig.getProcessContainerFactory() != null) {
             this.runtimeFactory = new ProcessRuntimeFactory(
                     workerConfig.getPulsarServiceUrl(),
+                    workerConfig.getClientAuthenticationPlugin(),
+                    workerConfig.getClientAuthenticationParameters(),
+                    workerConfig.isUseTls(),
+                    workerConfig.isTlsAllowInsecureConnection(),
                     workerConfig.getProcessContainerFactory().getJavaInstanceJarLocation(),
                     workerConfig.getProcessContainerFactory().getPythonInstanceLocation(),
                     workerConfig.getProcessContainerFactory().getLogDirectory());

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
@@ -26,6 +26,7 @@ import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Reader;
 import org.apache.pulsar.functions.proto.Function.Assignment;
+import org.apache.pulsar.functions.instance.AuthenticationConfig;
 import org.apache.pulsar.functions.proto.InstanceCommunication;
 import org.apache.pulsar.functions.proto.Request.AssignmentsUpdate;
 import org.apache.pulsar.functions.runtime.RuntimeFactory;
@@ -92,22 +93,20 @@ public class FunctionRuntimeManager implements AutoCloseable{
 
         this.functionAssignmentTailer = new FunctionAssignmentTailer(this, reader);
 
+        AuthenticationConfig authConfig = AuthenticationConfig.builder().clientAuthenticationPlugin(workerConfig.getClientAuthenticationPlugin())
+        .clientAuthenticationParameters(workerConfig.getClientAuthenticationParameters()).useTls(workerConfig.isUseTls())
+        .tlsAllowInsecureConnection(workerConfig.isTlsAllowInsecureConnection()).build();
+        
         if (workerConfig.getThreadContainerFactory() != null) {
             this.runtimeFactory = new ThreadRuntimeFactory(
                     workerConfig.getThreadContainerFactory().getThreadGroupName(),
                     workerConfig.getPulsarServiceUrl(),
                     workerConfig.getStateStorageServiceUrl(),
-                    workerConfig.getClientAuthenticationPlugin(),
-                    workerConfig.getClientAuthenticationParameters(),
-                    workerConfig.isUseTls(),
-                    workerConfig.isTlsAllowInsecureConnection());
+                    authConfig);
         } else if (workerConfig.getProcessContainerFactory() != null) {
             this.runtimeFactory = new ProcessRuntimeFactory(
                     workerConfig.getPulsarServiceUrl(),
-                    workerConfig.getClientAuthenticationPlugin(),
-                    workerConfig.getClientAuthenticationParameters(),
-                    workerConfig.isUseTls(),
-                    workerConfig.isTlsAllowInsecureConnection(),
+                    authConfig,
                     workerConfig.getProcessContainerFactory().getJavaInstanceJarLocation(),
                     workerConfig.getProcessContainerFactory().getPythonInstanceLocation(),
                     workerConfig.getProcessContainerFactory().getLogDirectory());

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/MembershipManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/MembershipManager.java
@@ -280,7 +280,9 @@ public class MembershipManager implements AutoCloseable, ConsumerEventListener {
 
     private PulsarAdmin getPulsarAdminClient() {
         if (this.pulsarAdminClient == null) {
-            this.pulsarAdminClient = Utils.getPulsarAdminClient(this.workerConfig.getPulsarWebServiceUrl());
+            this.pulsarAdminClient = Utils.getPulsarAdminClient(this.workerConfig.getPulsarWebServiceUrl(),
+                    workerConfig.getClientAuthenticationPlugin(), workerConfig.getClientAuthenticationParameters(),
+                    workerConfig.getTlsTrustCertsFilePath(), workerConfig.isTlsAllowInsecureConnection());
         }
         return this.pulsarAdminClient;
     }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/Worker.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/Worker.java
@@ -71,7 +71,9 @@ public class Worker extends AbstractService {
     private static URI initialize(WorkerConfig workerConfig)
             throws InterruptedException, PulsarAdminException, IOException {
         // initializing pulsar functions namespace
-        PulsarAdmin admin = Utils.getPulsarAdminClient(workerConfig.getPulsarWebServiceUrl());
+        PulsarAdmin admin = Utils.getPulsarAdminClient(workerConfig.getPulsarWebServiceUrl(),
+                workerConfig.getClientAuthenticationPlugin(), workerConfig.getClientAuthenticationParameters(),
+                workerConfig.getTlsTrustCertsFilePath(), workerConfig.isTlsAllowInsecureConnection());
         InternalConfigurationData internalConf;
         // make sure pulsar broker is up
         log.info("Checking if pulsar service at {} is up...", workerConfig.getPulsarWebServiceUrl());

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -63,6 +63,11 @@ public class WorkerConfig implements Serializable {
     private int initialBrokerReconnectMaxRetries;
     private int assignmentWriteMaxRetries;
     private long instanceLivenessCheckFreqMs;
+    private String clientAuthenticationPlugin;
+    private String clientAuthenticationParameters;
+    private boolean useTls = false;
+    private String tlsTrustCertsFilePath = "";
+    private boolean tlsAllowInsecureConnection = false;
 
     @Data
     @Setter

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -68,7 +68,8 @@ public class WorkerConfig implements Serializable {
     private boolean useTls = false;
     private String tlsTrustCertsFilePath = "";
     private boolean tlsAllowInsecureConnection = false;
-
+    private boolean tlsHostnameVerificationEnable = false;
+    
     @Data
     @Setter
     @Getter

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerService.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerService.java
@@ -88,6 +88,8 @@ public class WorkerService {
             }
             clientBuilder.enableTls(workerConfig.isUseTls());
             clientBuilder.allowTlsInsecureConnection(workerConfig.isTlsAllowInsecureConnection());
+            clientBuilder.tlsTrustCertsFilePath(workerConfig.getTlsTrustCertsFilePath());
+            clientBuilder.enableTlsHostnameVerification(workerConfig.isTlsHostnameVerificationEnable());
             this.client = clientBuilder.build();
             log.info("Created Pulsar client");
 

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerService.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerService.java
@@ -23,9 +23,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.URI;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import org.apache.distributedlog.DistributedLogConfiguration;
 import org.apache.distributedlog.api.namespace.Namespace;
 import org.apache.distributedlog.api.namespace.NamespaceBuilder;
+import org.apache.pulsar.client.api.ClientBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 
@@ -77,7 +80,15 @@ public class WorkerService {
         // initialize the function metadata manager
         try {
 
-            this.client = PulsarClient.builder().serviceUrl(this.workerConfig.getPulsarServiceUrl()).build();
+            ClientBuilder clientBuilder = PulsarClient.builder().serviceUrl(this.workerConfig.getPulsarServiceUrl());
+            if (isNotBlank(workerConfig.getClientAuthenticationPlugin())
+                    && isNotBlank(workerConfig.getClientAuthenticationParameters())) {
+                clientBuilder.authentication(workerConfig.getClientAuthenticationPlugin(),
+                        workerConfig.getClientAuthenticationParameters());
+            }
+            clientBuilder.enableTls(workerConfig.isUseTls());
+            clientBuilder.allowTlsInsecureConnection(workerConfig.isTlsAllowInsecureConnection());
+            this.client = clientBuilder.build();
             log.info("Created Pulsar client");
 
             //create scheduler manager


### PR DESCRIPTION
### Motivation

If broker has authentication and tls enabled then function doesn't have support to pass auth data to broker.

### Modifications

Add auth-plugin and TLS support at function to connect with broker.

### Result

Function can connect to broker over tls and with custom auth-plugin
