### PR TITLE
avoid unnecessary reflection to create pulsar source instance

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -467,14 +467,7 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
             if (sourceSpec.getTimeoutMs() > 0 ) {
                 pulsarSourceConfig.setTimeoutMs(sourceSpec.getTimeoutMs());
             }
-
-            Object[] params = {this.client, pulsarSourceConfig};
-            Class[] paramTypes = {PulsarClient.class, PulsarSourceConfig.class};
-
-            object = Reflections.createInstance(
-                    PulsarSource.class.getName(),
-                    PulsarSource.class.getClassLoader(), params, paramTypes);
-
+            object = new PulsarSource(this.client, pulsarSourceConfig);
         } else {
             object = Reflections.createInstance(
                     sourceSpec.getClassName(),


### PR DESCRIPTION
### Motivation

`PulsarSource` class is already loaded into the class-loader and part of the existing classpath so, we can avoid reflection to create PulsarSource object.

### Result

no functional change.
