### PR TITLE
fix: configure crypto-action for internal consumer independently cryptoReader

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -484,14 +484,14 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         internalConsumerConfig.setPriorityLevel(conf.getPriorityLevel());
         internalConsumerConfig.setProperties(conf.getProperties());
         internalConsumerConfig.setReadCompacted(conf.isReadCompacted());
-
+        internalConsumerConfig.setCryptoFailureAction(conf.getCryptoFailureAction());
+        
         if (null != conf.getConsumerEventListener()) {
             internalConsumerConfig.setConsumerEventListener(conf.getConsumerEventListener());
         }
 
         if (conf.getCryptoKeyReader() != null) {
             internalConsumerConfig.setCryptoKeyReader(conf.getCryptoKeyReader());
-            internalConsumerConfig.setCryptoFailureAction(conf.getCryptoFailureAction());
         }
         if (conf.getAckTimeoutMillis() != 0) {
             internalConsumerConfig.setAckTimeoutMillis(conf.getAckTimeoutMillis());


### PR DESCRIPTION
### Motivation

Right now, MultiTopicConsumer doesn't configure `CryptoFailureAction` for internal consumer-configuration if CryptoReader is null which causes unexpected behavior.

### Modifications

Set `CryptoFailureAction` correctly for internal-consumer.

