### PR TITLE
Forward encryption properties with encrypted payload to consumer

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleProducerConsumerTest.java
@@ -27,6 +27,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
+import static org.testng.Assert.assertNotNull;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -54,10 +55,22 @@ import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.api.PulsarClientException.InvalidConfigurationException;
 import org.apache.pulsar.client.impl.ConsumerImpl;
+import org.apache.pulsar.client.impl.EncryptionProperties;
+import org.apache.pulsar.client.impl.MessageCrypto;
 import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.apache.pulsar.client.impl.MessageImpl;
+import org.apache.pulsar.common.api.Commands;
 import org.apache.pulsar.common.api.PulsarDecoder;
+import org.apache.pulsar.common.api.proto.PulsarApi;
+import org.apache.pulsar.common.api.proto.PulsarApi.EncryptionKeys;
+import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata;
+import org.apache.pulsar.common.api.proto.PulsarApi.MessageMetadata.Builder;
+import org.apache.pulsar.common.compression.CompressionCodec;
+import org.apache.pulsar.common.compression.CompressionCodecProvider;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.apache.pulsar.shaded.com.google.protobuf.v241.ByteString;
+import org.inferred.freebuilder.shaded.com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -68,6 +81,12 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.google.gson.Gson;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+
+import static java.util.Base64.getDecoder;
 
 public class SimpleProducerConsumerTest extends ProducerConsumerBase {
     private static final Logger log = LoggerFactory.getLogger(SimpleProducerConsumerTest.class);
@@ -2359,6 +2378,133 @@ public class SimpleProducerConsumerTest extends ProducerConsumerBase {
         Assert.assertNull(msg, "Message received even aftet ConsumerCryptoFailureAction.DISCARD is set.");
 
         log.info("-- Exiting {} test --", methodName);
+    }
+
+    @Test(groups = "encryption")
+    public void testEncryptionConsumerWithoutCryptoReader() throws Exception {
+        log.info("-- Starting {} test --", methodName);
+
+        final String encryptionKeyName = "client-rsa.pem";
+        final String encryptionKeyVersion = "1.0";
+        Map<String, String> metadata = Maps.newHashMap();
+        metadata.put("version", encryptionKeyVersion);
+        class EncKeyReader implements CryptoKeyReader {
+
+            EncryptionKeyInfo keyInfo = new EncryptionKeyInfo();
+
+            @Override
+            public EncryptionKeyInfo getPublicKey(String keyName, Map<String, String> keyMeta) {
+                String CERT_FILE_PATH = "./src/test/resources/certificate/public-key." + keyName;
+                if (Files.isReadable(Paths.get(CERT_FILE_PATH))) {
+                    try {
+                        keyInfo.setKey(Files.readAllBytes(Paths.get(CERT_FILE_PATH)));
+                        keyInfo.setMetadata(metadata);
+                        return keyInfo;
+                    } catch (IOException e) {
+                        Assert.fail("Failed to read certificate from " + CERT_FILE_PATH);
+                    }
+                } else {
+                    Assert.fail("Certificate file " + CERT_FILE_PATH + " is not present or not readable.");
+                }
+                return null;
+            }
+
+            @Override
+            public EncryptionKeyInfo getPrivateKey(String keyName, Map<String, String> keyMeta) {
+                String CERT_FILE_PATH = "./src/test/resources/certificate/private-key." + keyName;
+                if (Files.isReadable(Paths.get(CERT_FILE_PATH))) {
+                    try {
+                        keyInfo.setKey(Files.readAllBytes(Paths.get(CERT_FILE_PATH)));
+                        keyInfo.setMetadata(metadata);
+                        return keyInfo;
+                    } catch (IOException e) {
+                        Assert.fail("Failed to read certificate from " + CERT_FILE_PATH);
+                    }
+                } else {
+                    Assert.fail("Certificate file " + CERT_FILE_PATH + " is not present or not readable.");
+                }
+                return null;
+            }
+        }
+
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic("persistent://my-property/my-ns/myrsa-topic1")
+                .subscriptionName("my-subscriber-name").cryptoFailureAction(ConsumerCryptoFailureAction.CONSUME)
+                .subscribe();
+
+        Producer<byte[]> producer = pulsarClient.newProducer().topic("persistent://my-property/my-ns/myrsa-topic1")
+                .addEncryptionKey(encryptionKeyName).compressionType(CompressionType.LZ4)
+                .cryptoKeyReader(new EncKeyReader()).create();
+
+        String message = "my-message";
+        producer.send(message.getBytes());
+
+        MessageImpl<byte[]> msg = (MessageImpl<byte[]>) consumer.receive(5, TimeUnit.SECONDS);
+
+        String receivedMessage = decryptMessage(msg, encryptionKeyName, new EncKeyReader());
+        assertEquals(message, receivedMessage);
+
+        consumer.close();
+        log.info("-- Exiting {} test --", methodName);
+    }
+    
+    private String decryptMessage(MessageImpl<byte[]> msg, String encryptionKeyName, CryptoKeyReader reader)
+            throws Exception {
+        Map<String, String> properties = msg.getProperties();
+        String encKeyName = properties.get(ConsumerCryptoFailureAction.PULSAR_ENCRYPTION_KEY_PROP + encryptionKeyName);
+        String compressionType = properties.get(ConsumerCryptoFailureAction.PULSAR_COMPRESSION_TYPE_PROP);
+        int uncompressedSize = Integer.parseInt(properties.get(ConsumerCryptoFailureAction.PULSAR_UNCOMPRESSED_MSG_SIZE_PROP));
+        byte[] encrParam = getDecoder()
+                .decode(properties.get(ConsumerCryptoFailureAction.PULSAR_ENCRYPTION_PARAM_BASE64_ENCODED_PROP));
+        String encAlgo = properties.get(ConsumerCryptoFailureAction.PULSAR_ENCRYPTION_ALGO_PROP);
+        int batchSize = properties.get(ConsumerCryptoFailureAction.PULSAR_BATCH_SIZE_PROP) != null
+                ? Integer.parseInt(properties.get(ConsumerCryptoFailureAction.PULSAR_BATCH_SIZE_PROP))
+                : 0;
+
+        assertNotNull(encKeyName);
+        EncryptionProperties encryptionKeyData = new Gson().fromJson(encKeyName, EncryptionProperties.class);
+        assertEquals(encryptionKeyData.getMetadata().size(), 1);
+
+        byte[] dataKey = getDecoder().decode(encryptionKeyData.getMsgDataKeyBase64Encoded());
+        String version = encryptionKeyData.getMetadata().get("version");
+        assertEquals(version, "1.0");
+
+        ByteBuf payloadBuf = Unpooled.wrappedBuffer(msg.getData());
+        // try to decrypt
+        MessageCrypto crypto = new MessageCrypto("test", false);
+        Builder metadataBuilder = MessageMetadata.newBuilder();
+        org.apache.pulsar.common.api.proto.PulsarApi.EncryptionKeys.Builder encKeyBuilder = EncryptionKeys.newBuilder();
+        encKeyBuilder.setKey(encryptionKeyName);
+        ByteString keyValue = ByteString.copyFrom(dataKey);
+        encKeyBuilder.setValue(keyValue);
+        EncryptionKeys encKey = encKeyBuilder.build();
+        metadataBuilder.setEncryptionParam(ByteString.copyFrom(encrParam));
+        metadataBuilder.setEncryptionAlgo(encAlgo);
+        metadataBuilder.setProducerName("test");
+        metadataBuilder.setSequenceId(123);
+        metadataBuilder.setPublishTime(12333453454L);
+        metadataBuilder.addEncryptionKeys(encKey);
+        metadataBuilder
+                .setCompression(org.apache.pulsar.common.api.proto.PulsarApi.CompressionType.valueOf(compressionType));
+        metadataBuilder.setUncompressedSize(uncompressedSize);
+        ByteBuf decryptedPayload = crypto.decrypt(metadataBuilder.build(), payloadBuf, reader);
+
+        // try to uncompress
+        org.apache.pulsar.common.api.proto.PulsarApi.CompressionType compression = org.apache.pulsar.common.api.proto.PulsarApi.CompressionType
+                .valueOf(compressionType);
+        CompressionCodec codec = CompressionCodecProvider.getCompressionCodec(compression);
+        ByteBuf uncompressedPayload = codec.decode(decryptedPayload, uncompressedSize);
+
+        if (batchSize > 0) {
+            PulsarApi.SingleMessageMetadata.Builder singleMessageMetadataBuilder = PulsarApi.SingleMessageMetadata
+                    .newBuilder();
+            uncompressedPayload = Commands.deSerializeSingleMessageInBatch(uncompressedPayload,
+                    singleMessageMetadataBuilder, 0, batchSize);
+        }
+
+        byte[] data = new byte[uncompressedPayload.readableBytes()];
+        uncompressedPayload.readBytes(data);
+        uncompressedPayload.release();
+        return new String(data);
     }
 
     @Test

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerCryptoFailureAction.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerCryptoFailureAction.java
@@ -19,6 +19,8 @@
 
 package org.apache.pulsar.client.api;
 
+import org.apache.pulsar.client.impl.EncryptionContext;
+
 public enum ConsumerCryptoFailureAction {
     FAIL, // This is the default option to fail consume until crypto succeeds
     DISCARD, // Message is silently acknowledged and not delivered to the application
@@ -30,29 +32,9 @@ public enum ConsumerCryptoFailureAction {
      * able to retrieve individual messages in the batch.
      * </pre>
      * 
-     * Delivered encrypted message will contain encrypted payload along with properties which can be used to uncompress
-     * and decrypt the payload. Message will contain following properties to decrypt message:
-     * 
-     * <ul>
-     * <li>{@value #PULSAR_ENCRYPTION_KEY_PROP}: Encryption keys in json format of {@link EncryptionKeyInfo}</li>
-     * <li>{@value #PULSAR_ENCRYPTION_PARAM_BASE64_ENCODED_PROP} : encryption param required to decrypt message</li>
-     * <li>{@value #PULSAR_ENCRYPTION_ALGO_PROP}: encryption algorithm</li>
-     * <li>{@value #PULSAR_COMPRESSION_TYPE_PROP}: compression type if message is already compressed
-     * {@link CompressionType} (null if message is not compressed).</li>
-     * <li>{@value #PULSAR_UNCOMPRESSED_MSG_SIZE_PROP}: uncompressed message size (null if message is not compressed).
-     * </li>
-     * <li>{@value #PULSAR_BATCH_SIZE_PROP}: number of messages present into batch message (null if message is not batch
-     * message).</li>
-     * </ul>
-     * 
+     * Delivered encrypted message contains {@link EncryptionContext} which contains encryption and compression
+     * information in it using which application can decrypt consumed message payload.
      * 
      */
     CONSUME;
-    
-    public static final String PULSAR_ENCRYPTION_KEY_PROP = "__pulsar_encryption_key__";
-    public static final String PULSAR_ENCRYPTION_PARAM_BASE64_ENCODED_PROP = "__pulsar_encryption_param_base64_encoded__";
-    public static final String PULSAR_ENCRYPTION_ALGO_PROP = "__pulsar_encryption_algo__";
-    public static final String PULSAR_COMPRESSION_TYPE_PROP = "__pulsar_compression_type__";
-    public static final String PULSAR_UNCOMPRESSED_MSG_SIZE_PROP = "__pulsar_uncompressed_msg_size__";
-    public static final String PULSAR_BATCH_SIZE_PROP = "__pulsar_batch_size__";
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerCryptoFailureAction.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerCryptoFailureAction.java
@@ -22,8 +22,37 @@ package org.apache.pulsar.client.api;
 public enum ConsumerCryptoFailureAction {
     FAIL, // This is the default option to fail consume until crypto succeeds
     DISCARD, // Message is silently acknowledged and not delivered to the application
-    CONSUME // Deliver the encrypted message to the application. It's the application's
-            // responsibility to decrypt the message. If message is also compressed,
-            // decompression will fail. If message contain batch messages, client will
-            // not be able to retrieve individual messages in the batch
+    /**
+     * 
+     * <pre>
+     * Deliver the encrypted message to the application. It's the application's responsibility to decrypt the message.
+     * If message is also compressed, decompression will fail. If message contain batch messages, client will not be
+     * able to retrieve individual messages in the batch.
+     * </pre>
+     * 
+     * Delivered encrypted message will contain encrypted payload along with properties which can be used to uncompress
+     * and decrypt the payload. Message will contain following properties to decrypt message:
+     * 
+     * <ul>
+     * <li>{@value #PULSAR_ENCRYPTION_KEY_PROP}: Encryption keys in json format of {@link EncryptionKeyInfo}</li>
+     * <li>{@value #PULSAR_ENCRYPTION_PARAM_BASE64_ENCODED_PROP} : encryption param required to decrypt message</li>
+     * <li>{@value #PULSAR_ENCRYPTION_ALGO_PROP}: encryption algorithm</li>
+     * <li>{@value #PULSAR_COMPRESSION_TYPE_PROP}: compression type if message is already compressed
+     * {@link CompressionType} (null if message is not compressed).</li>
+     * <li>{@value #PULSAR_UNCOMPRESSED_MSG_SIZE_PROP}: uncompressed message size (null if message is not compressed).
+     * </li>
+     * <li>{@value #PULSAR_BATCH_SIZE_PROP}: number of messages present into batch message (null if message is not batch
+     * message).</li>
+     * </ul>
+     * 
+     * 
+     */
+    CONSUME;
+    
+    public static final String PULSAR_ENCRYPTION_KEY_PROP = "__pulsar_encryption_key__";
+    public static final String PULSAR_ENCRYPTION_PARAM_BASE64_ENCODED_PROP = "__pulsar_encryption_param_base64_encoded__";
+    public static final String PULSAR_ENCRYPTION_ALGO_PROP = "__pulsar_encryption_algo__";
+    public static final String PULSAR_COMPRESSION_TYPE_PROP = "__pulsar_compression_type__";
+    public static final String PULSAR_UNCOMPRESSED_MSG_SIZE_PROP = "__pulsar_uncompressed_msg_size__";
+    public static final String PULSAR_BATCH_SIZE_PROP = "__pulsar_batch_size__";
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/EncryptionContext.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/EncryptionContext.java
@@ -19,8 +19,9 @@
 package org.apache.pulsar.client.impl;
 
 import java.util.Map;
+import java.util.Optional;
 
-import com.google.gson.Gson;
+import org.apache.pulsar.common.api.proto.PulsarApi.CompressionType;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -29,13 +30,23 @@ import lombok.Setter;
 
 @Getter
 @Setter
-@AllArgsConstructor
-@NoArgsConstructor
-public class EncryptionProperties {
-    String msgDataKeyBase64Encoded;
-    Map<String,String> metadata;
+public class EncryptionContext {
 
-    public static String toJson(EncryptionProperties encProps) {
-        return new Gson().toJson(encProps);
+    private Map<String, EncryptionKey> keys;
+    private byte[] param;
+    private Map<String, String> metadata;
+    private String algorithm;
+    private CompressionType compressionType;
+    private int uncompressedMessageSize;
+    private Optional<Integer> batchSize;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EncryptionKey {
+        private byte[] keyValue;
+        private Map<String, String> metadata;
     }
+
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/EncryptionProperties.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/EncryptionProperties.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import java.util.Map;
+
+import com.google.gson.Gson;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class EncryptionProperties {
+    String msgDataKeyBase64Encoded;
+    Map<String,String> metadata;
+
+    public static String toJson(EncryptionProperties encProps) {
+        return new Gson().toJson(encProps);
+    }
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageCrypto.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageCrypto.java
@@ -97,7 +97,7 @@ public class MessageCrypto {
 
     private static KeyGenerator keyGenerator;
     private static final int tagLen = 16 * 8;
-    private static final int ivLen = 12;
+    public static final int ivLen = 12;
     private byte[] iv = new byte[ivLen];
     private Cipher cipher;
     MessageDigest digest;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -50,6 +51,7 @@ public class MessageImpl<T> extends MessageRecordImpl<T, MessageId> {
     private ClientCnx cnx;
     private ByteBuf payload;
     private Schema<T> schema;
+    private Optional<EncryptionContext> encryptionCtx = Optional.empty();
 
     transient private Map<String, String> properties;
 
@@ -85,7 +87,7 @@ public class MessageImpl<T> extends MessageRecordImpl<T, MessageId> {
     }
     
     MessageImpl(MessageIdImpl messageId, MessageMetadata msgMetadata, ByteBuf payload,
-            Map<String, String> encryptionProperties, ClientCnx cnx, Schema<T> schema) {
+            Optional<EncryptionContext> encryptionCtx, ClientCnx cnx, Schema<T> schema) {
         this.msgMetadataBuilder = MessageMetadata.newBuilder(msgMetadata);
         this.messageId = messageId;
         this.cnx = cnx;
@@ -94,14 +96,11 @@ public class MessageImpl<T> extends MessageRecordImpl<T, MessageId> {
         // release, since the Message is passed to the user. Also, the passed ByteBuf is coming from network and is
         // backed by a direct buffer which we could not expose as a byte[]
         this.payload = Unpooled.copiedBuffer(payload);
+        this.encryptionCtx = encryptionCtx;
 
-        if (msgMetadata.getPropertiesCount() > 0 || encryptionProperties != null) {
-            Map<String, String> props = msgMetadata.getPropertiesCount() > 0 ? msgMetadataBuilder.getPropertiesList()
-                    .stream().collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue)) : Maps.newHashMap();
-            if (encryptionProperties != null) {
-                props.putAll(encryptionProperties);
-            }
-            this.properties = Collections.unmodifiableMap(props);
+        if (msgMetadata.getPropertiesCount() > 0) {
+            this.properties = Collections.unmodifiableMap(msgMetadataBuilder.getPropertiesList().stream()
+                    .collect(Collectors.toMap(KeyValue::getKey, KeyValue::getValue)));
         } else {
             properties = Collections.emptyMap();
         }
@@ -109,12 +108,14 @@ public class MessageImpl<T> extends MessageRecordImpl<T, MessageId> {
     }
 
     MessageImpl(BatchMessageIdImpl batchMessageIdImpl, MessageMetadata msgMetadata,
-            PulsarApi.SingleMessageMetadata singleMessageMetadata, ByteBuf payload, ClientCnx cnx, Schema<T> schema) {
+            PulsarApi.SingleMessageMetadata singleMessageMetadata, ByteBuf payload,
+            Optional<EncryptionContext> encryptionCtx, ClientCnx cnx, Schema<T> schema) {
         this.msgMetadataBuilder = MessageMetadata.newBuilder(msgMetadata);
         this.messageId = batchMessageIdImpl;
         this.cnx = cnx;
 
         this.payload = Unpooled.copiedBuffer(payload);
+        this.encryptionCtx = encryptionCtx;
 
         if (singleMessageMetadata.getPropertiesCount() > 0) {
             Map<String, String> properties = Maps.newTreeMap();
@@ -327,5 +328,9 @@ public class MessageImpl<T> extends MessageRecordImpl<T, MessageId> {
 
     void setMessageId(MessageIdImpl messageId) {
         this.messageId = messageId;
+    }
+    
+    public Optional<EncryptionContext> getEncryptionCtx() {
+        return encryptionCtx;
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageParser.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageParser.java
@@ -25,6 +25,7 @@ import static org.apache.pulsar.common.api.Commands.readChecksum;
 import io.netty.buffer.ByteBuf;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
@@ -175,7 +176,7 @@ public class MessageParser {
                 BatchMessageIdImpl batchMessageIdImpl = new BatchMessageIdImpl(messageId.getLedgerId(),
                         messageId.getEntryId(), partitionIndex, i, null);
                 final MessageImpl<?> message = new MessageImpl<>(batchMessageIdImpl, msgMetadata,
-                        singleMessageMetadataBuilder.build(), singleMessagePayload, cnx, null);
+                        singleMessageMetadataBuilder.build(), singleMessagePayload, Optional.empty(), cnx, null);
 
                 processor.process(batchMessageIdImpl, message, singleMessagePayload);
 


### PR DESCRIPTION
### Motivation

Right now, if Consumer doesn't configure CryptoReader and set the `ConsumerCryptoFailureAction::Consume` then consumer delivers encrypted message-payload to the application. However, message doesn't contain metadata which requires to decrypt message so, message payload is useless without metadata and application can't decrypt message payload.

### Modifications

Add encryption metadata in message properties if message is not decryptable.

### Result

Application receives message with encryption metadata along with encrypted payload so, application can decrypt payload with metadata.
