### PR TITLE
Fixed lookups for v2 topics in C++ client lib with HTTP service URL

### DIFF
--- a/pulsar-client-cpp/lib/HTTPLookupService.cc
+++ b/pulsar-client-cpp/lib/HTTPLookupService.cc
@@ -21,8 +21,14 @@
 DECLARE_LOG_OBJECT()
 
 namespace pulsar {
-const static std::string V2_PATH = "/lookup/v2/destination/";
-const static std::string PARTITION_PATH = "/admin/persistent/";
+
+const static std::string V1_PATH = "/lookup/v2/destination/";
+const static std::string V2_PATH = "/lookup/v2/topic/";
+
+
+const static std::string ADMIN_PATH_V1 = "/admin/";
+const static std::string ADMIN_PATH_V2 = "/admin/v2";
+
 const static int MAX_HTTP_REDIRECTS = 20;
 const static std::string PARTITION_METHOD_NAME = "partitions";
 const static int NUMBER_OF_LOOKUP_THREADS = 1;
@@ -53,9 +59,16 @@ Future<Result, LookupDataResultPtr> HTTPLookupService::lookupAsync(const std::st
     }
 
     std::stringstream completeUrlStream;
-    completeUrlStream << adminUrl_ << V2_PATH << "persistent/" << topicName->getProperty() << '/'
+    if (topicName->isV2Topic()) {
+        completeUrlStream << adminUrl_ << V2_PATH << topicName->getDomain() << "/" << topicName->getProperty() << '/'
+                      << topicName->getNamespacePortion() << '/'
+                      << topicName->getEncodedLocalName();
+    } else {
+        completeUrlStream << adminUrl_ << V1_PATH << topicName->getDomain() << "/" << topicName->getProperty() << '/'
                       << topicName->getCluster() << '/' << topicName->getNamespacePortion() << '/'
                       << topicName->getEncodedLocalName();
+    }
+
     executorProvider_->get()->postWork(boost::bind(&HTTPLookupService::sendHTTPRequest, shared_from_this(),
                                                    promise, completeUrlStream.str(), Lookup));
     return promise.getFuture();
@@ -65,9 +78,17 @@ Future<Result, LookupDataResultPtr> HTTPLookupService::getPartitionMetadataAsync
     const TopicNamePtr &topicName) {
     LookupPromise promise;
     std::stringstream completeUrlStream;
-    completeUrlStream << adminUrl_ << PARTITION_PATH << topicName->getProperty() << '/'
-                      << topicName->getCluster() << '/' << topicName->getNamespacePortion() << '/'
-                      << topicName->getEncodedLocalName() << '/' << PARTITION_METHOD_NAME;
+
+    if (topicName->isV2Topic()) {
+        completeUrlStream << adminUrl_ << ADMIN_PATH_V2 << topicName->getDomain() << '/' << topicName->getProperty() << '/'
+                          << topicName->getNamespacePortion() << '/'
+                          << topicName->getEncodedLocalName() << '/' << PARTITION_METHOD_NAME;
+    } else {
+        completeUrlStream << adminUrl_ << ADMIN_PATH_V1 << topicName->getDomain() << '/' << topicName->getProperty() << '/'
+                          << topicName->getCluster() << '/' << topicName->getNamespacePortion() << '/'
+                          << topicName->getEncodedLocalName() << '/' << PARTITION_METHOD_NAME;
+    }
+
     executorProvider_->get()->postWork(boost::bind(&HTTPLookupService::sendHTTPRequest, shared_from_this(),
                                                    promise, completeUrlStream.str(), PartitionMetaData));
     return promise.getFuture();

--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -543,6 +543,33 @@ class PulsarTest(TestCase):
         self.assertEqual(msg.data(), b'hello-0')
         client.close()
 
+    def test_v2_topics(self):
+        self._v2_topics(self.serviceUrl)
+
+    def test_v2_topics_http(self):
+        self._v2_topics(self.adminUrl)
+
+    def _v2_topics(self, url):
+        client = Client(url)
+        consumer = client.subscribe('my-v2-topic-producer-consumer',
+                                    'my-sub',
+                                    consumer_type=ConsumerType.Shared)
+        producer = client.create_producer('my-v2-topic-producer-consumer')
+        producer.send('hello')
+
+        msg = consumer.receive(1000)
+        self.assertTrue(msg)
+        self.assertEqual(msg.data(), b'hello')
+        consumer.acknowledge(msg)
+
+        try:
+            msg = consumer.receive(100)
+            self.assertTrue(False)  # Should not reach this point
+        except:
+            pass  # Exception is expected
+
+        client.close()
+
     def _check_value_error(self, fun):
         try:
             fun()

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -260,6 +260,30 @@ TEST(BasicEndToEndTest, testNonPersistentTopic) {
     ASSERT_EQ(ResultOk, result);
 }
 
+TEST(BasicEndToEndTest, testV2TopicProtobuf) {
+    std::string topicName = "my-topic";
+    Client client(lookupUrl);
+    Producer producer;
+    Result result = client.createProducer(topicName, producer);
+    ASSERT_EQ(ResultOk, result);
+
+    Consumer consumer;
+    result = client.subscribe(topicName, "my-sub-name", consumer);
+    ASSERT_EQ(ResultOk, result);
+}
+
+TEST(BasicEndToEndTest, testV2TopicHttp) {
+    std::string topicName = "my-topic";
+    Client client(adminUrl);
+    Producer producer;
+    Result result = client.createProducer(topicName, producer);
+    ASSERT_EQ(ResultOk, result);
+
+    Consumer consumer;
+    result = client.subscribe(topicName, "my-sub-name", consumer);
+    ASSERT_EQ(ResultOk, result);
+}
+
 TEST(BasicEndToEndTest, testSingleClientMultipleSubscriptions) {
     std::string topicName = "persistent://prop/unit/ns1/testSingleClientMultipleSubscriptions";
 


### PR DESCRIPTION
### Motivation

V2 topics are currently not working in C++ when using HTTP based service url. While we encourage to use the protobuf based protocol for service discovery, the HTTP endpoint must still work for all features.

### Modifications

Fixes the HTTP endpoints depending on the topic name format.