### PR TITLE
add bk dependency to fun-worker for runtime execution

### DIFF
--- a/pulsar-functions/worker/pom.xml
+++ b/pulsar-functions/worker/pom.xml
@@ -97,7 +97,12 @@
       <groupId>org.apache.distributedlog</groupId>
       <artifactId>distributedlog-core</artifactId>
     </dependency>
-    
+
+    <dependency>
+      <groupId>org.apache.bookkeeper</groupId>
+      <artifactId>bookkeeper-server</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>


### PR DESCRIPTION
### Motivation

function-worker requires on bk-server dependency at runtime which is not part of worker dependencies and if anyone tries to create build using function-worker and try to start `FunctionWorkerStarter.main` then we see below error
```
01:00:13.041 [main] ERROR org.apache.pulsar.functions.worker.Worker - Failed to start worker
java.lang.NoClassDefFoundError: org/apache/bookkeeper/net/DNSToSwitchMapping
    at java.lang.ClassLoader.defineClass1(Native Method) ~[?:1.8.0_92]
    at java.lang.ClassLoader.defineClass(ClassLoader.java:763) ~[?:1.8.0_92]
    at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142) ~[?:1.8.0_92]
    at java.net.URLClassLoader.defineClass(URLClassLoader.java:467) ~[?:1.8.0_92]
    at java.net.URLClassLoader.access$100(URLClassLoader.java:73) ~[?:1.8.0_92]
    at java.net.URLClassLoader$1.run(URLClassLoader.java:368) ~[?:1.8.0_92]
    at java.net.URLClassLoader$1.run(URLClassLoader.java:362) ~[?:1.8.0_92]
    at java.security.AccessController.doPrivileged(Native Method) ~[?:1.8.0_92]
    at java.net.URLClassLoader.findClass(URLClassLoader.java:361) ~[?:1.8.0_92]
    at java.lang.ClassLoader.loadClass(ClassLoader.java:424) ~[?:1.8.0_92]
    at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331) ~[?:1.8.0_92]
    at java.lang.ClassLoader.loadClass(ClassLoader.java:357) ~[?:1.8.0_92]
    at java.lang.ClassLoader.defineClass1(Native Method) ~[?:1.8.0_92]
    at java.lang.ClassLoader.defineClass(ClassLoader.java:763) ~[?:1.8.0_92]
    at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142) ~[?:1.8.0_92]
    at java.net.URLClassLoader.defineClass(URLClassLoader.java:467) ~[?:1.8.0_92]
    at java.net.URLClassLoader.access$100(URLClassLoader.java:73) ~[?:1.8.0_92]
    at java.net.URLClassLoader$1.run(URLClassLoader.java:368) ~[?:1.8.0_92]
    at java.net.URLClassLoader$1.run(URLClassLoader.java:362) ~[?:1.8.0_92]
    at java.security.AccessController.doPrivileged(Native Method) ~[?:1.8.0_92]
    at java.net.URLClassLoader.findClass(URLClassLoader.java:361) ~[?:1.8.0_92]
    at java.lang.ClassLoader.loadClass(ClassLoader.java:424) ~[?:1.8.0_92]
    at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331) ~[?:1.8.0_92]
    at java.lang.ClassLoader.loadClass(ClassLoader.java:357) ~[?:1.8.0_92]
    at org.apache.distributedlog.DistributedLogConfiguration.<clinit>(DistributedLogConfiguration.java:147) ~[distributedlog-core-4.7.0.jar:4.7.0]
    at org.apache.distributedlog.metadata.DLMetadata.create(DLMetadata.java:140) ~[distributedlog-core-4.7.0.jar:4.7.0]
    at org.apache.pulsar.functions.worker.Utils.initializeDlogNamespace(Utils.java:206) ~[classes/:?]
    at org.apache.pulsar.functions.worker.Worker.initialize(Worker.java:141) ~[classes/:?]
    at org.apache.pulsar.functions.worker.Worker.doStartImpl(Worker.java:61) ~[classes/:?]
    at org.apache.pulsar.functions.worker.Worker.doStart(Worker.java:51) [classes/:?]
    at com.google.common.util.concurrent.AbstractService.startAsync(AbstractService.java:211) [guava-21.0.jar:?]
    at org.apache.pulsar.functions.worker.FunctionWorkerStarter.main(FunctionWorkerStarter.java:63) [classes/:?]
Caused by: java.lang.ClassNotFoundException: org.apache.bookkeeper.net.DNSToSwitchMapping
    at java.net.URLClassLoader.findClass(URLClassLoader.java:381) ~[?:1.8.0_92]
    at java.lang.ClassLoader.loadClass(ClassLoader.java:424) ~[?:1.8.0_92]
    at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331) ~[?:1.8.0_92]
    at java.lang.ClassLoader.loadClass(ClassLoader.java:357) ~[?:1.8.0_92]
    ... 32 more

```

### Modifications

add bk-server dependency to function-worker to fix worker-runtime error.

