### PR TITLE
Downgrade pulsar-client CLI consume warning message (#1485)

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdConsume.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/client/cli/CmdConsume.java
@@ -132,7 +132,7 @@ public class CmdConsume {
 
                 Message<byte[]> msg = consumer.receive(5, TimeUnit.SECONDS);
                 if (msg == null) {
-                    LOG.warn("No message to consume after waiting for 20 seconds.");
+                    LOG.debug("No message to consume after waiting for 5 seconds.");
                 } else {
                     numMessagesConsumed += 1;
                     System.out.println(MESSAGE_BOUNDARY);


### PR DESCRIPTION
Previously this log would spam the stdout if there were no messages
coming in. The message wasn't even factually correct, as the timeout
had changed.

I've downgraded the log warn to debug can corrected the factual error.
