### PR TITLE
Fixed message popover def

### DIFF
--- a/site/_data/popovers.yaml
+++ b/site/_data/popovers.yaml
@@ -63,7 +63,7 @@ ledger:
   def: An append-only data structure in BookKeeper that is used to persistently store messages in Pulsar topics.
 message:
   q: What is a message in Pulsar?
-  def: Messages are the basic "unit" of Pulsar. They're what producers publish to topics and what consumers then consume from topics.
+  def: Messages are the basic unit of Pulsar. They're what producers publish to topics and what consumers then consume from topics.
 multi-tenancy:
   q: What is multi-tenancy?
   def: The ability to isolate namespaces, specify quotas, and configure authentication and authorization on a per-property basis.


### PR DESCRIPTION
### Motivation
Currently, site can't display message popover correctly.

### Modifications

Remove double quote from message def in popovers.yaml.

### Result

For example, in [pulsar functions overview page](https://pulsar.incubator.apache.org/docs/latest/functions/overview/):
<br/>
**before**
<img src="https://user-images.githubusercontent.com/22829228/41578353-cdc928d4-73cc-11e8-8c07-e284cf4f8be8.png" width=400>

<br/>

**after**
<img src="https://user-images.githubusercontent.com/22829228/41578379-f2cd0be6-73cc-11e8-94b9-102a0d650e02.png" width=400>
