### PR TITLE
fix: jackson conflict dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -568,7 +568,7 @@ flexible messaging model and an intuitive client API.</description>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-jsonSchema</artifactId>
-        <version>2.9.0</version>
+        <version>${jackson.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
### Motivation

Our CI build intermittently failing with below error while creating shaded artifact because maven fails while creating shaded artifact if it finds out same class coming from multiple dependencies.
 
```
18:02:41 [INFO] Pulsar Client Java ................................ FAILURE [13.255s]
:
08:46:39 [ERROR] Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:3.1.0:shade (default) on project pulsar-client: Error creating shaded jar: duplicate entry: META-INF/services/org.apache.pulsar.shade.com.fasterxml.jackson.core.JsonFactory -> [Help 1]
08:46:39 [ERROR] 
08:46:39 [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
08:46:39 [ERROR] Re-run Maven using the -X switch to enable full debug logging.
08:46:39 [ERROR] 
08:46:39 [ERROR] For more information about the errors and possible solutions, please read the following articles:
08:46:39 [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
08:46:39 [ERROR] 
08:46:39 [ERROR] After correcting the problems, you can resume the build with the command
08:46:39 [ERROR]   mvn <goals> -rf :pulsar-client
```

### Modifications

use same jackson version for all jackson dependency including `jackson-module-jsonSchema`

### Result

pulsar-client-shade artifact will not fail due to duplicate class entry.
