### PR TITLE
Upgrade to RocksDB-5.13.3

### DIFF
--- a/all/src/assemble/LICENSE.bin.txt
+++ b/all/src/assemble/LICENSE.bin.txt
@@ -398,7 +398,7 @@ The Apache Software License, Version 2.0
     - org.eclipse.jetty.websocket-websocket-server-9.3.11.v20160721.jar
     - org.eclipse.jetty.websocket-websocket-servlet-9.3.11.v20160721.jar
  * SnakeYaml -- org.yaml-snakeyaml-1.15.jar
- * RocksDB - org.rocksdb-rocksdbjni-5.13.1.jar
+ * RocksDB - org.rocksdb-rocksdbjni-5.13.3.jar
  * HttpClient
     - org.apache.httpcomponents-httpclient-4.5.5.jar
     - org.apache.httpcomponents-httpcore-4.4.9.jar

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@ flexible messaging model and an intuitive client API.</description>
     <athenz.version>1.7.17</athenz.version>
     <prometheus.version>0.0.23</prometheus.version>
     <aspectj.version>1.9.1</aspectj.version>
-    <rocksdb.version>5.13.1</rocksdb.version>
+    <rocksdb.version>5.13.3</rocksdb.version>
     <slf4j.version>1.7.25</slf4j.version>
     <log4j2.version>2.10.0</log4j2.version>
     <bouncycastle.version>1.55</bouncycastle.version>


### PR DESCRIPTION
### Motivation

Fixes #1049 . The actual fix was included in RocksDB-5.13.3 https://github.com/facebook/rocksdb/issues/2717 and it's now available in Maven central.

The commit that fixed the assertion for empty SSTs was at https://github.com/facebook/rocksdb/commit/8d7396418c11063481ab5b332188509ec0301a7f