### PR TITLE
Fix race in MultiTopicsConsumerImpl#redeliverUnacknowledgedMessages

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -502,12 +502,15 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
 
     @Override
     public void redeliverUnacknowledgedMessages() {
-        synchronized (this) {
+        lock.writeLock().lock();
+        try {
             consumers.values().stream().forEach(consumer -> consumer.redeliverUnacknowledgedMessages());
             incomingMessages.clear();
             unAckedMessageTracker.clear();
-            resumeReceivingFromPausedConsumersIfNeeded();
+        } finally {
+            lock.writeLock().unlock();
         }
+        resumeReceivingFromPausedConsumersIfNeeded();
     }
 
     @Override


### PR DESCRIPTION
This method calls #redeliverUnacknowledgedMessages on all underlying
consumers and clears the incomingMessages queue. There was a race that
the redelivery could happen before the incomingMessages was cleared,
and therefore redelivered messages could be lost. Previously this
block was protected by synchronized(this) block, but this didn't
protect against any other blocks.

This patch changes the synchronization to use the writeLock of the
same lock which is acquired before messages are pushed onto the queue.

This race was the source of flake in
ResendRequestTest.testSharedSingleAckedPartitionedTopic

Issue: #1160
