### PR TITLE
Forward user-properties to sink

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -184,8 +184,8 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
 
                 if (currentRecord instanceof PulsarRecord) {
                     PulsarRecord pulsarRecord = (PulsarRecord) currentRecord;
-                     messageId = pulsarRecord.getMessageId();
-                     topicName = pulsarRecord.getTopicName();
+                    messageId = pulsarRecord.getMessageId();
+                    topicName = pulsarRecord.getTopicName();
                 }
                 result = javaInstance.handleMessage(messageId, topicName, currentRecord.getValue());
 

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
@@ -221,10 +221,13 @@ public class PulsarSink<T> implements Sink<T> {
         msgBuilder.setContent(output);
         if (recordContext instanceof PulsarRecord) {
             PulsarRecord pulsarRecord = (PulsarRecord) recordContext;
-            msgBuilder
-                    .setProperty("__pfn_input_topic__", pulsarRecord.getTopicName())
-                    .setProperty("__pfn_input_msg_id__", new String(
-                            Base64.getEncoder().encode(pulsarRecord.getMessageId().toByteArray())));
+            // forward user properties to sink-topic
+            if (pulsarRecord.getProperties() != null) {
+                msgBuilder.setProperties(pulsarRecord.getProperties());
+            }
+            msgBuilder.setProperty("__pfn_input_topic__", pulsarRecord.getTopicName()).setProperty(
+                    "__pfn_input_msg_id__",
+                    new String(Base64.getEncoder().encode(pulsarRecord.getMessageId().toByteArray())));
         }
 
         this.pulsarSinkProcessor.sendOutputMessage(msgBuilder, recordContext);

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarRecord.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarRecord.java
@@ -23,6 +23,9 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+
+import java.util.Map;
+
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.io.core.Record;
 
@@ -38,6 +41,7 @@ public class PulsarRecord<T> implements Record<T> {
     private T value;
     private MessageId messageId;
     private String topicName;
+    private Map<String, String> properties;
     private Runnable failFunction;
     private Runnable ackFunction;
 

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
@@ -132,6 +132,7 @@ public class PulsarSource<T> implements Source<T> {
                 .partitionId(String.format("%s-%s", topicName, partitionId))
                 .recordSequence(Utils.getSequenceId(message.getMessageId()))
                 .topicName(topicName)
+                .properties(message.getProperties())
                 .ackFunction(() -> {
                     if (pulsarSourceConfig.getProcessingGuarantees() == FunctionConfig.ProcessingGuarantees.EFFECTIVELY_ONCE) {
                         inputConsumer.acknowledgeCumulativeAsync(message);


### PR DESCRIPTION
### Motivation

While using pulsar-sink, sometimes application wants sink-impl to forward user-properties coming from the pulsar-source into the message.

### Modifications

- pass user-properties to PulsarRecord so, sink can read it.

### Result

- Pulsar sink can receive user-properties in submitted function.
