### PR TITLE
GCS support(1): rename s3offload related classes to be reuse-able

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -61,7 +61,7 @@ import org.apache.pulsar.broker.loadbalance.LoadResourceQuotaUpdaterTask;
 import org.apache.pulsar.broker.loadbalance.LoadSheddingTask;
 import org.apache.pulsar.broker.loadbalance.impl.LoadManagerShared;
 import org.apache.pulsar.broker.namespace.NamespaceService;
-import org.apache.pulsar.broker.s3offload.S3ManagedLedgerOffloader;
+import org.apache.pulsar.broker.offload.impl.S3ManagedLedgerOffloader;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.Topic;
 import org.apache.pulsar.broker.service.schema.SchemaRegistryService;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/BackedInputStream.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/BackedInputStream.java
@@ -16,12 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.broker.s3offload;
+package org.apache.pulsar.broker.offload;
 
 import java.io.InputStream;
 import java.io.IOException;
 
-public abstract class S3BackedInputStream extends InputStream {
+public abstract class BackedInputStream extends InputStream {
     public abstract void seek(long position);
     public abstract void seekForward(long position) throws IOException;
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/BlockAwareSegmentInputStream.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/BlockAwareSegmentInputStream.java
@@ -16,9 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.broker.s3offload;
+package org.apache.pulsar.broker.offload;
 
-import java.io.IOException;
 import java.io.InputStream;
 import org.apache.bookkeeper.client.api.ReadHandle;
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/DataBlockHeader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/DataBlockHeader.java
@@ -16,40 +16,41 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.broker.s3offload;
+package org.apache.pulsar.broker.offload;
 
-import org.apache.bookkeeper.common.annotation.InterfaceAudience.LimitedPrivate;
+import java.io.InputStream;
 import org.apache.bookkeeper.common.annotation.InterfaceStability.Unstable;
 
 /**
+ * The data block header in code storage for each data block
  *
- * The Index Entry in OffloadIndexBlock.
- * It consists of the message entry id, the code storage block part id for this message entry,
- * and the offset in code storage block for this message id.
+ * Currently, It is in format:
+ * [ magic_word -- int ][ block_len -- int ][ first_entry_id  -- long][padding]
  *
+ * with the size: 4 + 4 + 8 + padding = 128 Bytes
  */
 @Unstable
-@LimitedPrivate
-public interface OffloadIndexEntry {
+public interface DataBlockHeader {
 
     /**
-     * Get the entryId that this entry contains.
+     * Get the length of the block in bytes, including the header.
      */
-    long getEntryId();
+    long getBlockLength();
 
     /**
-     * Get the block part id of code storage.
+     * Get the message entry Id for the first message that stored in this data block.
      */
-    int getPartId();
+    long getFirstEntryId();
 
     /**
-     * Get the offset of this block within the object.
+     * Get the size of this DataBlockHeader.
      */
-    long getOffset();
+    long getHeaderLength();
 
     /**
-     * Get the offset of the block's data within the object.
+     * Get the content of the data block header as InputStream.
+     * Read out in current format.
      */
-    long getDataOffset();
+    InputStream toStream();
 }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/OffloadIndexBlock.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/OffloadIndexBlock.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.broker.s3offload;
+package org.apache.pulsar.broker.offload;
 
 import java.io.Closeable;
 import java.io.FilterInputStream;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/OffloadIndexBlockBuilder.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/OffloadIndexBlockBuilder.java
@@ -16,14 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.broker.s3offload;
+package org.apache.pulsar.broker.offload;
 
 import java.io.IOException;
 import java.io.InputStream;
 import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.common.annotation.InterfaceAudience.LimitedPrivate;
 import org.apache.bookkeeper.common.annotation.InterfaceStability.Unstable;
-import org.apache.pulsar.broker.s3offload.impl.OffloadIndexBlockBuilderImpl;
+import org.apache.pulsar.broker.offload.impl.OffloadIndexBlockBuilderImpl;
 
 /**
  * Interface for builder of index block used for offload a ledger to long term storage.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/OffloadIndexEntry.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/OffloadIndexEntry.java
@@ -16,42 +16,40 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.broker.s3offload;
+package org.apache.pulsar.broker.offload;
 
-import java.io.IOException;
-import java.io.InputStream;
+import org.apache.bookkeeper.common.annotation.InterfaceAudience.LimitedPrivate;
 import org.apache.bookkeeper.common.annotation.InterfaceStability.Unstable;
 
 /**
- * The data block header in code storage for each data block
  *
- * Currently, It is in format:
- * [ magic_word -- int ][ block_len -- int ][ first_entry_id  -- long][padding]
+ * The Index Entry in OffloadIndexBlock.
+ * It consists of the message entry id, the code storage block part id for this message entry,
+ * and the offset in code storage block for this message id.
  *
- * with the size: 4 + 4 + 8 + padding = 128 Bytes
  */
 @Unstable
-public interface DataBlockHeader {
+@LimitedPrivate
+public interface OffloadIndexEntry {
 
     /**
-     * Get the length of the block in bytes, including the header.
+     * Get the entryId that this entry contains.
      */
-    long getBlockLength();
+    long getEntryId();
 
     /**
-     * Get the message entry Id for the first message that stored in this data block.
+     * Get the block part id of code storage.
      */
-    long getFirstEntryId();
+    int getPartId();
 
     /**
-     * Get the size of this DataBlockHeader.
+     * Get the offset of this block within the object.
      */
-    long getHeaderLength();
+    long getOffset();
 
     /**
-     * Get the content of the data block header as InputStream.
-     * Read out in current format.
+     * Get the offset of the block's data within the object.
      */
-    InputStream toStream();
+    long getDataOffset();
 }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/impl/BlockAwareSegmentInputStreamImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/impl/BlockAwareSegmentInputStreamImpl.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.broker.s3offload.impl;
+package org.apache.pulsar.broker.offload.impl;
 
 import static com.google.common.base.Preconditions.checkState;
 
@@ -32,7 +32,7 @@ import java.util.concurrent.ExecutionException;
 import org.apache.bookkeeper.client.api.LedgerEntries;
 import org.apache.bookkeeper.client.api.LedgerEntry;
 import org.apache.bookkeeper.client.api.ReadHandle;
-import org.apache.pulsar.broker.s3offload.BlockAwareSegmentInputStream;
+import org.apache.pulsar.broker.offload.BlockAwareSegmentInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/impl/DataBlockHeaderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/impl/DataBlockHeaderImpl.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.broker.s3offload.impl;
+package org.apache.pulsar.broker.offload.impl;
 
 import com.google.common.io.CountingInputStream;
 
@@ -27,7 +27,7 @@ import java.io.DataInputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
-import org.apache.pulsar.broker.s3offload.DataBlockHeader;
+import org.apache.pulsar.broker.offload.DataBlockHeader;
 
 /**
  *

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/impl/OffloadIndexBlockBuilderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/impl/OffloadIndexBlockBuilderImpl.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.broker.s3offload.impl;
+package org.apache.pulsar.broker.offload.impl;
 
 import static com.google.common.base.Preconditions.checkState;
 
@@ -25,8 +25,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import org.apache.bookkeeper.client.api.LedgerMetadata;
-import org.apache.pulsar.broker.s3offload.OffloadIndexBlock;
-import org.apache.pulsar.broker.s3offload.OffloadIndexBlockBuilder;
+import org.apache.pulsar.broker.offload.OffloadIndexBlock;
+import org.apache.pulsar.broker.offload.OffloadIndexBlockBuilder;
 
 /**
  * Interface for builder of index block used for offload a ledger to long term storage.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/impl/OffloadIndexBlockImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/impl/OffloadIndexBlockImpl.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.broker.s3offload.impl;
+package org.apache.pulsar.broker.offload.impl;
 
 import static com.google.common.base.Preconditions.checkState;
 
@@ -31,7 +31,6 @@ import io.netty.util.Recycler.Handle;
 
 import java.io.DataInputStream;
 import java.io.IOException;
-import java.io.FilterInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -47,8 +46,8 @@ import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.DataFormats;
 import org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat;
 import org.apache.bookkeeper.proto.DataFormats.LedgerMetadataFormat.State;
-import org.apache.pulsar.broker.s3offload.OffloadIndexBlock;
-import org.apache.pulsar.broker.s3offload.OffloadIndexEntry;
+import org.apache.pulsar.broker.offload.OffloadIndexBlock;
+import org.apache.pulsar.broker.offload.OffloadIndexEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/impl/OffloadIndexEntryImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/impl/OffloadIndexEntryImpl.java
@@ -16,9 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.broker.s3offload.impl;
+package org.apache.pulsar.broker.offload.impl;
 
-import org.apache.pulsar.broker.s3offload.OffloadIndexEntry;
+import org.apache.pulsar.broker.offload.OffloadIndexEntry;
 
 /**
  *

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/impl/S3BackedInputStreamImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/impl/S3BackedInputStreamImpl.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.broker.s3offload.impl;
+package org.apache.pulsar.broker.offload.impl;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.s3.AmazonS3;
@@ -29,13 +29,13 @@ import io.netty.buffer.PooledByteBufAllocator;
 import java.io.InputStream;
 import java.io.IOException;
 
-import org.apache.pulsar.broker.s3offload.S3BackedInputStream;
-import org.apache.pulsar.broker.s3offload.S3ManagedLedgerOffloader.VersionCheck;
+import org.apache.pulsar.broker.offload.BackedInputStream;
+import org.apache.pulsar.broker.offload.impl.S3ManagedLedgerOffloader.VersionCheck;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class S3BackedInputStreamImpl extends S3BackedInputStream {
+public class S3BackedInputStreamImpl extends BackedInputStream {
     private static final Logger log = LoggerFactory.getLogger(S3BackedInputStreamImpl.class);
 
     private final AmazonS3 s3client;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/impl/S3BackedReadHandleImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/impl/S3BackedReadHandleImpl.java
@@ -16,12 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.broker.s3offload.impl;
+package org.apache.pulsar.broker.offload.impl;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.GetObjectRequest;
-import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3Object;
 
 import io.netty.buffer.ByteBuf;
@@ -44,11 +43,11 @@ import org.apache.bookkeeper.client.api.ReadHandle;
 import org.apache.bookkeeper.client.impl.LedgerEntriesImpl;
 import org.apache.bookkeeper.client.impl.LedgerEntryImpl;
 
-import org.apache.pulsar.broker.s3offload.OffloadIndexBlock;
-import org.apache.pulsar.broker.s3offload.OffloadIndexBlockBuilder;
-import org.apache.pulsar.broker.s3offload.OffloadIndexEntry;
-import org.apache.pulsar.broker.s3offload.S3BackedInputStream;
-import org.apache.pulsar.broker.s3offload.S3ManagedLedgerOffloader.VersionCheck;
+import org.apache.pulsar.broker.offload.OffloadIndexBlock;
+import org.apache.pulsar.broker.offload.OffloadIndexBlockBuilder;
+import org.apache.pulsar.broker.offload.OffloadIndexEntry;
+import org.apache.pulsar.broker.offload.BackedInputStream;
+import org.apache.pulsar.broker.offload.impl.S3ManagedLedgerOffloader.VersionCheck;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,12 +57,12 @@ public class S3BackedReadHandleImpl implements ReadHandle {
 
     private final long ledgerId;
     private final OffloadIndexBlock index;
-    private final S3BackedInputStream inputStream;
+    private final BackedInputStream inputStream;
     private final DataInputStream dataStream;
     private final ExecutorService executor;
 
     private S3BackedReadHandleImpl(long ledgerId, OffloadIndexBlock index,
-                                   S3BackedInputStream inputStream,
+                                   BackedInputStream inputStream,
                                    ExecutorService executor) {
         this.ledgerId = ledgerId;
         this.index = index;
@@ -201,7 +200,7 @@ public class S3BackedReadHandleImpl implements ReadHandle {
             OffloadIndexBlockBuilder indexBuilder = OffloadIndexBlockBuilder.create();
             OffloadIndexBlock index = indexBuilder.fromStream(obj.getObjectContent());
 
-            S3BackedInputStream inputStream = new S3BackedInputStreamImpl(s3client, bucket, key,
+            BackedInputStream inputStream = new S3BackedInputStreamImpl(s3client, bucket, key,
                                                                           versionCheck,
                                                                           index.getDataObjectLength(),
                                                                           readBufferSize);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/impl/S3ManagedLedgerOffloader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/impl/S3ManagedLedgerOffloader.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.broker.s3offload;
+package org.apache.pulsar.broker.offload.impl;
 
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.services.s3.AmazonS3;
@@ -32,7 +32,6 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.UploadPartRequest;
 import com.amazonaws.services.s3.model.UploadPartResult;
 import com.google.common.base.Strings;
-import java.io.InputStream;
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
@@ -44,8 +43,9 @@ import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.bookkeeper.mledger.LedgerOffloader;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.ServiceConfiguration;
-import org.apache.pulsar.broker.s3offload.impl.BlockAwareSegmentInputStreamImpl;
-import org.apache.pulsar.broker.s3offload.impl.S3BackedReadHandleImpl;
+import org.apache.pulsar.broker.offload.BlockAwareSegmentInputStream;
+import org.apache.pulsar.broker.offload.OffloadIndexBlock;
+import org.apache.pulsar.broker.offload.OffloadIndexBlockBuilder;
 import org.apache.pulsar.utils.PulsarBrokerVersionStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/offload/S3BackedInputStreamTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/offload/S3BackedInputStreamTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.broker.s3offload;
+package org.apache.pulsar.broker.offload;
 
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.spy;
@@ -34,11 +34,9 @@ import java.util.Random;
 
 import lombok.extern.slf4j.Slf4j;
 
-import org.apache.pulsar.broker.s3offload.impl.S3BackedInputStreamImpl;
+import org.apache.pulsar.broker.offload.impl.S3BackedInputStreamImpl;
 
 import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 @Slf4j
@@ -96,7 +94,7 @@ class S3BackedInputStreamTest extends S3TestBase {
         metadata.setContentLength(objectSize);
         s3client.putObject(BUCKET, objectKey, toWrite, metadata);
 
-        S3BackedInputStream toTest = new S3BackedInputStreamImpl(s3client, BUCKET, objectKey,
+        BackedInputStream toTest = new S3BackedInputStreamImpl(s3client, BUCKET, objectKey,
                                                                  (key, md) -> {},
                                                                  objectSize, 1000);
         assertStreamsMatch(toTest, toCompare);
@@ -113,7 +111,7 @@ class S3BackedInputStreamTest extends S3TestBase {
         metadata.setContentLength(objectSize);
         s3client.putObject(BUCKET, objectKey, toWrite, metadata);
 
-        S3BackedInputStream toTest = new S3BackedInputStreamImpl(s3client, BUCKET, objectKey,
+        BackedInputStream toTest = new S3BackedInputStreamImpl(s3client, BUCKET, objectKey,
                                                                  (key, md) -> {},
                                                                  objectSize, 1000);
         assertStreamsMatchByBytes(toTest, toCompare);
@@ -121,7 +119,7 @@ class S3BackedInputStreamTest extends S3TestBase {
 
     @Test(expectedExceptions = IOException.class)
     public void testErrorOnS3Read() throws Exception {
-        S3BackedInputStream toTest = new S3BackedInputStreamImpl(s3client, BUCKET, "doesn't exist",
+        BackedInputStream toTest = new S3BackedInputStreamImpl(s3client, BUCKET, "doesn't exist",
                                                                  (key, md) -> {},
                                                                  1234, 1000);
         toTest.read();
@@ -147,7 +145,7 @@ class S3BackedInputStreamTest extends S3TestBase {
         metadata.setContentLength(objectSize);
         s3client.putObject(BUCKET, objectKey, toWrite, metadata);
 
-        S3BackedInputStream toTest = new S3BackedInputStreamImpl(s3client, BUCKET, objectKey,
+        BackedInputStream toTest = new S3BackedInputStreamImpl(s3client, BUCKET, objectKey,
                                                                  (key, md) -> {},
                                                                  objectSize, 1000);
         for (Map.Entry<Integer, InputStream> e : seeks.entrySet()) {
@@ -167,7 +165,7 @@ class S3BackedInputStreamTest extends S3TestBase {
         s3client.putObject(BUCKET, objectKey, toWrite, metadata);
 
         AmazonS3 spiedClient = spy(s3client);
-        S3BackedInputStream toTest = new S3BackedInputStreamImpl(spiedClient, BUCKET, objectKey,
+        BackedInputStream toTest = new S3BackedInputStreamImpl(spiedClient, BUCKET, objectKey,
                                                                  (key, md) -> {},
                                                                  objectSize, 1000);
 
@@ -208,7 +206,7 @@ class S3BackedInputStreamTest extends S3TestBase {
         metadata.setContentLength(objectSize);
         s3client.putObject(BUCKET, objectKey, toWrite, metadata);
 
-        S3BackedInputStream toTest = new S3BackedInputStreamImpl(s3client, BUCKET, objectKey,
+        BackedInputStream toTest = new S3BackedInputStreamImpl(s3client, BUCKET, objectKey,
                                                                  (key, md) -> {},
                                                                  objectSize, 1000);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/offload/S3Mock.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/offload/S3Mock.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.broker.s3offload;
+package org.apache.pulsar.broker.offload;
 
 import com.amazonaws.services.s3.AbstractAmazonS3;
 import com.amazonaws.services.s3.model.AmazonS3Exception;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/offload/S3TestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/offload/S3TestBase.java
@@ -16,18 +16,15 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.broker.s3offload;
+package org.apache.pulsar.broker.offload;
 
-import com.amazonaws.auth.AnonymousAWSCredentials;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 
 import org.testng.annotations.BeforeMethod;
 
 public class S3TestBase {
-    final static String BUCKET = "pulsar-unittest";
+    public final static String BUCKET = "pulsar-unittest";
 
     protected AmazonS3 s3client = null;
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/offload/impl/BlockAwareSegmentInputStreamTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/offload/impl/BlockAwareSegmentInputStreamTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.broker.s3offload.impl;
+package org.apache.pulsar.broker.offload.impl;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
@@ -27,7 +27,6 @@ import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.util.concurrent.DefaultThreadFactory;
 import java.io.ByteArrayInputStream;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -35,7 +34,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import lombok.Data;
@@ -45,7 +43,7 @@ import org.apache.bookkeeper.client.api.LedgerEntries;
 import org.apache.bookkeeper.client.api.LedgerEntry;
 import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.client.api.ReadHandle;
-import org.apache.pulsar.broker.s3offload.DataBlockHeader;
+import org.apache.pulsar.broker.offload.DataBlockHeader;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/offload/impl/DataBlockHeaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/offload/impl/DataBlockHeaderTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.broker.s3offload.impl;
+package org.apache.pulsar.broker.offload.impl;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -27,7 +27,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.pulsar.broker.s3offload.DataBlockHeader;
+import org.apache.pulsar.broker.offload.DataBlockHeader;
 import org.testng.annotations.Test;
 
 @Slf4j

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/offload/impl/OffloadIndexTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/offload/impl/OffloadIndexTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.broker.s3offload.impl;
+package org.apache.pulsar.broker.offload.impl;
 
 import static com.google.common.base.Charsets.UTF_8;
 import static org.testng.Assert.assertEquals;
@@ -36,9 +36,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.BookKeeper.DigestType;
 import org.apache.bookkeeper.client.api.LedgerMetadata;
 import org.apache.bookkeeper.net.BookieSocketAddress;
-import org.apache.pulsar.broker.s3offload.OffloadIndexBlock;
-import org.apache.pulsar.broker.s3offload.OffloadIndexBlockBuilder;
-import org.apache.pulsar.broker.s3offload.OffloadIndexEntry;
+import org.apache.pulsar.broker.offload.OffloadIndexBlock;
+import org.apache.pulsar.broker.offload.OffloadIndexBlockBuilder;
+import org.apache.pulsar.broker.offload.OffloadIndexEntry;
 import org.testng.annotations.Test;
 
 @Slf4j

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/offload/impl/S3ManagedLedgerOffloaderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/offload/impl/S3ManagedLedgerOffloaderTest.java
@@ -16,10 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.broker.s3offload;
+package org.apache.pulsar.broker.offload.impl;
 
-import static org.apache.pulsar.broker.s3offload.S3ManagedLedgerOffloader.dataBlockOffloadKey;
-import static org.apache.pulsar.broker.s3offload.S3ManagedLedgerOffloader.indexBlockOffloadKey;
+import static org.apache.pulsar.broker.offload.impl.S3ManagedLedgerOffloader.dataBlockOffloadKey;
+import static org.apache.pulsar.broker.offload.impl.S3ManagedLedgerOffloader.indexBlockOffloadKey;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 
@@ -27,7 +27,6 @@ import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CopyObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
-import io.netty.util.concurrent.DefaultThreadFactory;
 import java.lang.reflect.Method;
 import java.io.IOException;
 import java.util.HashMap;
@@ -36,7 +35,6 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.client.BKException;
@@ -53,7 +51,9 @@ import org.apache.bookkeeper.mledger.LedgerOffloader;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
-import org.apache.pulsar.broker.s3offload.impl.DataBlockHeaderImpl;
+import org.apache.pulsar.broker.offload.S3TestBase;
+import org.apache.pulsar.broker.offload.impl.DataBlockHeaderImpl;
+import org.apache.pulsar.broker.offload.impl.S3ManagedLedgerOffloader;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;


### PR DESCRIPTION
This is the first part to support `Google Cloud Storage` offload.
change:
rename Offload related classes to make them also reuse-able for GCS.