### PR TITLE
Add documentation and flexible aws-credential plugin to support aws-role

### DIFF
--- a/pulsar-io/kinesis/pom.xml
+++ b/pulsar-io/kinesis/pom.xml
@@ -108,6 +108,12 @@
                   <include>com.fasterxml.jackson*:*</include>
                 </includes>
               </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>com.google.protobuf</pattern>
+                  <shadedPattern>org.apache.pulsar.replicator.com.google.protobuf</shadedPattern>
+                </relocation>
+              </relocations>
             </configuration>
           </execution>
         </executions>

--- a/pulsar-io/kinesis/pom.xml
+++ b/pulsar-io/kinesis/pom.xml
@@ -47,13 +47,16 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <version>${jackson.version}</version>
+    </dependency>
+    
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
     </dependency>
 
     <!-- kinesis dependencies -->
@@ -105,16 +108,6 @@
                   <include>com.fasterxml.jackson*:*</include>
                 </includes>
               </artifactSet>
-              <relocations>
-                <relocation>
-                  <pattern>com.google.protobuf</pattern>
-                  <shadedPattern>org.apache.pulsar.replicator.com.google.protobuf</shadedPattern>
-                </relocation>
-                <relocation>
-                  <pattern>com.amazonaws</pattern>
-                  <shadedPattern>org.apache.pulsar.com.amazonaws</shadedPattern>
-                </relocation>
-              </relocations>
             </configuration>
           </execution>
         </executions>

--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/AwsCredentialProviderPlugin.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/AwsCredentialProviderPlugin.java
@@ -19,42 +19,32 @@
 
 package org.apache.pulsar.io.kinesis;
 
+import java.io.Closeable;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.BasicSessionCredentials;
+
 /**
  * Kinesis source/sink calls credential-provider while refreshing aws accessKey and secreKey. So, implementation
  * AwsCredentialProviderPlugin needs to makes sure to return non-expired keys when it requires.
  *
  */
