### PR TITLE
Capture zookeeper journal when integration tests end

### DIFF
--- a/tests/integration-tests-topologies/src/main/resources/cube-definitions/single-cluster-2-bookie-1-broker-unstarted-with-s3.yaml
+++ b/tests/integration-tests-topologies/src/main/resources/cube-definitions/single-cluster-2-bookie-1-broker-unstarted-with-s3.yaml
@@ -35,6 +35,8 @@ zookeeper*:
   beforeStop:
     - customBeforeStopAction:
         strategy: org.apache.pulsar.tests.PulsarLogsToTargetDirStopAction
+    - customBeforeStopAction:
+        strategy: org.apache.pulsar.tests.ZKJournalToTargetDirStopAction
   networkMode: pulsarnet*
 
 configuration-store*:
@@ -51,6 +53,8 @@ configuration-store*:
   beforeStop:
     - customBeforeStopAction:
         strategy: org.apache.pulsar.tests.PulsarLogsToTargetDirStopAction
+    - customBeforeStopAction:
+        strategy: org.apache.pulsar.tests.ZKJournalToTargetDirStopAction
   networkMode: pulsarnet*
 
 init*:

--- a/tests/integration-tests-topologies/src/main/resources/cube-definitions/single-cluster-3-bookie-2-broker-unstarted.yaml
+++ b/tests/integration-tests-topologies/src/main/resources/cube-definitions/single-cluster-3-bookie-2-broker-unstarted.yaml
@@ -35,6 +35,8 @@ zookeeper*:
   beforeStop:
     - customBeforeStopAction:
         strategy: org.apache.pulsar.tests.PulsarLogsToTargetDirStopAction
+    - customBeforeStopAction:
+        strategy: org.apache.pulsar.tests.ZKJournalToTargetDirStopAction
   networkMode: pulsarnet*
 
 configuration-store*:
@@ -51,6 +53,8 @@ configuration-store*:
   beforeStop:
     - customBeforeStopAction:
         strategy: org.apache.pulsar.tests.PulsarLogsToTargetDirStopAction
+    - customBeforeStopAction:
+        strategy: org.apache.pulsar.tests.ZKJournalToTargetDirStopAction
   networkMode: pulsarnet*
 
 init*:

--- a/tests/integration-tests-topologies/src/main/resources/cube-definitions/single-cluster-3-bookie-2-broker.yaml
+++ b/tests/integration-tests-topologies/src/main/resources/cube-definitions/single-cluster-3-bookie-2-broker.yaml
@@ -35,6 +35,8 @@ zookeeper*:
   beforeStop:
     - customBeforeStopAction:
         strategy: org.apache.pulsar.tests.PulsarLogsToTargetDirStopAction
+    - customBeforeStopAction:
+        strategy: org.apache.pulsar.tests.ZKJournalToTargetDirStopAction
   networkMode: pulsarnet*
 
 configuration-store*:
@@ -51,6 +53,8 @@ configuration-store*:
   beforeStop:
     - customBeforeStopAction:
         strategy: org.apache.pulsar.tests.PulsarLogsToTargetDirStopAction
+    - customBeforeStopAction:
+        strategy: org.apache.pulsar.tests.ZKJournalToTargetDirStopAction
   networkMode: pulsarnet*
 
 init*:

--- a/tests/integration-tests-utils/src/main/java/org/apache/pulsar/tests/ZKJournalToTargetDirStopAction.java
+++ b/tests/integration-tests-utils/src/main/java/org/apache/pulsar/tests/ZKJournalToTargetDirStopAction.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests;
+
+import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
+import org.arquillian.cube.impl.model.CubeId;
+import org.arquillian.cube.spi.beforeStop.BeforeStopAction;
+
+public class ZKJournalToTargetDirStopAction implements BeforeStopAction {
+    private DockerClientExecutor dockerClientExecutor;
+    private CubeId containerID;
+
+    public void setDockerClientExecutor(DockerClientExecutor executor) {
+        this.dockerClientExecutor = executor;
+    }
+
+    public void setContainerID(CubeId containerID) {
+        this.containerID = containerID;
+    }
+
+    @Override
+    public void doBeforeStop() {
+        DockerUtils.dumpContainerDirToTargetCompressed(dockerClientExecutor.getDockerClient(),
+                                                       containerID.getId(), "/pulsar/data/zookeeper");
+    }
+}


### PR DESCRIPTION
Some issues with integration are hard to debug from the logs
alone. For example, #1916 looks like bookies are registering with
zookeeper, but the broker never sees them. It's hard to narrow the
issue to the client or the server.

This patch adds a stop action for arquillian, which pulls the
zookeeper data directory at the end of the run, so we can at least
verify the state of the cluster from the zookeeper point of view.
