### PR TITLE
Fixed path for Postgres in dashboard docker image

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get -y install postgresql python sudo nginx supervisor
 RUN pip install uwsgi 'Django<2.0' psycopg2 pytz requests
 
 # Postgres configuration
-COPY conf/postgresql.conf /etc/postgresql/9.4/main/
+COPY conf/postgresql.conf /etc/postgresql/9.6/main/
 
 # Configure nginx and supervisor
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf

--- a/dashboard/conf/postgresql.conf
+++ b/dashboard/conf/postgresql.conf
@@ -23,16 +23,16 @@ full_page_writes = off
 synchronous_commit = off
 
 # Default configs
-data_directory = '/var/lib/postgresql/9.4/main'
-hba_file = '/etc/postgresql/9.4/main/pg_hba.conf'
-ident_file = '/etc/postgresql/9.4/main/pg_ident.conf'
-external_pid_file = '/var/run/postgresql/9.4-main.pid'
+data_directory = '/var/lib/postgresql/9.6/main'
+hba_file = '/etc/postgresql/9.6/main/pg_hba.conf'
+ident_file = '/etc/postgresql/9.6/main/pg_ident.conf'
+external_pid_file = '/var/run/postgresql/9.6-main.pid'
 
 port = 5432
 max_connections = 100
 
 datestyle = 'iso, mdy'
 default_text_search_config = 'pg_catalog.english'
-stats_temp_directory = '/var/run/postgresql/9.4-main.pg_stat_tmp'
+stats_temp_directory = '/var/run/postgresql/9.6-main.pg_stat_tmp'
 timezone = 'UTC'
 log_timezone = 'UTC'

--- a/dashboard/conf/supervisor-app.conf
+++ b/dashboard/conf/supervisor-app.conf
@@ -18,7 +18,7 @@
 #
 
 [program:postgres]
-command = /usr/lib/postgresql/9.4/bin/postgres -D /etc/postgresql/9.4/main
+command = /usr/lib/postgresql/9.6/bin/postgres -D /etc/postgresql/9.6/main
 user = postgres
 
 [program:uwsgi]


### PR DESCRIPTION
### Motivation

The Postgres version from the Debian base image was updated from 9.4 to 9.6 and the scripts in our docker image were now incorrect.