### PR TITLE
Add std=c99 to CMAKE_C_FLAGS to avoid compile error with gcc-4.8

### DIFF
--- a/pulsar-client-cpp/examples/CMakeLists.txt
+++ b/pulsar-client-cpp/examples/CMakeLists.txt
@@ -17,6 +17,8 @@
 # under the License.
 #
 
+set(CMAKE_C_FLAGS " -std=c99 ${CMAKE_C_FLAGS}")
+
 set(SAMPLE_ASYNC_PRODUCER_SOURCES
   SampleAsyncProducer.cc
 )


### PR DESCRIPTION
### Motivation

I got following error when I compile example codes with gcc-4.8 on centos7.
```
[ 89%] Building C object examples/CMakeFiles/SampleProducerCApi.dir/SampleProducerCApi.c.o
/root/incubator-pulsar/pulsar-client-cpp/examples/SampleProducerCApi.c: In function ‘main’:
/root/incubator-pulsar/pulsar-client-cpp/examples/SampleProducerCApi.c:39:5: error: ‘for’ loop initial declarations are only allowed in C99 mode
     for (int i = 0; i < 10; i++) {
     ^
/root/incubator-pulsar/pulsar-client-cpp/examples/SampleProducerCApi.c:39:5: note: use option -std=c99 or -std=gnu99 to compile your code
make[2]: *** [examples/CMakeFiles/SampleProducerCApi.dir/SampleProducerCApi.c.o] Error 1
make[1]: *** [examples/CMakeFiles/SampleProducerCApi.dir/all] Error 2
make: *** [all] Error 2
```

### Modifications

Add -std=c99 to CMAKE_C_FLAGS to avoid compile error with gcc-4.8.

### Result

I can compile example codes with gcc-4.8.