### PR TITLE
Issue 2090: Links to connector source code are broken

### DIFF
--- a/site/_data/connectors.yaml
+++ b/site/_data/connectors.yaml
@@ -21,22 +21,22 @@
   url: https://www.aerospike.com/
   class:
     group: aerospike
-    name: AerospikeSink
+    name: AerospikeStringSink
 - name: Cassandra sink
   url: https://cassandra.apache.org
   class:
     group: cassandra
-    name: CassandraSink
+    name: CassandraStringSink
 - name: Kafka source
   url: https://kafka.apache.org
   class:
     group: kafka
-    name: KafkaSource
+    name: KafkaStringSource
 - name: Kafka sink
   url: https://kafka.apache.org
   class:
     group: kafka
-    name: KafkaSink
+    name: KafkaStringSink
 - name: RabbitMQ source
   url: https://www.rabbitmq.com
   class:

--- a/site/_includes/connectors.html
+++ b/site/_includes/connectors.html
@@ -34,7 +34,7 @@
             </a>
         </td>
         <td>
-            <a href="https://github.com/apache/incubator-pulsar/blob/master/pulsar-io/{{ connector.class.group }}/src/main/java/org/apache/pulsar/connect/{{ connector.class.group }}/{{ connector.class.name }}.java">
+            <a href="https://github.com/apache/incubator-pulsar/blob/master/pulsar-io/{{ connector.class.group }}/src/main/java/org/apache/pulsar/io/{{ connector.class.group }}/{{ connector.class.name }}.java">
                 <code>org.apache.pulsar.io.{{ connector.class.group }}.{{ connector.class.name }}</code>
             </a>
         </td>


### PR DESCRIPTION
*Motivation*

Fixes #2090.

Links to connector source code are broken

*Changes*

- Change package name from `connect` to `io`
- Fix the connector class name

