### PR TITLE
Dump container & pulsar log before container stops

### DIFF
--- a/tests/integration-tests-topologies/src/main/java/org/apache/pulsar/tests/containers/CSContainer.java
+++ b/tests/integration-tests-topologies/src/main/java/org/apache/pulsar/tests/containers/CSContainer.java
@@ -21,7 +21,7 @@ package org.apache.pulsar.tests.containers;
 /**
  * A pulsar container that runs configuration store.
  */
-public class CSContainer extends PulsarContainer<CSContainer> {
+public class CSContainer extends ZKContainer<CSContainer> {
 
     public static final String NAME = "configuration-store";
 

--- a/tests/integration-tests-topologies/src/main/java/org/apache/pulsar/tests/containers/ChaosContainer.java
+++ b/tests/integration-tests-topologies/src/main/java/org/apache/pulsar/tests/containers/ChaosContainer.java
@@ -28,6 +28,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
+import org.apache.pulsar.tests.DockerUtils;
 import org.testcontainers.containers.GenericContainer;
 
 /**
@@ -41,6 +42,24 @@ public class ChaosContainer<SelfT extends ChaosContainer<SelfT>> extends Generic
     protected ChaosContainer(String clusterName, String image) {
         super(image);
         this.clusterName = clusterName;
+    }
+
+    protected void beforeStop() {
+        if (null == containerId) {
+            return;
+        }
+
+        // dump the container log
+        DockerUtils.dumpContainerLogToTarget(
+            getDockerClient(),
+            containerId
+        );
+    }
+
+    @Override
+    public void stop() {
+        beforeStop();
+        super.stop();
     }
 
     public void tailContainerLog() {

--- a/tests/integration-tests-topologies/src/main/java/org/apache/pulsar/tests/containers/PulsarContainer.java
+++ b/tests/integration-tests-topologies/src/main/java/org/apache/pulsar/tests/containers/PulsarContainer.java
@@ -23,6 +23,7 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 import java.time.Duration;
 import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.tests.DockerUtils;
 import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 
 /**
@@ -58,6 +59,18 @@ public abstract class PulsarContainer<SelfT extends PulsarContainer<SelfT>> exte
         this.serviceEntrypoint = serviceEntrypoint;
         this.servicePort = servicePort;
         this.httpPort = httpPort;
+    }
+
+    @Override
+    protected void beforeStop() {
+        super.beforeStop();
+        if (null != containerId) {
+            DockerUtils.dumpContainerDirToTargetCompressed(
+                getDockerClient(),
+                containerId,
+                "/var/log/pulsar"
+            );
+        }
     }
 
     @Override

--- a/tests/integration-tests-topologies/src/main/java/org/apache/pulsar/tests/containers/ZKContainer.java
+++ b/tests/integration-tests-topologies/src/main/java/org/apache/pulsar/tests/containers/ZKContainer.java
@@ -18,12 +18,16 @@
  */
 package org.apache.pulsar.tests.containers;
 
+import org.apache.pulsar.tests.DockerUtils;
+
 /**
  * A pulsar container that runs zookeeper.
  */
-public class ZKContainer extends PulsarContainer<ZKContainer> {
+public class ZKContainer<SelfT extends ZKContainer<SelfT>> extends PulsarContainer<SelfT> {
 
     public static final String NAME = "zookeeper";
+
+    private volatile boolean dumpZkDataBeforeStop = false;
 
     public ZKContainer(String clusterName) {
         super(
@@ -35,4 +39,34 @@ public class ZKContainer extends PulsarContainer<ZKContainer> {
             INVALID_PORT);
     }
 
+    public ZKContainer(String clusterName,
+                       String hostname,
+                       String serviceName,
+                       String serviceEntrypoint,
+                       int servicePort,
+                       int httpPort) {
+        super(
+            clusterName,
+            hostname,
+            serviceName,
+            serviceEntrypoint,
+            servicePort,
+            httpPort);
+    }
+
+    public void enableDumpZkDataBeforeStop(boolean enabled) {
+        this.dumpZkDataBeforeStop = enabled;
+    }
+
+    @Override
+    protected void beforeStop() {
+        super.beforeStop();
+        if (null != containerId && dumpZkDataBeforeStop) {
+            DockerUtils.dumpContainerDirToTargetCompressed(
+                getDockerClient(),
+                containerId,
+                "/pulsar/data/zookeeper"
+            );
+        }
+    }
 }

--- a/tests/integration-tests-topologies/src/main/java/org/apache/pulsar/tests/topologies/PulsarCluster.java
+++ b/tests/integration-tests-topologies/src/main/java/org/apache/pulsar/tests/topologies/PulsarCluster.java
@@ -75,7 +75,7 @@ public class PulsarCluster {
         this.spec = spec;
         this.clusterName = spec.clusterName();
         this.network = Network.newNetwork();
-        this.zkContainer = new ZKContainer(clusterName)
+        this.zkContainer = (ZKContainer) new ZKContainer(clusterName)
             .withNetwork(network)
             .withNetworkAliases(ZKContainer.NAME)
             .withEnv("clusterName", clusterName)


### PR DESCRIPTION
*Motivation*

Arquillian tests dump container & pulsar logs before container stops.
When moving integration tests from arquillian to testcontainers, we
should have same behavior.

*Changes*

Add a hook `beforeStop` to add logic to run before a container is stopped.

