### PR TITLE
Fixed resetting of producer sequence id counter after receiving SendError before any message was successfully published

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBkEnsemblesTests.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerBkEnsemblesTests.java
@@ -60,11 +60,11 @@ import com.google.common.collect.Sets;
  */
 public class BrokerBkEnsemblesTests {
     protected static int BROKER_SERVICE_PORT = 16650;
-    PulsarService pulsar;
+    protected PulsarService pulsar;
     ServiceConfiguration config;
 
     URL adminUrl;
-    PulsarAdmin admin;
+    protected PulsarAdmin admin;
 
     LocalBookkeeperEnsemble bkEnsemble;
 
@@ -83,7 +83,7 @@ public class BrokerBkEnsemblesTests {
     }
 
     @BeforeMethod
-    void setup() throws Exception {
+    protected void setup() throws Exception {
         try {
             // start local bookie and zookeeper
             bkEnsemble = new LocalBookkeeperEnsemble(numberOfBookies, ZOOKEEPER_PORT, 5001);
@@ -118,7 +118,7 @@ public class BrokerBkEnsemblesTests {
     }
 
     @AfterMethod
-    void shutdown() throws Exception {
+    protected void shutdown() throws Exception {
         try {
             admin.close();
             pulsar.close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/RackAwareTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/RackAwareTest.java
@@ -52,7 +52,7 @@ public class RackAwareTest extends BrokerBkEnsemblesTests {
 
     @SuppressWarnings("deprecation")
     @BeforeClass
-    void setup() throws Exception {
+    protected void setup() throws Exception {
         super.setup();
 
         // Start bookies with specific racks
@@ -83,7 +83,7 @@ public class RackAwareTest extends BrokerBkEnsemblesTests {
     }
 
     @AfterClass
-    void shutdown() throws Exception {
+    protected void shutdown() throws Exception {
         super.shutdown();
 
         for (BookieServer bs : bookies) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/SequenceIdWithErrorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/SequenceIdWithErrorTest.java
@@ -1,0 +1,102 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import static org.testng.Assert.assertEquals;
+
+import java.util.Collections;
+
+import org.apache.bookkeeper.mledger.ManagedLedger;
+import org.apache.bookkeeper.mledger.ManagedLedgerFactory;
+import org.apache.pulsar.broker.ManagedLedgerClientFactory;
+import org.apache.pulsar.broker.service.BrokerBkEnsemblesTests;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.naming.TopicName;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class SequenceIdWithErrorTest extends BrokerBkEnsemblesTests {
+    @Override
+    @BeforeMethod
+    public void setup() throws Exception {
+        super.setup();
+    }
+
+    @AfterMethod
+    public void cleanup() throws Exception {
+        super.shutdown();
+    }
+
+    /**
+     * Test that sequence id from a producer is correct when there are send errors
+     */
+    @Test
+    public void testCheckSequenceId() throws Exception {
+        admin.namespaces().createNamespace("prop/my-test", Collections.singleton("usc"));
+
+        String topicName = "prop/my-test/my-topic";
+        int N = 10;
+
+        PulsarClient client = PulsarClient.builder().serviceUrl("pulsar://localhost:" + BROKER_SERVICE_PORT).build();
+
+        // Create consumer
+        Consumer<String> consumer = client.newConsumer(Schema.STRING).topic(topicName).subscriptionName("sub")
+                .subscribe();
+
+        // Fence the topic by opening the ManagedLedger for the topic outside the Pulsar broker. This will cause the
+        // broker to fail subsequent send operation and it will trigger a recover
+        ManagedLedgerClientFactory clientFactory = new ManagedLedgerClientFactory(pulsar.getConfiguration(),
+                pulsar.getZkClient(), pulsar.getBookKeeperClientFactory());
+        ManagedLedgerFactory mlFactory = clientFactory.getManagedLedgerFactory();
+        ManagedLedger ml = mlFactory.open(TopicName.get(topicName).getPersistenceNamingEncoding());
+        ml.close();
+        clientFactory.close();
+
+        // Create a producer
+        Producer<String> producer = client.newProducer(Schema.STRING).topic(topicName).create();
+
+        for (int i = 0; i < N; i++) {
+            producer.send("Hello-" + i);
+        }
+
+        for (int i = 0; i < N; i++) {
+            Message<String> msg = consumer.receive();
+            assertEquals(msg.getValue(), "Hello-" + i);
+            assertEquals(msg.getSequenceId(), i);
+            consumer.acknowledge(msg);
+        }
+
+        client.close();
+    }
+
+    @Override
+    public void testCrashBrokerWithoutCursorLedgerLeak() throws Exception {
+        // Ignore test
+    }
+
+    @Override
+    public void testSkipCorruptDataLedger() throws Exception {
+        // Ignore test
+    }
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -873,7 +873,10 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                             this.producerName = producerName;
                         }
 
-                        if (this.lastSequenceIdPublished == -1 && conf.getInitialSequenceId() == null) {
+                        if (this.msgIdGenerator == 0 && conf.getInitialSequenceId() == null) {
+                            // Only update sequence id generator if it wasn't already modified. That means we only want
+                            // to update the id generator the first time the producer gets established, and ignore the
+                            // sequence id sent by broker in subsequent producer reconnects
                             this.lastSequenceIdPublished = lastSequenceId;
                             this.msgIdGenerator = lastSequenceId + 1;
                         }


### PR DESCRIPTION
### Motivation

There is a combination of events that make the producer to reuse the sequence id on multiple messages: 
 1. Topic is fenced (eg: by opening ManagedLedger from outside the broker or potentially, by a race condition on ZK lock ownership).
 2. Producer connects and try to publish a message
 3. The broker gets persistence error since it was fenced and eventually it recovers. 
 4. When the producer reconnects, the `msgIdGenerator` (which is used to assign sequence ids to messages) is being reset. 
 5. The first messages (msg-0) was already in the queue and gets finally published
 6. The next message (msg-0) is set to use sequence-id 0 as well, since the counter was reset.

The `msgIdGenerator` and `lastSequenceIdPublished` only need to be reset with broker values the first time the producer connects, but not in subsequent reconnects.

The problem was that by checking `lastSequenceIdPublished` we would see a `-1`, because no message was published successfully, but `msgIdGenerator` was already incremented since we had a message in the queue, and thus it should not be reset.

### Modifications

Use `msgIdGenerator` for the check since it will detect when messages where already queued and not successfully acked yet.
