### PR TITLE
Enable listener to receive messages even if receiver queue size is zero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ logs
 /data
 pulsar-broker/tmp.*
 pulsar-broker/src/test/resources/log4j2.yaml
+pulsar-functions/worker/test-tenant/
 *.log
 
 *.versionsBackup

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -679,7 +679,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                 log.debug("[{}][{}] Ignoring message as it was already being acked earlier by same consumer {}/{}",
                         topic, subscription, msgId);
             }
-            if (listener != null && conf.getReceiverQueueSize() == 0) {
+            if (conf.getReceiverQueueSize() == 0) {
                 increaseAvailablePermits(cnx);
             }
             return;


### PR DESCRIPTION
### Motivation

If `receiverQueueSize` is set to 0, consumer using message listener can not receive any messages.
I think there are two causes:

- The consumer does not send flow command when the connection has been opened
- Even if the client receive a message, the message is not added to `incomingMessages` so the listener can not handle it

### Modifications

If the queue size is zero and the message listener is registered,

- the client sends a flow command when the connection has been opened
- the received message is passed directly to the listener without being added to `incomingMessages`

I am not confident about this change, so please review carefully.

### Result

Even if the queue size is zero, the message listener can process the received messages.