-public interface AwsCredentialProviderPlugin {
-    
+public interface AwsCredentialProviderPlugin extends Closeable {
+
     /**
      * accepts aws-account related param and initialize credential provider.
-     *  
+     * 
      * @param param
      */
     void init(String param);
-    
-    /**
-     * Returns the AWS access key ID for this credentials object.
-     * 
-     * @return The AWS access key ID for this credentials object.
-     */
-    String getAWSAccessKeyId();
 
     /**
-     * Returns the AWS secret access key for this credentials object.
+     * Returned {@link AWSCredentialsProvider} can give {@link AWSCredentials} in case credential belongs to IAM user or
+     * it can return {@link BasicSessionCredentials} if user wants to generate temporary credential for a given IAM
+     * role.
      * 
-     * @return The AWS secret access key for this credentials object.
+     * @return
      */
-    String getAWSSecretKey();
-    
-    /**
-     * Forces this credentials provider to refresh its credentials. For many
-     * implementations of credentials provider, this method may simply be a
-     * no-op, such as any credentials provider implementation that vends
-     * static/non-changing credentials. For other implementations that vend
-     * different credentials through out their lifetime, this method should
-     * force the credentials provider to refresh its credentials.
-     */
-    void refresh();
+    AWSCredentialsProvider getCredentialProvider();
 
 }

--- a/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSinkTest.java
+++ b/pulsar-io/kinesis/src/test/java/org/apache/pulsar/io/kinesis/KinesisSinkTest.java
@@ -1,0 +1,149 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.io.kinesis;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.testng.collections.Maps;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.BasicSessionCredentials;
+import com.google.gson.Gson;
+
+/**
+ * Unit test of {@link KinesisSink}.
+ */
+public class KinesisSinkTest {
+
+    @Test
+    public void testDefaultCredentialProvider() throws Exception {
+        KinesisSink sink = new KinesisSink();
+        Map<String, String> credentialParam = Maps.newHashMap();
+        String awsCredentialPluginParam = new Gson().toJson(credentialParam);
+        try {
+            sink.defaultCredentialProvider(awsCredentialPluginParam);
+            Assert.fail("accessKey and SecretKey validation not applied");
+        } catch (IllegalArgumentException ie) {
+            // Ok..
+        }
+
+        final String accesKey = "ak";
+        final String secretKey = "sk";
+        credentialParam.put(KinesisSink.ACCESS_KEY_NAME, accesKey);
+        credentialParam.put(KinesisSink.SECRET_KEY_NAME, secretKey);
+        awsCredentialPluginParam = new Gson().toJson(credentialParam);
+        AWSCredentialsProvider credentialProvider = sink.defaultCredentialProvider(awsCredentialPluginParam);
+        Assert.assertNotNull(credentialProvider);
+        Assert.assertEquals(credentialProvider.getCredentials().getAWSAccessKeyId(), accesKey);
+        Assert.assertEquals(credentialProvider.getCredentials().getAWSSecretKey(), secretKey);
+
+        sink.close();
+    }
+
+    @Test
+    public void testCredentialProvider() throws Exception {
+        KinesisSink sink = new KinesisSink();
+
+        final String accesKey = "ak";
+        final String secretKey = "sk";
+        Map<String, String> credentialParam = Maps.newHashMap();
+        credentialParam.put(KinesisSink.ACCESS_KEY_NAME, accesKey);
+        credentialParam.put(KinesisSink.SECRET_KEY_NAME, secretKey);
+        String awsCredentialPluginParam = new Gson().toJson(credentialParam);
+        AWSCredentialsProvider credentialProvider = sink.createCredentialProvider(null, awsCredentialPluginParam);
+        Assert.assertEquals(credentialProvider.getCredentials().getAWSAccessKeyId(), accesKey);
+        Assert.assertEquals(credentialProvider.getCredentials().getAWSSecretKey(), secretKey);
+
+        credentialProvider = sink.createCredentialProvider(AwsCredentialProviderPluginImpl.class.getName(), "{}");
+        Assert.assertNotNull(credentialProvider);
+        Assert.assertEquals(credentialProvider.getCredentials().getAWSAccessKeyId(),
+                AwsCredentialProviderPluginImpl.accessKey);
+        Assert.assertEquals(credentialProvider.getCredentials().getAWSSecretKey(),
+                AwsCredentialProviderPluginImpl.secretKey);
+        Assert.assertEquals(((BasicSessionCredentials) credentialProvider.getCredentials()).getSessionToken(),
+                AwsCredentialProviderPluginImpl.sessionToken);
+
+        sink.close();
+    }
+
+    @Test
+    public void testCredentialProviderPlugin() throws Exception {
+        KinesisSink sink = new KinesisSink();
+
+        AWSCredentialsProvider credentialProvider = sink
+                .createCredentialProviderWithPlugin(AwsCredentialProviderPluginImpl.class.getName(), "{}");
+        Assert.assertNotNull(credentialProvider);
+        Assert.assertEquals(credentialProvider.getCredentials().getAWSAccessKeyId(),
+                AwsCredentialProviderPluginImpl.accessKey);
+        Assert.assertEquals(credentialProvider.getCredentials().getAWSSecretKey(),
+                AwsCredentialProviderPluginImpl.secretKey);
+        Assert.assertEquals(((BasicSessionCredentials) credentialProvider.getCredentials()).getSessionToken(),
+                AwsCredentialProviderPluginImpl.sessionToken);
+
+        sink.close();
+    }
+
+    public static class AwsCredentialProviderPluginImpl implements AwsCredentialProviderPlugin {
+
+        public final static String accessKey = "ak";
+        public final static String secretKey = "sk";
+        public final static String sessionToken = "st";
+
+        public void init(String param) {
+            // no-op
+        }
+
+        @Override
+        public AWSCredentialsProvider getCredentialProvider() {
+            return new AWSCredentialsProvider() {
+                @Override
+                public AWSCredentials getCredentials() {
+                    return new BasicSessionCredentials(accessKey, secretKey, sessionToken) {
+
+                        @Override
+                        public String getAWSAccessKeyId() {
+                            return accessKey;
+                        }
+                        @Override
+                        public String getAWSSecretKey() {
+                            return secretKey;
+                        }
+                        @Override
+                        public String getSessionToken() {
+                            return sessionToken;
+                        }
+                    };
+                }
+                @Override
+                public void refresh() {
+                    // TODO Auto-generated method stub
+                }
+            };
+        }
+        @Override
+        public void close() throws IOException {
+            // TODO Auto-generated method stub
+        }
+    }
+
+}


### PR DESCRIPTION
### Motivation

Right now, KinesisSink's credentialProvider-plugin doesn't support session-token which can be used in case user access stream with IAM-role instead IAM-user.

### Modifications

- Made KinesisSink's credentialProvider plugin more generic which can be used by both IAM user and roles.
- Add documentation for KinesisSink usage.
- Add test cases for Kinesis Sink.

### Result

- KinesisSink can be used for IAM roles as well.
