### PR TITLE
fix bug with specifying jar via config file

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -715,8 +715,8 @@ public class CmdFunctions extends CmdBase {
     class CreateFunction extends FunctionDetailsCommand {
         @Override
         void runCmd() throws Exception {
-            if (Utils.isFunctionPackageUrlSupported(jarFile)) {
-                admin.functions().createFunctionWithUrl(convert(functionConfig), jarFile);
+            if (Utils.isFunctionPackageUrlSupported(functionConfig.getJar())) {
+                admin.functions().createFunctionWithUrl(convert(functionConfig), functionConfig.getJar());
             } else {
                 admin.functions().createFunction(convert(functionConfig), userCodeFile);
             }
@@ -758,8 +758,8 @@ public class CmdFunctions extends CmdBase {
     class UpdateFunction extends FunctionDetailsCommand {
         @Override
         void runCmd() throws Exception {
-            if (Utils.isFunctionPackageUrlSupported(jarFile)) {
-                admin.functions().updateFunctionWithUrl(convert(functionConfig), jarFile);
+            if (Utils.isFunctionPackageUrlSupported(functionConfig.getJar())) {
+                admin.functions().updateFunctionWithUrl(convert(functionConfig), functionConfig.getJar());
             } else {
                 admin.functions().updateFunction(convert(functionConfig), userCodeFile);
             }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
@@ -135,7 +135,7 @@ public class CmdSinks extends CmdBase {
                             .tlsAllowInsecureConnection(tlsAllowInsecureConnection)
                             .tlsHostnameVerificationEnable(tlsHostNameVerificationEnabled)
                             .tlsTrustCertsFilePath(tlsTrustCertFilePath).build(),
-                    jarFile, admin);
+                    sinkConfig.getJar(), admin);
         }
     }
 
@@ -144,9 +144,9 @@ public class CmdSinks extends CmdBase {
         @Override
         void runCmd() throws Exception {
             if (Utils.isFunctionPackageUrlSupported(jarFile)) {
-                admin.functions().createFunctionWithUrl(createSinkConfig(sinkConfig), jarFile);
+                admin.functions().createFunctionWithUrl(createSinkConfig(sinkConfig), sinkConfig.getJar());
             } else {
-                admin.functions().createFunction(createSinkConfig(sinkConfig), jarFile);
+                admin.functions().createFunction(createSinkConfig(sinkConfig), sinkConfig.getJar());
             }
             print("Created successfully");
         }
@@ -157,9 +157,9 @@ public class CmdSinks extends CmdBase {
         @Override
         void runCmd() throws Exception {
             if (Utils.isFunctionPackageUrlSupported(jarFile)) {
-                admin.functions().updateFunctionWithUrl(createSinkConfig(sinkConfig), jarFile);
+                admin.functions().updateFunctionWithUrl(createSinkConfig(sinkConfig), sinkConfig.getJar());
             } else {
-                admin.functions().updateFunction(createSinkConfig(sinkConfig), jarFile);
+                admin.functions().updateFunction(createSinkConfig(sinkConfig), sinkConfig.getJar());
             }
             print("Updated successfully");
         }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
@@ -130,7 +130,7 @@ public class CmdSources extends CmdBase {
                             .tlsAllowInsecureConnection(tlsAllowInsecureConnection)
                             .tlsHostnameVerificationEnable(tlsHostNameVerificationEnabled)
                             .tlsTrustCertsFilePath(tlsTrustCertFilePath).build(),
-                    jarFile, admin);
+                    sourceConfig.getJar(), admin);
         }
     }
 
@@ -138,10 +138,10 @@ public class CmdSources extends CmdBase {
     public class CreateSource extends SourceCommand {
         @Override
         void runCmd() throws Exception {
-            if (Utils.isFunctionPackageUrlSupported(jarFile)) {
-                admin.functions().createFunctionWithUrl(createSourceConfig(sourceConfig), jarFile);
+            if (Utils.isFunctionPackageUrlSupported(this.sourceConfig.getJar())) {
+                admin.functions().createFunctionWithUrl(createSourceConfig(sourceConfig), sourceConfig.getJar());
             } else {
-                admin.functions().createFunction(createSourceConfig(sourceConfig), jarFile);
+                admin.functions().createFunction(createSourceConfig(sourceConfig), sourceConfig.getJar());
             }
             print("Created successfully");
         }
@@ -151,10 +151,10 @@ public class CmdSources extends CmdBase {
     public class UpdateSource extends SourceCommand {
         @Override
         void runCmd() throws Exception {
-            if (Utils.isFunctionPackageUrlSupported(jarFile)) {
-                admin.functions().updateFunctionWithUrl(createSourceConfig(sourceConfig), jarFile);
+            if (Utils.isFunctionPackageUrlSupported(sourceConfig.getJar())) {
+                admin.functions().updateFunctionWithUrl(createSourceConfig(sourceConfig), sourceConfig.getJar());
             } else {
-                admin.functions().updateFunction(createSourceConfig(sourceConfig), jarFile);
+                admin.functions().updateFunction(createSourceConfig(sourceConfig), sourceConfig.getJar());
             }
             print("Updated successfully");
         }


### PR DESCRIPTION
When jar is specified via config file it is not being used since the param "jarFile" is being used.  We should always use what is in *Config.getJar() as source of truth
