### PR TITLE
Issue 1943: remove serializable from builders and add loadData to load configuration from a config map

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
@@ -36,6 +36,26 @@ public interface ClientBuilder extends Cloneable {
     PulsarClient build() throws PulsarClientException;
 
     /**
+     * Load the configuration from provided <tt>config</tt> map.
+     *
+     * <p>Example:
+     * <pre>
+     * Map&lt;String, Object&gt; config = new HashMap&lt;&gt;();
+     * config.put("serviceUrl", "pulsar://localhost:5550");
+     * config.put("numIoThreads", 20);
+     *
+     * ClientBuilder builder = ...;
+     * builder = builder.loadConf(config);
+     *
+     * PulsarClient client = builder.build();
+     * </pre>
+     *
+     * @param config configuration to load
+     * @return client builder instance
+     */
+    ClientBuilder loadConf(Map<String, Object> config);
+
+    /**
      * Create a copy of the current client builder.
      * <p>
      * Cloning the builder can be used to share an incomplete configuration and specialize it multiple times. For

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ClientBuilder.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.client.api;
 
-import java.io.Serializable;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -29,7 +28,7 @@ import org.apache.pulsar.client.api.PulsarClientException.UnsupportedAuthenticat
  *
  * @since 2.0.0
  */
-public interface ClientBuilder extends Serializable, Cloneable {
+public interface ClientBuilder extends Cloneable {
 
     /**
      * @return the new {@link PulsarClient} instance

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -54,6 +54,18 @@ public interface ConsumerBuilder<T> extends Cloneable {
     /**
      * Load the configuration from provided <tt>config</tt> map.
      *
+     * <p>Example:
+     * <pre>
+     * Map&lt;String, Object&gt; config = new HashMap&lt;&gt;();
+     * config.put("ackTimeoutMillis", 1000);
+     * config.put("receiverQueueSize", 2000);
+     *
+     * ConsumerBuilder&lt;byte[]&gt; builder = ...;
+     * builder = builder.loadConf(config);
+     *
+     * Consumer&lt;byte[]&gt; consumer = builder.subscribe();
+     * </pre>
+     *
      * @param config configuration to load
      * @return consumer builder instance
      */

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.client.api;
 
-import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -32,7 +31,7 @@ import java.util.regex.Pattern;
  *
  * @since 2.0.0
  */
-public interface ConsumerBuilder<T> extends Serializable, Cloneable {
+public interface ConsumerBuilder<T> extends Cloneable {
 
     /**
      * Create a copy of the current consumer builder.
@@ -51,6 +50,14 @@ public interface ConsumerBuilder<T> extends Serializable, Cloneable {
      * </pre>
      */
     ConsumerBuilder<T> clone();
+
+    /**
+     * Load the configuration from provided <tt>config</tt> map.
+     *
+     * @param config configuration to load
+     * @return consumer builder instance
+     */
+    ConsumerBuilder<T> loadConf(Map<String, Object> config);
 
     /**
      * Finalize the {@link Consumer} creation by subscribing to the topic.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/CryptoKeyReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/CryptoKeyReader.java
@@ -18,9 +18,10 @@
  */
 package org.apache.pulsar.client.api;
 
+import java.io.Serializable;
 import java.util.Map;
 
-public interface CryptoKeyReader {
+public interface CryptoKeyReader extends Serializable {
 
     /**
      * Return the encryption key corresponding to the key name in the argument

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/MessageId.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/MessageId.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.client.api;
 
 import java.io.IOException;
 
+import java.io.Serializable;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 
 /**
@@ -30,7 +31,7 @@ import org.apache.pulsar.client.impl.MessageIdImpl;
  *
  *
  */
-public interface MessageId extends Comparable<MessageId>{
+public interface MessageId extends Comparable<MessageId>, Serializable {
 
     /**
      * Serialize the message ID into a byte array

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ProducerBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ProducerBuilder.java
@@ -60,6 +60,18 @@ public interface ProducerBuilder<T> extends Cloneable {
     /**
      * Load the configuration from provided <tt>config</tt> map.
      *
+     * <p>Example:
+     * <pre>
+     * Map&lt;String, Object&gt; config = new HashMap&lt;&gt;();
+     * config.put("producerName", "test-producer");
+     * config.put("sendTimeoutMs", 2000);
+     *
+     * ProducerBuilder&lt;byte[]&gt; builder = ...;
+     * builder = builder.loadConf(config);
+     *
+     * Producer&lt;byte[]&gt; producer = builder.create();
+     * </pre>
+     *
      * @param config configuration to load
      * @return producer builder instance
      */

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ProducerBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ProducerBuilder.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.client.api;
 
-import java.io.Serializable;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -30,7 +29,7 @@ import org.apache.pulsar.client.api.PulsarClientException.ProducerQueueIsFullErr
  *
  * @see PulsarClient#newProducer()
  */
-public interface ProducerBuilder<T> extends Serializable, Cloneable {
+public interface ProducerBuilder<T> extends Cloneable {
 
     /**
      * Finalize the creation of the {@link Producer} instance.
@@ -57,6 +56,14 @@ public interface ProducerBuilder<T> extends Serializable, Cloneable {
      *             if the producer creation fails
      */
     CompletableFuture<Producer<T>> createAsync();
+
+    /**
+     * Load the configuration from provided <tt>config</tt> map.
+     *
+     * @param config configuration to load
+     * @return producer builder instance
+     */
+    ProducerBuilder<T> loadConf(Map<String, Object> config);
 
     /**
      * Create a copy of the current {@link ProducerBuilder}.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/PulsarClient.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/PulsarClient.java
@@ -47,17 +47,6 @@ public interface PulsarClient extends Closeable {
     }
 
     /**
-     * Create a pulsar client builder instance with a provided configuration map.
-     *
-     * @param config configuration map.
-     * @return client builder
-     * @since 2.1.0
-     */
-    static ClientBuilder builder(Map<String, Object> config) {
-        return new ClientBuilderImpl(ConfigurationDataUtils.loadData(config, ClientConfigurationData.class));
-    }
-
-    /**
      * Create a new PulsarClient object using default client configuration
      *
      * @param serviceUrl

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/PulsarClient.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/PulsarClient.java
@@ -19,10 +19,13 @@
 package org.apache.pulsar.client.api;
 
 import java.io.Closeable;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.pulsar.client.impl.ClientBuilderImpl;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.apache.pulsar.client.impl.conf.ConfigurationDataUtils;
 
 /**
  * Class that provides a client interface to Pulsar.
@@ -41,6 +44,17 @@ public interface PulsarClient extends Closeable {
      */
     public static ClientBuilder builder() {
         return new ClientBuilderImpl();
+    }
+
+    /**
+     * Create a pulsar client builder instance with a provided configuration map.
+     *
+     * @param config configuration map.
+     * @return client builder
+     * @since 2.1.0
+     */
+    static ClientBuilder builder(Map<String, Object> config) {
+        return new ClientBuilderImpl(ConfigurationDataUtils.loadData(config, ClientConfigurationData.class));
     }
 
     /**

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ReaderBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ReaderBuilder.java
@@ -57,6 +57,18 @@ public interface ReaderBuilder<T> extends Cloneable {
     /**
      * Load the configuration from provided <tt>config</tt> map.
      *
+     * <p>Example:
+     * <pre>
+     * Map&lt;String, Object&gt; config = new HashMap&lt;&gt;();
+     * config.put("topicName", "test-topic");
+     * config.put("receiverQueueSize", 2000);
+     *
+     * ReaderBuilder&lt;byte[]&gt; builder = ...;
+     * builder = builder.loadConf(config);
+     *
+     * Reader&lt;byte[]&gt; reader = builder.create();
+     * </pre>
+     *
      * @param config configuration to load
      * @return reader builder instance
      */

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ReaderBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ReaderBuilder.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pulsar.client.api;
 
-import java.io.Serializable;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -28,7 +28,7 @@ import java.util.concurrent.CompletableFuture;
  *
  * @since 2.0.0
  */
-public interface ReaderBuilder<T> extends Serializable, Cloneable {
+public interface ReaderBuilder<T> extends Cloneable {
 
     /**
      * Finalize the creation of the {@link Reader} instance.
@@ -53,6 +53,14 @@ public interface ReaderBuilder<T> extends Serializable, Cloneable {
      *             if the reader creation fails
      */
     CompletableFuture<Reader<T>> createAsync();
+
+    /**
+     * Load the configuration from provided <tt>config</tt> map.
+     *
+     * @param config configuration to load
+     * @return reader builder instance
+     */
+    ReaderBuilder<T> loadConf(Map<String, Object> config);
 
     /**
      * Create a copy of the current {@link ReaderBuilder}.

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
@@ -31,15 +31,13 @@ import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
 
 public class ClientBuilderImpl implements ClientBuilder {
 
-    private static final long serialVersionUID = 1L;
-
     final ClientConfigurationData conf;
 
     public ClientBuilderImpl() {
         this(new ClientConfigurationData());
     }
 
-    private ClientBuilderImpl(ClientConfigurationData conf) {
+    public ClientBuilderImpl(ClientConfigurationData conf) {
         this.conf = conf;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientBuilderImpl.java
@@ -28,10 +28,11 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.PulsarClientException.UnsupportedAuthenticationException;
 import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.apache.pulsar.client.impl.conf.ConfigurationDataUtils;
 
 public class ClientBuilderImpl implements ClientBuilder {
 
-    final ClientConfigurationData conf;
+    ClientConfigurationData conf;
 
     public ClientBuilderImpl() {
         this(new ClientConfigurationData());
@@ -53,6 +54,13 @@ public class ClientBuilderImpl implements ClientBuilder {
     @Override
     public ClientBuilder clone() {
         return new ClientBuilderImpl(conf.clone());
+    }
+
+    @Override
+    public ClientBuilder loadConf(Map<String, Object> config) {
+        conf = ConfigurationDataUtils.loadData(
+            config, conf, ClientConfigurationData.class);
+        return this;
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -39,6 +39,7 @@ import org.apache.pulsar.client.api.PulsarClientException.InvalidConfigurationEx
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.impl.conf.ConfigurationDataUtils;
 import org.apache.pulsar.client.impl.conf.ConsumerConfigurationData;
 import org.apache.pulsar.common.util.FutureUtil;
 
@@ -48,10 +49,8 @@ import lombok.NonNull;
 
 public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
 
-    private static final long serialVersionUID = 1L;
-
     private final PulsarClientImpl client;
-    private final ConsumerConfigurationData<T> conf;
+    private ConsumerConfigurationData<T> conf;
     private final Schema<T> schema;
 
     private static long MIN_ACK_TIMEOUT_MILLIS = 1000;
@@ -60,10 +59,16 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
         this(client, new ConsumerConfigurationData<T>(), schema);
     }
 
-    private ConsumerBuilderImpl(PulsarClientImpl client, ConsumerConfigurationData<T> conf, Schema<T> schema) {
+    ConsumerBuilderImpl(PulsarClientImpl client, ConsumerConfigurationData<T> conf, Schema<T> schema) {
         this.client = client;
         this.conf = conf;
         this.schema = schema;
+    }
+
+    @Override
+    public ConsumerBuilder<T> loadConf(Map<String, Object> config) {
+        this.conf = ConfigurationDataUtils.loadData(config, ConsumerConfigurationData.class);
+        return this;
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -67,7 +67,7 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
 
     @Override
     public ConsumerBuilder<T> loadConf(Map<String, Object> config) {
-        this.conf = ConfigurationDataUtils.loadData(config, ConsumerConfigurationData.class);
+        this.conf = ConfigurationDataUtils.loadData(config, conf, ConsumerConfigurationData.class);
         return this;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
@@ -89,7 +89,8 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
 
     @Override
     public ProducerBuilder<T> loadConf(Map<String, Object> config) {
-        conf = ConfigurationDataUtils.loadData(config, ProducerConfigurationData.class);
+        conf = ConfigurationDataUtils.loadData(
+            config, conf, ProducerConfigurationData.class);
         return this;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
@@ -33,6 +33,7 @@ import org.apache.pulsar.client.api.ProducerBuilder;
 import org.apache.pulsar.client.api.ProducerCryptoFailureAction;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.conf.ConfigurationDataUtils;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 import org.apache.pulsar.common.util.FutureUtil;
 
@@ -40,10 +41,8 @@ import lombok.NonNull;
 
 public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
 
-    private static final long serialVersionUID = 1L;
-
     private final PulsarClientImpl client;
-    private final ProducerConfigurationData conf;
+    private ProducerConfigurationData conf;
     private final Schema<T> schema;
 
     ProducerBuilderImpl(PulsarClientImpl client, Schema<T> schema) {
@@ -86,6 +85,12 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
         }
 
         return client.createProducerAsync(conf, schema);
+    }
+
+    @Override
+    public ProducerBuilder<T> loadConf(Map<String, Object> config) {
+        conf = ConfigurationDataUtils.loadData(config, ProducerConfigurationData.class);
+        return this;
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderBuilderImpl.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.impl;
 
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -29,16 +30,15 @@ import org.apache.pulsar.client.api.Reader;
 import org.apache.pulsar.client.api.ReaderBuilder;
 import org.apache.pulsar.client.api.ReaderListener;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.conf.ConfigurationDataUtils;
 import org.apache.pulsar.client.impl.conf.ReaderConfigurationData;
 import org.apache.pulsar.common.util.FutureUtil;
 
 public class ReaderBuilderImpl<T> implements ReaderBuilder<T> {
 
-    private static final long serialVersionUID = 1L;
-
     private final PulsarClientImpl client;
 
-    private final ReaderConfigurationData<T> conf;
+    private ReaderConfigurationData<T> conf;
 
     private final Schema<T> schema;
 
@@ -92,6 +92,12 @@ public class ReaderBuilderImpl<T> implements ReaderBuilder<T> {
         }
 
         return client.createReaderAsync(conf, schema);
+    }
+
+    @Override
+    public ReaderBuilder<T> loadConf(Map<String, Object> config) {
+        conf = ConfigurationDataUtils.loadData(config, ReaderConfigurationData.class);
+        return this;
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderBuilderImpl.java
@@ -96,7 +96,7 @@ public class ReaderBuilderImpl<T> implements ReaderBuilder<T> {
 
     @Override
     public ReaderBuilder<T> loadConf(Map<String, Object> config) {
-        conf = ConfigurationDataUtils.loadData(config, ReaderConfigurationData.class);
+        conf = ConfigurationDataUtils.loadData(config, conf, ReaderConfigurationData.class);
         return this;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -18,10 +18,8 @@
  */
 package org.apache.pulsar.client.impl.conf;
 
-import com.google.gson.Gson;
 import java.io.Serializable;
 
-import java.util.Map;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.impl.auth.AuthenticationDisabled;
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ClientConfigurationData.java
@@ -18,8 +18,10 @@
  */
 package org.apache.pulsar.client.impl.conf;
 
+import com.google.gson.Gson;
 import java.io.Serializable;
 
+import java.util.Map;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.impl.auth.AuthenticationDisabled;
 
@@ -63,4 +65,6 @@ public class ClientConfigurationData implements Serializable, Cloneable {
             throw new RuntimeException("Failed to clone ClientConfigurationData");
         }
     }
+
+
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtils.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtils.java
@@ -16,23 +16,23 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.client.api;
+package org.apache.pulsar.client.impl.conf;
 
-import java.io.Serializable;
+import com.google.gson.Gson;
+import java.util.Map;
 
 /**
- * Listener on the consumer state changes.
+ * Utils for loading configuration data.
  */
-public interface ConsumerEventListener extends Serializable {
+public final class ConfigurationDataUtils {
 
-    /**
-     * Notified when the consumer group is changed, and the consumer becomes the active consumer.
-     */
-    void becameActive(Consumer<?> consumer, int partitionId);
+    private ConfigurationDataUtils() {}
 
-    /**
-     * Notified when the consumer group is changed, and the consumer is still inactive or becomes inactive.
-     */
-    void becameInactive(Consumer<?> consumer, int partitionId);
+    public static <T> T loadData(Map<String, Object> config, Class<T> configurationDataCls) {
+        Gson gson = new Gson();
+        String configJson = gson.toJson(config);
+        return gson.fromJson(configJson, configurationDataCls);
+    }
 
 }
+

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/conf/ProducerConfigurationData.java
@@ -80,6 +80,7 @@ public class ProducerConfigurationData implements Serializable, Cloneable {
      * Returns true if encryption keys are added
      *
      */
+    @JsonIgnore
     public boolean isEncryptionEnabled() {
         return (this.encryptionKeys != null) && !this.encryptionKeys.isEmpty() && (this.cryptoKeyReader != null);
     }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtilsTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtilsTest.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.conf;
+
+import static org.testng.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+/**
+ * Unit test {@link ConfigurationDataUtils}.
+ */
+public class ConfigurationDataUtilsTest {
+
+    @Test
+    public void testLoadClientConfigurationData() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("serviceUrl", "pulsar://localhost:6650");
+        config.put("maxLookupRequest", 70000);
+        ClientConfigurationData confData = ConfigurationDataUtils.loadData(config, ClientConfigurationData.class);
+        assertEquals("pulsar://localhost:6650", confData.getServiceUrl());
+        assertEquals(70000, confData.getMaxLookupRequest());
+    }
+
+    @Test
+    public void testLoadProducerConfigurationData() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("producerName", "test-producer");
+        config.put("batchingEnabled", false);
+        ProducerConfigurationData confData = ConfigurationDataUtils.loadData(config, ProducerConfigurationData.class);
+        assertEquals("test-producer", confData.getProducerName());
+        assertEquals(false, confData.isBatchingEnabled());
+    }
+
+    @Test
+    public void testLoadConsumerConfigurationData() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("subscriptionName", "test-subscription");
+        config.put("priorityLevel", 100);
+        ConsumerConfigurationData confData = ConfigurationDataUtils.loadData(config, ConsumerConfigurationData.class);
+        assertEquals("test-subscription", confData.getSubscriptionName());
+        assertEquals(100, confData.getPriorityLevel());
+    }
+
+    @Test
+    public void testLoadReaderConfigurationData() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("topicName", "test-topic");
+        config.put("receiverQueueSize", 100);
+        ReaderConfigurationData confData = ConfigurationDataUtils.loadData(config, ReaderConfigurationData.class);
+        assertEquals("test-topic", confData.getTopicName());
+        assertEquals(100, confData.getReceiverQueueSize());
+    }
+
+}

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtilsTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtilsTest.java
@@ -19,7 +19,10 @@
 package org.apache.pulsar.client.impl.conf;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import org.testng.annotations.Test;
@@ -89,4 +92,20 @@ public class ConfigurationDataUtilsTest {
         assertEquals("unknown-reader", confData.getReaderName());
     }
 
+    @Test
+    public void testLoadConfigurationDataWithUnknownFields() {
+        ReaderConfigurationData confData = new ReaderConfigurationData();
+        confData.setTopicName("unknown");
+        confData.setReceiverQueueSize(1000000);
+        confData.setReaderName("unknown-reader");
+        Map<String, Object> config = new HashMap<>();
+        config.put("unknown", "test-topic");
+        config.put("receiverQueueSize", 100);
+        try {
+            ConfigurationDataUtils.loadData(config, confData, ReaderConfigurationData.class);
+            fail("Should fail loading configuration data with unknown fields");
+        } catch (RuntimeException re) {
+            assertTrue(re.getCause() instanceof IOException);
+        }
+    }
 }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtilsTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/conf/ConfigurationDataUtilsTest.java
@@ -31,42 +31,62 @@ public class ConfigurationDataUtilsTest {
 
     @Test
     public void testLoadClientConfigurationData() {
+        ClientConfigurationData confData = new ClientConfigurationData();
+        confData.setServiceUrl("pulsar://unknown:6650");
+        confData.setMaxLookupRequest(600);
+        confData.setNumIoThreads(33);
         Map<String, Object> config = new HashMap<>();
         config.put("serviceUrl", "pulsar://localhost:6650");
         config.put("maxLookupRequest", 70000);
-        ClientConfigurationData confData = ConfigurationDataUtils.loadData(config, ClientConfigurationData.class);
+        confData = ConfigurationDataUtils.loadData(config, confData, ClientConfigurationData.class);
         assertEquals("pulsar://localhost:6650", confData.getServiceUrl());
         assertEquals(70000, confData.getMaxLookupRequest());
+        assertEquals(33, confData.getNumIoThreads());
     }
 
     @Test
     public void testLoadProducerConfigurationData() {
+        ProducerConfigurationData confData = new ProducerConfigurationData();
+        confData.setProducerName("unset");
+        confData.setBatchingEnabled(true);
+        confData.setBatchingMaxMessages(1234);
         Map<String, Object> config = new HashMap<>();
         config.put("producerName", "test-producer");
         config.put("batchingEnabled", false);
-        ProducerConfigurationData confData = ConfigurationDataUtils.loadData(config, ProducerConfigurationData.class);
+        confData = ConfigurationDataUtils.loadData(config, confData, ProducerConfigurationData.class);
         assertEquals("test-producer", confData.getProducerName());
         assertEquals(false, confData.isBatchingEnabled());
+        assertEquals(1234, confData.getBatchingMaxMessages());
     }
 
     @Test
     public void testLoadConsumerConfigurationData() {
+        ConsumerConfigurationData confData = new ConsumerConfigurationData();
+        confData.setSubscriptionName("unknown-subscription");
+        confData.setPriorityLevel(10000);
+        confData.setConsumerName("unknown-consumer");
         Map<String, Object> config = new HashMap<>();
         config.put("subscriptionName", "test-subscription");
         config.put("priorityLevel", 100);
-        ConsumerConfigurationData confData = ConfigurationDataUtils.loadData(config, ConsumerConfigurationData.class);
+        confData = ConfigurationDataUtils.loadData(config, confData, ConsumerConfigurationData.class);
         assertEquals("test-subscription", confData.getSubscriptionName());
         assertEquals(100, confData.getPriorityLevel());
+        assertEquals("unknown-consumer", confData.getConsumerName());
     }
 
     @Test
     public void testLoadReaderConfigurationData() {
+        ReaderConfigurationData confData = new ReaderConfigurationData();
+        confData.setTopicName("unknown");
+        confData.setReceiverQueueSize(1000000);
+        confData.setReaderName("unknown-reader");
         Map<String, Object> config = new HashMap<>();
         config.put("topicName", "test-topic");
         config.put("receiverQueueSize", 100);
-        ReaderConfigurationData confData = ConfigurationDataUtils.loadData(config, ReaderConfigurationData.class);
+        confData = ConfigurationDataUtils.loadData(config, confData, ReaderConfigurationData.class);
         assertEquals("test-topic", confData.getTopicName());
         assertEquals(100, confData.getReceiverQueueSize());
+        assertEquals("unknown-reader", confData.getReaderName());
     }
 
 }

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/producers/MultiConsumersOneOutputTopicProducersTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/producers/MultiConsumersOneOutputTopicProducersTest.java
@@ -89,6 +89,11 @@ public class MultiConsumersOneOutputTopicProducersTest {
         }
 
         @Override
+        public ProducerBuilder<byte[]> loadConf(Map<String, Object> config) {
+            return this;
+        }
+
+        @Override
         public ProducerBuilder<byte[]> clone() {
             return this;
         }


### PR DESCRIPTION

*Motivation*

Make pulsar users be able to use java Serialization framework for distributing client settings. This is required for using pulsar in frameworks like Spark.

*Changes*

- Remove serializable from builders
- Add a tool to load client/producer/consumer/reader configuration data from a Map config (which is serializable)

Fixes #1943
