### PR TITLE
Fix doc build error on broker config

### DIFF
--- a/site/_data/config/broker.yaml
+++ b/site/_data/config/broker.yaml
@@ -319,7 +319,7 @@ configs:
   description: Name of load manager to use
 - name: managedLedgerOffloadDriver
   default: ''
-  description: Driver to use to offload old data to long term storage (Possible values: S3)
+  description: "Driver to use to offload old data to long term storage (Possible values: S3)"
 - name: managedLedgerOffloadMaxThreads
   default: '2'
   description: Maximum number of thread pool threads for ledger offloading


### PR DESCRIPTION
A recent change added a description with a : to the config data. This
broke the yaml parser.

Solution is to quote the string in question.
