### PR TITLE
Issue 1252: Enable bookie autorecovery daemon by default

### DIFF
--- a/conf/bookkeeper.conf
+++ b/conf/bookkeeper.conf
@@ -229,13 +229,13 @@ rereplicationEntryBatchSize=5000
 # Auto-replication
 # The grace period, in seconds, that the replication worker waits before fencing and
 # replicating a ledger fragment that's still being written to upon bookie failure.
-# openLedgerRereplicationGracePeriod=30
+openLedgerRereplicationGracePeriod=30
 
 # Whether the bookie itself can start auto-recovery service also or not
-# autoRecoveryDaemonEnabled=false
+autoRecoveryDaemonEnabled=true
 
 # How long to wait, in seconds, before starting auto recovery of a lost bookie
-# lostBookieRecoveryDelay=0
+lostBookieRecoveryDelay=0
 
 #############################################################################
 ## Netty server settings


### PR DESCRIPTION
*Motivation*

Fixes #1252

AutoRecovery daemon should be enabled by default for new users.

*Changes*

Turn on `autoRecoveryDaemonEnabled`. uncommeted recovery related settings to allow them being configured in containers.

