### PR TITLE
Allow ML offload immediately after ledger closed

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerConfig.java
@@ -412,7 +412,7 @@ public class ManagedLedgerConfig {
 
     /**
      * Size, in bytes, at which the managed ledger will start to automatically offload ledgers to longterm storage.
-     * A negative value disables autotriggering.
+     * A negative value disables autotriggering. A threshold of 0 offloads data as soon as possible.
      * Offloading will not occur if no offloader has been set {@link #setLedgerOffloader(LedgerOffloader)}.
      * Automatical offloading occurs when the ledger is rolled, and the ledgers up to that point exceed the threshold.
      *

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1582,7 +1582,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     }
 
     private void maybeOffloadInBackground(CompletableFuture<PositionImpl> promise) {
-        if (config.getOffloadAutoTriggerSizeThresholdBytes() > 0) {
+        if (config.getOffloadAutoTriggerSizeThresholdBytes() >= 0) {
             executor.executeOrdered(name, safeRun(() -> maybeOffload(promise)));
         }
     }


### PR DESCRIPTION
The documentation said that only negative values disabled. If a user
wants data to be offloaded as soon as possible, the obvious thing is
to set the threshold to 0. Previously this disabled as the check
was > 0, rather than >=.

This patch changes the ML implementation to accept 0 as a threshold
and adds a test to ensure if specified, the ledgers are offloaded as
soon as possible.

Master Issue: #1511
