### PR TITLE
Issue 1918: Improve message id comparison

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageIdImpl.java
@@ -72,6 +72,8 @@ public class BatchMessageIdImpl extends MessageIdImpl {
             } else {
                 return res;
             }
+        } else if (o instanceof TopicMessageIdImpl) {
+            return compareTo(((TopicMessageIdImpl) o).getInnerMessageId());
         } else {
             throw new IllegalArgumentException(
                     "expected BatchMessageIdImpl object. Got instance of " + o.getClass().getName());

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageIdImpl.java
@@ -73,6 +73,9 @@ public class MessageIdImpl implements MessageId {
         if (obj instanceof MessageIdImpl) {
             MessageIdImpl other = (MessageIdImpl) obj;
             return ledgerId == other.ledgerId && entryId == other.entryId && partitionIndex == other.partitionIndex;
+        } else if (obj instanceof BatchMessageIdImpl){
+            BatchMessageIdImpl other = (BatchMessageIdImpl) obj;
+            return other.equals(this);
         }
         return false;
     }
@@ -148,16 +151,18 @@ public class MessageIdImpl implements MessageId {
 
     @Override
     public int compareTo(MessageId o) {
-        if (!(o instanceof MessageIdImpl)) {
+        if (o instanceof MessageIdImpl) {
+            MessageIdImpl other = (MessageIdImpl) o;
+            return ComparisonChain.start()
+                .compare(this.ledgerId, other.ledgerId)
+                .compare(this.entryId, other.entryId)
+                .compare(this.getPartitionIndex(), other.getPartitionIndex())
+                .result();
+        } else if (o instanceof TopicMessageIdImpl) {
+            return compareTo(((TopicMessageIdImpl) o).getInnerMessageId());
+        } else {
             throw new IllegalArgumentException(
                 "expected MessageIdImpl object. Got instance of " + o.getClass().getName());
         }
-
-        MessageIdImpl other = (MessageIdImpl) o;
-        return ComparisonChain.start()
-            .compare(this.ledgerId, other.ledgerId)
-            .compare(this.entryId, other.entryId)
-            .compare(this.getPartitionIndex(), other.getPartitionIndex())
-            .result();
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageIdImpl.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.impl;
 
+import java.util.Objects;
 import org.apache.pulsar.client.api.MessageId;
 
 public class TopicMessageIdImpl implements MessageId {
@@ -40,6 +41,16 @@ public class TopicMessageIdImpl implements MessageId {
     @Override
     public byte[] toByteArray() {
         return messageId.toByteArray();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof TopicMessageIdImpl)) {
+            return false;
+        }
+        TopicMessageIdImpl other = (TopicMessageIdImpl) obj;
+        return Objects.equals(topicName, other.topicName)
+            && Objects.equals(messageId, other.messageId);
     }
 
     @Override

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageIdCompareToTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageIdCompareToTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.impl;
 
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import org.testng.annotations.Test;
@@ -115,6 +116,47 @@ public class MessageIdCompareToTest  {
         assertTrue(batchMessageId1.compareTo(messageIdImpl) < 0, "Expected to be less than");
         assertTrue(batchMessageId2.compareTo(messageIdImpl) > 0, "Expected to be greater than");
         assertTrue(batchMessageId3.compareTo(messageIdImpl) == 0, "Expected to be equal");
+    }
+
+    @Test
+    public void testMessageIdImplCompareToTopicMessageId() {
+        MessageIdImpl messageIdImpl = new MessageIdImpl(123L, 345L, 567);
+        TopicMessageIdImpl topicMessageId1 = new TopicMessageIdImpl(
+            "test-topic",
+            new BatchMessageIdImpl(123L, 345L, 566, 789));
+        TopicMessageIdImpl topicMessageId2 = new TopicMessageIdImpl(
+            "test-topic",
+            new BatchMessageIdImpl(123L, 345L, 567, 789));
+        TopicMessageIdImpl topicMessageId3 = new TopicMessageIdImpl(
+            "test-topic",
+            new BatchMessageIdImpl(messageIdImpl));
+        assertTrue(messageIdImpl.compareTo(topicMessageId1) > 0, "Expected to be greater than");
+        assertTrue(messageIdImpl.compareTo(topicMessageId2) == 0, "Expected to be equal");
+        assertTrue(messageIdImpl.compareTo(topicMessageId3) == 0, "Expected to be equal");
+        assertTrue(topicMessageId1.compareTo(messageIdImpl) < 0, "Expected to be less than");
+        assertTrue(topicMessageId2.compareTo(messageIdImpl) > 0, "Expected to be greater than");
+        assertTrue(topicMessageId3.compareTo(messageIdImpl) == 0, "Expected to be equal");
+    }
+
+    @Test
+    public void testBatchMessageIdImplCompareToTopicMessageId() {
+        BatchMessageIdImpl messageIdImpl1 = new BatchMessageIdImpl(123L, 345L, 567, 789);
+        BatchMessageIdImpl messageIdImpl2 = new BatchMessageIdImpl(123L, 345L, 567, 0);
+        BatchMessageIdImpl messageIdImpl3 = new BatchMessageIdImpl(123L, 345L, 567, -1);
+        TopicMessageIdImpl topicMessageId1 = new TopicMessageIdImpl(
+            "test-topic",
+            new MessageIdImpl(123L, 345L, 566));
+        TopicMessageIdImpl topicMessageId2 = new TopicMessageIdImpl(
+            "test-topic",
+            new MessageIdImpl(123L, 345L, 567));
+        assertTrue(messageIdImpl1.compareTo(topicMessageId1) > 0, "Expected to be greater than");
+        assertTrue(messageIdImpl1.compareTo(topicMessageId2) > 0, "Expected to be greater than");
+        assertTrue(messageIdImpl2.compareTo(topicMessageId2) > 0, "Expected to be greater than");
+        assertTrue(messageIdImpl3.compareTo(topicMessageId2) == 0, "Expected to be equal");
+        assertTrue(topicMessageId1.compareTo(messageIdImpl1) < 0, "Expected to be less than");
+        assertTrue(topicMessageId2.compareTo(messageIdImpl1) == 0, "Expected to be equal");
+        assertTrue(topicMessageId2.compareTo(messageIdImpl2) == 0, "Expected to be equal");
+        assertTrue(topicMessageId2.compareTo(messageIdImpl2) == 0, "Expected to be equal");
     }
 
 }


### PR DESCRIPTION
*Motivation*

Fixes #1918

*Solution*

Make sure `MessageIdImpl` and `BatchMessageIdImpl` recognize TopicMessageIdImpl
