### PR TITLE
Fix wget argument

### DIFF
--- a/site/_includes/explanations/install-package.md
+++ b/site/_includes/explanations/install-package.md
@@ -38,7 +38,7 @@ To get started running Pulsar, download a binary tarball release in one of the f
 * using [wget](https://www.gnu.org/software/wget):
 
   ```shell
-  $ wget 'https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=incubator/pulsar/pulsar-{{ site.current_version }}-incubating/apache-pulsar-{{ site.current_version }}-incubating-bin.tar.gz' -O apache-pulsar-{{ site.current_version }}-incubating-bin.tar.gz
+  $ wget 'https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=incubator/pulsar/pulsar-{{ site.current_version }}/apache-pulsar-{{ site.current_version }}-bin.tar.gz' -O apache-pulsar-{{ site.current_version }}-bin.tar.gz
   ```
 
 Once the tarball is downloaded, untar it and `cd` into the resulting directory:

--- a/site/_includes/explanations/install-package.md
+++ b/site/_includes/explanations/install-package.md
@@ -38,7 +38,7 @@ To get started running Pulsar, download a binary tarball release in one of the f
 * using [wget](https://www.gnu.org/software/wget):
 
   ```shell
-  $ wget {{ binary_release_url }}
+  $ wget 'https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=incubator/pulsar/pulsar-{{ site.current_version }}-incubating/apache-pulsar-{{ site.current_version }}-incubating-bin.tar.gz' -O apache-pulsar-{{ site.current_version }}-incubating-bin.tar.gz
   ```
 
 Once the tarball is downloaded, untar it and `cd` into the resulting directory:


### PR DESCRIPTION
### Motivation

In https://pulsar.incubator.apache.org/docs/latest/getting-started/LocalCluster/ , `wget` argument is wrong.

```
$ wget http://www.apache.org/dyn/closer.cgi/incubator/pulsar/pulsar-2.0.1-incubating/apache-pulsar-2.0.1-incubating-bin.tar.gz
```

HTML file is downloaded if this command is executed. 

```
$ wget http://www.apache.org/dyn/closer.cgi/incubator/pulsar/pulsar-2.0.1-incubating/apache-pulsar-2.0.1-incubating-bin.tar.gz
--2018-07-05 16:08:33--  http://www.apache.org/dyn/closer.cgi/incubator/pulsar/pulsar-2.0.1-incubating/apache-pulsar-2.0.1-incubating-bin.tar.gz
Resolving www.apache.org... 95.216.24.32, 40.79.78.1, 2a01:4f9:2a:185f::2
Connecting to www.apache.org|95.216.24.32|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: unspecified [text/html]
Saving to: “apache-pulsar-2.0.1-incubating-bin.tar.gz”

    [  <=>                                                                                                                                                                                                                 ] 18,878      66.9K/s   in 0.3s

2018-07-05 16:08:33 (66.9 KB/s) - “apache-pulsar-2.0.1-incubating-bin.tar.gz” saved [18878]

$ file apache-pulsar-2.0.1-incubating-bin.tar.gz
apache-pulsar-2.0.1-incubating-bin.tar.gz: HTML document text
```

### Modifications

I changed `wget` argument:

```
$ wget 'https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=incubator/pulsar/pulsar-2.0.1-incubating/apache-pulsar-2.0.1-incubating-bin.tar.gz' -O apache-pulsar-2.0.1-incubating-bin.tar.gz
```

### Result

It enabled us to download `apache-pulsar-2.0.1-incubating-bin.tar.gz` successfully.