### PR TITLE
Enable CRC32-C by default in BK client

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -298,9 +298,9 @@ managedLedgerDefaultWriteQuorum=2
 # Number of guaranteed copies (acks to wait before write is complete)
 managedLedgerDefaultAckQuorum=2
 
-# Default type of checksum to use when writing to BookKeeper. Default is "CRC32"
-# Other possible options are "CRC32C" (which is faster), "MAC" or "DUMMY" (no checksum).
-managedLedgerDigestType=CRC32
+# Default type of checksum to use when writing to BookKeeper. Default is "CRC32C"
+# Other possible options are "CRC32", "MAC" or "DUMMY" (no checksum).
+managedLedgerDigestType=CRC32C
 
 # Amount of memory to use for caching data payload in managed ledger. This memory
 # is allocated from JVM direct memory and it's shared across all the topics

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -304,9 +304,9 @@ public class ServiceConfiguration implements PulsarConfiguration {
     @FieldContext(minValue = 1)
     private int managedLedgerDefaultAckQuorum = 1;
 
-    // Default type of checksum to use when writing to BookKeeper. Default is "CRC32"
-    // Other possible options are "CRC32C" (which is faster), "MAC" or "DUMMY" (no checksum).
-    private DigestType managedLedgerDigestType = DigestType.CRC32;
+    // Default type of checksum to use when writing to BookKeeper. Default is "CRC32C"
+    // Other possible options are "CRC32", "MAC" or "DUMMY" (no checksum).
+    private DigestType managedLedgerDigestType = DigestType.CRC32C;
 
     // Max number of bookies to use when creating a ledger
     @FieldContext(minValue = 1)

--- a/site/release-notes.md
+++ b/site/release-notes.md
@@ -26,6 +26,17 @@ layout: content
 
 ## Apache incubator
 
+<!--
+### 2.1.0-incubating &mdash; XXXX-XX-XX <a id="2.1.0-incubating"></a>
+
+Notes:
+
+ * [#2002](https://github.com/apache/incubator-pulsar/pull/2002) Updated
+  default checksum configured in BookKeeper client to CRC32-C. This will mean
+  that,  while it is possible to downgrade a Pulsar cluster from 2.1 to 2.0,
+  it will not be possible to downgrade from 2.1 to 1.22 release directly.
+-->
+
 ### 2.0.1-incubating &mdash; 2018-06-18 <a id="2.0.1-incubating"></a>
 
 This release fixes issues reported for 2.0.0-rc1-incubating.


### PR DESCRIPTION
### Motivation

In Pulsar 2.0 when we switched to BK 4.7 we had the option to use CRC32-C as checksum for BK. CRC32-C is considerably faster than CRC32 since it uses hardware instructions to compute. We didn't immediately switch the default to crc32-c to allow for release rollback (Pulsar 2.0 -> 1.22).
We can now enable this, since rolling back from 2.1 -> 2.0 will work now.

Fixes #1371 