### PR TITLE
Fix reference configuration display

### DIFF
--- a/site/_sass/_docs.scss
+++ b/site/_sass/_docs.scss
@@ -247,9 +247,7 @@
             padding: 5px 0;
 
             &:nth-child(1), &:nth-child(2) {
-              max-width: 225px;
               overflow: auto;
-              white-space: nowrap;
             }
 
             &:nth-child(2), &:nth-child(3)  {


### PR DESCRIPTION
Long lines were not wrapping, so they were overflowing on the next
cell. Maybe not a problem if you have a gigantic monitor, but a lot of
people do not.
