### PR TITLE
Cleanup unused function resource

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
@@ -19,9 +19,11 @@
 package org.apache.pulsar.functions.worker.rest.api;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-
-import com.google.gson.Gson;
-
+import static org.apache.pulsar.functions.utils.Reflections.createInstance;
+import static org.apache.pulsar.functions.utils.Utils.FILE;
+import static org.apache.pulsar.functions.utils.Utils.HTTP;
+import static org.apache.pulsar.functions.utils.Utils.isFunctionPackageUrlSupported;
+import static org.apache.pulsar.functions.utils.functioncache.FunctionClassLoaders.create;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -32,25 +34,21 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.*;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.QueryParam;
+
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.StreamingOutput;
-import lombok.extern.slf4j.Slf4j;
-import net.jodah.typetools.TypeResolver;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -66,22 +64,21 @@ import org.apache.pulsar.functions.proto.Function.FunctionMetaData;
 import org.apache.pulsar.functions.proto.Function.PackageLocationMetaData;
 import org.apache.pulsar.functions.proto.InstanceCommunication;
 import org.apache.pulsar.functions.proto.InstanceCommunication.FunctionStatus;
-import static org.apache.pulsar.functions.utils.Reflections.createInstance;
 import org.apache.pulsar.functions.utils.functioncache.FunctionClassLoaders;
-import static org.apache.pulsar.functions.utils.functioncache.FunctionClassLoaders.create;
 import org.apache.pulsar.functions.worker.FunctionMetaDataManager;
 import org.apache.pulsar.functions.worker.FunctionRuntimeManager;
 import org.apache.pulsar.functions.worker.MembershipManager;
 import org.apache.pulsar.functions.worker.Utils;
-import static org.apache.pulsar.functions.utils.Utils.HTTP;
-import static org.apache.pulsar.functions.utils.Utils.FILE;
-import static org.apache.pulsar.functions.utils.Utils.isFunctionPackageUrlSupported;
 import org.apache.pulsar.functions.worker.WorkerService;
 import org.apache.pulsar.functions.worker.request.RequestResult;
 import org.apache.pulsar.io.core.Sink;
 import org.apache.pulsar.io.core.Source;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
