### PR TITLE
Tests Python Wheel packaging in CI build

### DIFF
--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -21,6 +21,7 @@
 
 from unittest import TestCase, main
 import time
+import os
 from pulsar import Client, MessageId, \
             CompressionType, ConsumerType, PartitionsRoutingMode, \
             AuthenticationTLS
@@ -125,7 +126,9 @@ class PulsarTest(TestCase):
         client.close()
 
     def test_tls_auth(self):
-        certs_dir = "../../pulsar-broker/src/test/resources/authentication/tls/"
+        certs_dir = '/pulsar/pulsar-broker/src/test/resources/authentication/tls/'
+        if not os.path.exists(certs_dir):
+            certs_dir = "../../pulsar-broker/src/test/resources/authentication/tls/"
         client = Client(self.serviceUrlTls,
                         tls_trust_certs_file_path=certs_dir + 'cacert.pem',
                         tls_allow_insecure_connection=False,

--- a/pulsar-client-cpp/run-unit-tests.sh
+++ b/pulsar-client-cpp/run-unit-tests.sh
@@ -57,7 +57,7 @@ PULSAR_CLIENT_CONF=$PWD/test-conf/client-ssl.conf pulsar-dist/bin/pulsar-admin c
 
 sleep 5
 
-cd tests
+pushd tests
 
 if [ -f /gtest-parallel/gtest-parallel ]; then
     echo "---- Run unit tests in parallel"
@@ -68,11 +68,31 @@ else
     RES=$?
 fi
 
+popd
+
+RES=0
+
 if [ $RES -eq 0 ]; then
+    pushd python
+    echo "---- Build Python Wheel file"
+    python setup.py bdist_wheel
+
+    echo "---- Installing  Python Wheel file"
+    pip install dist/pulsar_client-*-linux_x86_64.whl
+
     echo "---- Running Python unit tests"
-    cd ../python
+
+    # Running tests from a different directory to avoid importing directly
+    # from the current dir, but rather using the installed wheel file
+    cp pulsar_test.py /tmp
+    pushd /tmp
+
     python pulsar_test.py
     RES=$?
+
+    popd
+    popd
+
 fi
 
 kill -9 $standalone_pid $auth_pid

--- a/pulsar-client-cpp/run-unit-tests.sh
+++ b/pulsar-client-cpp/run-unit-tests.sh
@@ -70,8 +70,6 @@ fi
 
 popd
 
-RES=0
-
 if [ $RES -eq 0 ]; then
     pushd python
     echo "---- Build Python Wheel file"


### PR DESCRIPTION
### Motivation

Currently, we're not testing the validity of the wheel file package for the Python client library. This leads to find packaging error later in the release phase.

### Modifications

Build Python wheel file as part of CI build and make sure the tests are importing the pulsar library from that installed wheel file.