### PR TITLE
adding protobuf schema check support

### DIFF
--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -332,6 +332,7 @@
           <execution>
             <goals>
               <goal>compile</goal>
+              <goal>test-compile</goal>
             </goals>
           </execution>
         </executions>

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/AvroSchemaCompatibilityCheck.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/AvroSchemaCompatibilityCheck.java
@@ -30,13 +30,13 @@ import java.util.Arrays;
 
 public class AvroSchemaCompatibilityCheck implements SchemaCompatibilityCheck {
 
-    private final CompatibilityStrategy compatibilityStrategy;
+    private final SchemaCompatibilityStrategy compatibilityStrategy;
 
     public AvroSchemaCompatibilityCheck () {
-        this(CompatibilityStrategy.FULL);
+        this(SchemaCompatibilityStrategy.FULL);
     }
 
-    public AvroSchemaCompatibilityCheck(CompatibilityStrategy compatibilityStrategy) {
+    public AvroSchemaCompatibilityCheck(SchemaCompatibilityStrategy compatibilityStrategy) {
         this.compatibilityStrategy = compatibilityStrategy;
     }
 
@@ -62,13 +62,7 @@ public class AvroSchemaCompatibilityCheck implements SchemaCompatibilityCheck {
         return true;
     }
 
-    public enum CompatibilityStrategy {
-        BACKWARD,
-        FORWARD,
-        FULL
-    }
-
-    private static SchemaValidator createSchemaValidator(CompatibilityStrategy compatibilityStrategy,
+    private static SchemaValidator createSchemaValidator(SchemaCompatibilityStrategy compatibilityStrategy,
                                                   boolean onlyLatestValidator) {
         final SchemaValidatorBuilder validatorBuilder = new SchemaValidatorBuilder();
         switch (compatibilityStrategy) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/ProtobufSchemaCompatibilityCheck.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/ProtobufSchemaCompatibilityCheck.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service.schema;
+
+import org.apache.pulsar.common.schema.SchemaType;
+
+public class ProtobufSchemaCompatibilityCheck extends AvroSchemaCompatibilityCheck {
+
+    public ProtobufSchemaCompatibilityCheck () {
+        this(SchemaCompatibilityStrategy.FULL);
+    }
+
+    public ProtobufSchemaCompatibilityCheck (SchemaCompatibilityStrategy compatibilityStrategy) {
+        super(compatibilityStrategy);
+    }
+
+    @Override
+    public SchemaType getSchemaType() {
+        return SchemaType.PROTOBUF;
+    }
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaCompatibilityStrategy.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/SchemaCompatibilityStrategy.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service.schema;
+
+public enum SchemaCompatibilityStrategy {
+    BACKWARD,
+    FORWARD,
+    FULL
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/AvroSchemaCompatibilityCheckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/schema/AvroSchemaCompatibilityCheckTest.java
@@ -74,7 +74,7 @@ public class AvroSchemaCompatibilityCheckTest {
     public void testBackwardCompatibility() {
 
         AvroSchemaCompatibilityCheck avroSchemaCompatibilityCheck = new AvroSchemaCompatibilityCheck(
-            AvroSchemaCompatibilityCheck.CompatibilityStrategy.BACKWARD
+            SchemaCompatibilityStrategy.BACKWARD
         );
 
         // adding a field with default is backwards compatible
@@ -107,7 +107,7 @@ public class AvroSchemaCompatibilityCheckTest {
     public void testForwardCompatibility() {
 
         AvroSchemaCompatibilityCheck avroSchemaCompatibilityCheck = new AvroSchemaCompatibilityCheck(
-                AvroSchemaCompatibilityCheck.CompatibilityStrategy.FORWARD
+                SchemaCompatibilityStrategy.FORWARD
         );
 
         Assert.assertTrue(avroSchemaCompatibilityCheck.isCompatible(schemaData1, schemaData2),
@@ -132,7 +132,7 @@ public class AvroSchemaCompatibilityCheckTest {
     @Test
     public void testFullCompatibility() {
         AvroSchemaCompatibilityCheck avroSchemaCompatibilityCheck = new AvroSchemaCompatibilityCheck(
-                AvroSchemaCompatibilityCheck.CompatibilityStrategy.FULL
+                SchemaCompatibilityStrategy.FULL
         );
         Assert.assertTrue(avroSchemaCompatibilityCheck.isCompatible(schemaData1, schemaData2),
                 "adding a field with default fully compatible");

--- a/pulsar-broker/src/test/proto/ProtobufSchemaTest.proto
+++ b/pulsar-broker/src/test/proto/ProtobufSchemaTest.proto
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+syntax = "proto3";
+package proto;
+
+option java_package = "org.apache.pulsar.client.api.schema.proto";
+option java_outer_classname = "Test";
+
+enum TestEnum {
+    SHARED = 0;
+    FAILOVER = 1;
+}
+
+message SubMessage {
+    string foo = 1;
+    double bar = 2;
+}
+
+message TestMessage {
+    string stringField = 1;
+    double doubleField = 2;
+    int32 intField = 3;
+    TestEnum testEnum = 4;
+    SubMessage nestedField = 5;
+}
+
+message TestMessageWrong {
+    float foo = 1;
+}

--- a/pulsar-client/pom.xml
+++ b/pulsar-client/pom.xml
@@ -46,18 +46,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.avro</groupId>
-      <artifactId>avro-protobuf</artifactId>
-      <version>1.8.2</version>
-      <exclusions>
-        <exclusion>
-          <groupId>*</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
@@ -107,6 +95,18 @@
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
       <version>${avro.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro-protobuf</artifactId>
+      <version>${avro.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/pulsar-client/pom.xml
+++ b/pulsar-client/pom.xml
@@ -46,6 +46,18 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro-protobuf</artifactId>
+      <version>1.8.2</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
@@ -137,5 +149,26 @@
         <filtering>true</filtering>
       </resource>
     </resources>
+    <!-- Generate protobuf for testing purposes -->
+    <plugins>
+      <plugin>
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <version>${protobuf-maven-plugin.version}</version>
+        <configuration>
+          <protocArtifact>com.google.protobuf:protoc:${protoc3.version}:exe:${os.detected.classifier}</protocArtifact>
+          <checkStaleness>true</checkStaleness>
+          <pluginId>grpc-java</pluginId>
+          <pluginArtifact>io.grpc:protoc-gen-grpc-java:${protoc-gen-grpc-java.version}:exe:${os.detected.classifier}</pluginArtifact>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ProtobufSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/ProtobufSchema.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.client.impl.schema;
 
 import com.google.protobuf.Parser;
+import org.apache.avro.protobuf.ProtobufDatumReader;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SchemaSerializationException;
 import org.apache.pulsar.common.schema.SchemaInfo;
@@ -73,9 +74,9 @@ public class ProtobufSchema<T extends com.google.protobuf.GeneratedMessageV3> im
         info.setName("");
         info.setProperties(properties);
         info.setType(SchemaType.PROTOBUF);
-
-        //TODO determine best method to extract schema from a protobuf message
-        info.setSchema(null);
+        ProtobufDatumReader<T> datumReader = new ProtobufDatumReader<>(pojo);
+        org.apache.avro.Schema schema = datumReader.getSchema();
+        info.setSchema(schema.toString().getBytes());
         return new ProtobufSchema<>(info, pojo);
     }
 }

--- a/pulsar-client/src/test/proto/Test.proto
+++ b/pulsar-client/src/test/proto/Test.proto
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+syntax = "proto3";
+package proto;
+
+option java_package = "org.apache.pulsar.client.schemas.proto";
+option java_outer_classname = "Test";
+
+enum TestEnum {
+    SHARED = 0;
+    FAILOVER = 1;
+}
+
+message SubMessage {
+    string foo = 1;
+    double bar = 2;
+}
+
+message TestMessage {
+    string stringField = 1;
+    double doubleField = 2;
+    int32 intField = 3;
+    TestEnum testEnum = 4;
+    SubMessage nestedField = 5;
+}


### PR DESCRIPTION
Add support to generate  schemas for protobuf classes via avro-protobuf library. 

This allow us to generate an Avro schema from a protobuf class and leverage the existing support for avro schema to determine compatibility between schemas