### PR TITLE
Trigger offload when managed ledger reaches a size threshold

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
@@ -55,6 +55,7 @@ public class ManagedLedgerConfig {
     private long retentionSizeInMB = 0;
     private boolean autoSkipNonRecoverableData;
     private long offloadLedgerDeletionLagMs = TimeUnit.HOURS.toMillis(4);
+    private long offloadAutoTriggerSizeThresholdBytes = -1;
 
     private DigestType digestType = DigestType.CRC32C;
     private byte[] password = "".getBytes(Charsets.UTF_8);
@@ -407,6 +408,27 @@ public class ManagedLedgerConfig {
      */
     public long getOffloadLedgerDeletionLagMillis() {
         return offloadLedgerDeletionLagMs;
+    }
+
+    /**
+     * Size, in bytes, at which the managed ledger will start to automatically offload ledgers to longterm storage.
+     * A negative value disables autotriggering.
+     * Offloading will not occur if no offloader has been set {@link #setLedgerOffloader(LedgerOffloader)}.
+     * Automatical offloading occurs when the ledger is rolled, and the ledgers up to that point exceed the threshold.
+     *
+     * @param threshold Threshold in bytes at which offload is automatically triggered
+     */
+    public ManagedLedgerConfig setOffloadAutoTriggerSizeThresholdBytes(long threshold) {
+        this.offloadAutoTriggerSizeThresholdBytes = threshold;
+        return this;
+    }
+
+    /**
+     * Size, in bytes, at which offloading will automatically be triggered for this managed ledger.
+     * @return the trigger threshold, in bytes
+     */
+    public long getOffloadAutoTriggerSizeThresholdBytes() {
+        return this.offloadAutoTriggerSizeThresholdBytes;
     }
 
     /**

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerException.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerException.java
@@ -127,6 +127,12 @@ public class ManagedLedgerException extends Exception {
         }
     }
 
+    public static class OffloadInProgressException extends ManagedLedgerException {
+        public OffloadInProgressException(String msg) {
+            super(msg);
+        }
+    }
+
     @Override
     public synchronized Throwable fillInStackTrace() {
         // Disable stack traces to be filled in

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
@@ -676,6 +676,195 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         Assert.assertEquals(offloader.offloadedLedgers(), ImmutableSet.of(firstLedgerId, thirdLedgerId));
     }
 
+    private static byte[] buildEntry(int size, String pattern) {
+        byte[] entry = new byte[size];
+        byte[] patternBytes = pattern.getBytes();
+
+        for (int i = 0; i < entry.length; i++) {
+            entry[i] = patternBytes[i % patternBytes.length];
+        }
+        return entry;
+    }
+
+    @Test
+    public void testAutoTriggerOffload() throws Exception {
+        MockLedgerOffloader offloader = new MockLedgerOffloader();
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setMaxEntriesPerLedger(10);
+        config.setOffloadAutoTriggerSizeThresholdBytes(100);
+        config.setRetentionTime(10, TimeUnit.MINUTES);
+        config.setLedgerOffloader(offloader);
+
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl)factory.open("my_test_ledger", config);
+
+        // Ledger will roll twice, offload will run on first ledger after second closed
+        for (int i = 0; i < 25; i++) {
+            ledger.addEntry(buildEntry(10, "entry-" + i));
+        }
+
+        Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 3);
+
+        // offload should eventually be triggered
+        assertEventuallyTrue(() -> offloader.offloadedLedgers().size() == 1);
+        Assert.assertEquals(offloader.offloadedLedgers(),
+                            ImmutableSet.of(ledger.getLedgersInfoAsList().get(0).getLedgerId()));
+    }
+
+    @Test
+    public void manualTriggerWhileAutoInProgress() throws Exception {
+        CompletableFuture<Void> slowOffload = new CompletableFuture<>();
+        CountDownLatch offloadRunning = new CountDownLatch(1);
+        MockLedgerOffloader offloader = new MockLedgerOffloader() {
+                @Override
+                public CompletableFuture<Void> offload(ReadHandle ledger,
+                                                       UUID uuid,
+                                                       Map<String, String> extraMetadata) {
+                    offloadRunning.countDown();
+                    return slowOffload.thenCompose((res) -> super.offload(ledger, uuid, extraMetadata));
+                }
+            };
+
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setMaxEntriesPerLedger(10);
+        config.setOffloadAutoTriggerSizeThresholdBytes(100);
+        config.setRetentionTime(10, TimeUnit.MINUTES);
+        config.setLedgerOffloader(offloader);
+
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl)factory.open("my_test_ledger", config);
+
+        // Ledger will roll twice, offload will run on first ledger after second closed
+        for (int i = 0; i < 25; i++) {
+            ledger.addEntry(buildEntry(10, "entry-" + i));
+        }
+        offloadRunning.await();
+
+        for (int i = 0; i < 20; i++) {
+            ledger.addEntry(buildEntry(10, "entry-" + i));
+        }
+        Position p = ledger.addEntry(buildEntry(10, "last-entry"));
+
+        try {
+            ledger.offloadPrefix(p);
+            Assert.fail("Shouldn't have succeeded");
+        } catch (ManagedLedgerException.OffloadInProgressException e) {
+            // expected
+        }
+
+        slowOffload.complete(null);
+
+        // eventually all over threshold will be offloaded
+        assertEventuallyTrue(() -> offloader.offloadedLedgers().size() == 3);
+        Assert.assertEquals(offloader.offloadedLedgers(),
+                            ImmutableSet.of(ledger.getLedgersInfoAsList().get(0).getLedgerId(),
+                                            ledger.getLedgersInfoAsList().get(1).getLedgerId(),
+                                            ledger.getLedgersInfoAsList().get(2).getLedgerId()));
+
+        // then a manual offload can run and offload the one ledger under the threshold
+        ledger.offloadPrefix(p);
+
+        Assert.assertEquals(offloader.offloadedLedgers().size(), 4);
+        Assert.assertEquals(offloader.offloadedLedgers(),
+                            ImmutableSet.of(ledger.getLedgersInfoAsList().get(0).getLedgerId(),
+                                            ledger.getLedgersInfoAsList().get(1).getLedgerId(),
+                                            ledger.getLedgersInfoAsList().get(2).getLedgerId(),
+                                            ledger.getLedgersInfoAsList().get(3).getLedgerId()));
+    }
+
+    @Test
+    public void autoTriggerWhileManualInProgress() throws Exception {
+        CompletableFuture<Void> slowOffload = new CompletableFuture<>();
+        CountDownLatch offloadRunning = new CountDownLatch(1);
+        MockLedgerOffloader offloader = new MockLedgerOffloader() {
+                @Override
+                public CompletableFuture<Void> offload(ReadHandle ledger,
+                                                       UUID uuid,
+                                                       Map<String, String> extraMetadata) {
+                    offloadRunning.countDown();
+                    return slowOffload.thenCompose((res) -> super.offload(ledger, uuid, extraMetadata));
+                }
+            };
+
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setMaxEntriesPerLedger(10);
+        config.setOffloadAutoTriggerSizeThresholdBytes(100);
+        config.setRetentionTime(10, TimeUnit.MINUTES);
+        config.setLedgerOffloader(offloader);
+
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl)factory.open("my_test_ledger", config);
+
+        // Ledger rolls once, threshold not hit so auto shouldn't run
+        for (int i = 0; i < 14; i++) {
+            ledger.addEntry(buildEntry(10, "entry-" + i));
+        }
+        Position p = ledger.addEntry(buildEntry(10, "trigger-entry"));
+
+        OffloadCallbackPromise cbPromise = new OffloadCallbackPromise();
+        ledger.asyncOffloadPrefix(p, cbPromise, null);
+        offloadRunning.await();
+
+        // add enough entries to roll the ledger a couple of times and trigger some offloads
+        for (int i = 0; i < 20; i++) {
+            ledger.addEntry(buildEntry(10, "entry-" + i));
+        }
+
+        // allow the manual offload to complete
+        slowOffload.complete(null);
+
+        Assert.assertEquals(cbPromise.join(),
+                            PositionImpl.get(ledger.getLedgersInfoAsList().get(1).getLedgerId(), 0));
+
+        // auto trigger should eventually offload everything else over threshold
+        assertEventuallyTrue(() -> offloader.offloadedLedgers().size() == 2);
+        Assert.assertEquals(offloader.offloadedLedgers(),
+                            ImmutableSet.of(ledger.getLedgersInfoAsList().get(0).getLedgerId(),
+                                            ledger.getLedgersInfoAsList().get(1).getLedgerId()));
+    }
+
+    @Test
+    public void multipleAutoTriggers() throws Exception {
+        CompletableFuture<Void> slowOffload = new CompletableFuture<>();
+        CountDownLatch offloadRunning = new CountDownLatch(1);
+        MockLedgerOffloader offloader = new MockLedgerOffloader() {
+                @Override
+                public CompletableFuture<Void> offload(ReadHandle ledger,
+                                                       UUID uuid,
+                                                       Map<String, String> extraMetadata) {
+                    offloadRunning.countDown();
+                    return slowOffload.thenCompose((res) -> super.offload(ledger, uuid, extraMetadata));
+                }
+            };
+
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setMaxEntriesPerLedger(10);
+        config.setOffloadAutoTriggerSizeThresholdBytes(100);
+        config.setRetentionTime(10, TimeUnit.MINUTES);
+        config.setLedgerOffloader(offloader);
+
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl)factory.open("my_test_ledger", config);
+
+        // Ledger will roll twice, offload will run on first ledger after second closed
+        for (int i = 0; i < 25; i++) {
+            ledger.addEntry(buildEntry(10, "entry-" + i));
+        }
+        offloadRunning.await();
+
+        // trigger a bunch more rolls. Eventually there will be 5 ledgers.
+        // first 3 should be offloaded, 4th is 100bytes, 5th is 0 bytes.
+        // 4th and 5th sum to 100 bytes so they're just at edge of threshold
+        for (int i = 0; i < 20; i++) {
+            ledger.addEntry(buildEntry(10, "entry-" + i));
+        }
+
+        // allow the first offload to continue
+        slowOffload.complete(null);
+
+        assertEventuallyTrue(() -> offloader.offloadedLedgers().size() == 3);
+        Assert.assertEquals(offloader.offloadedLedgers(),
+                            ImmutableSet.of(ledger.getLedgersInfoAsList().get(0).getLedgerId(),
+                                            ledger.getLedgersInfoAsList().get(1).getLedgerId(),
+                                            ledger.getLedgersInfoAsList().get(2).getLedgerId()));
+    }
+
     static void assertEventuallyTrue(BooleanSupplier predicate) throws Exception {
         // wait up to 3 seconds
         for (int i = 0; i < 30 && !predicate.getAsBoolean(); i++) {


### PR DESCRIPTION
When a managed ledger reaches a certain size, start offloading ledgers
in the background.

Master Issue: #1511
