### PR TITLE
Fixed C99 variable initialization in cgo header

### DIFF
--- a/pulsar-client-go/pulsar/c_go_pulsar.h
+++ b/pulsar-client-go/pulsar/c_go_pulsar.h
@@ -129,7 +129,8 @@ static void setString(char** array, char *str, int n) {
 }
 
 static void freeStringArray(char* *array, int size) {
-    for (int i = 0; i < size; i++) {
+    int i;
+    for (i = 0; i < size; i++) {
         free(array[i]);
     }
 


### PR DESCRIPTION
### Motivation

Getting this error on Centos7 when fetching and compiling the go client lib.

```
$ go get -u github.com/apache/incubator-pulsar/pulsar-client-go/pulsar
# github.com/apache/incubator-pulsar/pulsar-client-go/pulsar
In file included from root/go/src/github.com/apache/incubator-pulsar/pulsar-client-go/pulsar/c_client.go:24:0:
./c_go_pulsar.h: In function 'freeStringArray':
./c_go_pulsar.h:132:5: error: 'for' loop initial declarations are only allowed in C99 mode
     for (int i = 0; i < size; i++) {
     ^
./c_go_pulsar.h:132:5: note: use option -std=c99 or -std=gnu99 to compile your code
```