### PR TITLE
Fixed libgtest path in document

### DIFF
--- a/site/docs/latest/project/CompileCpp.md
+++ b/site/docs/latest/project/CompileCpp.md
@@ -64,7 +64,7 @@ Then compile and install [Google Test](https://github.com/google/googletest):
 $ cd /usr/src/googletest
 $ sudo cmake .
 $ sudo make
-$ sudo cp ./googlemock/libgmock.a ./googletest/libgtest.a /usr/lib/
+$ sudo cp ./googlemock/libgmock.a ./googlemock/gtest/libgtest.a /usr/lib/
 
 # less than 1.18.0
 $ cd /usr/src/gtest


### PR DESCRIPTION
### Motivation
`libgtest.a` path is wrong, so I correct it.