### PR TITLE
Fix: avoid closing RuntimeFactory when any function stops

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceMain.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceMain.java
@@ -155,6 +155,7 @@ public class JavaInstanceMain implements AutoCloseable {
 
     private Server server;
     private RuntimeSpawner runtimeSpawner;
+    private ThreadRuntimeFactory containerFactory;
     private Long lastHealthCheckTs = null;
     private ScheduledExecutorService timer;
 
@@ -222,7 +223,7 @@ public class JavaInstanceMain implements AutoCloseable {
         instanceConfig.setFunctionDetails(functionDetails);
         instanceConfig.setPort(port);
 
-        ThreadRuntimeFactory containerFactory = new ThreadRuntimeFactory("LocalRunnerThreadGroup", pulsarServiceUrl,
+        containerFactory = new ThreadRuntimeFactory("LocalRunnerThreadGroup", pulsarServiceUrl,
                 stateStorageServiceUrl,
                 AuthenticationConfig.builder().clientAuthenticationPlugin(clientAuthenticationPlugin)
                         .clientAuthenticationParameters(clientAuthenticationParameters).useTls(isTrue(useTls))
@@ -301,6 +302,9 @@ public class JavaInstanceMain implements AutoCloseable {
             }
             if (timer != null) {
                 timer.shutdown();
+            }
+            if (containerFactory != null) {
+                containerFactory.close();
             }
         } catch (Exception ex) {
             System.err.println(ex);

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeSpawner.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeSpawner.java
@@ -27,14 +27,12 @@ import java.io.IOException;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.functions.instance.InstanceConfig;
-import org.apache.pulsar.functions.proto.InstanceCommunication;
 import org.apache.pulsar.functions.proto.InstanceCommunication.FunctionStatus;
 import org.apache.pulsar.functions.utils.Utils;
 import static org.apache.pulsar.functions.proto.Function.FunctionDetails.Runtime.PYTHON;
@@ -129,9 +127,6 @@ public class RuntimeSpawner implements AutoCloseable {
         if (null != runtime) {
             runtime.stop();
             runtime = null;
-        }
-        if (runtimeFactory != null) {
-            runtimeFactory.close();
         }
         if (processLivenessCheckTimer != null) {
             processLivenessCheckTimer.cancel();

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
@@ -521,6 +521,9 @@ public class FunctionRuntimeManager implements AutoCloseable{
     public void close() throws Exception {
         this.functionActioner.close();
         this.functionAssignmentTailer.close();
+        if (runtimeFactory != null) {
+            runtimeFactory.close();
+        }
     }
 
     private Map<String, Assignment> diff(Map<String, Assignment> assignmentMap1, Map<String, Assignment> assignmentMap2) {


### PR DESCRIPTION
### Motivation

With #1833 , when any function-stops, worker is closing `RuntimeFactory` along with `RuntimeSpawner` which makes `RuntimeFactory` unusable for any new function.

### Modifications

Close `RuntimeFactory` when FunctionRuntimeManager closes.

### Result

RuntimeFactory will not be closed on any function-stop so, new function loading can happen successfully.
