### PR TITLE
source consumer ack message with retry to avoid ack-holes

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -68,6 +69,7 @@ import org.apache.pulsar.functions.utils.Reflections;
 import org.apache.pulsar.io.core.Record;
 import org.apache.pulsar.io.core.Sink;
 import org.apache.pulsar.io.core.Source;
+import org.apache.pulsar.functions.utils.functioncache.FunctionCacheManagerImpl;
 
 /**
  * A function container implemented using java thread.
@@ -468,12 +470,8 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
                 pulsarSourceConfig.setTimeoutMs(sourceSpec.getTimeoutMs());
             }
 
-            Object[] params = {this.client, pulsarSourceConfig};
-            Class[] paramTypes = {PulsarClient.class, PulsarSourceConfig.class};
-
-            object = Reflections.createInstance(
-                    PulsarSource.class.getName(),
-                    PulsarSource.class.getClassLoader(), params, paramTypes);
+            ScheduledExecutorService executor = ((FunctionCacheManagerImpl) fnCache).getExecutor();
+            object = new PulsarSource<>(this.client, pulsarSourceConfig, executor);
 
         } else {
             object = Reflections.createInstance(

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/source/PulsarSourceTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/source/PulsarSourceTest.java
@@ -118,7 +118,7 @@ public class PulsarSourceTest {
         PulsarSourceConfig pulsarConfig = getPulsarConfigs();
         // set type to void
         pulsarConfig.setTypeClassName(Void.class.getName());
-        PulsarSource pulsarSource = new PulsarSource(getPulsarClient(), pulsarConfig);
+        PulsarSource pulsarSource = new PulsarSource(getPulsarClient(), pulsarConfig, null);
 
         try {
             pulsarSource.open(new HashMap<>());
@@ -143,7 +143,7 @@ public class PulsarSourceTest {
         Map<String, String> topicSerdeClassNameMap = new HashMap<>();
         topicSerdeClassNameMap.put("persistent://sample/standalone/ns1/test_result", TestSerDe.class.getName());
         pulsarConfig.setTopicSerdeClassNameMap(topicSerdeClassNameMap);
-        PulsarSource pulsarSource = new PulsarSource(getPulsarClient(), pulsarConfig);
+        PulsarSource pulsarSource = new PulsarSource(getPulsarClient(), pulsarConfig, null);
         try {
             pulsarSource.open(new HashMap<>());
             fail("Should fail constructing java instance if function type is inconsistent with serde type");
@@ -167,7 +167,7 @@ public class PulsarSourceTest {
         pulsarConfig.setTypeClassName(String.class.getName());
         topicSerdeClassNameMap.put("persistent://sample/standalone/ns1/test_result", null);
         pulsarConfig.setTopicSerdeClassNameMap(topicSerdeClassNameMap);
-        PulsarSource pulsarSource = new PulsarSource(getPulsarClient(), pulsarConfig);
+        PulsarSource pulsarSource = new PulsarSource(getPulsarClient(), pulsarConfig, null);
 
         pulsarSource.open(new HashMap<>());
     }
@@ -182,7 +182,7 @@ public class PulsarSourceTest {
         pulsarConfig.setTypeClassName(String.class.getName());
         topicSerdeClassNameMap.put("persistent://sample/standalone/ns1/test_result", DefaultSerDe.class.getName());
         pulsarConfig.setTopicSerdeClassNameMap(topicSerdeClassNameMap);
-        PulsarSource pulsarSource = new PulsarSource(getPulsarClient(), pulsarConfig);
+        PulsarSource pulsarSource = new PulsarSource(getPulsarClient(), pulsarConfig, null);
 
         pulsarSource.open(new HashMap<>());
     }
@@ -194,7 +194,7 @@ public class PulsarSourceTest {
         pulsarConfig.setTypeClassName(ComplexUserDefinedType.class.getName());
         topicSerdeClassNameMap.put("persistent://sample/standalone/ns1/test_result",ComplexSerDe.class.getName());
         pulsarConfig.setTopicSerdeClassNameMap(topicSerdeClassNameMap);
-        PulsarSource pulsarSource = new PulsarSource(getPulsarClient(), pulsarConfig);
+        PulsarSource pulsarSource = new PulsarSource(getPulsarClient(), pulsarConfig, null);
 
         try {
             pulsarSource.setupSerDe();


### PR DESCRIPTION
### Motivation

Right now, if Pulsar-source fails to ack message then it doesn't retry again which leads to ack-hole for shared consumers. If consumer is not connected with broker while trying to ack message then ack-op will fail immediately in that case, client should retry again to avoid ack-holes for the consumer.

### Modifications

Pulsar source retries when it fails while trying to ack the message.

### Result

It avoids ack-holes for pulsar-source consumers.
