### PR TITLE
Add trademark for "Apache Pulsar" on website footer

### DIFF
--- a/site/_includes/footer.html
+++ b/site/_includes/footer.html
@@ -21,6 +21,6 @@
 <footer class="footer">
   <div class="container">
     <p class="text-center">Copyright {{'now' | date: '%Y'}} The Apache Software Foundation. All Rights Reserved.</p>
-    <p class="text-center">Apache and the Apache feather logo are trademarks of The Apache Software Foundation.</p>
+    <p class="text-center">Apache, Apache Pulsar and the Apache feather logo are trademarks of The Apache Software Foundation.</p>
   </div>
 </footer>


### PR DESCRIPTION
### Motivation

The footer should contain the "Apache Pulsar" trademark mention.