### PR TITLE
Added REST/CLI tools to manage bookies rack placement config

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Bookies.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Bookies.java
@@ -1,0 +1,142 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.admin.v2;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+
+import java.util.Map.Entry;
+import java.util.Optional;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response.Status;
+
+import org.apache.pulsar.broker.admin.AdminResource;
+import org.apache.pulsar.broker.web.RestException;
+import org.apache.pulsar.common.policies.data.BookieInfo;
+import org.apache.pulsar.common.policies.data.BookiesRackConfiguration;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
+import org.apache.pulsar.zookeeper.ZkBookieRackAffinityMapping;
+import org.apache.pulsar.zookeeper.ZooKeeperCache.Deserializer;
+import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Path("/bookies")
+@Api(value = "/bookies", description = "Configure bookies rack placement", tags = "bookies")
+@Produces(MediaType.APPLICATION_JSON)
+public class Bookies extends AdminResource {
+
+    @GET
+    @Path("/racks-info")
+    @ApiOperation(value = "Gets the rack placement information for all the bookies in the cluster", response = BookiesRackConfiguration.class)
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission") })
+    public BookiesRackConfiguration getBookiesRackInfo() throws Exception {
+        validateSuperUserAccess();
+
+        return localZkCache().getData(ZkBookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH,
+                new Deserializer<BookiesRackConfiguration>() {
+
+                    @Override
+                    public BookiesRackConfiguration deserialize(String key, byte[] content) throws Exception {
+                        return ObjectMapperFactory.getThreadLocal().readValue(content, BookiesRackConfiguration.class);
+                    }
+
+                }).orElse(new BookiesRackConfiguration());
+    }
+
+    @GET
+    @Path("/racks-info/{bookie}")
+    @ApiOperation(value = "Gets the rack placement information for a specific bookie in the cluster", response = BookieInfo.class)
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission") })
+    public BookieInfo getBookieRackInfo(@PathParam("bookie") String bookieAddress) throws Exception {
+        validateSuperUserAccess();
+
+        BookiesRackConfiguration racks = localZkCache()
+                .getData(ZkBookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH, (key, content) -> ObjectMapperFactory
+                        .getThreadLocal().readValue(content, BookiesRackConfiguration.class))
+                .orElse(new BookiesRackConfiguration());
+
+        return racks.getBookie(bookieAddress)
+                .orElseThrow(() -> new RestException(Status.NOT_FOUND, "Bookie address not found: " + bookieAddress));
+    }
+
+    @DELETE
+    @Path("/racks-info/{bookie}")
+    @ApiOperation(value = "Removed the rack placement information for a specific bookie in the cluster")
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission") })
+    public void deleteBookieRackInfo(@PathParam("bookie") String bookieAddress) throws Exception {
+        validateSuperUserAccess();
+
+        BookiesRackConfiguration racks = localZkCache()
+                .getData(ZkBookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH, (key, content) -> ObjectMapperFactory
+                        .getThreadLocal().readValue(content, BookiesRackConfiguration.class))
+                .orElse(new BookiesRackConfiguration());
+
+        if (!racks.removeBookie(bookieAddress)) {
+            throw new RestException(Status.NOT_FOUND, "Bookie address not found: " + bookieAddress);
+        }
+
+        log.info("Removed {} from rack mapping info", bookieAddress);
+    }
+
+    @POST
+    @Path("/racks-info/{bookie}")
+    @ApiOperation(value = "Updates the rack placement information for a specific bookie in the cluster")
+    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission") })
+    public void updateBookieRackInfo(@PathParam("bookie") String bookieAddress, @QueryParam("group") String group,
+            BookieInfo bookieInfo) throws Exception {
+        validateSuperUserAccess();
+
+        if (group == null) {
+            throw new RestException(Status.PRECONDITION_FAILED, "Bookie 'group' parameters is missing");
+        }
+
+        Optional<Entry<BookiesRackConfiguration, Stat>> entry = localZkCache()
+                .getEntry(ZkBookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH, (key, content) -> ObjectMapperFactory
+                        .getThreadLocal().readValue(content, BookiesRackConfiguration.class));
+
+        if (entry.isPresent()) {
+            // Update the racks info
+            BookiesRackConfiguration racks = entry.get().getKey();
+            racks.updateBookie(group, bookieAddress, bookieInfo);
+
+            localZk().setData(ZkBookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH, jsonMapper().writeValueAsBytes(racks),
+                    entry.get().getValue().getVersion());
+            log.info("Updated rack mapping info for {}", bookieAddress);
+        } else {
+            // Creates the z-node with racks info
+            BookiesRackConfiguration racks = new BookiesRackConfiguration();
+            racks.updateBookie(group, bookieAddress, bookieInfo);
+            zkCreate(ZkBookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH, jsonMapper().writeValueAsBytes(racks));
+            log.info("Created rack mapping info and added {}", bookieAddress);
+        }
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(Bookies.class);
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBkEnsemblesTests.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBkEnsemblesTests.java
@@ -71,11 +71,22 @@ public class BrokerBkEnsemblesTests {
     private final int ZOOKEEPER_PORT = 12759;
     protected final int BROKER_WEBSERVICE_PORT = 15782;
 
+    protected final int bkBasePort = 5001;
+    private final int numberOfBookies;
+
+    public BrokerBkEnsemblesTests() {
+        this(3);
+    }
+
+    public BrokerBkEnsemblesTests(int numberOfBookies) {
+        this.numberOfBookies = numberOfBookies;
+    }
+
     @BeforeMethod
     void setup() throws Exception {
         try {
             // start local bookie and zookeeper
-            bkEnsemble = new LocalBookkeeperEnsemble(3, ZOOKEEPER_PORT, 5001);
+            bkEnsemble = new LocalBookkeeperEnsemble(numberOfBookies, ZOOKEEPER_PORT, 5001);
             bkEnsemble.start();
 
             // start pulsar service

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/RackAwareTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/RackAwareTest.java
@@ -55,7 +55,7 @@ public class RackAwareTest extends BrokerBkEnsemblesTests {
     void setup() throws Exception {
         super.setup();
 
-        // Start bookies
+        // Start bookies with specific racks
         for (int i = 0; i < NUM_BOOKIES; i++) {
             File bkDataDir = Files.createTempDirectory("bk" + Integer.toString(i) + "test").toFile();
             ServerConfiguration conf = new ServerConfiguration();
@@ -79,6 +79,7 @@ public class RackAwareTest extends BrokerBkEnsemblesTests {
             bookies.add(bs);
             log.info("Local BK[{}] started (port: {}, adddress: {})", i, bookiePort, addr);
         }
+
     }
 
     @AfterClass
@@ -88,6 +89,8 @@ public class RackAwareTest extends BrokerBkEnsemblesTests {
         for (BookieServer bs : bookies) {
             bs.shutdown();
         }
+
+        bookies.clear();
     }
 
     @Test
@@ -116,6 +119,14 @@ public class RackAwareTest extends BrokerBkEnsemblesTests {
                     "first bookie in rack 0 not included in ensemble");
             lh.close();
         }
+    }
+
+    public void testCrashBrokerWithoutCursorLedgerLeak() throws Exception {
+        // Ignore test
+    }
+
+    public void testSkipCorruptDataLedger() throws Exception {
+        // Ignore test
     }
 
     private static final Logger log = LoggerFactory.getLogger(RackAwareTest.class);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/RackAwareTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/RackAwareTest.java
@@ -1,0 +1,122 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import static org.testng.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.bookkeeper.client.BookKeeper;
+import org.apache.bookkeeper.client.BookKeeper.DigestType;
+import org.apache.bookkeeper.client.LedgerHandle;
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.bookkeeper.net.BookieSocketAddress;
+import org.apache.bookkeeper.proto.BookieServer;
+import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.apache.bookkeeper.test.PortManager;
+import org.apache.pulsar.common.policies.data.BookieInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class RackAwareTest extends BrokerBkEnsemblesTests {
+
+    private static final int NUM_BOOKIES = 6;
+    private final List<BookieServer> bookies = new ArrayList<>();
+
+    public RackAwareTest() {
+        // Start bookies manually
+        super(0);
+    }
+
+    @SuppressWarnings("deprecation")
+    @BeforeClass
+    void setup() throws Exception {
+        super.setup();
+
+        // Start bookies
+        for (int i = 0; i < NUM_BOOKIES; i++) {
+            File bkDataDir = Files.createTempDirectory("bk" + Integer.toString(i) + "test").toFile();
+            ServerConfiguration conf = new ServerConfiguration();
+
+            int bookiePort = PortManager.nextFreePort();
+            conf.setBookiePort(bookiePort);
+            conf.setZkServers("127.0.0.1:" + this.bkEnsemble.getZkServer().getClientPort());
+            conf.setJournalDirName(bkDataDir.getPath());
+            conf.setLedgerDirNames(new String[] { bkDataDir.getPath() });
+            conf.setAllowLoopback(true);
+
+            // Use different advertised addresses for each bookie, so we can place them in different
+            // racks.
+            // Eg: 1st bookie will be 10.0.0.1, 2nd 10.0.0.2 and so on
+            String addr = String.format("10.0.0.%d", i + 1);
+            conf.setAdvertisedAddress(addr);
+
+            BookieServer bs = new BookieServer(conf, NullStatsLogger.INSTANCE);
+
+            bs.start();
+            bookies.add(bs);
+            log.info("Local BK[{}] started (port: {}, adddress: {})", i, bookiePort, addr);
+        }
+    }
+
+    @AfterClass
+    void shutdown() throws Exception {
+        super.shutdown();
+
+        for (BookieServer bs : bookies) {
+            bs.shutdown();
+        }
+    }
+
+    @Test
+    public void testPlacement() throws Exception {
+        for (int i = 0; i < NUM_BOOKIES; i++) {
+            String bookie = bookies.get(i).getLocalAddress().toString();
+
+            // Place bookie-1 in "rack-1" and the rest in "rack-2"
+            int rackId = i == 0 ? 1 : 2;
+            BookieInfo bi = new BookieInfo("rack-" + rackId, "bookie-" + (i + 1));
+            log.info("setting rack for bookie at {} -- {}", bookie, bi);
+            admin.bookies().updateBookieRackInfo(bookie, "default", bi);
+        }
+
+        // Make sure the racks cache gets updated through the ZK watch
+        Thread.sleep(1000);
+
+        BookKeeper bkc = this.pulsar.getBookKeeperClient();
+
+        // Create few ledgers and verify all of them should have a copy in the first bookie
+        BookieSocketAddress fistBookie = bookies.get(0).getLocalAddress();
+        for (int i = 0; i < 100; i++) {
+            LedgerHandle lh = bkc.createLedger(2, 2, DigestType.DUMMY, new byte[0]);
+            log.info("Ledger: {} -- Ensemble: {}", i, lh.getLedgerMetadata().getEnsembleAt(0));
+            assertTrue(lh.getLedgerMetadata().getEnsembleAt(0).contains(fistBookie),
+                    "first bookie in rack 0 not included in ensemble");
+            lh.close();
+        }
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(RackAwareTest.class);
+}

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Bookies.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Bookies.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.admin;
+
+import org.apache.pulsar.common.policies.data.BookieInfo;
+import org.apache.pulsar.common.policies.data.BookiesRackConfiguration;
+
+/**
+ * Admin interface for bookies rack placement management.
+ */
+public interface Bookies {
+
+    /**
+     * Gets the rack placement information for all the bookies in the cluster
+     */
+    BookiesRackConfiguration getBookiesRackInfo() throws PulsarAdminException;
+
+    /**
+     * Gets the rack placement information for a specific bookie in the cluster
+     */
+    BookieInfo getBookieRackInfo(String bookieAddress) throws PulsarAdminException;
+
+    /**
+     * Remove rack placement information for a specific bookie in the cluster
+     */
+    void deleteBookieRackInfo(String bookieAddress) throws PulsarAdminException;
+
+    /**
+     * Updates the rack placement information for a specific bookie in the cluster
+     */
+    void updateBookieRackInfo(String bookieAddress, String group, BookieInfo bookieInfo) throws PulsarAdminException;
+}

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PulsarAdmin.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PulsarAdmin.java
@@ -32,6 +32,7 @@ import javax.ws.rs.client.WebTarget;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.conn.ssl.DefaultHostnameVerifier;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.pulsar.client.admin.internal.BookiesImpl;
 import org.apache.pulsar.client.admin.internal.BrokerStatsImpl;
 import org.apache.pulsar.client.admin.internal.BrokersImpl;
 import org.apache.pulsar.client.admin.internal.ClustersImpl;
@@ -74,6 +75,7 @@ public class PulsarAdmin implements Closeable {
     private final Tenants tenants;
     private final Properties properties;
     private final Namespaces namespaces;
+    private final Bookies bookies;
     private final TopicsImpl topics;
     private final NonPersistentTopics nonPersistentTopics;
     private final ResourceQuotas resourceQuotas;
@@ -186,6 +188,7 @@ public class PulsarAdmin implements Closeable {
         this.lookups = new LookupImpl(root, auth, useTls);
         this.functions = new FunctionsImpl(root, auth);
         this.schemas = new SchemasImpl(root, auth);
+        this.bookies = new BookiesImpl(root, auth);
     }
 
     /**
@@ -302,6 +305,13 @@ public class PulsarAdmin implements Closeable {
 
     public Topics topics() {
         return topics;
+    }
+
+    /**
+     * @return the bookies management object
+     */
+    public Bookies bookies() {
+        return bookies;
     }
 
     /**

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BookiesImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BookiesImpl.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.admin.internal;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+
+import org.apache.pulsar.client.admin.Bookies;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.common.policies.data.BookieInfo;
+import org.apache.pulsar.common.policies.data.BookiesRackConfiguration;
+import org.apache.pulsar.common.policies.data.ErrorData;
+
+public class BookiesImpl extends BaseResource implements Bookies {
+    private final WebTarget adminBookies;
+
+    public BookiesImpl(WebTarget web, Authentication auth) {
+        super(auth);
+        adminBookies = web.path("/admin/v2/bookies");
+    }
+
+    @Override
+    public BookiesRackConfiguration getBookiesRackInfo() throws PulsarAdminException {
+        try {
+            return request(adminBookies.path("racks-info")).get(BookiesRackConfiguration.class);
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
+
+    @Override
+    public BookieInfo getBookieRackInfo(String bookieAddress) throws PulsarAdminException {
+        try {
+            return request(adminBookies.path("racks-info").path(bookieAddress)).get(BookieInfo.class);
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
+
+    @Override
+    public void deleteBookieRackInfo(String bookieAddress) throws PulsarAdminException {
+        try {
+            request(adminBookies.path("racks-info").path(bookieAddress)).delete(ErrorData.class);
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
+
+    @Override
+    public void updateBookieRackInfo(String bookieAddress, String group, BookieInfo bookieInfo)
+            throws PulsarAdminException {
+        try {
+            request(adminBookies.path("racks-info").path(bookieAddress).queryParam("group", group))
+                    .post(Entity.entity(bookieInfo, MediaType.APPLICATION_JSON), ErrorData.class);
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
+}

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Sets;
 
 import java.util.EnumSet;
 
+import org.apache.pulsar.client.admin.Bookies;
 import org.apache.pulsar.client.admin.BrokerStats;
 import org.apache.pulsar.client.admin.Brokers;
 import org.apache.pulsar.client.admin.Clusters;
@@ -43,6 +44,7 @@ import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.BacklogQuota;
 import org.apache.pulsar.common.policies.data.BacklogQuota.RetentionPolicy;
+import org.apache.pulsar.common.policies.data.BookieInfo;
 import org.apache.pulsar.common.policies.data.BundlesData;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.FailureDomain;
@@ -686,6 +688,27 @@ public class PulsarAdminToolTest {
         topics.run(split("list-in-bundle myprop/clust/ns1 --bundle 0x23d70a30_0x26666658"));
         verify(mockTopics).getListInBundle("myprop/clust/ns1", "0x23d70a30_0x26666658");
 
+    }
+
+    @Test
+    void bookies() throws Exception {
+        PulsarAdmin admin = Mockito.mock(PulsarAdmin.class);
+        Bookies mockBookies = mock(Bookies.class);
+        doReturn(mockBookies).when(admin).bookies();
+
+        CmdBookies bookies = new CmdBookies(admin);
+
+        bookies.run(split("racks-placement"));
+        verify(mockBookies).getBookiesRackInfo();
+
+        bookies.run(split("get-bookie-rack --bookie my-bookie:3181"));
+        verify(mockBookies).getBookieRackInfo("my-bookie:3181");
+
+        bookies.run(split("delete-bookie-rack --bookie my-bookie:3181"));
+        verify(mockBookies).deleteBookieRackInfo("my-bookie:3181");
+
+        bookies.run(split("set-bookie-rack --group my-group --bookie my-bookie:3181 --rack rack-1 --hostname host-1"));
+        verify(mockBookies).updateBookieRackInfo("my-bookie:3181", "my-group", new BookieInfo("rack-1", "host-1"));
     }
 
     String[] split(String s) {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBookies.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdBookies.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.admin.cli;
+
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.common.policies.data.BookieInfo;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+
+@Parameters(commandDescription = "Operations about bookies rack placement")
+public class CmdBookies extends CmdBase {
+
+    @Parameters(commandDescription = "Gets the rack placement information for all the bookies in the cluster")
+    private class GetAll extends CliCommand {
+
+        @Override
+        void run() throws Exception {
+            print(admin.bookies().getBookiesRackInfo());
+        }
+    }
+
+    @Parameters(commandDescription = "Gets the rack placement information for a specific bookie in the cluster")
+    private class GetBookie extends CliCommand {
+
+        @Parameter(names = { "-b", "--bookie" }, description = "bookie address", required = true)
+        private String bookieAddress;
+
+        @Override
+        void run() throws Exception {
+            print(admin.bookies().getBookieRackInfo(bookieAddress));
+        }
+    }
+
+    @Parameters(commandDescription = "Remove rack placement information for a specific bookie in the cluster")
+    private class RemoveBookie extends CliCommand {
+
+        @Parameter(names = { "-b", "--bookie" }, description = "bookie address", required = true)
+        private String bookieAddress;
+
+        @Override
+        void run() throws Exception {
+            admin.bookies().deleteBookieRackInfo(bookieAddress);
+        }
+    }
+
+    @Parameters(commandDescription = "Updates the rack placement information for a specific bookie in the cluster")
+    private class UpdateBookie extends CliCommand {
+        @Parameter(names = { "-g", "--group" }, description = "Bookie group name", required = false)
+        private String group = "default";
+
+        @Parameter(names = { "-b", "--bookie" }, description = "Bookie address", required = true)
+        private String bookieAddress;
+
+        @Parameter(names = { "-r", "--rack" }, description = "Bookie rack name", required = true)
+        private String bookieRack;
+
+        @Parameter(names = { "--hostname" }, description = "Bookie host name", required = false)
+        private String bookieHost;
+
+        @Override
+        void run() throws Exception {
+            admin.bookies().updateBookieRackInfo(bookieAddress, group, new BookieInfo(bookieRack, bookieHost));
+        }
+    }
+
+    public CmdBookies(PulsarAdmin admin) {
+        super("bookies", admin);
+        jcommander.addCommand("racks-placement", new GetAll());
+        jcommander.addCommand("get-bookie-rack", new GetBookie());
+        jcommander.addCommand("delete-bookie-rack", new RemoveBookie());
+        jcommander.addCommand("set-bookie-rack", new UpdateBookie());
+    }
+}

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/PulsarAdminTool.java
@@ -90,6 +90,7 @@ public class PulsarAdminTool {
         commandMap.put("namespaces", CmdNamespaces.class);
         commandMap.put("topics", CmdTopics.class);
         commandMap.put("schemas", CmdSchemas.class);
+        commandMap.put("bookies", CmdBookies.class);
 
         // Hidden deprecated "persistent" and "non-persistent" subcommands
         commandMap.put("persistent", CmdPersistentTopics.class);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/BookieInfo.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/BookieInfo.java
@@ -16,26 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.zookeeper;
+package org.apache.pulsar.common.policies.data;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class BookieInfo {
-
     private String rack;
     private String hostname;
-
-    public String getRack() {
-        return rack;
-    }
-
-    public void setRack(String rack) {
-        this.rack = rack;
-    }
-
-    public String getHostname() {
-        return hostname;
-    }
-
-    public void setHostname(String hostname) {
-        this.hostname = hostname;
-    }
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/BookiesRackConfiguration.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/BookiesRackConfiguration.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.common.policies.data;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+
+public class BookiesRackConfiguration extends TreeMap<String, Map<String, BookieInfo>> {
+
+    public boolean removeBookie(String address) {
+        for (Map<String, BookieInfo> m : values()) {
+            if (m.remove(address) != null ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public Optional<BookieInfo> getBookie(String address) {
+        for (Map<String, BookieInfo> m : values()) {
+            BookieInfo bi = m.get(address);
+            if (bi != null) {
+                return Optional.of(bi);
+            }
+        }
+        return Optional.empty();
+    }
+
+    public void updateBookie(String group, String address, BookieInfo bookieInfo) {
+        checkNotNull(group);
+        checkNotNull(address);
+        checkNotNull(bookieInfo);
+
+        // Remove from any group first
+        removeBookie(address);
+        computeIfAbsent(group, key -> new TreeMap<>()).put(address, bookieInfo);
+    }
+}

--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
@@ -190,6 +190,11 @@ public class LocalBookkeeperEnsemble {
             if (zkc.exists("/ledgers/available/readonly", false) == null) {
                 zkc.create("/ledgers/available/readonly", new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
             }
+            if (zkc.exists(ZkBookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH, false) == null) {
+                zkc.create(ZkBookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH, "{}".getBytes(), Ids.OPEN_ACL_UNSAFE,
+                        CreateMode.PERSISTENT);
+            }
+
             // No need to create an entry for each requested bookie anymore as the
             // BookieServers will register themselves with ZooKeeper on startup.
         } catch (KeeperException e) {

--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZkIsolatedBookieEnsemblePlacementPolicy.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/ZkIsolatedBookieEnsemblePlacementPolicy.java
@@ -35,6 +35,7 @@ import org.apache.bookkeeper.net.DNSToSwitchMapping;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.bookkeeper.zookeeper.ZooKeeperClient;
 import org.apache.commons.configuration.Configuration;
+import org.apache.pulsar.common.policies.data.BookieInfo;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.zookeeper.ZooKeeperCache.Deserializer;
 import org.apache.zookeeper.KeeperException;

--- a/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZkBookieRackAffinityMappingTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZkBookieRackAffinityMappingTest.java
@@ -30,6 +30,7 @@ import org.apache.bookkeeper.net.NetworkTopology;
 import org.apache.bookkeeper.test.PortManager;
 import org.apache.bookkeeper.util.ZkUtils;
 import org.apache.bookkeeper.zookeeper.ZooKeeperClient;
+import org.apache.pulsar.common.policies.data.BookieInfo;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.ZooDefs;
@@ -119,13 +120,8 @@ public class ZkBookieRackAffinityMappingTest {
         Map<String, Map<BookieSocketAddress, BookieInfo>> bookieMapping = new HashMap<>();
         Map<BookieSocketAddress, BookieInfo> mainBookieGroup = new HashMap<>();
 
-        BookieInfo bookieInfo0 = new BookieInfo();
-        bookieInfo0.setRack("/rack0");
-        mainBookieGroup.put(BOOKIE1, bookieInfo0);
-
-        BookieInfo bookieInfo1 = new BookieInfo();
-        bookieInfo1.setRack("/rack1");
-        mainBookieGroup.put(BOOKIE2, bookieInfo1);
+        mainBookieGroup.put(BOOKIE1, new BookieInfo("/rack0", null));
+        mainBookieGroup.put(BOOKIE2, new BookieInfo("/rack1", null));
 
         bookieMapping.put("group1", mainBookieGroup);
 
@@ -147,13 +143,8 @@ public class ZkBookieRackAffinityMappingTest {
         Map<String, Map<BookieSocketAddress, BookieInfo>> bookieMapping = new HashMap<>();
         Map<BookieSocketAddress, BookieInfo> mainBookieGroup = new HashMap<>();
 
-        BookieInfo bookieInfo0 = new BookieInfo();
-        bookieInfo0.setRack("rack0");
-        mainBookieGroup.put(BOOKIE1, bookieInfo0);
-
-        BookieInfo bookieInfo1 = new BookieInfo();
-        bookieInfo1.setRack("rack1");
-        mainBookieGroup.put(BOOKIE2, bookieInfo1);
+        mainBookieGroup.put(BOOKIE1, new BookieInfo("rack0", null));
+        mainBookieGroup.put(BOOKIE2, new BookieInfo("rack1", null));
 
         bookieMapping.put("group1", mainBookieGroup);
 
@@ -173,9 +164,7 @@ public class ZkBookieRackAffinityMappingTest {
 
         // add info for BOOKIE3 and check if the mapping picks up the change
         Map<BookieSocketAddress, BookieInfo> secondaryBookieGroup = new HashMap<>();
-        BookieInfo bookieInfo2 = new BookieInfo();
-        bookieInfo2.setRack("rack0");
-        secondaryBookieGroup.put(BOOKIE3, bookieInfo2);
+        secondaryBookieGroup.put(BOOKIE3, new BookieInfo("rack0", null));
 
         bookieMapping.put("group2", secondaryBookieGroup);
         localZkc.setData(ZkBookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH, jsonMapper.writeValueAsBytes(bookieMapping),

--- a/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZkBookieRackAffinityMappingTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZkBookieRackAffinityMappingTest.java
@@ -111,8 +111,7 @@ public class ZkBookieRackAffinityMappingTest {
         bkClientConf.setProperty(ZooKeeperCache.ZK_CACHE_INSTANCE, new ZooKeeperCache(localZkc) {
         });
         mapping.setConf(bkClientConf);
-        List<String> racks = mapping
-                .resolve(Lists.newArrayList(BOOKIE1.toString(), BOOKIE2.toString(), BOOKIE3.toString()));
+        List<String> racks = mapping.resolve(Lists.newArrayList("127.0.0.1", "127.0.0.2", "127.0.0.3"));
         assertEquals(racks.get(0), NetworkTopology.DEFAULT_RACK);
         assertEquals(racks.get(1), NetworkTopology.DEFAULT_RACK);
         assertEquals(racks.get(2), NetworkTopology.DEFAULT_RACK);
@@ -130,7 +129,7 @@ public class ZkBookieRackAffinityMappingTest {
 
         Thread.sleep(100);
 
-        racks = mapping.resolve(Lists.newArrayList(BOOKIE1.toString(), BOOKIE2.toString(), BOOKIE3.toString()));
+        racks = mapping.resolve(Lists.newArrayList("127.0.0.1", "127.0.0.2", "127.0.0.3"));
         assertEquals(racks.get(0), "/rack0");
         assertEquals(racks.get(1), "/rack1");
         assertEquals(racks.get(2), NetworkTopology.DEFAULT_RACK);
@@ -173,16 +172,16 @@ public class ZkBookieRackAffinityMappingTest {
         // wait for the zk to notify and update the mappings
         Thread.sleep(100);
 
-        racks = mapping.resolve(Lists.newArrayList(BOOKIE1.toString(), BOOKIE2.toString(), BOOKIE3.toString()));
+        racks = mapping.resolve(Lists.newArrayList("127.0.0.1", "127.0.0.2", "127.0.0.3"));
         assertEquals(racks.get(0), "/rack0");
         assertEquals(racks.get(1), "/rack1");
         assertEquals(racks.get(2), "/rack0");
 
-        localZkc.delete(ZkBookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH, -1);
+        localZkc.setData(ZkBookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH, "{}".getBytes(), -1);
 
         Thread.sleep(100);
 
-        racks = mapping.resolve(Lists.newArrayList(BOOKIE1.toString(), BOOKIE2.toString(), BOOKIE3.toString()));
+        racks = mapping.resolve(Lists.newArrayList("127.0.0.1", "127.0.0.2", "127.0.0.3"));
         assertEquals(racks.get(0), NetworkTopology.DEFAULT_RACK);
         assertEquals(racks.get(1), NetworkTopology.DEFAULT_RACK);
         assertEquals(racks.get(2), NetworkTopology.DEFAULT_RACK);

--- a/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZkIsolatedBookieEnsemblePlacementPolicyTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZkIsolatedBookieEnsemblePlacementPolicyTest.java
@@ -39,6 +39,7 @@ import org.apache.bookkeeper.stats.NullStatsLogger;
 import org.apache.bookkeeper.test.PortManager;
 import org.apache.bookkeeper.util.ZkUtils;
 import org.apache.bookkeeper.zookeeper.ZooKeeperClient;
+import org.apache.pulsar.common.policies.data.BookieInfo;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.ZooDefs;
@@ -96,18 +97,11 @@ public class ZkIsolatedBookieEnsemblePlacementPolicyTest {
         Map<String, Map<String, BookieInfo>> bookieMapping = new HashMap<>();
         Map<String, BookieInfo> mainBookieGroup = new HashMap<>();
 
-        BookieInfo bookieInfo0 = new BookieInfo();
-        bookieInfo0.setRack("rack0");
-        mainBookieGroup.put(BOOKIE1, bookieInfo0);
-
-        BookieInfo bookieInfo1 = new BookieInfo();
-        bookieInfo1.setRack("rack1");
-        mainBookieGroup.put(BOOKIE2, bookieInfo1);
+        mainBookieGroup.put(BOOKIE1, new BookieInfo("rack0", null));
+        mainBookieGroup.put(BOOKIE2, new BookieInfo("rack1", null));
 
         Map<String, BookieInfo> secondaryBookieGroup = new HashMap<>();
-        BookieInfo bookieInfo2 = new BookieInfo();
-        bookieInfo2.setRack("rack0");
-        secondaryBookieGroup.put(BOOKIE3, bookieInfo2);
+        secondaryBookieGroup.put(BOOKIE3, new BookieInfo("rack0", null));
 
         bookieMapping.put("group1", mainBookieGroup);
         bookieMapping.put("group2", secondaryBookieGroup);
@@ -146,9 +140,7 @@ public class ZkIsolatedBookieEnsemblePlacementPolicyTest {
         assertTrue(ensemble.contains(new BookieSocketAddress(BOOKIE4)));
         assertTrue(ensemble.contains(new BookieSocketAddress(BOOKIE2)));
 
-        BookieInfo bookieInfo3 = new BookieInfo();
-        bookieInfo3.setRack("rack0");
-        secondaryBookieGroup.put(BOOKIE4, bookieInfo3);
+        secondaryBookieGroup.put(BOOKIE4, new BookieInfo("rack0", null));
         bookieMapping.put("group2", secondaryBookieGroup);
 
         localZkc.setData(ZkBookieRackAffinityMapping.BOOKIE_INFO_ROOT_PATH, jsonMapper.writeValueAsBytes(bookieMapping),
@@ -229,21 +221,10 @@ public class ZkIsolatedBookieEnsemblePlacementPolicyTest {
         Map<String, BookieInfo> mainBookieGroup = new HashMap<>();
         Map<String, BookieInfo> secondaryBookieGroup = new HashMap<>();
 
-        BookieInfo bookieInfo0 = new BookieInfo();
-        bookieInfo0.setRack("rack0");
-        mainBookieGroup.put(BOOKIE1, bookieInfo0);
-
-        BookieInfo bookieInfo1 = new BookieInfo();
-        bookieInfo1.setRack("rack1");
-        mainBookieGroup.put(BOOKIE2, bookieInfo1);
-
-        BookieInfo bookieInfo2 = new BookieInfo();
-        bookieInfo2.setRack("rack0");
-        secondaryBookieGroup.put(BOOKIE3, bookieInfo2);
-
-        BookieInfo bookieInfo3 = new BookieInfo();
-        bookieInfo3.setRack("rack2");
-        secondaryBookieGroup.put(BOOKIE4, bookieInfo3);
+        mainBookieGroup.put(BOOKIE1, new BookieInfo("rack0", null));
+        mainBookieGroup.put(BOOKIE2, new BookieInfo("rack1", null));
+        secondaryBookieGroup.put(BOOKIE3, new BookieInfo("rack0", null));
+        secondaryBookieGroup.put(BOOKIE4, new BookieInfo("rack2", null));
 
         bookieMapping.put("group1", mainBookieGroup);
         bookieMapping.put("group2", secondaryBookieGroup);
@@ -272,7 +253,7 @@ public class ZkIsolatedBookieEnsemblePlacementPolicyTest {
             // ok
         }
 
-        mainBookieGroup.put(BOOKIE3, bookieInfo2);
+        mainBookieGroup.put(BOOKIE3, new BookieInfo("rack1", null));
         secondaryBookieGroup.remove(BOOKIE3);
         bookieMapping.put("group1", mainBookieGroup);
         bookieMapping.put("group2", secondaryBookieGroup);


### PR DESCRIPTION
### Motivation

Currently we don't have tools to manage the rack placement configuration for bookies in a Pulsar cluster. 

### Modifications

 * Added `/admin/v2/bookie` REST handler
 * Added `admin.bookie()` in Java admin client
 * Added `pulsar-admin bookies ...` CLI tool 
 * Worked around an issue with bookie hostname and hostname:port that prevented BK client to detect the correct rack.

Fixes #151