### PR TITLE
Update pulsar cpp client docs

### DIFF
--- a/site/docs/latest/clients/Cpp.md
+++ b/site/docs/latest/clients/Cpp.md
@@ -60,16 +60,28 @@ First, install all of the necessary dependencies:
 
 ```shell
 $ apt-get install cmake libssl-dev libcurl4-openssl-dev liblog4cxx-dev \
-  libprotobuf-dev libboost-all-dev libgtest-dev libjsoncpp-dev
+  libprotobuf-dev libboost-all-dev google-mock libgtest-dev libjsoncpp-dev
 ```
 
 Then compile and install [Google Test](https://github.com/google/googletest):
 
 ```shell
-$ git clone https://github.com/google/googletest.git && cd googletest
+# libgtest-dev version is 1.18.0 or above
+$ cd /usr/src/googletest
 $ sudo cmake .
 $ sudo make
-$ sudo cp *.a /usr/lib
+$ sudo cp ./googlemock/libgmock.a ./googletest/libgtest.a /usr/lib/
+
+# less than 1.18.0
+$ cd /usr/src/gtest
+$ sudo cmake .
+$ sudo make
+$ sudo cp libgtest.a /usr/lib
+
+$ cd /usr/src/gmock
+$ sudo cmake .
+$ sudo make
+$ sudo cp libgmock.a /usr/lib
 ```
 
 Finally, compile the Pulsar client library for C++ inside the Pulsar repo:


### PR DESCRIPTION
### Motivation

`cmake` command failed with below error on ubuntu-16.04.
```
$ cd pulsar-client-cpp
$ cmake .
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
GMOCK_INCLUDE_PATH
   used as include directory in directory /root/incubator-pulsar/pulsar-client-cpp
   used as include directory in directory /root/incubator-pulsar/pulsar-client-cpp
・
・
GMOCK_LIBRARY_PATH
    linked by target "main" in directory /root/incubator-pulsar/pulsar-client-cpp/tests

-- Configuring incomplete, errors occurred!
See also "/root/incubator-pulsar/pulsar-client-cpp/CMakeFiles/CMakeOutput.log".
See also "/root/incubator-pulsar/pulsar-client-cpp/CMakeFiles/CMakeError.log”. 
```

Also, we have to complie codes under `/usr/src/googletest`, not `/usr/src/gmock` and `/usr/src/gtest` on ubuntu-18.04(installed libgtest-dev-1.18.0)
```
$ cd /usr/src/gmock/
$ cmake .
CMake Error at /usr/src/googletest/CMakeLists.txt:13 (add_subdirectory):
  add_subdirectory not given a binary directory but the given source
  directory "/usr/src/gmock" is not a subdirectory of "/usr/src/googletest".
  When specifying an out-of-tree source a binary directory must be explicitly
  specified.


CMake Error at CMakeLists.txt:56 (config_compiler_and_linker):
  Unknown CMake command "config_compiler_and_linker".


-- Configuring incomplete, errors occurred!
See also "/usr/src/gmock/CMakeFiles/CMakeOutput.log".
```