### PR TITLE
Have the ability to specify instance id offset in localrun

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -643,10 +643,13 @@ public class CmdFunctions extends CmdBase {
         @Parameter(names = "--brokerServiceUrl", description = "The URL for the Pulsar broker")
         protected String brokerServiceUrl;
 
+        @Parameter(names = "--instanceIdOffset", description = "Start the instanceIds from this offset")
+        protected Integer instanceIdOffset;
+
         @Override
         void runCmd() throws Exception {
             CmdFunctions.startLocalRun(convertProto2(functionConfig),
-                    functionConfig.getParallelism(), brokerServiceUrl, userCodeFile, admin);
+                    functionConfig.getParallelism(), instanceIdOffset, brokerServiceUrl, userCodeFile, admin);
         }
     }
 
@@ -911,7 +914,7 @@ public class CmdFunctions extends CmdBase {
     }
 
     protected static void startLocalRun(org.apache.pulsar.functions.proto.Function.FunctionDetails functionDetails,
-                                        int parallelism, String brokerServiceUrl, String userCodeFile, PulsarAdmin admin)
+                                        int parallelism, int instanceIdOffset, String brokerServiceUrl, String userCodeFile, PulsarAdmin admin)
             throws Exception {
 
         String serviceUrl = admin.getServiceUrl();
@@ -930,7 +933,7 @@ public class CmdFunctions extends CmdBase {
                 // TODO: correctly implement function version and id
                 instanceConfig.setFunctionVersion(UUID.randomUUID().toString());
                 instanceConfig.setFunctionId(UUID.randomUUID().toString());
-                instanceConfig.setInstanceId(Integer.toString(i));
+                instanceConfig.setInstanceId(Integer.toString(i + instanceIdOffset));
                 instanceConfig.setMaxBufferedTuples(1024);
                 instanceConfig.setPort(Utils.findAvailablePort());
                 RuntimeSpawner runtimeSpawner = new RuntimeSpawner(

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -644,7 +644,7 @@ public class CmdFunctions extends CmdBase {
         protected String brokerServiceUrl;
 
         @Parameter(names = "--instanceIdOffset", description = "Start the instanceIds from this offset")
-        protected Integer instanceIdOffset;
+        protected Integer instanceIdOffset = 0;
 
         @Override
         void runCmd() throws Exception {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
@@ -103,7 +103,7 @@ public class CmdSinks extends CmdBase {
         @Override
         void runCmd() throws Exception {
             CmdFunctions.startLocalRun(createSinkConfigProto2(sinkConfig),
-                    sinkConfig.getParallelism(), brokerServiceUrl, jarFile, admin);
+                    sinkConfig.getParallelism(), 0, brokerServiceUrl, jarFile, admin);
         }
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
@@ -99,7 +99,7 @@ public class CmdSources extends CmdBase {
         @Override
         void runCmd() throws Exception {
             CmdFunctions.startLocalRun(createSourceConfigProto2(sourceConfig),
-                    sourceConfig.getParallelism(), brokerServiceUrl, jarFile, admin);
+                    sourceConfig.getParallelism(), 0, brokerServiceUrl, jarFile, admin);
         }
     }
 


### PR DESCRIPTION
### Motivation

To run functions in kubernetes, the most easiest approach would be to launch the k8 containers running functions in localrun mode. In that mechanism each container will run 1 function instance(i.e. parallelism of 1). The k8 template will manage the real parallelism factor as specified by the user. However we need to make sure that each running function gets the right instance id. Adding this instanceIdOffset allows us to do it.
### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
