### PR TITLE
Remove unused test annotation

### DIFF
--- a/tests/integration/semantics/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
+++ b/tests/integration/semantics/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
@@ -34,7 +34,6 @@ public class PulsarFunctionsTest extends PulsarFunctionsTestBase {
     // Tests on uploading/downloading function packages.
     //
 
-    @Test
     public String checkUpload() throws Exception {
         String bkPkgPath = String.format("%s/%s/%s",
             "tenant-" + randomName(8),


### PR DESCRIPTION
checkUpload has an incorrect testAnnotation that's not being used.

test can only have a void method this test has never run
also download method already calls upload

```java
    @Test
    public void checkDownload() throws Exception {
        String bkPkgPath = checkUpload();
        String localPkgFile = "/tmp/checkdownload-" + randomName(16);

        UploadDownloadCommandGenerator generator = UploadDownloadCommandGenerator.createDownloader(
                localPkgFile,
                bkPkgPath);
```
