### PR TITLE
Added ReadOnlyCursor to ManagedLedger

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/AsyncCallbacks.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/AsyncCallbacks.java
@@ -35,6 +35,12 @@ public interface AsyncCallbacks {
         void openLedgerFailed(ManagedLedgerException exception, Object ctx);
     }
 
+    interface OpenReadOnlyCursorCallback {
+        void openReadOnlyCursorComplete(ReadOnlyCursor cursor, Object ctx);
+
+        void openReadOnlyCursorFailed(ManagedLedgerException exception, Object ctx);
+    }
+
     interface DeleteLedgerCallback {
         void deleteLedgerComplete(Object ctx);
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactory.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedLedgerFactory.java
@@ -21,6 +21,7 @@ package org.apache.bookkeeper.mledger;
 import com.google.common.annotations.Beta;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ManagedLedgerInfoCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.OpenLedgerCallback;
+import org.apache.bookkeeper.mledger.AsyncCallbacks.OpenReadOnlyCursorCallback;
 
 /**
  * A factory to open/create managed ledgers and delete them.
@@ -80,6 +81,31 @@ public interface ManagedLedgerFactory {
      *            opaque context
      */
     void asyncOpen(String name, ManagedLedgerConfig config, OpenLedgerCallback callback, Object ctx);
+
+    /**
+     * Open a {@link ReadOnlyCursor} positioned to the earliest entry for the specified managed ledger
+     *
+     * @param managedLedgerName
+     * @param startPosition
+     *            set the cursor on that particular position. If setting to `PositionImpl.earliest` it will be
+     *            positioned on the first available entry.
+     * @return
+     */
+    ReadOnlyCursor openReadOnlyCursor(String managedLedgerName, Position startPosition, ManagedLedgerConfig config)
+            throws InterruptedException, ManagedLedgerException;
+
+    /**
+     * Open a {@link ReadOnlyCursor} positioned to the earliest entry for the specified managed ledger
+     *
+     * @param name
+     * @param startPosition
+     *            set the cursor on that particular position. If setting to `PositionImpl.earliest` it will be
+     *            positioned on the first available entry.
+     * @param callback
+     * @param ctx
+     */
+    void asyncOpenReadOnlyCursor(String managedLedgerName, Position startPosition, ManagedLedgerConfig config,
+            OpenReadOnlyCursorCallback callback, Object ctx);
 
     /**
      * Get the current metadata info for a managed ledger.

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ReadOnlyCursor.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ReadOnlyCursor.java
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger;
+
+import java.util.List;
+
+import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntriesCallback;
+
+public interface ReadOnlyCursor {
+    /**
+     * Read entries from the ManagedLedger, up to the specified number. The returned list can be smaller.
+     *
+     * @param numberOfEntriesToRead
+     *            maximum number of entries to return
+     * @return the list of entries
+     * @throws ManagedLedgerException
+     */
+    List<Entry> readEntries(int numberOfEntriesToRead) throws InterruptedException, ManagedLedgerException;
+
+    /**
+     * Asynchronously read entries from the ManagedLedger.
+     *
+     * @see #readEntries(int)
+     * @param numberOfEntriesToRead
+     *            maximum number of entries to return
+     * @param callback
+     *            callback object
+     * @param ctx
+     *            opaque context
+     */
+    void asyncReadEntries(int numberOfEntriesToRead, ReadEntriesCallback callback, Object ctx);
+
+    /**
+     * Get the read position. This points to the next message to be read from the cursor.
+     *
+     * @return the read position
+     */
+    Position getReadPosition();
+
+    /**
+     * Tells whether this cursor has already consumed all the available entries.
+     *
+     * <p/>
+     * This method is not blocking.
+     *
+     * @return true if there are pending entries to read, false otherwise
+     */
+    boolean hasMoreEntries();
+
+    /**
+     * Return the number of messages that this cursor still has to read.
+     *
+     * <p/>
+     * This method has linear time complexity on the number of ledgers included in the managed ledger.
+     *
+     * @return the number of entries
+     */
+    long getNumberOfEntries();
+
+    /**
+     * Skip n entries from the read position of this cursor.
+     *
+     * @param numEntriesToSkip
+     *            number of entries to skip
+     */
+    void skipEntries(int numEntriesToSkip);
+
+    /**
+     * Close the cursor and releases the associated resources.
+     *
+     * @throws InterruptedException
+     * @throws ManagedLedgerException
+     */
+    void close() throws InterruptedException, ManagedLedgerException;
+
+    /**
+     * Close the cursor asynchronously and release the associated resources.
+     *
+     * @param callback
+     *            callback object
+     * @param ctx
+     *            opaque context
+     */
+    void asyncClose(AsyncCallbacks.CloseCallback callback, Object ctx);
+}

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -171,7 +171,7 @@ public class ManagedCursorImpl implements ManagedCursor {
 
     private static final AtomicReferenceFieldUpdater<ManagedCursorImpl, State> STATE_UPDATER =
         AtomicReferenceFieldUpdater.newUpdater(ManagedCursorImpl.class, State.class, "state");
-    private volatile State state = null;
+    protected volatile State state = null;
 
     @SuppressWarnings("checkstyle:javadoctype")
     public interface VoidCallback {
@@ -1014,7 +1014,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         return alreadyAcknowledgedPositions;
     }
 
-    private long getNumberOfEntries(Range<PositionImpl> range) {
+    protected long getNumberOfEntries(Range<PositionImpl> range) {
         long allEntries = ledger.getNumberOfEntries(range);
 
         if (log.isDebugEnabled()) {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -29,7 +29,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
 import com.google.common.collect.Range;
 import com.google.common.util.concurrent.RateLimiter;
-import com.google.protobuf.ByteString;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -50,8 +49,8 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReference;
@@ -73,8 +72,8 @@ import org.apache.bookkeeper.mledger.AsyncCallbacks.AddEntryCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.CloseCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteCursorCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.DeleteLedgerCallback;
-import org.apache.bookkeeper.mledger.AsyncCallbacks.OpenCursorCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.OffloadCallback;
+import org.apache.bookkeeper.mledger.AsyncCallbacks.OpenCursorCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntryCallback;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.TerminateCallback;
 import org.apache.bookkeeper.mledger.Entry;
@@ -98,9 +97,9 @@ import org.apache.bookkeeper.mledger.impl.ManagedCursorImpl.VoidCallback;
 import org.apache.bookkeeper.mledger.impl.MetaStore.MetaStoreCallback;
 import org.apache.bookkeeper.mledger.impl.MetaStore.Stat;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo;
-import org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.NestedPositionInfo;
+import org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext;
 import org.apache.bookkeeper.mledger.util.CallbackMutex;
 import org.apache.bookkeeper.mledger.util.Futures;
 import org.apache.commons.lang3.tuple.Pair;
@@ -118,15 +117,15 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     private final static long maxActiveCursorBacklogEntries = 100;
     private static long maxMessageCacheRetentionTimeMillis = 10 * 1000;
 
-    private final BookKeeper bookKeeper;
-    private final String name;
+    protected final BookKeeper bookKeeper;
+    protected final String name;
     private final BookKeeper.DigestType digestType;
 
-    private ManagedLedgerConfig config;
-    private final MetaStore store;
+    protected ManagedLedgerConfig config;
+    protected final MetaStore store;
 
     private final ConcurrentLongHashMap<CompletableFuture<ReadHandle>> ledgerCache = new ConcurrentLongHashMap<>();
-    private final NavigableMap<Long, LedgerInfo> ledgers = new ConcurrentSkipListMap<>();
+    protected final NavigableMap<Long, LedgerInfo> ledgers = new ConcurrentSkipListMap<>();
     private volatile Stat ledgersStat;
 
     private final ManagedCursorContainer cursors = new ManagedCursorContainer();
@@ -209,13 +208,13 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
     private static final AtomicReferenceFieldUpdater<ManagedLedgerImpl, State> STATE_UPDATER =
             AtomicReferenceFieldUpdater.newUpdater(ManagedLedgerImpl.class, State.class, "state");
-    private volatile State state = null;
+    protected volatile State state = null;
 
     private final OrderedScheduler scheduledExecutor;
     private final OrderedExecutor executor;
     final ManagedLedgerFactoryImpl factory;
     protected final ManagedLedgerMBeanImpl mbean;
-    private final Clock clock;
+    protected final Clock clock;
 
     /**
      * Queue of pending entries to be added to the managed ledger. Typically entries are queued when a new ledger is
@@ -1344,7 +1343,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
         LedgerHandle currentLedger = this.currentLedger;
 
-        if (ledgerId == currentLedger.getId()) {
+        if (currentLedger != null && ledgerId == currentLedger.getId()) {
             // Current writing ledger is not in the cache (since we don't want
             // it to be automatically evicted), and we cannot use 2 different
             // ledger handles (read & write)for the same ledger.
@@ -2356,7 +2355,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         while (entriesToSkip >= 0) {
             // for the current ledger, the number of entries written is deduced from the lastConfirmedEntry
             // for previous ledgers, LedgerInfo in ZK has the number of entries
-            if (currentLedgerId == currentLedger.getId()) {
+            if (currentLedger != null && currentLedgerId == currentLedger.getId()) {
                 lastLedger = true;
                 totalEntriesInCurrentLedger = lastConfirmedEntry.getEntryId() + 1;
             } else {

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1394,7 +1394,7 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                     openFuture = config.getLedgerOffloader().readOffloaded(ledgerId, uid);
                 } else {
                     openFuture = bookKeeper.newOpenLedgerOp()
-                        .withRecovery(true)
+                        .withRecovery(!isReadOnly())
                         .withLedgerId(ledgerId)
                         .withDigestType(config.getDigestType())
                         .withPassword(config.getPassword()).execute();
@@ -2699,6 +2699,11 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
 
     public long getCacheSize() {
         return entryCache.getSize();
+    }
+
+    protected boolean isReadOnly() {
+        // Default managed ledger implementation is read-write
+        return false;
     }
 
     /**

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2377,7 +2377,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                     currentEntryId = totalEntriesInCurrentLedger;
                     break;
                 } else {
-                    currentLedgerId = ledgers.ceilingKey(currentLedgerId + 1);
+                    Long lid = ledgers.ceilingKey(currentLedgerId + 1);
+                    currentLedgerId = lid != null ? lid : (ledgers.lastKey() + 1);
                     currentEntryId = 0;
                 }
             }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyCursorImpl.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import com.google.common.collect.Range;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.bookkeeper.client.BookKeeper;
+import org.apache.bookkeeper.mledger.AsyncCallbacks;
+import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
+import org.apache.bookkeeper.mledger.ReadOnlyCursor;
+import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.PositionBound;
+
+@Slf4j
+public class ReadOnlyCursorImpl extends ManagedCursorImpl implements ReadOnlyCursor {
+
+    public ReadOnlyCursorImpl(BookKeeper bookkeeper, ManagedLedgerConfig config, ManagedLedgerImpl ledger,
+            PositionImpl startPosition, String cursorName) {
+        super(bookkeeper, config, ledger, cursorName);
+
+        if (startPosition.equals(PositionImpl.earliest)) {
+            readPosition = ledger.getFirstPosition().getNext();
+        } else {
+            readPosition = startPosition;
+        }
+
+        if (ledger.getLastPosition().compareTo(readPosition) <= 0) {
+            messagesConsumedCounter = 0;
+        } else {
+            messagesConsumedCounter = -getNumberOfEntries(Range.closed(readPosition, ledger.getLastPosition()));
+        }
+
+        state = State.NoLedger;
+    }
+
+    @Override
+    public void skipEntries(int numEntriesToSkip) {
+        log.info("[{}] Skipping {} entries on read-only cursor {}", ledger.getName(), numEntriesToSkip);
+        readPosition = ledger.getPositionAfterN(readPosition, numEntriesToSkip, PositionBound.startExcluded);
+    }
+
+    @Override
+    public void asyncClose(final AsyncCallbacks.CloseCallback callback, final Object ctx) {
+        state = State.Closed;
+        callback.closeComplete(ctx);
+    }
+
+}

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyCursorImpl.java
@@ -53,7 +53,7 @@ public class ReadOnlyCursorImpl extends ManagedCursorImpl implements ReadOnlyCur
     @Override
     public void skipEntries(int numEntriesToSkip) {
         log.info("[{}] Skipping {} entries on read-only cursor {}", ledger.getName(), numEntriesToSkip);
-        readPosition = ledger.getPositionAfterN(readPosition, numEntriesToSkip, PositionBound.startExcluded);
+        readPosition = ledger.getPositionAfterN(readPosition, numEntriesToSkip, PositionBound.startIncluded).getNext();
     }
 
     @Override

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyManagedLedgerImpl.java
@@ -1,0 +1,127 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import org.apache.bookkeeper.client.BookKeeper;
+import org.apache.bookkeeper.common.util.OrderedExecutor;
+import org.apache.bookkeeper.common.util.OrderedScheduler;
+import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
+import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.bookkeeper.mledger.ManagedLedgerException.ManagedLedgerNotFoundException;
+import org.apache.bookkeeper.mledger.ManagedLedgerException.MetaStoreException;
+import org.apache.bookkeeper.mledger.ManagedLedgerException.MetadataNotFoundException;
+import org.apache.bookkeeper.mledger.ReadOnlyCursor;
+import org.apache.bookkeeper.mledger.impl.MetaStore.MetaStoreCallback;
+import org.apache.bookkeeper.mledger.impl.MetaStore.Stat;
+import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo;
+import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo;
+
+public class ReadOnlyManagedLedgerImpl extends ManagedLedgerImpl {
+
+    public ReadOnlyManagedLedgerImpl(ManagedLedgerFactoryImpl factory, BookKeeper bookKeeper, MetaStore store,
+            ManagedLedgerConfig config, OrderedScheduler scheduledExecutor, OrderedExecutor orderedExecutor,
+            String name) {
+        super(factory, bookKeeper, store, config, scheduledExecutor, orderedExecutor, name);
+    }
+
+    CompletableFuture<ReadOnlyCursor> initializeAndCreateCursor(PositionImpl startPosition) {
+        CompletableFuture<ReadOnlyCursor> future = new CompletableFuture<>();
+
+        // Fetch the list of existing ledgers in the managed ledger
+        store.getManagedLedgerInfo(name, false, new MetaStoreCallback<ManagedLedgerInfo>() {
+            @Override
+            public void operationComplete(ManagedLedgerInfo mlInfo, Stat stat) {
+                state = State.LedgerOpened;
+
+                for (LedgerInfo ls : mlInfo.getLedgerInfoList()) {
+                    ledgers.put(ls.getLedgerId(), ls);
+                }
+
+                // Last ledger stat may be zeroed, we must update it
+                if (ledgers.size() > 0 && ledgers.lastEntry().getValue().getEntries() == 0) {
+                    long lastLedgerId = ledgers.lastKey();
+
+                    // Fetch last add confirmed for last ledger
+                    bookKeeper.newOpenLedgerOp().withRecovery(false).withLedgerId(lastLedgerId)
+                            .withDigestType(config.getDigestType()).withPassword(config.getPassword()).execute()
+                            .thenAccept(readHandle -> {
+                                readHandle.readLastAddConfirmedAsync().thenAccept(lastAddConfirmed -> {
+                                    LedgerInfo info = LedgerInfo.newBuilder().setLedgerId(lastLedgerId)
+                                            .setEntries(lastAddConfirmed + 1).setSize(readHandle.getLength())
+                                            .setTimestamp(clock.millis()).build();
+                                    ledgers.put(lastLedgerId, info);
+
+                                    future.complete(createReadOnlyCursor(startPosition));
+                                }).exceptionally(ex -> {
+                                    if (ex instanceof CompletionException
+                                            && ex.getCause() instanceof IllegalArgumentException) {
+                                        // The last ledger was empty, so we cannot read the last add confirmed.
+                                        LedgerInfo info = LedgerInfo.newBuilder().setLedgerId(lastLedgerId)
+                                                .setEntries(0).setSize(0).setTimestamp(clock.millis()).build();
+                                        ledgers.put(lastLedgerId, info);
+                                        future.complete(createReadOnlyCursor(startPosition));
+                                    } else {
+                                        future.completeExceptionally(new ManagedLedgerException(ex));
+                                    }
+                                    return null;
+                                });
+                            }).exceptionally(ex -> {
+                                if (ex instanceof CompletionException
+                                        && ex.getCause() instanceof ArrayIndexOutOfBoundsException) {
+                                    // The last ledger was empty, so we cannot read the last add confirmed.
+                                    LedgerInfo info = LedgerInfo.newBuilder().setLedgerId(lastLedgerId).setEntries(0)
+                                            .setSize(0).setTimestamp(clock.millis()).build();
+                                    ledgers.put(lastLedgerId, info);
+                                    future.complete(createReadOnlyCursor(startPosition));
+                                } else {
+                                    future.completeExceptionally(new ManagedLedgerException(ex));
+                                }
+                                return null;
+                            });
+                } else {
+                    // The read-only managed ledger is ready to use
+                    future.complete(createReadOnlyCursor(startPosition));
+                }
+            }
+
+            @Override
+            public void operationFailed(MetaStoreException e) {
+                if (e instanceof MetadataNotFoundException) {
+                    future.completeExceptionally(new ManagedLedgerNotFoundException(e));
+                } else {
+                    future.completeExceptionally(new ManagedLedgerException(e));
+                }
+            }
+        });
+
+        return future;
+    }
+
+    private ReadOnlyCursor createReadOnlyCursor(PositionImpl startPosition) {
+        lastConfirmedEntry = ledgers.size() == 0 ? PositionImpl.earliest
+                : new PositionImpl(ledgers.lastKey(), ledgers.lastEntry().getValue().getEntries() - 1);
+
+        ReadOnlyCursorImpl cursor = new ReadOnlyCursorImpl(bookKeeper, config, this, startPosition, "read-only-cursor");
+        return cursor;
+    }
+
+}

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyManagedLedgerImpl.java
@@ -124,4 +124,7 @@ public class ReadOnlyManagedLedgerImpl extends ManagedLedgerImpl {
         return cursor;
     }
 
+    protected boolean isReadOnly() {
+        return true;
+    }
 }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ReadOnlyCursorTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ReadOnlyCursorTest.java
@@ -1,0 +1,171 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.impl;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.bookkeeper.mledger.Entry;
+import org.apache.bookkeeper.mledger.ManagedLedger;
+import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
+import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
+import org.apache.bookkeeper.mledger.ManagedLedgerFactoryConfig;
+import org.apache.bookkeeper.mledger.ManagedLedgerException.ManagedLedgerNotFoundException;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.ReadOnlyCursor;
+import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
+import org.testng.annotations.Test;
+
+public class ReadOnlyCursorTest extends MockedBookKeeperTestCase {
+
+    @Test
+    void notFound() throws Exception {
+        try {
+            factory.openReadOnlyCursor("notFound", PositionImpl.earliest, new ManagedLedgerConfig());
+            fail("Should have failed");
+        } catch (ManagedLedgerNotFoundException e) {
+            // Expected
+        }
+
+        factory.shutdown();
+    }
+
+    @Test
+    void simple() throws Exception {
+        ManagedLedger ledger = factory.open("simple", new ManagedLedgerConfig().setRetentionTime(1, TimeUnit.HOURS));
+
+        int N = 10;
+
+        for (int i = 0; i < N; i++) {
+            ledger.addEntry(("entry-" + i).getBytes());
+        }
+
+        ReadOnlyCursor cursor = factory.openReadOnlyCursor("simple", PositionImpl.earliest, new ManagedLedgerConfig());
+
+        assertEquals(cursor.getNumberOfEntries(), N);
+        assertTrue(cursor.hasMoreEntries());
+
+        List<Entry> entries = cursor.readEntries(N);
+        assertEquals(entries.size(), N);
+
+        assertEquals(cursor.getNumberOfEntries(), 0);
+        assertFalse(cursor.hasMoreEntries());
+        entries.forEach(Entry::release);
+        cursor.close();
+
+        // Ensure we can still write to ledger
+        for (int i = 0; i < N; i++) {
+            ledger.addEntry(("entry-" + i).getBytes());
+        }
+
+        // Open a new cursor
+        cursor = factory.openReadOnlyCursor("simple", PositionImpl.earliest, new ManagedLedgerConfig());
+
+        assertEquals(cursor.getNumberOfEntries(), 2 * N);
+        assertTrue(cursor.hasMoreEntries());
+
+        entries = cursor.readEntries(N);
+        assertEquals(entries.size(), N);
+
+        assertEquals(cursor.getNumberOfEntries(), N);
+        assertTrue(cursor.hasMoreEntries());
+        entries.forEach(Entry::release);
+
+        entries = cursor.readEntries(N);
+        assertEquals(entries.size(), N);
+
+        assertEquals(cursor.getNumberOfEntries(), 0);
+        assertFalse(cursor.hasMoreEntries());
+        entries.forEach(Entry::release);
+
+        cursor.close();
+    }
+
+    @Test
+    void skip() throws Exception {
+        ManagedLedger ledger = factory.open("skip",
+                new ManagedLedgerConfig().setMaxEntriesPerLedger(2).setRetentionTime(1, TimeUnit.HOURS));
+
+        int N = 10;
+
+        for (int i = 0; i < N; i++) {
+            ledger.addEntry(("entry-" + i).getBytes());
+        }
+
+        ReadOnlyCursor cursor = factory.openReadOnlyCursor("skip", PositionImpl.earliest, new ManagedLedgerConfig());
+
+        assertEquals(cursor.getNumberOfEntries(), N);
+        assertTrue(cursor.hasMoreEntries());
+
+        cursor.skipEntries(5);
+
+        assertEquals(cursor.getNumberOfEntries(), N - 5);
+        assertTrue(cursor.hasMoreEntries());
+
+        cursor.close();
+    }
+
+    @Test
+    void empty() throws Exception {
+        factory.open("empty", new ManagedLedgerConfig().setRetentionTime(1, TimeUnit.HOURS));
+
+        ReadOnlyCursor cursor = factory.openReadOnlyCursor("empty", PositionImpl.earliest, new ManagedLedgerConfig());
+
+        assertEquals(cursor.getNumberOfEntries(), 0);
+        assertFalse(cursor.hasMoreEntries());
+
+        cursor.close();
+    }
+
+    @Test
+    void specifyStartPosition() throws Exception {
+        ManagedLedger ledger = factory.open("simple", new ManagedLedgerConfig().setRetentionTime(1, TimeUnit.HOURS));
+
+        int N = 10;
+
+        for (int i = 0; i < N; i++) {
+            ledger.addEntry(("entry-" + i).getBytes());
+        }
+
+        ReadOnlyCursor cursor = factory.openReadOnlyCursor("simple", PositionImpl.earliest, new ManagedLedgerConfig());
+
+        assertEquals(cursor.getNumberOfEntries(), N);
+        assertTrue(cursor.hasMoreEntries());
+
+        Position readPosition = cursor.getReadPosition();
+        cursor = factory.openReadOnlyCursor("simple", readPosition, new ManagedLedgerConfig());
+
+        assertEquals(cursor.getNumberOfEntries(), N);
+        assertTrue(cursor.hasMoreEntries());
+
+        cursor.skipEntries(5);
+
+        Position newReadPosition = cursor.getReadPosition();
+        cursor = factory.openReadOnlyCursor("simple", newReadPosition, new ManagedLedgerConfig());
+
+        assertEquals(cursor.getNumberOfEntries(), N - 5);
+        assertTrue(cursor.hasMoreEntries());
+    }
+
+}


### PR DESCRIPTION
### Motivation

Added a read-only cursor that can be used to read data out of a managed ledger without interfering with the managed ledger instance that is active in the Pulsar broker that owns a particular topic.

### Modifications

 * Added `ReadOnlyCursor` that can be obtained directly from a `ManagedLedgerFactory`
 * The read only cursor has only subset of the functionality of the regular `ManagedCursor`
