### PR TITLE
Add function-package-url support in function cli add url support to function cli

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarSinkE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarSinkE2ETest.java
@@ -64,7 +64,7 @@ import org.apache.pulsar.functions.proto.Function.SinkSpec;
 import org.apache.pulsar.functions.proto.Function.SourceSpec;
 import org.apache.pulsar.functions.sink.PulsarSink;
 import org.apache.pulsar.functions.utils.Reflections;
-import org.apache.pulsar.functions.worker.Utils;
+import org.apache.pulsar.functions.utils.Utils;
 import org.apache.pulsar.functions.worker.WorkerConfig;
 import org.apache.pulsar.functions.worker.WorkerService;
 import org.apache.pulsar.functions.worker.rest.WorkerServer;

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/CmdFunctionsTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/CmdFunctionsTest.java
@@ -230,7 +230,6 @@ public class CmdFunctionsTest {
             "--inputs", inputTopicName,
             "--output", outputTopicName,
             "--jar", url,
-            "--classNameArgType", byte[].class.getName(),
             "--tenant", "sample",
             "--namespace", "ns1",
             "--className", DummyFunction.class.getName(),
@@ -260,8 +259,6 @@ public class CmdFunctionsTest {
             "--inputs", inputTopicName,
             "--output", outputTopicName,
             "--jar", url,
-            "--classNameArgType", byte[].class.getName(),
-            "--classNameResultType", byte[].class.getName(),
             "--tenant", "sample",
             "--namespace", "ns1",
             "--className", DummyFunction.class.getName(),
@@ -290,7 +287,6 @@ public class CmdFunctionsTest {
             "--name", fnName,
             "--inputs", inputTopicName,
             "--jar", url,
-            "--classNameArgType", byte[].class.getName(),
             "--tenant", "sample",
             "--namespace", "ns1",
             "--className", "DummySink"
@@ -309,7 +305,6 @@ public class CmdFunctionsTest {
     @Test
     public void testCreateSource() throws Exception {
         String fnName = TEST_NAME + "-function";
-        String inputTopicName = TEST_NAME + "-input-topic";
         
         ConsoleOutputCapturer consoleOutputCapturer = new ConsoleOutputCapturer();
         consoleOutputCapturer.start();
@@ -319,7 +314,6 @@ public class CmdFunctionsTest {
             "create",
             "--name", fnName,
             "--jar", url,
-            "--classNameArgType", byte[].class.getName(),
             "--tenant", "sample",
             "--namespace", "ns1",
             "--className", "DummySink"

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/CmdFunctionsTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/CmdFunctionsTest.java
@@ -32,6 +32,8 @@ import org.apache.pulsar.admin.cli.CmdFunctions.DeleteFunction;
 import org.apache.pulsar.admin.cli.CmdFunctions.GetFunction;
 import org.apache.pulsar.admin.cli.CmdFunctions.ListFunctions;
 import org.apache.pulsar.admin.cli.CmdFunctions.UpdateFunction;
+import org.apache.pulsar.admin.cli.CmdSinks.CreateSink;
+import org.apache.pulsar.admin.cli.CmdSources.CreateSource;
 import org.apache.pulsar.client.admin.Functions;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
@@ -39,8 +41,10 @@ import org.apache.pulsar.functions.api.Context;
 import org.apache.pulsar.functions.api.Function;
 import org.apache.pulsar.functions.api.utils.DefaultSerDe;
 import org.apache.pulsar.functions.proto.Function.FunctionDetails;
+import org.apache.pulsar.functions.sink.PulsarSink;
 import org.apache.pulsar.functions.utils.Reflections;
 import org.apache.pulsar.functions.utils.Utils;
+import org.apache.pulsar.io.core.RecordContext;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -72,6 +76,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Unit test of {@link CmdFunctions}.
@@ -91,6 +96,8 @@ public class CmdFunctionsTest {
     private PulsarAdmin admin;
     private Functions functions;
     private CmdFunctions cmd;
+    private CmdSinks cmdSinks;
+    private CmdSources cmdSources;
 
     public static class DummyFunction implements Function<String, String> {
 
@@ -103,7 +110,7 @@ public class CmdFunctionsTest {
             return null;
         }
     }
-
+    
     private String generateCustomSerdeInputs(String topic, String serde) {
         Map<String, String> map = new HashMap<>();
         map.put(topic, serde);
@@ -118,6 +125,8 @@ public class CmdFunctionsTest {
         when(admin.getServiceUrl()).thenReturn("http://localhost:1234");
         when(admin.getClientConfigData()).thenReturn(new ClientConfigurationData());
         this.cmd = new CmdFunctions(admin);
+        this.cmdSinks = new CmdSinks(admin);
+        this.cmdSources = new CmdSources(admin);
 
         // mock reflections
         mockStatic(Reflections.class);
@@ -204,7 +213,128 @@ public class CmdFunctionsTest {
         verify(functions, times(1)).createFunction(any(FunctionDetails.class), anyString());
 
     }
+    
+    @Test
+    public void testCreateFunctionWithHttpUrl() throws Exception {
+        String fnName = TEST_NAME + "-function";
+        String inputTopicName = TEST_NAME + "-input-topic";
+        String outputTopicName = TEST_NAME + "-output-topic";
+        
+        ConsoleOutputCapturer consoleOutputCapturer = new ConsoleOutputCapturer();
+        consoleOutputCapturer.start();
+        
+        final String url = "http://localhost:1234/test";
+        cmd.run(new String[] {
+            "create",
+            "--name", fnName,
+            "--inputs", inputTopicName,
+            "--output", outputTopicName,
+            "--jar", url,
+            "--classNameArgType", byte[].class.getName(),
+            "--tenant", "sample",
+            "--namespace", "ns1",
+            "--className", DummyFunction.class.getName(),
+        });
 
+        CreateFunction creater = cmd.getCreater();
+        
+        consoleOutputCapturer.stop();
+        String output = consoleOutputCapturer.getStderr();
+        
+        assertTrue(output.contains("Failed to download jar"));
+        assertEquals(fnName, creater.getFunctionName());
+        assertEquals(inputTopicName, creater.getInputs());
+        assertEquals(outputTopicName, creater.getOutput());
+    }
+
+    @Test
+    public void testCreateFunctionWithFileUrl() throws Exception {
+        String fnName = TEST_NAME + "-function";
+        String inputTopicName = TEST_NAME + "-input-topic";
+        String outputTopicName = TEST_NAME + "-output-topic";
+        
+        final String url = "file:/usr/temp/myfile.jar";
+        cmd.run(new String[] {
+            "create",
+            "--name", fnName,
+            "--inputs", inputTopicName,
+            "--output", outputTopicName,
+            "--jar", url,
+            "--classNameArgType", byte[].class.getName(),
+            "--classNameResultType", byte[].class.getName(),
+            "--tenant", "sample",
+            "--namespace", "ns1",
+            "--className", DummyFunction.class.getName(),
+        });
+
+        CreateFunction creater = cmd.getCreater();
+        
+        assertEquals(fnName, creater.getFunctionName());
+        assertEquals(inputTopicName, creater.getInputs());
+        assertEquals(outputTopicName, creater.getOutput());
+        verify(functions, times(1)).createFunctionWithUrl(any(FunctionDetails.class), anyString());
+    }
+    
+    @Test
+    public void testCreateSink() throws Exception {
+        String fnName = TEST_NAME + "-function";
+        String inputTopicName = TEST_NAME + "-input-topic";
+        
+        
+        ConsoleOutputCapturer consoleOutputCapturer = new ConsoleOutputCapturer();
+        consoleOutputCapturer.start();
+
+        final String url = "http://localhost:1234/test";
+        cmdSinks.run(new String[] {
+            "create",
+            "--name", fnName,
+            "--inputs", inputTopicName,
+            "--jar", url,
+            "--classNameArgType", byte[].class.getName(),
+            "--tenant", "sample",
+            "--namespace", "ns1",
+            "--className", "DummySink"
+        });
+
+        CreateSink creater = cmdSinks.getCreateSink();
+        
+        consoleOutputCapturer.stop();
+        String output = consoleOutputCapturer.getStderr();
+        
+        assertTrue(output.contains("Failed to download jar"));
+        assertEquals("DummySink", creater.className);
+        assertEquals(url, creater.jarFile);
+    }
+    
+    @Test
+    public void testCreateSource() throws Exception {
+        String fnName = TEST_NAME + "-function";
+        String inputTopicName = TEST_NAME + "-input-topic";
+        
+        ConsoleOutputCapturer consoleOutputCapturer = new ConsoleOutputCapturer();
+        consoleOutputCapturer.start();
+
+        final String url = "http://localhost:1234/test";
+        cmdSources.run(new String[] {
+            "create",
+            "--name", fnName,
+            "--jar", url,
+            "--classNameArgType", byte[].class.getName(),
+            "--tenant", "sample",
+            "--namespace", "ns1",
+            "--className", "DummySink"
+        });
+
+        CreateSource creater = cmdSources.getCreateSource();
+        
+        consoleOutputCapturer.stop();
+        String output = consoleOutputCapturer.getStderr();
+        
+        assertTrue(output.contains("Failed to download jar"));
+        assertEquals("DummySink", creater.className);
+        assertEquals(url, creater.jarFile);
+    }
+    
     @Test
     public void testCreateFunctionWithTopicPatterns() throws Exception {
         String fnName = TEST_NAME + "-function";
@@ -505,7 +635,7 @@ public class CmdFunctionsTest {
 
             consoleOutputCapturer.stop();
             String output = consoleOutputCapturer.getStderr();
-            assertEquals(output.replace("\n", ""), errMessageCheck);
+            assertTrue(output.replace("\n", "").contains(errMessageCheck));
         }
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -221,7 +221,7 @@ public class CmdFunctions extends CmdBase {
         @Parameter(names = "--jar", description = "Path to the jar file for the function (if the function is written in Java). It also supports url-path (http/https/file) from which worker can download the package.", listConverter = StringConverter.class)
         protected String jarFile;
         
-        @Parameter(names = "--classNameArgType", description = "Function impl class's argument class-name if jar path is url.")
+        @Parameter(names = "--classNameArgType", description = "Function impl class's argument class-name if jar path is file-url.")
         protected String classNameArgType;
         @Parameter(names = "--classNameResultType", description = "Function impl class's result/return class-name if jar path is url.")
         protected String classNameResultType;

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
@@ -185,7 +185,7 @@ public class CmdSinks extends CmdBase {
         @Parameter(names = "--jar", description = "Path to the jar file for the sink. It also supports url-path (http/https/file) from which worker can download the package.", listConverter = StringConverter.class)
         protected String jarFile;
         
-        @Parameter(names = "--classNameArgType", description = "Sink impl class's argument type if jar-file path is url")
+        @Parameter(names = "--classNameArgType", description = "Sink impl class's argument type if jar-file path is file-url")
         protected String classNameArgType;
 
         @Parameter(names = "--sinkConfigFile", description = "The path to a YAML config file specifying the "

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
@@ -175,7 +175,7 @@ public class CmdSources extends CmdBase {
         protected Integer parallelism;
         @Parameter(names = "--jar", description = "Path to the jar file for the Source. It also supports url-path (http/https/file) from which worker can download the package.", listConverter = StringConverter.class)
         protected String jarFile;
-        @Parameter(names = "--classNameArgType", description = "Source impl class's argument type if jar-file path is url")
+        @Parameter(names = "--classNameArgType", description = "Source impl class's argument type if jar-file path is file-url")
         protected String classNameArgType;
 
         @Parameter(names = "--sourceConfigFile", description = "The path to a YAML config file specifying the "

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfig.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfig.java
@@ -102,4 +102,7 @@ public class FunctionConfig {
     private String jar;
     @isFileExists
     private String py;
+    private String classNameArgType;
+    private String classNameResultType;
+
 }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfig.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfig.java
@@ -102,7 +102,4 @@ public class FunctionConfig {
     private String jar;
     @isFileExists
     private String py;
-    private String classNameArgType;
-    private String classNameResultType;
-
 }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfig.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfig.java
@@ -63,5 +63,4 @@ public class SinkConfig {
     private Resources resources;
     @isFileExists
     private String jar;
-    protected String classNameArgType;
 }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfig.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfig.java
@@ -25,14 +25,12 @@ import lombok.Setter;
 import lombok.ToString;
 import org.apache.pulsar.functions.utils.validation.ConfigValidationAnnotations.NotNull;
 import org.apache.pulsar.functions.utils.validation.ConfigValidationAnnotations.isFileExists;
-import org.apache.pulsar.functions.utils.validation.ConfigValidationAnnotations.isImplementationOfClass;
 import org.apache.pulsar.functions.utils.validation.ConfigValidationAnnotations.isMapEntryCustom;
 import org.apache.pulsar.functions.utils.validation.ConfigValidationAnnotations.isPositiveNumber;
 import org.apache.pulsar.functions.utils.validation.ConfigValidationAnnotations.isValidResources;
 import org.apache.pulsar.functions.utils.validation.ConfigValidationAnnotations.isValidSinkConfig;
 import org.apache.pulsar.functions.utils.validation.ConfigValidationAnnotations.isValidTopicName;
 import org.apache.pulsar.functions.utils.validation.ValidatorImpls;
-import org.apache.pulsar.io.core.Sink;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -51,7 +49,6 @@ public class SinkConfig {
     @NotNull
     private String name;
     @NotNull
-    @isImplementationOfClass(implementsClass = Sink.class)
     private String className;
     @isMapEntryCustom(keyValidatorClasses = { ValidatorImpls.TopicNameValidator.class },
             valueValidatorClasses = { ValidatorImpls.SerdeValidator.class })
@@ -66,4 +63,5 @@ public class SinkConfig {
     private Resources resources;
     @isFileExists
     private String jar;
+    protected String classNameArgType;
 }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfig.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfig.java
@@ -64,5 +64,4 @@ public class SourceConfig {
     private Resources resources;
     @isFileExists
     private String jar;
-    private String classNameArgType;
 }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfig.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfig.java
@@ -50,7 +50,6 @@ public class SourceConfig {
     @NotNull
     private String name;
     @NotNull
-    @isImplementationOfClass(implementsClass = Source.class)
     private String className;
     @NotNull
     @isValidTopicName
@@ -65,4 +64,5 @@ public class SourceConfig {
     private Resources resources;
     @isFileExists
     private String jar;
+    private String classNameArgType;
 }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Utils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Utils.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.functions.utils;
 
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
@@ -51,6 +53,9 @@ import net.jodah.typetools.TypeResolver;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class Utils {
 
+    public static String HTTP = "http";
+    public static String FILE = "file";
+    
     public static final long getSequenceId(MessageId messageId) {
         MessageIdImpl msgId = (MessageIdImpl) ((messageId instanceof TopicMessageIdImpl)
                 ? ((TopicMessageIdImpl) messageId).getInnerMessageId()
@@ -206,5 +211,10 @@ public class Utils {
 
     public static boolean fileExists(String file) {
         return new File(file).exists();
+    }
+    
+    public static boolean isFunctionPackageUrlSupported(String functionPkgUrl) {
+        return isNotBlank(functionPkgUrl)
+                && (functionPkgUrl.startsWith(Utils.HTTP) || functionPkgUrl.startsWith(Utils.FILE));
     }
 }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/Utils.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/Utils.java
@@ -50,13 +50,11 @@ import org.apache.pulsar.functions.worker.dlog.DLInputStream;
 import org.apache.pulsar.functions.worker.dlog.DLOutputStream;
 import org.apache.zookeeper.KeeperException.Code;
 import org.apache.pulsar.functions.proto.Function;
+import static org.apache.pulsar.functions.utils.Utils.FILE;
 
 @Slf4j
 public final class Utils {
 
-    public static String HTTP = "http";
-    public static String FILE = "file";
-    
     private Utils(){}
 
     public static Object getObject(byte[] byteArr) throws IOException, ClassNotFoundException {
@@ -243,8 +241,4 @@ public final class Utils {
         return String.format("%s/%s/%s:%d", tenant, namespace, functionName, instanceId);
     }
     
-    public static boolean isFunctionPackageUrlSupported(String functionPkgUrl) {
-        return isNotBlank(functionPkgUrl)
-                && (functionPkgUrl.startsWith(Utils.HTTP) || functionPkgUrl.startsWith(Utils.FILE));
-    }
 }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
@@ -22,14 +22,16 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.gson.Gson;
 
+
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -48,6 +50,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.StreamingOutput;
 import lombok.extern.slf4j.Slf4j;
+import net.jodah.typetools.TypeResolver;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -63,6 +66,9 @@ import org.apache.pulsar.functions.proto.Function.FunctionMetaData;
 import org.apache.pulsar.functions.proto.Function.PackageLocationMetaData;
 import org.apache.pulsar.functions.proto.InstanceCommunication;
 import org.apache.pulsar.functions.proto.InstanceCommunication.FunctionStatus;
+import static org.apache.pulsar.functions.utils.Reflections.createInstance;
+import org.apache.pulsar.functions.utils.functioncache.FunctionClassLoaders;
+import static org.apache.pulsar.functions.utils.functioncache.FunctionClassLoaders.create;
 import org.apache.pulsar.functions.worker.FunctionMetaDataManager;
 import org.apache.pulsar.functions.worker.FunctionRuntimeManager;
 import org.apache.pulsar.functions.worker.MembershipManager;
@@ -72,6 +78,8 @@ import static org.apache.pulsar.functions.utils.Utils.FILE;
 import static org.apache.pulsar.functions.utils.Utils.isFunctionPackageUrlSupported;
 import org.apache.pulsar.functions.worker.WorkerService;
 import org.apache.pulsar.functions.worker.request.RequestResult;
+import org.apache.pulsar.io.core.Sink;
+import org.apache.pulsar.io.core.Source;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 
@@ -124,8 +132,8 @@ public class FunctionsImpl {
         // validate parameters
         try {
             if(isPkgUrlProvided) {
-                functionDetails = validateUpdateRequestParams(tenant, namespace, functionName,
-                        functionPkgUrl, functionDetailsJson);
+                functionDetails = validateUpdateRequestParamsWithPkgUrl(tenant, namespace, functionName, functionPkgUrl,
+                        functionDetailsJson);
             }else {
                 functionDetails = validateUpdateRequestParams(tenant, namespace, functionName,
                         uploadedInputStream, fileDetail, functionDetailsJson);
@@ -712,14 +720,17 @@ public class FunctionsImpl {
         }
     }
 
-    private FunctionDetails validateUpdateRequestParams(String tenant, String namespace, String functionName,
+    private FunctionDetails validateUpdateRequestParamsWithPkgUrl(String tenant, String namespace, String functionName,
             String functionPkgUrl, String functionDetailsJson)
             throws IllegalArgumentException, IOException, URISyntaxException {
         if (!isFunctionPackageUrlSupported(functionPkgUrl)) {
             throw new IllegalArgumentException("Function Package url is not valid. supported url (http/https/file)");
         }
         Utils.validateFileUrl(functionPkgUrl, workerServiceSupplier.get().getWorkerConfig().getDownloadDirectory());
-        return validateUpdateRequestParams(tenant, namespace, functionName, functionDetailsJson);
+        File jarWithFileUrl = functionPkgUrl.startsWith(FILE) ? (new File((new URL(functionPkgUrl)).toURI())) : null;
+        FunctionDetails functionDetails = validateUpdateRequestParams(tenant, namespace, functionName,
+                functionDetailsJson, jarWithFileUrl);
+        return functionDetails;
     }
 
     private FunctionDetails validateUpdateRequestParams(String tenant,
@@ -731,13 +742,14 @@ public class FunctionsImpl {
         if (uploadedInputStream == null || fileDetail == null) {
             throw new IllegalArgumentException("Function Package is not provided");
         }
-        return validateUpdateRequestParams(tenant, namespace, functionName, functionDetailsJson);
+        return validateUpdateRequestParams(tenant, namespace, functionName, functionDetailsJson, null);
     }
     
     private FunctionDetails validateUpdateRequestParams(String tenant,
                                              String namespace,
                                              String functionName,
-                                             String functionDetailsJson) throws IllegalArgumentException {
+                                             String functionDetailsJson,
+                                             File jarWithFileUrl) throws IllegalArgumentException {
         if (tenant == null) {
             throw new IllegalArgumentException("Tenant is not provided");
         }
@@ -754,6 +766,7 @@ public class FunctionsImpl {
         try {
             FunctionDetails.Builder functionDetailsBuilder = FunctionDetails.newBuilder();
             org.apache.pulsar.functions.utils.Utils.mergeJson(functionDetailsJson, functionDetailsBuilder);
+            validateFunctionClassTypes(jarWithFileUrl, functionDetailsBuilder);
             FunctionDetails functionDetails = functionDetailsBuilder.build();
 
             List<String> missingFields = new LinkedList<>();
@@ -790,6 +803,85 @@ public class FunctionsImpl {
         } catch (Exception ex) {
             throw new IllegalArgumentException("Invalid FunctionDetails");
         }
+    }
+
+    private void validateFunctionClassTypes(File jarFile, FunctionDetails.Builder functionDetailsBuilder)
+            throws MalformedURLException {
+
+        // validate only if jar-file is provided
+        if(jarFile == null) {
+            return;
+        }
+        
+        if (StringUtils.isBlank(functionDetailsBuilder.getClassName())) {
+            throw new IllegalArgumentException("function class-name can't be empty");
+        }
+
+        URL[] urls = new URL[1];
+        urls[0] = jarFile.toURI().toURL();
+        URLClassLoader classLoader = create(urls, FunctionClassLoaders.class.getClassLoader());
+
+        // validate function class-type
+        Object functionObject = createInstance(functionDetailsBuilder.getClassName(), classLoader);
+        if (!(functionObject instanceof org.apache.pulsar.functions.api.Function) && !(functionObject instanceof java.util.function.Function)) {
+            throw new RuntimeException("User class must either be Function or java.util.Function");
+        }
+
+        if (functionDetailsBuilder.hasSource() && functionDetailsBuilder.getSource() != null
+                && StringUtils.isNotBlank(functionDetailsBuilder.getSource().getClassName())) {
+            try {
+                String sourceClassName = functionDetailsBuilder.getSource().getClassName();
+                String argClassName = getTypeArg(sourceClassName, Source.class, classLoader).getName();
+                functionDetailsBuilder.setSource(functionDetailsBuilder.getSourceBuilder()
+                        .setTypeClassName(argClassName));
+                
+                // if sink-class not present then set same arg as source
+                if (!functionDetailsBuilder.hasSink()
+                        || StringUtils.isBlank(functionDetailsBuilder.getSink().getClassName())) {
+                    functionDetailsBuilder
+                            .setSink(functionDetailsBuilder.getSinkBuilder().setTypeClassName(argClassName));
+                }
+                
+            } catch (IllegalArgumentException ie) {
+                throw ie;
+            } catch (Exception e) {
+                log.error("Failed to validate source class", e);
+                throw new IllegalArgumentException("Failed to validate source class-name", e);
+            }
+        }
+
+        if (functionDetailsBuilder.hasSink() && functionDetailsBuilder.getSink() != null
+                && StringUtils.isNotBlank(functionDetailsBuilder.getSink().getClassName())) {
+            try {
+                String sinkClassName = functionDetailsBuilder.getSink().getClassName();
+                String argClassName = getTypeArg(sinkClassName, Sink.class, classLoader).getName();
+                functionDetailsBuilder.setSink(functionDetailsBuilder.getSinkBuilder()
+                        .setTypeClassName(argClassName));
+                
+                // if source-class not present then set same arg as sink
+                if (!functionDetailsBuilder.hasSource()
+                        || StringUtils.isBlank(functionDetailsBuilder.getSource().getClassName())) {
+                    functionDetailsBuilder
+                            .setSource(functionDetailsBuilder.getSourceBuilder().setTypeClassName(argClassName));
+                }
+                
+            } catch (IllegalArgumentException ie) {
+                throw ie;
+            } catch (Exception e) {
+                log.error("Failed to validate sink class", e);
+                throw new IllegalArgumentException("Failed to validate sink class-name", e);
+            }
+        }
+    }
+
+    private Class<?> getTypeArg(String className, Class<?> funClass, URLClassLoader classLoader)
+            throws ClassNotFoundException {
+        Class<?> loadedClass = classLoader.loadClass(className);
+        if (!funClass.isAssignableFrom(loadedClass)) {
+            throw new IllegalArgumentException(
+                    String.format("class %s is not type of %s", className, funClass.getName()));
+        }
+        return TypeResolver.resolveRawArgument(funClass, loadedClass);
     }
 
     private void validateTriggerRequestParams(String tenant,

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
@@ -63,11 +63,13 @@ import org.apache.pulsar.functions.proto.Function.FunctionMetaData;
 import org.apache.pulsar.functions.proto.Function.PackageLocationMetaData;
 import org.apache.pulsar.functions.proto.InstanceCommunication;
 import org.apache.pulsar.functions.proto.InstanceCommunication.FunctionStatus;
-import org.apache.pulsar.functions.worker.FunctionActioner;
 import org.apache.pulsar.functions.worker.FunctionMetaDataManager;
 import org.apache.pulsar.functions.worker.FunctionRuntimeManager;
 import org.apache.pulsar.functions.worker.MembershipManager;
 import org.apache.pulsar.functions.worker.Utils;
+import static org.apache.pulsar.functions.utils.Utils.HTTP;
+import static org.apache.pulsar.functions.utils.Utils.FILE;
+import static org.apache.pulsar.functions.utils.Utils.isFunctionPackageUrlSupported;
 import org.apache.pulsar.functions.worker.WorkerService;
 import org.apache.pulsar.functions.worker.request.RequestResult;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
@@ -640,10 +642,10 @@ public class FunctionsImpl {
         return Response.status(Status.OK).entity(new StreamingOutput() {
             @Override
             public void write(final OutputStream output) throws IOException {
-                if (path.startsWith(Utils.HTTP)) {
+                if (path.startsWith(HTTP)) {
                     URL url = new URL(path);
                     IOUtils.copy(url.openStream(), output);
-                } else if (path.startsWith(Utils.FILE)) {
+                } else if (path.startsWith(FILE)) {
                     URL url = new URL(path);
                     File file;
                     try {
@@ -713,7 +715,7 @@ public class FunctionsImpl {
     private FunctionDetails validateUpdateRequestParams(String tenant, String namespace, String functionName,
             String functionPkgUrl, String functionDetailsJson)
             throws IllegalArgumentException, IOException, URISyntaxException {
-        if (!Utils.isFunctionPackageUrlSupported(functionPkgUrl)) {
+        if (!isFunctionPackageUrlSupported(functionPkgUrl)) {
             throw new IllegalArgumentException("Function Package url is not valid. supported url (http/https/file)");
         }
         Utils.validateFileUrl(functionPkgUrl, workerServiceSupplier.get().getWorkerConfig().getDownloadDirectory());

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionActionerTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionActionerTest.java
@@ -38,6 +38,7 @@ import org.apache.pulsar.functions.runtime.Runtime;
 import org.apache.pulsar.functions.runtime.RuntimeFactory;
 import org.apache.pulsar.functions.runtime.ThreadRuntimeFactory;
 import org.testng.annotations.Test;
+import static org.apache.pulsar.functions.utils.Utils.FILE;
 
 /**
  * Unit test of {@link FunctionActioner}.
@@ -113,7 +114,7 @@ public class FunctionActionerTest {
 
         // (1) test with file url. functionActioner should be able to consider file-url and it should be able to call
         // RuntimeSpawner
-        String pkgPathLocation = Utils.FILE + ":/user/my-file.jar";
+        String pkgPathLocation = FILE + ":/user/my-file.jar";
         Function.FunctionMetaData function1 = Function.FunctionMetaData.newBuilder()
                 .setFunctionDetails(Function.FunctionDetails.newBuilder().setTenant("test-tenant")
                         .setNamespace("test-namespace").setName("func-1"))


### PR DESCRIPTION
### Motivation

Pulsar-Function supports package-url from which worker can download and load function package. But right now, cli tool is not having a way to pass url arguments while calling function api.

### Modifications

add cli support for function url.

### Result

User can submit function with url.