-import org.glassfish.jersey.media.multipart.FormDataParam;
+
+import com.google.gson.Gson;
+
+import lombok.extern.slf4j.Slf4j;
+import net.jodah.typetools.TypeResolver;
 
 @Slf4j
 public class FunctionsImpl {
@@ -112,16 +109,9 @@ public class FunctionsImpl {
         return true;
     }
 
-    @POST
-    @Path("/{tenant}/{namespace}/{functionName}")
-    @Consumes(MediaType.MULTIPART_FORM_DATA)
-    public Response registerFunction(final @PathParam("tenant") String tenant,
-                                     final @PathParam("namespace") String namespace,
-                                     final @PathParam("functionName") String functionName,
-                                     final @FormDataParam("data") InputStream uploadedInputStream,
-                                     final @FormDataParam("data") FormDataContentDisposition fileDetail,
-                                     final @FormDataParam("url") String functionPkgUrl,
-                                     final @FormDataParam("functionDetails") String functionDetailsJson) {
+    public Response registerFunction(final String tenant, final String namespace, final String functionName,
+            final InputStream uploadedInputStream, final FormDataContentDisposition fileDetail,
+            final String functionPkgUrl, final String functionDetailsJson) {
 
         if (!isWorkerServiceAvailable()) {
             return getUnavailableResponse();
@@ -131,18 +121,16 @@ public class FunctionsImpl {
         boolean isPkgUrlProvided = StringUtils.isNotBlank(functionPkgUrl);
         // validate parameters
         try {
-            if(isPkgUrlProvided) {
+            if (isPkgUrlProvided) {
                 functionDetails = validateUpdateRequestParamsWithPkgUrl(tenant, namespace, functionName, functionPkgUrl,
                         functionDetailsJson);
-            }else {
-                functionDetails = validateUpdateRequestParams(tenant, namespace, functionName,
-                        uploadedInputStream, fileDetail, functionDetailsJson);
+            } else {
+                functionDetails = validateUpdateRequestParams(tenant, namespace, functionName, uploadedInputStream,
+                        fileDetail, functionDetailsJson);
             }
         } catch (Exception e) {
-            log.error("Invalid register function request @ /{}/{}/{}",
-                tenant, namespace, functionName, e);
-            return Response.status(Status.BAD_REQUEST)
-                    .type(MediaType.APPLICATION_JSON)
+            log.error("Invalid register function request @ /{}/{}/{}", tenant, namespace, functionName, e);
+            return Response.status(Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON)
                     .entity(new ErrorData(e.getMessage())).build();
         }
 
@@ -150,34 +138,26 @@ public class FunctionsImpl {
 
         if (functionMetaDataManager.containsFunction(tenant, namespace, functionName)) {
             log.error("Function {}/{}/{} already exists", tenant, namespace, functionName);
-            return Response.status(Status.BAD_REQUEST)
-                    .type(MediaType.APPLICATION_JSON)
+            return Response.status(Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON)
                     .entity(new ErrorData(String.format("Function %s already exists", functionName))).build();
         }
 
         // function state
         FunctionMetaData.Builder functionMetaDataBuilder = FunctionMetaData.newBuilder()
-                .setFunctionDetails(functionDetails)
-                .setCreateTime(System.currentTimeMillis())
-                .setVersion(0);
+                .setFunctionDetails(functionDetails).setCreateTime(System.currentTimeMillis()).setVersion(0);
 
         PackageLocationMetaData.Builder packageLocationMetaDataBuilder = PackageLocationMetaData.newBuilder()
-                .setPackagePath(isPkgUrlProvided ? functionPkgUrl : createPackagePath(tenant, namespace, functionName, fileDetail.getFileName()));
+                .setPackagePath(isPkgUrlProvided ? functionPkgUrl
+                        : createPackagePath(tenant, namespace, functionName, fileDetail.getFileName()));
         functionMetaDataBuilder.setPackageLocation(packageLocationMetaDataBuilder);
 
-        return isPkgUrlProvided ? updateRequest(functionMetaDataBuilder.build()) : updateRequest(functionMetaDataBuilder.build(), uploadedInputStream);
+        return isPkgUrlProvided ? updateRequest(functionMetaDataBuilder.build())
+                : updateRequest(functionMetaDataBuilder.build(), uploadedInputStream);
     }
 
-    @PUT
-    @Path("/{tenant}/{namespace}/{functionName}")
-    @Consumes(MediaType.MULTIPART_FORM_DATA)
-    public Response updateFunction(final @PathParam("tenant") String tenant,
-                                   final @PathParam("namespace") String namespace,
-                                   final @PathParam("functionName") String functionName,
-                                   final @FormDataParam("data") InputStream uploadedInputStream,
-                                   final @FormDataParam("data") FormDataContentDisposition fileDetail,
-                                   final @FormDataParam("url") String functionPkgUrl,
-                                   final @FormDataParam("functionDetails") String functionDetailsJson) {
+    public Response updateFunction(final String tenant, final String namespace, final String functionName,
+            final InputStream uploadedInputStream, final FormDataContentDisposition fileDetail,
+            final String functionPkgUrl, final String functionDetailsJson) {
 
         if (!isWorkerServiceAvailable()) {
             return getUnavailableResponse();
@@ -187,48 +167,40 @@ public class FunctionsImpl {
         boolean isPkgUrlProvided = StringUtils.isNotBlank(functionPkgUrl);
         // validate parameters
         try {
-            if(isPkgUrlProvided) {
-                functionDetails = validateUpdateRequestParamsWithPkgUrl(tenant, namespace, functionName,
-                        functionPkgUrl, functionDetailsJson);
-            }else {
-                functionDetails = validateUpdateRequestParams(tenant, namespace, functionName,
-                        uploadedInputStream, fileDetail, functionDetailsJson);
+            if (isPkgUrlProvided) {
+                functionDetails = validateUpdateRequestParamsWithPkgUrl(tenant, namespace, functionName, functionPkgUrl,
+                        functionDetailsJson);
+            } else {
+                functionDetails = validateUpdateRequestParams(tenant, namespace, functionName, uploadedInputStream,
+                        fileDetail, functionDetailsJson);
             }
         } catch (Exception e) {
-            log.error("Invalid register function request @ /{}/{}/{}",
-                tenant, namespace, functionName, e);
-            return Response.status(Status.BAD_REQUEST)
-                    .type(MediaType.APPLICATION_JSON)
+            log.error("Invalid register function request @ /{}/{}/{}", tenant, namespace, functionName, e);
+            return Response.status(Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON)
                     .entity(new ErrorData(e.getMessage())).build();
         }
 
         FunctionMetaDataManager functionMetaDataManager = worker().getFunctionMetaDataManager();
 
         if (!functionMetaDataManager.containsFunction(tenant, namespace, functionName)) {
-            return Response.status(Status.BAD_REQUEST)
-                    .type(MediaType.APPLICATION_JSON)
+            return Response.status(Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON)
                     .entity(new ErrorData(String.format("Function %s doesn't exist", functionName))).build();
         }
 
         // function state
         FunctionMetaData.Builder functionMetaDataBuilder = FunctionMetaData.newBuilder()
-                .setFunctionDetails(functionDetails)
-                .setCreateTime(System.currentTimeMillis())
-                .setVersion(0);
+                .setFunctionDetails(functionDetails).setCreateTime(System.currentTimeMillis()).setVersion(0);
 
         PackageLocationMetaData.Builder packageLocationMetaDataBuilder = PackageLocationMetaData.newBuilder()
-                .setPackagePath(isPkgUrlProvided ? functionPkgUrl : createPackagePath(tenant, namespace, functionName, fileDetail.getFileName()));
+                .setPackagePath(isPkgUrlProvided ? functionPkgUrl
+                        : createPackagePath(tenant, namespace, functionName, fileDetail.getFileName()));
         functionMetaDataBuilder.setPackageLocation(packageLocationMetaDataBuilder);
 
-        return isPkgUrlProvided ? updateRequest(functionMetaDataBuilder.build()) : updateRequest(functionMetaDataBuilder.build(), uploadedInputStream);
+        return isPkgUrlProvided ? updateRequest(functionMetaDataBuilder.build())
+                : updateRequest(functionMetaDataBuilder.build(), uploadedInputStream);
     }
 
-
-    @DELETE
-    @Path("/{tenant}/{namespace}/{functionName}")
-    public Response deregisterFunction(final @PathParam("tenant") String tenant,
-                                       final @PathParam("namespace") String namespace,
-                                       final @PathParam("functionName") String functionName) {
+    public Response deregisterFunction(final String tenant, final String namespace, final String functionName) {
 
         if (!isWorkerServiceAvailable()) {
             return getUnavailableResponse();
@@ -238,57 +210,43 @@ public class FunctionsImpl {
         try {
             validateDeregisterRequestParams(tenant, namespace, functionName);
         } catch (IllegalArgumentException e) {
-            log.error("Invalid deregister function request @ /{}/{}/{}",
-                    tenant, namespace, functionName, e);
-            return Response.status(Status.BAD_REQUEST)
-                    .type(MediaType.APPLICATION_JSON)
+            log.error("Invalid deregister function request @ /{}/{}/{}", tenant, namespace, functionName, e);
+            return Response.status(Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON)
                     .entity(new ErrorData(e.getMessage())).build();
         }
 
         FunctionMetaDataManager functionMetaDataManager = worker().getFunctionMetaDataManager();
         if (!functionMetaDataManager.containsFunction(tenant, namespace, functionName)) {
-            log.error("Function to deregister does not exist @ /{}/{}/{}",
-                    tenant, namespace, functionName);
-            return Response.status(Status.NOT_FOUND)
-                    .type(MediaType.APPLICATION_JSON)
+            log.error("Function to deregister does not exist @ /{}/{}/{}", tenant, namespace, functionName);
+            return Response.status(Status.NOT_FOUND).type(MediaType.APPLICATION_JSON)
                     .entity(new ErrorData(String.format("Function %s doesn't exist", functionName))).build();
         }
 
-        CompletableFuture<RequestResult> completableFuture
-                = functionMetaDataManager.deregisterFunction(tenant, namespace, functionName);
+        CompletableFuture<RequestResult> completableFuture = functionMetaDataManager.deregisterFunction(tenant,
+                namespace, functionName);
 
         RequestResult requestResult = null;
         try {
             requestResult = completableFuture.get();
             if (!requestResult.isSuccess()) {
-                return Response.status(Status.BAD_REQUEST)
-                    .type(MediaType.APPLICATION_JSON)
-                    .entity(new ErrorData(requestResult.getMessage()))
-                    .build();
+                return Response.status(Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON)
+                        .entity(new ErrorData(requestResult.getMessage())).build();
             }
         } catch (ExecutionException e) {
-            log.error("Execution Exception while deregistering function @ /{}/{}/{}",
-                    tenant, namespace, functionName, e);
-            return Response.serverError()
-                    .type(MediaType.APPLICATION_JSON)
-                    .entity(new ErrorData(e.getCause().getMessage()))
-                    .build();
+            log.error("Execution Exception while deregistering function @ /{}/{}/{}", tenant, namespace, functionName,
+                    e);
+            return Response.serverError().type(MediaType.APPLICATION_JSON)
+                    .entity(new ErrorData(e.getCause().getMessage())).build();
         } catch (InterruptedException e) {
-            log.error("Interrupted Exception while deregistering function @ /{}/{}/{}",
-                    tenant, namespace, functionName, e);
-            return Response.status(Status.REQUEST_TIMEOUT)
-                    .type(MediaType.APPLICATION_JSON)
-                    .build();
+            log.error("Interrupted Exception while deregistering function @ /{}/{}/{}", tenant, namespace, functionName,
+                    e);
+            return Response.status(Status.REQUEST_TIMEOUT).type(MediaType.APPLICATION_JSON).build();
         }
 
         return Response.status(Status.OK).entity(requestResult.toJson()).build();
     }
 
-    @GET
-    @Path("/{tenant}/{namespace}/{functionName}")
-    public Response getFunctionInfo(final @PathParam("tenant") String tenant,
-                                    final @PathParam("namespace") String namespace,
-                                    final @PathParam("functionName") String functionName)
+    public Response getFunctionInfo(final String tenant, final String namespace, final String functionName)
             throws IOException {
 
         if (!isWorkerServiceAvailable()) {
@@ -299,33 +257,27 @@ public class FunctionsImpl {
         try {
             validateGetFunctionRequestParams(tenant, namespace, functionName);
         } catch (IllegalArgumentException e) {
-            log.error("Invalid getFunction request @ /{}/{}/{}",
-                    tenant, namespace, functionName, e);
-            return Response.status(Status.BAD_REQUEST)
-                    .type(MediaType.APPLICATION_JSON)
+            log.error("Invalid getFunction request @ /{}/{}/{}", tenant, namespace, functionName, e);
+            return Response.status(Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON)
                     .entity(new ErrorData(e.getMessage())).build();
         }
 
         FunctionMetaDataManager functionMetaDataManager = worker().getFunctionMetaDataManager();
         if (!functionMetaDataManager.containsFunction(tenant, namespace, functionName)) {
-            log.error("Function in getFunction does not exist @ /{}/{}/{}",
-                    tenant, namespace, functionName);
-            return Response.status(Status.NOT_FOUND)
-                    .type(MediaType.APPLICATION_JSON)
+            log.error("Function in getFunction does not exist @ /{}/{}/{}", tenant, namespace, functionName);
+            return Response.status(Status.NOT_FOUND).type(MediaType.APPLICATION_JSON)
                     .entity(new ErrorData(String.format("Function %s doesn't exist", functionName))).build();
         }
 
-        FunctionMetaData functionMetaData = functionMetaDataManager.getFunctionMetaData(tenant, namespace, functionName);
-        String functionDetailsJson = org.apache.pulsar.functions.utils.Utils.printJson(functionMetaData.getFunctionDetails());
+        FunctionMetaData functionMetaData = functionMetaDataManager.getFunctionMetaData(tenant, namespace,
+                functionName);
+        String functionDetailsJson = org.apache.pulsar.functions.utils.Utils
+                .printJson(functionMetaData.getFunctionDetails());
         return Response.status(Status.OK).entity(functionDetailsJson).build();
     }
 
-    @GET
-    @Path("/{tenant}/{namespace}/{functionName}/{instanceId}/status")
-    public Response getFunctionInstanceStatus(final @PathParam("tenant") String tenant,
-                                              final @PathParam("namespace") String namespace,
-                                              final @PathParam("functionName") String functionName,
-                                              final @PathParam("instanceId") String instanceId) throws IOException {
+    public Response getFunctionInstanceStatus(final String tenant, final String namespace, final String functionName,
+            final String instanceId) throws IOException {
 
         if (!isWorkerServiceAvailable()) {
             return getUnavailableResponse();
@@ -335,32 +287,29 @@ public class FunctionsImpl {
         try {
             validateGetFunctionInstanceRequestParams(tenant, namespace, functionName, instanceId);
         } catch (IllegalArgumentException e) {
-            log.error("Invalid getFunctionStatus request @ /{}/{}/{}",
-                    tenant, namespace, functionName, e);
-            return Response.status(Status.BAD_REQUEST)
-                    .type(MediaType.APPLICATION_JSON)
+            log.error("Invalid getFunctionStatus request @ /{}/{}/{}", tenant, namespace, functionName, e);
+            return Response.status(Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON)
                     .entity(new ErrorData(e.getMessage())).build();
         }
 
         FunctionMetaDataManager functionMetaDataManager = worker().getFunctionMetaDataManager();
         if (!functionMetaDataManager.containsFunction(tenant, namespace, functionName)) {
-            log.error("Function in getFunctionStatus does not exist @ /{}/{}/{}",
-                    tenant, namespace, functionName);
-            return Response.status(Status.NOT_FOUND)
-                    .type(MediaType.APPLICATION_JSON)
+            log.error("Function in getFunctionStatus does not exist @ /{}/{}/{}", tenant, namespace, functionName);
+            return Response.status(Status.NOT_FOUND).type(MediaType.APPLICATION_JSON)
                     .entity(new ErrorData(String.format("Function %s doesn't exist", functionName))).build();
         }
 
         FunctionRuntimeManager functionRuntimeManager = worker().getFunctionRuntimeManager();
         FunctionStatus functionStatus = null;
         try {
-            functionStatus = functionRuntimeManager.getFunctionInstanceStatus(
-                    tenant, namespace, functionName, Integer.parseInt(instanceId));
+            functionStatus = functionRuntimeManager.getFunctionInstanceStatus(tenant, namespace, functionName,
+                    Integer.parseInt(instanceId));
         } catch (Exception e) {
             log.error("Got Exception Getting Status", e);
             FunctionStatus.Builder functionStatusBuilder = FunctionStatus.newBuilder();
             functionStatusBuilder.setRunning(false);
-            String functionDetailsJson = org.apache.pulsar.functions.utils.Utils.printJson(functionStatusBuilder.build());
+            String functionDetailsJson = org.apache.pulsar.functions.utils.Utils
+                    .printJson(functionStatusBuilder.build());
             return Response.status(Status.OK).entity(functionDetailsJson).build();
         }
 
@@ -368,11 +317,8 @@ public class FunctionsImpl {
         return Response.status(Status.OK).entity(jsonResponse).build();
     }
 
-    @GET
-    @Path("/{tenant}/{namespace}/{functionName}/status")
-    public Response getFunctionStatus(final @PathParam("tenant") String tenant,
-                                      final @PathParam("namespace") String namespace,
-                                      final @PathParam("functionName") String functionName) throws IOException {
+    public Response getFunctionStatus(final String tenant, final String namespace, final String functionName)
+            throws IOException {
 
         if (!isWorkerServiceAvailable()) {
             return getUnavailableResponse();
@@ -382,19 +328,15 @@ public class FunctionsImpl {
         try {
             validateGetFunctionRequestParams(tenant, namespace, functionName);
         } catch (IllegalArgumentException e) {
-            log.error("Invalid getFunctionStatus request @ /{}/{}/{}",
-                    tenant, namespace, functionName, e);
-            return Response.status(Status.BAD_REQUEST)
-                    .type(MediaType.APPLICATION_JSON)
+            log.error("Invalid getFunctionStatus request @ /{}/{}/{}", tenant, namespace, functionName, e);
+            return Response.status(Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON)
                     .entity(new ErrorData(e.getMessage())).build();
         }
 
         FunctionMetaDataManager functionMetaDataManager = worker().getFunctionMetaDataManager();
         if (!functionMetaDataManager.containsFunction(tenant, namespace, functionName)) {
-            log.error("Function in getFunctionStatus does not exist @ /{}/{}/{}",
-                    tenant, namespace, functionName);
-            return Response.status(Status.NOT_FOUND)
-                    .type(MediaType.APPLICATION_JSON)
+            log.error("Function in getFunctionStatus does not exist @ /{}/{}/{}", tenant, namespace, functionName);
+            return Response.status(Status.NOT_FOUND).type(MediaType.APPLICATION_JSON)
                     .entity(new ErrorData(String.format("Function %s doesn't exist", functionName))).build();
         }
 
@@ -406,7 +348,8 @@ public class FunctionsImpl {
             log.error("Got Exception Getting Status", e);
             FunctionStatus.Builder functionStatusBuilder = FunctionStatus.newBuilder();
             functionStatusBuilder.setRunning(false);
-            String functionDetailsJson = org.apache.pulsar.functions.utils.Utils.printJson(functionStatusBuilder.build());
+            String functionDetailsJson = org.apache.pulsar.functions.utils.Utils
+                    .printJson(functionStatusBuilder.build());
             return Response.status(Status.OK).entity(functionDetailsJson).build();
         }
 
@@ -414,10 +357,7 @@ public class FunctionsImpl {
         return Response.status(Status.OK).entity(jsonResponse).build();
     }
 
-    @GET
-    @Path("/{tenant}/{namespace}")
-    public Response listFunctions(final @PathParam("tenant") String tenant,
-                                  final @PathParam("namespace") String namespace) {
+    public Response listFunctions(final String tenant, final String namespace) {
 
         if (!isWorkerServiceAvailable()) {
             return getUnavailableResponse();
@@ -427,10 +367,8 @@ public class FunctionsImpl {
         try {
             validateListFunctionRequestParams(tenant, namespace);
         } catch (IllegalArgumentException e) {
-            log.error("Invalid listFunctions request @ /{}/{}",
-                    tenant, namespace, e);
-            return Response.status(Status.BAD_REQUEST)
-                    .type(MediaType.APPLICATION_JSON)
+            log.error("Invalid listFunctions request @ /{}/{}", tenant, namespace, e);
+            return Response.status(Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON)
                     .entity(new ErrorData(e.getMessage())).build();
         }
 
@@ -455,41 +393,32 @@ public class FunctionsImpl {
         }
         return updateRequest(functionMetaData);
     }
-    
+
     private Response updateRequest(FunctionMetaData functionMetaData) {
 
         // Submit to FMT
         FunctionMetaDataManager functionMetaDataManager = worker().getFunctionMetaDataManager();
 
-        CompletableFuture<RequestResult> completableFuture
-                = functionMetaDataManager.updateFunction(functionMetaData);
+        CompletableFuture<RequestResult> completableFuture = functionMetaDataManager.updateFunction(functionMetaData);
 
         RequestResult requestResult = null;
         try {
             requestResult = completableFuture.get();
             if (!requestResult.isSuccess()) {
-                return Response.status(Status.BAD_REQUEST)
-                    .type(MediaType.APPLICATION_JSON)
-                    .entity(new ErrorData(requestResult.getMessage()))
-                    .build();
+                return Response.status(Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON)
+                        .entity(new ErrorData(requestResult.getMessage())).build();
             }
         } catch (ExecutionException e) {
-            return Response.serverError()
-                    .type(MediaType.APPLICATION_JSON)
-                    .entity(new ErrorData(e.getCause().getMessage()))
-                    .build();
+            return Response.serverError().type(MediaType.APPLICATION_JSON)
+                    .entity(new ErrorData(e.getCause().getMessage())).build();
         } catch (InterruptedException e) {
-            return Response.status(Status.REQUEST_TIMEOUT)
-                .type(MediaType.APPLICATION_JSON)
-                .entity(new ErrorData(e.getCause().getMessage()))
-                .build();
+            return Response.status(Status.REQUEST_TIMEOUT).type(MediaType.APPLICATION_JSON)
+                    .entity(new ErrorData(e.getCause().getMessage())).build();
         }
 
         return Response.status(Status.OK).build();
     }
 
-    @GET
-    @Path("/cluster")
     public Response getCluster() {
 
         if (!isWorkerServiceAvailable()) {
@@ -501,8 +430,6 @@ public class FunctionsImpl {
         return Response.status(Status.OK).entity(new Gson().toJson(members)).build();
     }
 
-    @GET
-    @Path("/assignments")
     public Response getAssignments() {
 
         if (!isWorkerServiceAvailable()) {
@@ -515,19 +442,11 @@ public class FunctionsImpl {
         for (Map.Entry<String, Map<String, Function.Assignment>> entry : assignments.entrySet()) {
             ret.put(entry.getKey(), entry.getValue().keySet());
         }
-        return Response.status(Status.OK).entity(
-                new Gson().toJson(ret)).build();
+        return Response.status(Status.OK).entity(new Gson().toJson(ret)).build();
     }
 
-    @POST
-    @Path("/{tenant}/{namespace}/{functionName}/trigger")
-    @Consumes(MediaType.MULTIPART_FORM_DATA)
-    public Response triggerFunction(final @PathParam("tenant") String tenant,
-                                    final @PathParam("namespace") String namespace,
-                                    final @PathParam("name") String functionName,
-                                    final @FormDataParam("data") String input,
-                                    final @FormDataParam("dataStream") InputStream uploadedInputStream,
-                                    final @FormDataParam("topic") String topic) {
+    public Response triggerFunction(final String tenant, final String namespace, final String functionName,
+            final String input, final InputStream uploadedInputStream, final String topic) {
 
         if (!isWorkerServiceAvailable()) {
             return getUnavailableResponse();
@@ -538,35 +457,33 @@ public class FunctionsImpl {
         try {
             validateTriggerRequestParams(tenant, namespace, functionName, topic, input, uploadedInputStream);
         } catch (IllegalArgumentException e) {
-            log.error("Invalid trigger function request @ /{}/{}/{}",
-                    tenant, namespace, functionName, e);
-            return Response.status(Status.BAD_REQUEST)
-                    .type(MediaType.APPLICATION_JSON)
+            log.error("Invalid trigger function request @ /{}/{}/{}", tenant, namespace, functionName, e);
+            return Response.status(Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON)
                     .entity(new ErrorData(e.getMessage())).build();
         }
 
         FunctionMetaDataManager functionMetaDataManager = worker().getFunctionMetaDataManager();
         if (!functionMetaDataManager.containsFunction(tenant, namespace, functionName)) {
-            log.error("Function in getFunction does not exist @ /{}/{}/{}",
-                    tenant, namespace, functionName);
-            return Response.status(Status.NOT_FOUND)
-                    .type(MediaType.APPLICATION_JSON)
+            log.error("Function in getFunction does not exist @ /{}/{}/{}", tenant, namespace, functionName);
+            return Response.status(Status.NOT_FOUND).type(MediaType.APPLICATION_JSON)
                     .entity(new ErrorData(String.format("Function %s doesn't exist", functionName))).build();
         }
 
-        FunctionMetaData functionMetaData = functionMetaDataManager.getFunctionMetaData(tenant, namespace, functionName);
+        FunctionMetaData functionMetaData = functionMetaDataManager.getFunctionMetaData(tenant, namespace,
+                functionName);
 
         String inputTopicToWrite;
         if (topic != null) {
             inputTopicToWrite = topic;
         } else if (functionMetaData.getFunctionDetails().getSource().getTopicsToSerDeClassNameMap().size() == 1) {
-            inputTopicToWrite =
-                    functionMetaData.getFunctionDetails().getSource().getTopicsToSerDeClassNameMap().keySet().iterator().next();
+            inputTopicToWrite = functionMetaData.getFunctionDetails().getSource().getTopicsToSerDeClassNameMap()
+                    .keySet().iterator().next();
         } else {
             return Response.status(Status.BAD_REQUEST).build();
         }
         if (functionMetaData.getFunctionDetails().getSource().getTopicsToSerDeClassNameMap() == null
-            || !functionMetaData.getFunctionDetails().getSource().getTopicsToSerDeClassNameMap().containsKey(inputTopicToWrite)) {
+                || !functionMetaData.getFunctionDetails().getSource().getTopicsToSerDeClassNameMap()
+                        .containsKey(inputTopicToWrite)) {
             return Response.status(Status.BAD_REQUEST).build();
         }
         String outputTopic = functionMetaData.getFunctionDetails().getSink().getTopic();
@@ -592,11 +509,14 @@ public class FunctionsImpl {
             long maxTime = curTime + 1000;
             while (curTime < maxTime) {
                 Message msg = reader.readNext(10000, TimeUnit.MILLISECONDS);
-                if (msg == null) break;
-                if (msg.getProperties().containsKey("__pfn_input_msg_id__") &&
-                        msg.getProperties().containsKey("__pfn_input_topic__")) {
-                    MessageId newMsgId = MessageId.fromByteArray(Base64.getDecoder().decode((String) msg.getProperties().get("__pfn_input_msg_id__")));
-                    if (msgId.equals(newMsgId) && msg.getProperties().get("__pfn_input_topic__").equals(inputTopicToWrite)) {
+                if (msg == null)
+                    break;
+                if (msg.getProperties().containsKey("__pfn_input_msg_id__")
+                        && msg.getProperties().containsKey("__pfn_input_topic__")) {
+                    MessageId newMsgId = MessageId.fromByteArray(
+                            Base64.getDecoder().decode((String) msg.getProperties().get("__pfn_input_msg_id__")));
+                    if (msgId.equals(newMsgId)
+                            && msg.getProperties().get("__pfn_input_topic__").equals(inputTopicToWrite)) {
                         return Response.status(Status.OK).entity(msg.getData()).build();
                     }
                 }
@@ -615,11 +535,7 @@ public class FunctionsImpl {
         }
     }
 
-    @POST
-    @Path("/upload")
-    @Consumes(MediaType.MULTIPART_FORM_DATA)
-    public Response uploadFunction(final @FormDataParam("data") InputStream uploadedInputStream,
-                                   final @FormDataParam("path") String path) {
+    public Response uploadFunction(final InputStream uploadedInputStream, final String path) {
         // validate parameters
         try {
             if (uploadedInputStream == null || path == null) {
@@ -627,8 +543,7 @@ public class FunctionsImpl {
             }
         } catch (IllegalArgumentException e) {
             log.error("Invalid upload function request @ /{}", path, e);
-            return Response.status(Status.BAD_REQUEST)
-                    .type(MediaType.APPLICATION_JSON)
+            return Response.status(Status.BAD_REQUEST).type(MediaType.APPLICATION_JSON)
                     .entity(new ErrorData(e.getMessage())).build();
         }
 
@@ -636,24 +551,17 @@ public class FunctionsImpl {
         try {
             log.info("Uploading function package to {}", path);
 
-            Utils.uploadToBookeeper(
-                    worker().getDlogNamespace(),
-                    uploadedInputStream,
-                    Codec.encode(path));
+            Utils.uploadToBookeeper(worker().getDlogNamespace(), uploadedInputStream, Codec.encode(path));
         } catch (IOException e) {
             log.error("Error uploading file {}", path, e);
-            return Response.serverError()
-                    .type(MediaType.APPLICATION_JSON)
-                    .entity(new ErrorData(e.getMessage()))
+            return Response.serverError().type(MediaType.APPLICATION_JSON).entity(new ErrorData(e.getMessage()))
                     .build();
         }
 
         return Response.status(Status.OK).build();
     }
 
-    @GET
-    @Path("/download")
-    public Response downloadFunction(final @QueryParam("path") String path) {
+    public Response downloadFunction(final String path) {
         return Response.status(Status.OK).entity(new StreamingOutput() {
             @Override
             public void write(final OutputStream output) throws IOException {
@@ -686,10 +594,8 @@ public class FunctionsImpl {
         }
     }
 
-    private void validateGetFunctionInstanceRequestParams(String tenant,
-                                                          String namespace,
-                                                          String functionName,
-                                                          String instanceId) throws IllegalArgumentException {
+    private void validateGetFunctionInstanceRequestParams(String tenant, String namespace, String functionName,
+            String instanceId) throws IllegalArgumentException {
         validateGetFunctionRequestParams(tenant, namespace, functionName);
         if (instanceId == null) {
             throw new IllegalArgumentException("Function Instance Id is not provided");
@@ -697,9 +603,8 @@ public class FunctionsImpl {
         }
     }
 
-    private void validateGetFunctionRequestParams(String tenant,
-                                                  String namespace,
-                                                  String functionName) throws IllegalArgumentException {
+    private void validateGetFunctionRequestParams(String tenant, String namespace, String functionName)
+            throws IllegalArgumentException {
 
         if (tenant == null) {
             throw new IllegalArgumentException("Tenant is not provided");
@@ -712,9 +617,8 @@ public class FunctionsImpl {
         }
     }
 
-    private void validateDeregisterRequestParams(String tenant,
-                                                 String namespace,
-                                                 String functionName) throws IllegalArgumentException {
+    private void validateDeregisterRequestParams(String tenant, String namespace, String functionName)
+            throws IllegalArgumentException {
 
         if (tenant == null) {
             throw new IllegalArgumentException("Tenant is not provided");
@@ -740,23 +644,17 @@ public class FunctionsImpl {
         return functionDetails;
     }
 
-    private FunctionDetails validateUpdateRequestParams(String tenant,
-            String namespace,
-            String functionName,
-            InputStream uploadedInputStream,
-            FormDataContentDisposition fileDetail,
-            String functionDetailsJson) throws IllegalArgumentException {
+    private FunctionDetails validateUpdateRequestParams(String tenant, String namespace, String functionName,
+            InputStream uploadedInputStream, FormDataContentDisposition fileDetail, String functionDetailsJson)
+            throws IllegalArgumentException {
         if (uploadedInputStream == null || fileDetail == null) {
             throw new IllegalArgumentException("Function Package is not provided");
         }
         return validateUpdateRequestParams(tenant, namespace, functionName, functionDetailsJson, null);
     }
-    
-    private FunctionDetails validateUpdateRequestParams(String tenant,
-                                             String namespace,
-                                             String functionName,
-                                             String functionDetailsJson,
-                                             File jarWithFileUrl) throws IllegalArgumentException {
+
+    private FunctionDetails validateUpdateRequestParams(String tenant, String namespace, String functionName,
+            String functionDetailsJson, File jarWithFileUrl) throws IllegalArgumentException {
         if (tenant == null) {
             throw new IllegalArgumentException("Tenant is not provided");
         }
@@ -766,7 +664,7 @@ public class FunctionsImpl {
         if (functionName == null) {
             throw new IllegalArgumentException("Function Name is not provided");
         }
-        
+
         if (functionDetailsJson == null) {
             throw new IllegalArgumentException("FunctionDetails is not provided");
         }
@@ -816,10 +714,10 @@ public class FunctionsImpl {
             throws MalformedURLException {
 
         // validate only if jar-file is provided
-        if(jarFile == null) {
+        if (jarFile == null) {
             return;
         }
-        
+
         if (StringUtils.isBlank(functionDetailsBuilder.getClassName())) {
             throw new IllegalArgumentException("function class-name can't be empty");
         }
@@ -830,7 +728,8 @@ public class FunctionsImpl {
 
         // validate function class-type
         Object functionObject = createInstance(functionDetailsBuilder.getClassName(), classLoader);
-        if (!(functionObject instanceof org.apache.pulsar.functions.api.Function) && !(functionObject instanceof java.util.function.Function)) {
+        if (!(functionObject instanceof org.apache.pulsar.functions.api.Function)
+                && !(functionObject instanceof java.util.function.Function)) {
             throw new RuntimeException("User class must either be Function or java.util.Function");
         }
 
@@ -839,16 +738,16 @@ public class FunctionsImpl {
             try {
                 String sourceClassName = functionDetailsBuilder.getSource().getClassName();
                 String argClassName = getTypeArg(sourceClassName, Source.class, classLoader).getName();
-                functionDetailsBuilder.setSource(functionDetailsBuilder.getSourceBuilder()
-                        .setTypeClassName(argClassName));
-                
+                functionDetailsBuilder
+                        .setSource(functionDetailsBuilder.getSourceBuilder().setTypeClassName(argClassName));
+
                 // if sink-class not present then set same arg as source
                 if (!functionDetailsBuilder.hasSink()
                         || StringUtils.isBlank(functionDetailsBuilder.getSink().getClassName())) {
                     functionDetailsBuilder
                             .setSink(functionDetailsBuilder.getSinkBuilder().setTypeClassName(argClassName));
                 }
-                
+
             } catch (IllegalArgumentException ie) {
                 throw ie;
             } catch (Exception e) {
@@ -862,16 +761,15 @@ public class FunctionsImpl {
             try {
                 String sinkClassName = functionDetailsBuilder.getSink().getClassName();
                 String argClassName = getTypeArg(sinkClassName, Sink.class, classLoader).getName();
-                functionDetailsBuilder.setSink(functionDetailsBuilder.getSinkBuilder()
-                        .setTypeClassName(argClassName));
-                
+                functionDetailsBuilder.setSink(functionDetailsBuilder.getSinkBuilder().setTypeClassName(argClassName));
+
                 // if source-class not present then set same arg as sink
                 if (!functionDetailsBuilder.hasSource()
                         || StringUtils.isBlank(functionDetailsBuilder.getSource().getClassName())) {
                     functionDetailsBuilder
                             .setSource(functionDetailsBuilder.getSourceBuilder().setTypeClassName(argClassName));
                 }
-                
+
             } catch (IllegalArgumentException ie) {
                 throw ie;
             } catch (Exception e) {
@@ -891,12 +789,8 @@ public class FunctionsImpl {
         return TypeResolver.resolveRawArgument(funClass, loadedClass);
     }
 
-    private void validateTriggerRequestParams(String tenant,
-                                              String namespace,
-                                              String functionName,
-                                              String topic,
-                                              String input,
-                                              InputStream uploadedInputStream) {
+    private void validateTriggerRequestParams(String tenant, String namespace, String functionName, String topic,
+            String input, InputStream uploadedInputStream) {
         if (tenant == null) {
             throw new IllegalArgumentException("Tenant is not provided");
         }
@@ -912,10 +806,9 @@ public class FunctionsImpl {
     }
 
     private Response getUnavailableResponse() {
-        return Response.status(Status.SERVICE_UNAVAILABLE)
-                .type(MediaType.APPLICATION_JSON)
-                .entity(new ErrorData("Function worker service is not done initializing. "
-                        + "Please try again in a little while."))
+        return Response.status(Status.SERVICE_UNAVAILABLE).type(MediaType.APPLICATION_JSON)
+                .entity(new ErrorData(
+                        "Function worker service is not done initializing. " + "Please try again in a little while."))
                 .build();
     }
 


### PR DESCRIPTION
### Motivation

Functions already has rest-api resources defined at broker: [Functions-v1](https://github.com/apache/incubator-pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Functions.java) / [Functions-v2](https://github.com/apache/incubator-pulsar/blob/master/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Functions.java) and in [function-workers](https://github.com/apache/incubator-pulsar/blob/master/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2Resource.java) and `FunctionsImpl` is not needed for rest-resource. So, clean up unnecessary rest-resource definition to avoid confusion.

### Modifications

Remove rest-api path definition from `FunctionsImpl`.

### Result

No functional change.
