### PR TITLE
Remove jboss-reflect dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,6 @@ flexible messaging model and an intuitive client API.</description>
     <puppycrawl.checkstyle.version>6.19</puppycrawl.checkstyle.version>
     <dockerfile-maven.version>1.3.7</dockerfile-maven.version>
     <typetools.version>0.5.0</typetools.version>
-    <jboss-reflect.version>2.2.1.SP1</jboss-reflect.version>
     <protobuf2.version>2.4.1</protobuf2.version>
     <protobuf3.version>3.5.1</protobuf3.version>
     <protoc3.version>3.5.1-1</protoc3.version>
@@ -718,12 +717,6 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>net.jodah</groupId>
         <artifactId>typetools</artifactId>
         <version>${typetools.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.jboss</groupId>
-        <artifactId>jboss-reflect</artifactId>
-        <version>${jboss-reflect.version}</version>
       </dependency>
 
       <dependency>

--- a/pulsar-functions/instance/pom.xml
+++ b/pulsar-functions/instance/pom.xml
@@ -101,11 +101,6 @@
       <artifactId>typetools</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.jboss</groupId>
-      <artifactId>jboss-reflect</artifactId>
-    </dependency>
-
   </dependencies>
 
 </project>

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
@@ -38,9 +38,9 @@ import org.apache.pulsar.functions.instance.producers.MultiConsumersOneOuputTopi
 import org.apache.pulsar.functions.instance.producers.Producers;
 import org.apache.pulsar.functions.source.PulsarRecord;
 import org.apache.pulsar.functions.utils.FunctionConfig;
+import org.apache.pulsar.functions.utils.Reflections;
 import org.apache.pulsar.io.core.RecordContext;
 import org.apache.pulsar.io.core.Sink;
-import org.jboss.util.Classes;
 
 import java.util.Base64;
 import java.util.Map;
@@ -240,7 +240,7 @@ public class PulsarSink<T> implements Sink<T> {
     @VisibleForTesting
     void setupSerDe() throws ClassNotFoundException {
 
-        Class<?> typeArg = Classes.loadClass(this.pulsarSinkConfig.getTypeClassName(),
+        Class<?> typeArg = Reflections.loadClass(this.pulsarSinkConfig.getTypeClassName(),
                 Thread.currentThread().getContextClassLoader());
 
         if (!Void.class.equals(typeArg)) { // return type is not `Void.class`

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
@@ -33,10 +33,10 @@ import org.apache.pulsar.functions.api.SerDe;
 import org.apache.pulsar.functions.api.utils.DefaultSerDe;
 import org.apache.pulsar.functions.instance.InstanceUtils;
 import org.apache.pulsar.functions.utils.FunctionConfig;
+import org.apache.pulsar.functions.utils.Reflections;
 import org.apache.pulsar.functions.utils.Utils;
 import org.apache.pulsar.io.core.Record;
 import org.apache.pulsar.io.core.Source;
-import org.jboss.util.Classes;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -157,7 +157,7 @@ public class PulsarSource<T> implements Source<T> {
     @VisibleForTesting
     void setupSerDe() throws ClassNotFoundException {
 
-        Class<?> typeArg = Classes.loadClass(this.pulsarSourceConfig.getTypeClassName(),
+        Class<?> typeArg = Reflections.loadClass(this.pulsarSourceConfig.getTypeClassName(),
                 Thread.currentThread().getContextClassLoader());
 
         if (Void.class.equals(typeArg)) {

--- a/pulsar-functions/runtime-shaded/pom.xml
+++ b/pulsar-functions/runtime-shaded/pom.xml
@@ -127,9 +127,6 @@
                   <include>com.google.googlejavaformat:google-java-format</include>
                   <include>com.google.errorprone:javac</include>
                   <include>net.jodah:typetools</include>
-                  <include>org.jboss:jboss-reflect</include>
-                  <include>org.jboss.logging:jboss-logging-spi</include>
-                  <include>org.jboss:jboss-common-core</include>
                   <include>com.beust:jcommander</include>
                   <include>com.fasterxml.jackson.dataformat:jackson-dataformat-yaml</include>
                   <include>org.yaml:snakeyaml</include>

--- a/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/ReflectionsTest.java
+++ b/pulsar-functions/utils/src/test/java/org/apache/pulsar/functions/utils/ReflectionsTest.java
@@ -164,4 +164,35 @@ public class ReflectionsTest {
         assertTrue(Reflections.classExists(String.class.getName()));
         assertTrue(!Reflections.classExists("com.fake.class"));
     }
+
+    @Test
+    public void testLoadClass() throws Exception {
+        ClassLoader clsLoader = ClassLoader.getSystemClassLoader();
+        Class[] classes = new Class[] {
+            Integer.class,
+            int.class,
+            Byte.class,
+            byte.class,
+            Double.class,
+            double.class,
+            Float.class,
+            float.class,
+            Character.class,
+            char.class,
+            Long.class,
+            long.class,
+            Short.class,
+            short.class,
+            Boolean.class,
+            boolean.class,
+            Void.class,
+            Reflections.class,
+            Integer[].class,
+            int[].class
+        };
+
+        for (Class cls : classes) {
+            assertEquals(cls, Reflections.loadClass(cls.getName(), clsLoader));
+        }
+    }
 }


### PR DESCRIPTION
*Motivation*

`jboss-reflect` is a LGPL dependency, which is in Category-X and can't be used for apache project.

*Solution*

Removed `jboss-reflect` dependency and replace it with a simple util function to load classes.

Signed-off-by: Sijie Guo <sijie@apache.org>

