### PR TITLE
Use single instances for compression codec providers

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -97,7 +97,6 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
     private final int partitionIndex;
 
     private final int receiverQueueRefillThreshold;
-    private final CompressionCodecProvider codecProvider;
 
     private volatile boolean waitingOnReceiveForZeroQueueSize = false;
 
@@ -149,7 +148,6 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         this.subscribeTimeout = System.currentTimeMillis() + client.getConfiguration().getOperationTimeoutMs();
         this.partitionIndex = partitionIndex;
         this.receiverQueueRefillThreshold = conf.getReceiverQueueSize() / 2;
-        this.codecProvider = new CompressionCodecProvider();
         this.priorityLevel = conf.getPriorityLevel();
         this.readCompacted = conf.isReadCompacted();
         this.subscriptionInitialPosition = conf.getSubscriptionInitialPosition();
@@ -1027,7 +1025,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
     private ByteBuf uncompressPayloadIfNeeded(MessageIdData messageId, MessageMetadata msgMetadata, ByteBuf payload,
             ClientCnx currentCnx) {
         CompressionType compressionType = msgMetadata.getCompression();
-        CompressionCodec codec = codecProvider.getCodec(compressionType);
+        CompressionCodec codec = CompressionCodecProvider.getCompressionCodec(compressionType);
         int uncompressedSize = msgMetadata.getUncompressedSize();
         int payloadSize = payload.readableBytes();
         if (payloadSize > PulsarDecoder.MaxMessageSize) {

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/compression/CompressionCodecProvider.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/compression/CompressionCodecProvider.java
@@ -20,47 +20,22 @@ package org.apache.pulsar.common.compression;
 
 import java.util.EnumMap;
 
+import lombok.experimental.UtilityClass;
+
 import org.apache.pulsar.common.api.proto.PulsarApi.CompressionType;
 
+@UtilityClass
 public class CompressionCodecProvider {
-    private static final EnumMap<CompressionType, Class<? extends CompressionCodec>> codecs;
-
-    private final static CompressionCodec compressionCodecNone = new CompressionCodecNone();
+    private static final EnumMap<CompressionType, CompressionCodec> codecs;
 
     static {
         codecs = new EnumMap<>(CompressionType.class);
-        codecs.put(CompressionType.NONE, CompressionCodecNone.class);
-        codecs.put(CompressionType.LZ4, CompressionCodecLZ4.class);
-        codecs.put(CompressionType.ZLIB, CompressionCodecZLib.class);
+        codecs.put(CompressionType.NONE, new CompressionCodecNone());
+        codecs.put(CompressionType.LZ4, new CompressionCodecLZ4());
+        codecs.put(CompressionType.ZLIB, new CompressionCodecZLib());
     }
 
     public static CompressionCodec getCompressionCodec(CompressionType type) {
-        if (type == CompressionType.NONE) {
-            // Always use the same instance for the none-codec
-            return compressionCodecNone;
-        }
-
-        try {
-            return codecs.get(type).newInstance();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private final EnumMap<CompressionType, CompressionCodec> codecInstances;
-
-    public CompressionCodecProvider() {
-        codecInstances = new EnumMap<>(CompressionType.class);
-        try {
-            for (CompressionType type : CompressionType.values()) {
-                codecInstances.put(type, codecs.get(type).newInstance());
-            }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public CompressionCodec getCodec(CompressionType type) {
-        return codecInstances.get(type);
+        return codecs.get(type);
     }
 }

--- a/pulsar-common/src/test/java/org/apache/pulsar/common/compression/CompressorCodecTest.java
+++ b/pulsar-common/src/test/java/org/apache/pulsar/common/compression/CompressorCodecTest.java
@@ -109,10 +109,8 @@ public class CompressorCodecTest {
 
     @Test(dataProvider = "codec")
     void testCodecProvider(CompressionType type) throws IOException {
-        CompressionCodecProvider provider = new CompressionCodecProvider();
-
-        CompressionCodec codec1 = provider.getCodec(type);
-        CompressionCodec codec2 = provider.getCodec(type);
+        CompressionCodec codec1 = CompressionCodecProvider.getCompressionCodec(type);
+        CompressionCodec codec2 = CompressionCodecProvider.getCompressionCodec(type);
 
         // A single provider instance must return the same codec instance every time
         assertTrue(codec1 == codec2);


### PR DESCRIPTION
### Motivation

Reduce number of instances of compression codecs since the implementations are sharable across threads anyway.