### PR TITLE
Load connectors from NAR archives

### DIFF
--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/CmdFunctionsTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/CmdFunctionsTest.java
@@ -296,7 +296,7 @@ public class CmdFunctionsTest {
         consoleOutputCapturer.stop();
         String output = consoleOutputCapturer.getStderr();
 
-        assertTrue(output.contains("Failed to download jar"));
+        assertTrue(output.contains("Failed to download archive"));
         assertEquals(url, creater.archive);
     }
 
@@ -321,7 +321,7 @@ public class CmdFunctionsTest {
         consoleOutputCapturer.stop();
         String output = consoleOutputCapturer.getStderr();
 
-        assertTrue(output.contains("Failed to download jar"));
+        assertTrue(output.contains("Failed to download archive"));
         assertEquals(url, creater.archive);
     }
 

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/CmdFunctionsTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/CmdFunctionsTest.java
@@ -110,7 +110,7 @@ public class CmdFunctionsTest {
             return null;
         }
     }
-    
+
     private String generateCustomSerdeInputs(String topic, String serde) {
         Map<String, String> map = new HashMap<>();
         map.put(topic, serde);
@@ -213,16 +213,16 @@ public class CmdFunctionsTest {
         verify(functions, times(1)).createFunction(any(FunctionDetails.class), anyString());
 
     }
-    
+
     @Test
     public void testCreateFunctionWithHttpUrl() throws Exception {
         String fnName = TEST_NAME + "-function";
         String inputTopicName = TEST_NAME + "-input-topic";
         String outputTopicName = TEST_NAME + "-output-topic";
-        
+
         ConsoleOutputCapturer consoleOutputCapturer = new ConsoleOutputCapturer();
         consoleOutputCapturer.start();
-        
+
         final String url = "http://localhost:1234/test";
         cmd.run(new String[] {
             "create",
@@ -236,10 +236,10 @@ public class CmdFunctionsTest {
         });
 
         CreateFunction creater = cmd.getCreater();
-        
+
         consoleOutputCapturer.stop();
         String output = consoleOutputCapturer.getStderr();
-        
+
         assertTrue(output.contains("Failed to download jar"));
         assertEquals(fnName, creater.getFunctionName());
         assertEquals(inputTopicName, creater.getInputs());
@@ -251,7 +251,7 @@ public class CmdFunctionsTest {
         String fnName = TEST_NAME + "-function";
         String inputTopicName = TEST_NAME + "-input-topic";
         String outputTopicName = TEST_NAME + "-output-topic";
-        
+
         final String url = "file:/usr/temp/myfile.jar";
         cmd.run(new String[] {
             "create",
@@ -265,19 +265,19 @@ public class CmdFunctionsTest {
         });
 
         CreateFunction creater = cmd.getCreater();
-        
+
         assertEquals(fnName, creater.getFunctionName());
         assertEquals(inputTopicName, creater.getInputs());
         assertEquals(outputTopicName, creater.getOutput());
         verify(functions, times(1)).createFunctionWithUrl(any(FunctionDetails.class), anyString());
     }
-    
+
     @Test
     public void testCreateSink() throws Exception {
         String fnName = TEST_NAME + "-function";
         String inputTopicName = TEST_NAME + "-input-topic";
-        
-        
+
+
         ConsoleOutputCapturer consoleOutputCapturer = new ConsoleOutputCapturer();
         consoleOutputCapturer.start();
 
@@ -286,26 +286,24 @@ public class CmdFunctionsTest {
             "create",
             "--name", fnName,
             "--inputs", inputTopicName,
-            "--jar", url,
+            "--archive", url,
             "--tenant", "sample",
-            "--namespace", "ns1",
-            "--className", "DummySink"
+            "--namespace", "ns1"
         });
 
         CreateSink creater = cmdSinks.getCreateSink();
-        
+
         consoleOutputCapturer.stop();
         String output = consoleOutputCapturer.getStderr();
-        
+
         assertTrue(output.contains("Failed to download jar"));
-        assertEquals("DummySink", creater.className);
-        assertEquals(url, creater.jarFile);
+        assertEquals(url, creater.archive);
     }
-    
+
     @Test
     public void testCreateSource() throws Exception {
         String fnName = TEST_NAME + "-function";
-        
+
         ConsoleOutputCapturer consoleOutputCapturer = new ConsoleOutputCapturer();
         consoleOutputCapturer.start();
 
@@ -313,22 +311,20 @@ public class CmdFunctionsTest {
         cmdSources.run(new String[] {
             "create",
             "--name", fnName,
-            "--jar", url,
+            "--archive", url,
             "--tenant", "sample",
             "--namespace", "ns1",
-            "--className", "DummySink"
         });
 
         CreateSource creater = cmdSources.getCreateSource();
-        
+
         consoleOutputCapturer.stop();
         String output = consoleOutputCapturer.getStderr();
-        
+
         assertTrue(output.contains("Failed to download jar"));
-        assertEquals("DummySink", creater.className);
-        assertEquals(url, creater.jarFile);
+        assertEquals(url, creater.archive);
     }
-    
+
     @Test
     public void testCreateFunctionWithTopicPatterns() throws Exception {
         String fnName = TEST_NAME + "-function";
@@ -353,7 +349,7 @@ public class CmdFunctionsTest {
         verify(functions, times(1)).createFunction(any(FunctionDetails.class), anyString());
 
     }
-    
+
     @Test
     public void testCreateWithoutTenant() throws Exception {
         String fnName = TEST_NAME + "-function";

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -22,8 +22,26 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.isNull;
 import static org.apache.bookkeeper.common.concurrent.FutureUtils.result;
+import static org.apache.commons.lang.StringUtils.isBlank;
+import static org.apache.commons.lang.StringUtils.isNotBlank;
 import static org.apache.pulsar.common.naming.TopicName.DEFAULT_NAMESPACE;
 import static org.apache.pulsar.common.naming.TopicName.PUBLIC_TENANT;
+import static org.apache.pulsar.functions.utils.Utils.fileExists;
+import static org.apache.pulsar.functions.worker.Utils.downloadFromHttpUrl;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
+import com.beust.jcommander.Parameters;
+import com.beust.jcommander.converters.StringConverter;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParser;
+import com.google.gson.reflect.TypeToken;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -41,16 +59,15 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
 import org.apache.bookkeeper.api.StorageClient;
 import org.apache.bookkeeper.api.kv.Table;
 import org.apache.bookkeeper.api.kv.result.KeyValue;
 import org.apache.bookkeeper.clients.StorageClientBuilder;
 import org.apache.bookkeeper.clients.config.StorageClientSettings;
 import org.apache.commons.lang.StringUtils;
-import static org.apache.commons.lang.StringUtils.isNotBlank;
-import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.apache.commons.lang.StringUtils.isBlank;
 import org.apache.pulsar.admin.cli.utils.CmdUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.internal.FunctionsImpl;
@@ -73,26 +90,6 @@ import org.apache.pulsar.functions.utils.validation.ConfigValidation;
 import org.apache.pulsar.functions.utils.validation.ValidatorImpls.ImplementsClassesValidator;
 import org.apache.pulsar.functions.windowing.WindowFunctionExecutor;
 import org.apache.pulsar.functions.windowing.WindowUtils;
-
-import com.beust.jcommander.Parameter;
-import com.beust.jcommander.ParameterException;
-import com.beust.jcommander.Parameters;
-import com.beust.jcommander.converters.StringConverter;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonParser;
-import com.google.gson.reflect.TypeToken;
-
-import static org.apache.pulsar.functions.utils.Utils.fileExists;
-import static org.apache.pulsar.functions.utils.Utils.getSinkType;
-import static org.apache.pulsar.functions.worker.Utils.downloadFromHttpUrl;
-
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufUtil;
-import io.netty.buffer.Unpooled;
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Parameters(commandDescription = "Interface for managing Pulsar Functions (lightweight, Lambda-style compute processes that work with Pulsar)")
@@ -384,7 +381,7 @@ public class CmdFunctions extends CmdBase {
             if (null != pyFile) {
                 functionConfig.setPy(pyFile);
             }
-            
+
             if (functionConfig.getJar() != null) {
                 userCodeFile = functionConfig.getJar();
             } else if (functionConfig.getPy() != null) {
@@ -427,13 +424,13 @@ public class CmdFunctions extends CmdBase {
                 }
             } else {
                 if (!fileExists(userCodeFile)) {
-                    throw new ParameterException("File " + userCodeFile + " does not exist");    
+                    throw new ParameterException("File " + userCodeFile + " does not exist");
                 }
                 jarFilePath = userCodeFile;
             }
 
             if (functionConfig.getRuntime() == FunctionConfig.Runtime.JAVA) {
-                
+
                 if (jarFilePath != null) {
                     File file = new File(jarFilePath);
                     ClassLoader userJarLoader;
@@ -676,22 +673,22 @@ public class CmdFunctions extends CmdBase {
 
         @Parameter(names = "--brokerServiceUrl", description = "The URL for the Pulsar broker")
         protected String brokerServiceUrl;
-        
+
         @Parameter(names = "--clientAuthPlugin", description = "Client authentication plugin using which function-process can connect to broker")
         protected String clientAuthPlugin;
-        
+
         @Parameter(names = "--clientAuthParams", description = "Client authentication param")
         protected String clientAuthParams;
-        
+
         @Parameter(names = "--use_tls", description = "Use tls connection\n")
         protected boolean useTls;
 
         @Parameter(names = "--tls_allow_insecure", description = "Allow insecure tls connection\n")
         protected boolean tlsAllowInsecureConnection;
-        
+
         @Parameter(names = "--hostname_verification_enabled", description = "Enable hostname verification")
         protected boolean tlsHostNameVerificationEnabled;
-        
+
         @Parameter(names = "--tls_trust_cert_path", description = "tls trust cert file path")
         protected String tlsTrustCertFilePath;
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
@@ -18,19 +18,38 @@
  */
 package org.apache.pulsar.admin.cli;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.pulsar.common.naming.TopicName.DEFAULT_NAMESPACE;
+import static org.apache.pulsar.common.naming.TopicName.PUBLIC_TENANT;
+import static org.apache.pulsar.functions.utils.Utils.convertProcessingGuarantee;
+import static org.apache.pulsar.functions.utils.Utils.fileExists;
+import static org.apache.pulsar.functions.worker.Utils.downloadFromHttpUrl;
+
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.converters.StringConverter;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import lombok.Getter;
 
-import static org.apache.commons.lang3.StringUtils.isBlank;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.net.MalformedURLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
 import org.apache.pulsar.admin.cli.utils.CmdUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.internal.FunctionsImpl;
+import org.apache.pulsar.common.nar.NarClassLoader;
 import org.apache.pulsar.functions.api.utils.IdentityFunction;
 import org.apache.pulsar.functions.instance.AuthenticationConfig;
 import org.apache.pulsar.functions.proto.Function;
@@ -42,29 +61,13 @@ import org.apache.pulsar.functions.utils.FunctionConfig;
 import org.apache.pulsar.functions.utils.Reflections;
 import org.apache.pulsar.functions.utils.SinkConfig;
 import org.apache.pulsar.functions.utils.Utils;
+import org.apache.pulsar.functions.utils.io.ConnectorDefinition;
+import org.apache.pulsar.functions.utils.io.ConnectorUtils;
 import org.apache.pulsar.functions.utils.validation.ConfigValidation;
-import org.apache.pulsar.functions.utils.validation.ValidatorImpls.ImplementsClassValidator;
-import org.apache.pulsar.io.core.Sink;
-
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.lang.reflect.Type;
-import java.net.MalformedURLException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.apache.pulsar.common.naming.TopicName.DEFAULT_NAMESPACE;
-import static org.apache.pulsar.common.naming.TopicName.PUBLIC_TENANT;
-import static org.apache.pulsar.functions.utils.Utils.convertProcessingGuarantee;
-import static org.apache.pulsar.functions.utils.Utils.fileExists;
-import static org.apache.pulsar.functions.utils.Utils.getSinkType;
-import static org.apache.pulsar.functions.worker.Utils.downloadFromHttpUrl;
 
 @Getter
 @Parameters(commandDescription = "Interface for managing Pulsar IO sinks (egress data from Pulsar)")
+@Slf4j
 public class CmdSinks extends CmdBase {
 
     private final CreateSink createSink;
@@ -107,22 +110,22 @@ public class CmdSinks extends CmdBase {
 
         @Parameter(names = "--brokerServiceUrl", description = "The URL for the Pulsar broker")
         protected String brokerServiceUrl;
-        
+
         @Parameter(names = "--clientAuthPlugin", description = "Client authentication plugin using which function-process can connect to broker")
         protected String clientAuthPlugin;
-        
+
         @Parameter(names = "--clientAuthParams", description = "Client authentication param")
         protected String clientAuthParams;
-        
+
         @Parameter(names = "--use_tls", description = "Use tls connection\n")
         protected boolean useTls;
 
         @Parameter(names = "--tls_allow_insecure", description = "Allow insecure tls connection\n")
         protected boolean tlsAllowInsecureConnection;
-        
+
         @Parameter(names = "--hostname_verification_enabled", description = "Enable hostname verification")
         protected boolean tlsHostNameVerificationEnabled;
-        
+
         @Parameter(names = "--tls_trust_cert_path", description = "tls trust cert file path")
         protected String tlsTrustCertFilePath;
 
@@ -135,7 +138,7 @@ public class CmdSinks extends CmdBase {
                             .tlsAllowInsecureConnection(tlsAllowInsecureConnection)
                             .tlsHostnameVerificationEnable(tlsHostNameVerificationEnabled)
                             .tlsTrustCertsFilePath(tlsTrustCertFilePath).build(),
-                    sinkConfig.getJar(), admin);
+                    sinkConfig.getArchive(), admin);
         }
     }
 
@@ -143,10 +146,10 @@ public class CmdSinks extends CmdBase {
     class CreateSink extends SinkCommand {
         @Override
         void runCmd() throws Exception {
-            if (Utils.isFunctionPackageUrlSupported(jarFile)) {
-                admin.functions().createFunctionWithUrl(createSinkConfig(sinkConfig), sinkConfig.getJar());
+            if (Utils.isFunctionPackageUrlSupported(archive)) {
+                admin.functions().createFunctionWithUrl(createSinkConfig(sinkConfig), sinkConfig.getArchive());
             } else {
-                admin.functions().createFunction(createSinkConfig(sinkConfig), sinkConfig.getJar());
+                admin.functions().createFunction(createSinkConfig(sinkConfig), sinkConfig.getArchive());
             }
             print("Created successfully");
         }
@@ -156,10 +159,10 @@ public class CmdSinks extends CmdBase {
     class UpdateSink extends SinkCommand {
         @Override
         void runCmd() throws Exception {
-            if (Utils.isFunctionPackageUrlSupported(jarFile)) {
-                admin.functions().updateFunctionWithUrl(createSinkConfig(sinkConfig), sinkConfig.getJar());
+            if (Utils.isFunctionPackageUrlSupported(archive)) {
+                admin.functions().updateFunctionWithUrl(createSinkConfig(sinkConfig), sinkConfig.getArchive());
             } else {
-                admin.functions().updateFunction(createSinkConfig(sinkConfig), sinkConfig.getJar());
+                admin.functions().updateFunction(createSinkConfig(sinkConfig), sinkConfig.getArchive());
             }
             print("Updated successfully");
         }
@@ -172,8 +175,6 @@ public class CmdSinks extends CmdBase {
         protected String namespace;
         @Parameter(names = "--name", description = "The sink's name")
         protected String name;
-        @Parameter(names = "--className", description = "The sink's class name")
-        protected String className;
         @Parameter(names = "--inputs", description = "The sink's input topic or topics (multiple topics can be specified as a comma-separated list)")
         protected String inputs;
         @Parameter(names = "--topicsPattern", description = "TopicsPattern to consume from list of topics under a namespace that match the pattern. [--input] and [--topicsPattern] are mutually exclusive. Add SerDe class name for a pattern in --customSerdeInputs  (supported for java fun only)")
@@ -184,9 +185,9 @@ public class CmdSinks extends CmdBase {
         protected FunctionConfig.ProcessingGuarantees processingGuarantees;
         @Parameter(names = "--parallelism", description = "The sink's parallelism factor (i.e. the number of sink instances to run)")
         protected Integer parallelism;
-        @Parameter(names = "--jar", description = "Path to the jar file for the sink. It also supports url-path [http/https/file (file protocol assumes that file already exists on worker host)] from which worker can download the package.", listConverter = StringConverter.class)
-        protected String jarFile;
-        
+        @Parameter(names = {"-a", "--archive"}, description = "Path to the archive file for the sink. It also supports url-path [http/https/file (file protocol assumes that file already exists on worker host)] from which worker can download the package.", listConverter = StringConverter.class)
+        protected String archive;
+
         @Parameter(names = "--sinkConfigFile", description = "The path to a YAML config file specifying the "
                 + "sink's configuration")
         protected String sinkConfigFile;
@@ -222,10 +223,6 @@ public class CmdSinks extends CmdBase {
             if (null != name) {
                 sinkConfig.setName(name);
             }
-
-            if (null != className) {
-                sinkConfig.setClassName(className);
-            }
             if (null != processingGuarantees) {
                 sinkConfig.setProcessingGuarantees(processingGuarantees);
             }
@@ -243,7 +240,7 @@ public class CmdSinks extends CmdBase {
                 });
             }
             sinkConfig.setTopicToSerdeClassName(topicsToSerDeClassName);
-            
+
             if (null != topicsPattern) {
                 sinkConfig.setTopicsPattern(topicsPattern);
             }
@@ -252,10 +249,10 @@ public class CmdSinks extends CmdBase {
                 sinkConfig.setParallelism(parallelism);
             }
 
-            if (null != jarFile) {
-                sinkConfig.setJar(jarFile);
+            if (null != archive) {
+                sinkConfig.setArchive(archive);
             }
-            
+
             sinkConfig.setResources(new org.apache.pulsar.functions.utils.Resources(cpu, ram, disk));
 
             if (null != sinkConfigString) {
@@ -277,54 +274,51 @@ public class CmdSinks extends CmdBase {
         }
 
         protected void validateSinkConfigs(SinkConfig sinkConfig) {
-            
-            if (isBlank(sinkConfig.getJar())) {
+
+            if (isBlank(sinkConfig.getArchive())) {
                 throw new ParameterException("Sink jar not specfied");
             }
-            
-            boolean isJarPathUrl = Utils.isFunctionPackageUrlSupported(sinkConfig.getJar());
 
-            String jarFilePath = null;
-            if (isJarPathUrl) {
+            boolean isArchivePathUrl = Utils.isFunctionPackageUrlSupported(sinkConfig.getArchive());
+
+            String archivePath = null;
+            if (isArchivePathUrl) {
                 // download jar file if url is http
-                if(sinkConfig.getJar().startsWith(Utils.HTTP)) {
+                if(sinkConfig.getArchive().startsWith(Utils.HTTP)) {
                     File tempPkgFile = null;
                     try {
                         tempPkgFile = File.createTempFile(sinkConfig.getName(), "sink");
-                        downloadFromHttpUrl(sinkConfig.getJar(), new FileOutputStream(tempPkgFile));
-                        jarFilePath = tempPkgFile.getAbsolutePath();
+                        downloadFromHttpUrl(sinkConfig.getArchive(), new FileOutputStream(tempPkgFile));
+                        archivePath = tempPkgFile.getAbsolutePath();
                     } catch(Exception e) {
                         if(tempPkgFile!=null ) {
                             tempPkgFile.deleteOnExit();
                         }
-                        throw new ParameterException("Failed to download jar from " + sinkConfig.getJar()
+                        throw new ParameterException("Failed to download archive from " + sinkConfig.getArchive()
                                 + ", due to =" + e.getMessage());
                     }
                 }
             } else {
-                jarFilePath = sinkConfig.getJar();
+                archivePath = sinkConfig.getArchive();
             }
-            
+
             // if jar file is present locally then load jar and validate SinkClass in it
-            if (jarFilePath != null) {
-                if (!fileExists(jarFilePath)) {
-                    throw new ParameterException("Jar file " + jarFilePath + " does not exist");
+            if (archivePath != null) {
+                if (!fileExists(archivePath)) {
+                    throw new ParameterException("Archive file " + archivePath + " does not exist");
                 }
 
-                File file = new File(jarFilePath);
-                ClassLoader userJarLoader;
                 try {
-                    userJarLoader = Reflections.loadJar(file);
-                } catch (MalformedURLException e) {
-                    throw new ParameterException("Failed to load user jar " + file + " with error " + e.getMessage());
-                }
-                // make sure the function class loader is accessible thread-locally
-                Thread.currentThread().setContextClassLoader(userJarLoader);
+                    ConnectorDefinition connector = ConnectorUtils.getConnectorDefinition(archivePath);
+                    log.info("Connector: {}", connector);
 
-                // jar is already loaded, validate against Sink-Class name
-                (new ImplementsClassValidator(Sink.class)).validateField("className", sinkConfig.getClassName());
+                    // Validate source class
+                    ConnectorUtils.getIOSourceClass(archivePath);
+                } catch (IOException e) {
+                    throw new ParameterException("Failed to validate connector from " + archivePath, e);
+                }
             }
-            
+
             try {
                 // Need to load jar and set context class loader before calling
                 ConfigValidation.validateConfig(sinkConfig, FunctionConfig.Runtime.JAVA.name());
@@ -342,13 +336,19 @@ public class CmdSinks extends CmdBase {
             return functionDetailsBuilder.build();
         }
 
-        protected FunctionDetails createSinkConfig(SinkConfig sinkConfig) {
+        protected FunctionDetails createSinkConfig(SinkConfig sinkConfig) throws IOException {
 
             // check if configs are valid
             validateSinkConfigs(sinkConfig);
 
-            String typeArg = sinkConfig.getJar().startsWith(Utils.FILE) ? null
-                    : getSinkType(sinkConfig.getClassName()).getName();
+            String sinkClassName = ConnectorUtils.getIOSinkClass(sinkConfig.getArchive());
+
+            String typeArg;
+            try (NarClassLoader ncl = NarClassLoader.getFromArchive(new File(sinkConfig.getArchive()),
+                    Collections.emptySet())) {
+                typeArg = sinkConfig.getArchive().startsWith(Utils.FILE) ? null
+                        : Utils.getSinkType(sinkClassName, ncl).getName();
+            }
 
             FunctionDetails.Builder functionDetailsBuilder = FunctionDetails.newBuilder();
             if (sinkConfig.getTenant() != null) {
@@ -384,7 +384,7 @@ public class CmdSinks extends CmdBase {
 
             // set up sink spec
             SinkSpec.Builder sinkSpecBuilder = SinkSpec.newBuilder();
-            sinkSpecBuilder.setClassName(sinkConfig.getClassName());
+            sinkSpecBuilder.setClassName(sinkClassName);
             if (sinkConfig.getConfigs() != null) {
                 sinkSpecBuilder.setConfigs(new Gson().toJson(sinkConfig.getConfigs()));
             }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
@@ -18,39 +18,6 @@
  */
 package org.apache.pulsar.admin.cli;
 
-import com.beust.jcommander.Parameter;
-import com.beust.jcommander.ParameterException;
-import com.beust.jcommander.Parameters;
-import com.beust.jcommander.converters.StringConverter;
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
-import lombok.Getter;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.pulsar.admin.cli.utils.CmdUtils;
-import org.apache.pulsar.client.admin.PulsarAdmin;
-import org.apache.pulsar.client.admin.internal.FunctionsImpl;
-import org.apache.pulsar.functions.api.utils.IdentityFunction;
-import org.apache.pulsar.functions.instance.AuthenticationConfig;
-import org.apache.pulsar.functions.proto.Function.FunctionDetails;
-import org.apache.pulsar.functions.proto.Function.Resources;
-import org.apache.pulsar.functions.proto.Function.SinkSpec;
-import org.apache.pulsar.functions.proto.Function.SourceSpec;
-import org.apache.pulsar.functions.utils.FunctionConfig;
-import org.apache.pulsar.functions.utils.Reflections;
-import org.apache.pulsar.functions.utils.SourceConfig;
-import org.apache.pulsar.functions.utils.Utils;
-import org.apache.pulsar.functions.utils.validation.ConfigValidation;
-import org.apache.pulsar.functions.utils.validation.ValidatorImpls.ImplementsClassValidator;
-import org.apache.pulsar.io.core.Source;
-
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.lang.reflect.Type;
-import java.net.MalformedURLException;
-import java.util.Map;
-
 import static org.apache.pulsar.common.naming.TopicName.DEFAULT_NAMESPACE;
 import static org.apache.pulsar.common.naming.TopicName.PUBLIC_TENANT;
 import static org.apache.pulsar.functions.utils.Utils.convertProcessingGuarantee;
@@ -58,8 +25,44 @@ import static org.apache.pulsar.functions.utils.Utils.fileExists;
 import static org.apache.pulsar.functions.utils.Utils.getSourceType;
 import static org.apache.pulsar.functions.worker.Utils.downloadFromHttpUrl;
 
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
+import com.beust.jcommander.Parameters;
+import com.beust.jcommander.converters.StringConverter;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.Map;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.admin.cli.utils.CmdUtils;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.internal.FunctionsImpl;
+import org.apache.pulsar.common.nar.NarClassLoader;
+import org.apache.pulsar.functions.api.utils.IdentityFunction;
+import org.apache.pulsar.functions.instance.AuthenticationConfig;
+import org.apache.pulsar.functions.proto.Function.FunctionDetails;
+import org.apache.pulsar.functions.proto.Function.Resources;
+import org.apache.pulsar.functions.proto.Function.SinkSpec;
+import org.apache.pulsar.functions.proto.Function.SourceSpec;
+import org.apache.pulsar.functions.utils.FunctionConfig;
+import org.apache.pulsar.functions.utils.SourceConfig;
+import org.apache.pulsar.functions.utils.Utils;
+import org.apache.pulsar.functions.utils.io.ConnectorDefinition;
+import org.apache.pulsar.functions.utils.io.ConnectorUtils;
+import org.apache.pulsar.functions.utils.validation.ConfigValidation;
+
 @Getter
 @Parameters(commandDescription = "Interface for managing Pulsar IO Sources (ingress data into Pulsar)")
+@Slf4j
 public class CmdSources extends CmdBase {
 
     private final CreateSource createSource;
@@ -102,35 +105,35 @@ public class CmdSources extends CmdBase {
 
         @Parameter(names = "--brokerServiceUrl", description = "The URL for the Pulsar broker")
         protected String brokerServiceUrl;
-        
+
         @Parameter(names = "--clientAuthPlugin", description = "Client authentication plugin using which function-process can connect to broker")
         protected String clientAuthPlugin;
-        
+
         @Parameter(names = "--clientAuthParams", description = "Client authentication param")
         protected String clientAuthParams;
-        
+
         @Parameter(names = "--use_tls", description = "Use tls connection\n")
         protected boolean useTls;
 
         @Parameter(names = "--tls_allow_insecure", description = "Allow insecure tls connection\n")
         protected boolean tlsAllowInsecureConnection;
-        
+
         @Parameter(names = "--hostname_verification_enabled", description = "Enable hostname verification")
         protected boolean tlsHostNameVerificationEnabled;
-        
+
         @Parameter(names = "--tls_trust_cert_path", description = "tls trust cert file path")
         protected String tlsTrustCertFilePath;
 
         @Override
         void runCmd() throws Exception {
-            CmdFunctions.startLocalRun(createSourceConfigProto2(sourceConfig), sourceConfig.getParallelism(),
+                CmdFunctions.startLocalRun(createSourceConfigProto2(sourceConfig), sourceConfig.getParallelism(),
                     0, brokerServiceUrl, null,
                     AuthenticationConfig.builder().clientAuthenticationPlugin(clientAuthPlugin)
                             .clientAuthenticationParameters(clientAuthParams).useTls(useTls)
                             .tlsAllowInsecureConnection(tlsAllowInsecureConnection)
                             .tlsHostnameVerificationEnable(tlsHostNameVerificationEnabled)
                             .tlsTrustCertsFilePath(tlsTrustCertFilePath).build(),
-                    sourceConfig.getJar(), admin);
+                    sourceConfig.getArchive(), admin);
         }
     }
 
@@ -138,10 +141,10 @@ public class CmdSources extends CmdBase {
     public class CreateSource extends SourceCommand {
         @Override
         void runCmd() throws Exception {
-            if (Utils.isFunctionPackageUrlSupported(this.sourceConfig.getJar())) {
-                admin.functions().createFunctionWithUrl(createSourceConfig(sourceConfig), sourceConfig.getJar());
+            if (Utils.isFunctionPackageUrlSupported(this.sourceConfig.getArchive())) {
+                admin.functions().createFunctionWithUrl(createSourceConfig(sourceConfig), sourceConfig.getArchive());
             } else {
-                admin.functions().createFunction(createSourceConfig(sourceConfig), sourceConfig.getJar());
+                admin.functions().createFunction(createSourceConfig(sourceConfig), sourceConfig.getArchive());
             }
             print("Created successfully");
         }
@@ -151,10 +154,10 @@ public class CmdSources extends CmdBase {
     public class UpdateSource extends SourceCommand {
         @Override
         void runCmd() throws Exception {
-            if (Utils.isFunctionPackageUrlSupported(sourceConfig.getJar())) {
-                admin.functions().updateFunctionWithUrl(createSourceConfig(sourceConfig), sourceConfig.getJar());
+            if (Utils.isFunctionPackageUrlSupported(sourceConfig.getArchive())) {
+                admin.functions().updateFunctionWithUrl(createSourceConfig(sourceConfig), sourceConfig.getArchive());
             } else {
-                admin.functions().updateFunction(createSourceConfig(sourceConfig), sourceConfig.getJar());
+                admin.functions().updateFunction(createSourceConfig(sourceConfig), sourceConfig.getArchive());
             }
             print("Updated successfully");
         }
@@ -177,8 +180,9 @@ public class CmdSources extends CmdBase {
         protected String deserializationClassName;
         @Parameter(names = "--parallelism", description = "The source's parallelism factor (i.e. the number of source instances to run)")
         protected Integer parallelism;
-        @Parameter(names = "--jar", description = "The path to the jar file for the Source. It also supports url-path [http/https/file (file protocol assumes that file already exists on worker host)] from which worker can download the package.", listConverter = StringConverter.class)
-        protected String jarFile;
+        @Parameter(names = { "-a", "--archive" },
+                description = "The path to the NAR archive for the Source. It also supports url-path [http/https/file (file protocol assumes that file already exists on worker host)] from which worker can download the package.", listConverter = StringConverter.class)
+        protected String archive;
         @Parameter(names = "--sourceConfigFile", description = "The path to a YAML config file specifying the "
                 + "source's configuration")
         protected String sourceConfigFile;
@@ -211,9 +215,6 @@ public class CmdSources extends CmdBase {
             if (null != name) {
                 sourceConfig.setName(name);
             }
-            if (null != className) {
-                this.sourceConfig.setClassName(className);
-            }
             if (null != destinationTopicName) {
                 sourceConfig.setTopicName(destinationTopicName);
             }
@@ -227,10 +228,10 @@ public class CmdSources extends CmdBase {
                 sourceConfig.setParallelism(parallelism);
             }
 
-            if (jarFile != null) {
-                sourceConfig.setJar(jarFile);
+            if (archive != null) {
+                sourceConfig.setArchive(archive);
             }
-            
+
             sourceConfig.setResources(new org.apache.pulsar.functions.utils.Resources(cpu, ram, disk));
 
             if (null != sourceConfigString) {
@@ -252,59 +253,57 @@ public class CmdSources extends CmdBase {
         }
 
         protected void validateSourceConfigs(SourceConfig sourceConfig) {
-            if (StringUtils.isBlank(sourceConfig.getJar())) {
-                throw new ParameterException("Source jar not specfied");
+            if (StringUtils.isBlank(sourceConfig.getArchive())) {
+                throw new ParameterException("Source archive not specfied");
             }
 
-            boolean isJarPathUrl = Utils.isFunctionPackageUrlSupported(sourceConfig.getJar());
-            
-            String jarFilePath = null;
-            if (isJarPathUrl) {
-                // download jar file if url is http
-                if(sourceConfig.getJar().startsWith(Utils.HTTP)) {
+            boolean isArchivePathUrl = Utils.isFunctionPackageUrlSupported(sourceConfig.getArchive());
+
+            String archivePath = null;
+            if (isArchivePathUrl) {
+                // download archive file if url is http
+                if(sourceConfig.getArchive().startsWith(Utils.HTTP)) {
                     File tempPkgFile = null;
                     try {
                         tempPkgFile = File.createTempFile(sourceConfig.getName(), "source");
-                        downloadFromHttpUrl(sourceConfig.getJar(), new FileOutputStream(tempPkgFile));
-                        jarFilePath = tempPkgFile.getAbsolutePath();
+                        downloadFromHttpUrl(sourceConfig.getArchive(), new FileOutputStream(tempPkgFile));
+                        archivePath = tempPkgFile.getAbsolutePath();
                     } catch(Exception e) {
                         if(tempPkgFile!=null ) {
                             tempPkgFile.deleteOnExit();
                         }
-                        throw new ParameterException("Failed to download jar from " + sourceConfig.getJar()
+                        throw new ParameterException("Failed to download archive from " + sourceConfig.getArchive()
                                 + ", due to =" + e.getMessage());
                     }
                 }
             } else {
-                jarFilePath = sourceConfig.getJar();
+                archivePath = sourceConfig.getArchive();
             }
-            
-            
+
+
             // if jar file is present locally then load jar and validate SinkClass in it
-            if (jarFilePath != null) {
-                if (!fileExists(jarFilePath)) {
-                    throw new ParameterException("Jar file " + jarFilePath + " does not exist");
+            if (archivePath != null) {
+                if (!fileExists(archivePath)) {
+                    throw new ParameterException("Archive file " + archivePath + " does not exist");
                 }
 
-                File file = new File(jarFilePath);
-                ClassLoader userJarLoader;
                 try {
-                    userJarLoader = Reflections.loadJar(file);
-                } catch (MalformedURLException e) {
-                    throw new ParameterException("Failed to load user jar " + file + " with error " + e.getMessage());
-                }
-                // make sure the function class loader is accessible thread-locally
-                Thread.currentThread().setContextClassLoader(userJarLoader);
+                    ConnectorDefinition connector = ConnectorUtils.getConnectorDefinition(archivePath);
+                    log.info("Connector: {}", connector);
 
-                // jar is already loaded, validate against Source-Class name
-                (new ImplementsClassValidator(Source.class)).validateField("className", sourceConfig.getClassName());
+                    // Validate source class
+                    ConnectorUtils.getIOSourceClass(archivePath);
+                } catch (IOException e) {
+                    throw new ParameterException("Failed to validate connector from " + archivePath, e);
+                }
             }
 
             try {
              // Need to load jar and set context class loader before calling
                 ConfigValidation.validateConfig(sourceConfig, FunctionConfig.Runtime.JAVA.name());
             } catch (Exception e) {
-                throw new ParameterException(e.getMessage());
+                e.printStackTrace();
+                throw new ParameterException(e);
             }
         }
 
@@ -316,13 +315,19 @@ public class CmdSources extends CmdBase {
             return functionDetailsBuilder.build();
         }
 
-        protected FunctionDetails createSourceConfig(SourceConfig sourceConfig) {
+        protected FunctionDetails createSourceConfig(SourceConfig sourceConfig) throws IOException {
 
             // check if source configs are valid
             validateSourceConfigs(sourceConfig);
 
-            String typeArg = sourceConfig.getJar().startsWith(Utils.FILE) ? null
-                    : getSourceType(sourceConfig.getClassName()).getName();
+            String sourceClassName = ConnectorUtils.getIOSourceClass(sourceConfig.getArchive());
+
+            String typeArg;
+            try (NarClassLoader ncl = NarClassLoader.getFromArchive(new File(sourceConfig.getArchive()),
+                    Collections.emptySet())) {
+                typeArg = sourceConfig.getArchive().startsWith(Utils.FILE) ? null
+                        : getSourceType(sourceClassName, ncl).getName();
+            }
 
             FunctionDetails.Builder functionDetailsBuilder = FunctionDetails.newBuilder();
             if (sourceConfig.getTenant() != null) {
@@ -345,10 +350,12 @@ public class CmdSources extends CmdBase {
 
             // set source spec
             SourceSpec.Builder sourceSpecBuilder = SourceSpec.newBuilder();
-            sourceSpecBuilder.setClassName(sourceConfig.getClassName());
+            sourceSpecBuilder.setClassName(sourceClassName);
+
             if (sourceConfig.getConfigs() != null) {
                 sourceSpecBuilder.setConfigs(new Gson().toJson(sourceConfig.getConfigs()));
             }
+
             if (typeArg != null) {
                 sourceSpecBuilder.setTypeClassName(typeArg);
             }
@@ -361,7 +368,7 @@ public class CmdSources extends CmdBase {
                 sinkSpecBuilder.setSerDeClassName(sourceConfig.getSerdeClassName());
             }
             sinkSpecBuilder.setTopic(sourceConfig.getTopicName());
-            
+
             if (typeArg != null) {
                 sinkSpecBuilder.setTypeClassName(typeArg);
             }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -246,7 +246,8 @@ public class PulsarClientImpl implements PulsarClient {
         String topic = conf.getTopicName();
 
         if (!TopicName.isValid(topic)) {
-            return FutureUtil.failedFuture(new PulsarClientException.InvalidTopicNameException("Invalid topic name"));
+            return FutureUtil.failedFuture(
+                    new PulsarClientException.InvalidTopicNameException("Invalid topic name: '" + topic + "'"));
         }
 
         CompletableFuture<Producer<T>> producerCreatedFuture = new CompletableFuture<>();

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -103,5 +103,10 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+    </dependency>
+
   </dependencies>
 </project>

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/nar/FileUtils.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/nar/FileUtils.java
@@ -1,0 +1,221 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+/**
+ * This class was adapted from NiFi NAR Utils
+ * https://github.com/apache/nifi/tree/master/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-nar-utils
+ */
+
+package org.apache.pulsar.common.nar;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.slf4j.Logger;
+
+/**
+ * A utility class containing a few useful static methods to do typical IO
+ * operations.
+ *
+ */
+public class FileUtils {
+
+    public static final long MILLIS_BETWEEN_ATTEMPTS = 50L;
+
+    public static void ensureDirectoryExistAndCanReadAndWrite(final File dir) throws IOException {
+        if (dir.exists() && !dir.isDirectory()) {
+            throw new IOException(dir.getAbsolutePath() + " is not a directory");
+        } else if (!dir.exists()) {
+            final boolean made = dir.mkdirs();
+            if (!made) {
+                throw new IOException(dir.getAbsolutePath() + " could not be created");
+            }
+        }
+        if (!(dir.canRead() && dir.canWrite())) {
+            throw new IOException(dir.getAbsolutePath() + " directory does not have read/write privilege");
+        }
+    }
+
+    public static void ensureDirectoryExistAndCanRead(final File dir) throws IOException {
+        if (dir.exists() && !dir.isDirectory()) {
+            throw new IOException(dir.getAbsolutePath() + " is not a directory");
+        } else if (!dir.exists()) {
+            final boolean made = dir.mkdirs();
+            if (!made) {
+                throw new IOException(dir.getAbsolutePath() + " could not be created");
+            }
+        }
+        if (!dir.canRead()) {
+            throw new IOException(dir.getAbsolutePath() + " directory does not have read privilege");
+        }
+    }
+
+    /**
+     * Deletes the given file. If the given file exists but could not be deleted
+     * this will be printed as a warning to the given logger
+     *
+     * @param file to delete
+     * @param logger to notify
+     * @return true if deleted
+     */
+    public static boolean deleteFile(final File file, final Logger logger) {
+        return FileUtils.deleteFile(file, logger, 1);
+    }
+
+    /**
+     * Deletes the given file. If the given file exists but could not be deleted
+     * this will be printed as a warning to the given logger
+     *
+     * @param file to delete
+     * @param logger to notify
+     * @param attempts indicates how many times an attempt to delete should be
+     * made
+     * @return true if given file no longer exists
+     */
+    public static boolean deleteFile(final File file, final Logger logger, final int attempts) {
+        if (file == null) {
+            return false;
+        }
+        boolean isGone = false;
+        try {
+            if (file.exists()) {
+                final int effectiveAttempts = Math.max(1, attempts);
+                for (int i = 0; i < effectiveAttempts && !isGone; i++) {
+                    isGone = file.delete() || !file.exists();
+                    if (!isGone && (effectiveAttempts - i) > 1) {
+                        FileUtils.sleepQuietly(MILLIS_BETWEEN_ATTEMPTS);
+                    }
+                }
+                if (!isGone && logger != null) {
+                    logger.warn("File appears to exist but unable to delete file: " + file.getAbsolutePath());
+                }
+            }
+        } catch (final Throwable t) {
+            if (logger != null) {
+                logger.warn("Unable to delete file: '" + file.getAbsolutePath() + "' due to " + t);
+            }
+        }
+        return isGone;
+    }
+
+    /**
+     * Deletes all files (not directories..) in the given directory (non
+     * recursive) that match the given filename filter. If any file cannot be
+     * deleted then this is printed at warn to the given logger.
+     *
+     * @param directory to delete contents of
+     * @param filter if null then no filter is used
+     * @param logger to notify
+     * @throws IOException if abstract pathname does not denote a directory, or
+     * if an I/O error occurs
+     */
+    public static void deleteFilesInDirectory(final File directory, final FilenameFilter filter, final Logger logger) throws IOException {
+        FileUtils.deleteFilesInDirectory(directory, filter, logger, false);
+    }
+
+    /**
+     * Deletes all files (not directories) in the given directory (recursive)
+     * that match the given filename filter. If any file cannot be deleted then
+     * this is printed at warn to the given logger.
+     *
+     * @param directory to delete contents of
+     * @param filter if null then no filter is used
+     * @param logger to notify
+     * @param recurse true if should recurse
+     * @throws IOException if abstract pathname does not denote a directory, or
+     * if an I/O error occurs
+     */
+    public static void deleteFilesInDirectory(final File directory, final FilenameFilter filter, final Logger logger, final boolean recurse) throws IOException {
+        FileUtils.deleteFilesInDirectory(directory, filter, logger, recurse, false);
+    }
+
+    /**
+     * Deletes all files (not directories) in the given directory (recursive)
+     * that match the given filename filter. If any file cannot be deleted then
+     * this is printed at warn to the given logger.
+     *
+     * @param directory to delete contents of
+     * @param filter if null then no filter is used
+     * @param logger to notify
+     * @param recurse will look for contents of sub directories.
+     * @param deleteEmptyDirectories default is false; if true will delete
+     * directories found that are empty
+     * @throws IOException if abstract pathname does not denote a directory, or
+     * if an I/O error occurs
+     */
+    public static void deleteFilesInDirectory(final File directory, final FilenameFilter filter, final Logger logger, final boolean recurse, final boolean deleteEmptyDirectories) throws IOException {
+        // ensure the specified directory is actually a directory and that it exists
+        if (null != directory && directory.isDirectory()) {
+            final File ingestFiles[] = directory.listFiles();
+            if (ingestFiles == null) {
+                // null if abstract pathname does not denote a directory, or if an I/O error occurs
+                throw new IOException("Unable to list directory content in: " + directory.getAbsolutePath());
+            }
+            for (File ingestFile : ingestFiles) {
+                boolean process = (filter == null) ? true : filter.accept(directory, ingestFile.getName());
+                if (ingestFile.isFile() && process) {
+                    FileUtils.deleteFile(ingestFile, logger, 3);
+                }
+                if (ingestFile.isDirectory() && recurse) {
+                    FileUtils.deleteFilesInDirectory(ingestFile, filter, logger, recurse, deleteEmptyDirectories);
+                    if (deleteEmptyDirectories && ingestFile.list().length == 0) {
+                        FileUtils.deleteFile(ingestFile, logger, 3);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Deletes given files.
+     *
+     * @param files to delete
+     * @param recurse will recurse
+     * @throws IOException if issues deleting files
+     */
+    public static void deleteFiles(final Collection<File> files, final boolean recurse) throws IOException {
+        for (final File file : files) {
+            FileUtils.deleteFile(file, recurse);
+        }
+    }
+
+    public static void deleteFile(final File file, final boolean recurse) throws IOException {
+        final File[] list = file.listFiles();
+        if (file.isDirectory() && recurse && list != null) {
+            FileUtils.deleteFiles(Arrays.asList(list), recurse);
+        }
+        //now delete the file itself regardless of whether it is plain file or a directory
+        if (!FileUtils.deleteFile(file, null, 5)) {
+            throw new IOException("Unable to delete " + file.getAbsolutePath());
+        }
+    }
+
+    public static void sleepQuietly(final long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (final InterruptedException ex) {
+            /* do nothing */
+        }
+    }
+}
+

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/nar/NarClassLoader.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/nar/NarClassLoader.java
@@ -1,0 +1,280 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * This class was adapted from NiFi NAR Utils
+ * https://github.com/apache/nifi/tree/master/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-nar-utils
+ */
+package org.apache.pulsar.common.nar;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileReader;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * <p>
+ * A <tt>ClassLoader</tt> for loading NARs (NiFi archives). NARs are designed to allow isolating bundles of code
+ * (comprising one-or-more NiFi <tt>FlowFileProcessor</tt>s, <tt>FlowFileComparator</tt>s and their dependencies) from
+ * other such bundles; this allows for dependencies and processors that require conflicting, incompatible versions of
+ * the same dependency to run in a single instance of NiFi.
+ * </p>
+ *
+ * <p>
+ * <tt>NarClassLoader</tt> follows the delegation model described in {@link ClassLoader#findClass(java.lang.String)
+ * ClassLoader.findClass(...)}; classes are first loaded from the parent <tt>ClassLoader</tt>, and only if they cannot
+ * be found there does the <tt>NarClassLoader</tt> provide a definition. Specifically, this means that resources are
+ * loaded from NiFi's <tt>conf</tt> and <tt>lib</tt> directories first, and if they cannot be found there, are loaded
+ * from the NAR.
+ * </p>
+ *
+ * <p>
+ * The packaging of a NAR is such that it is a ZIP file with the following directory structure:
+ *
+ * <pre>
+ *   +META-INF/
+ *   +-- bundled-dependencies/
+ *   +-- &lt;JAR files&gt;
+ *   +-- MANIFEST.MF
+ * </pre>
+ * </p>
+ *
+ * <p>
+ * The MANIFEST.MF file contains the same information as a typical JAR file but also includes two additional NiFi
+ * properties: {@code Nar-Id} and {@code Nar-Dependency-Id}.
+ * </p>
+ *
+ * <p>
+ * The {@code Nar-Id} provides a unique identifier for this NAR.
+ * </p>
+ *
+ * <p>
+ * The {@code Nar-Dependency-Id} is optional. If provided, it indicates that this NAR should inherit all of the
+ * dependencies of the NAR with the provided ID. Often times, the NAR that is depended upon is referred to as the
+ * Parent. This is because its ClassLoader will be the parent ClassLoader of the dependent NAR.
+ * </p>
+ *
+ * <p>
+ * If a NAR is built using NiFi's Maven NAR Plugin, the {@code Nar-Id} property will be set to the artifactId of the
+ * NAR. The {@code Nar-Dependency-Id} will be set to the artifactId of the NAR that is depended upon. For example, if
+ * NAR A is defined as such:
+ *
+ * <pre>
+ * ...
+ * &lt;artifactId&gt;nar-a&lt;/artifactId&gt;
+ * &lt;packaging&gt;nar&lt;/packaging&gt;
+ * ...
+ * &lt;dependencies&gt;
+ *   &lt;dependency&gt;
+ *     &lt;groupId&gt;group&lt;/groupId&gt;
+ *     &lt;artifactId&gt;nar-z&lt;/artifactId&gt;
+ *     <b>&lt;type&gt;nar&lt;/type&gt;</b>
+ *   &lt;/dependency&gt;
+ * &lt;/dependencies&gt;
+ * </pre>
+ * </p>
+ *
+ *
+ * <p>
+ * Then the MANIFEST.MF file that is created for NAR A will have the following properties set:
+ * <ul>
+ * <li>{@code Nar-Id: nar-a}</li>
+ * <li>{@code Nar-Dependency-Id: nar-z}</li>
+ * </ul>
+ * </p>
+ *
+ * <p>
+ * Note, above, that the {@code type} of the dependency is set to {@code nar}.
+ * </p>
+ *
+ * <p>
+ * If the NAR has more than one dependency of {@code type} {@code nar}, then the Maven NAR plugin will fail to build the
+ * NAR.
+ * </p>
+ */
+@Slf4j
+public class NarClassLoader extends URLClassLoader {
+
+    private static final FileFilter JAR_FILTER = new FileFilter() {
+        @Override
+        public boolean accept(File pathname) {
+            final String nameToTest = pathname.getName().toLowerCase();
+            return nameToTest.endsWith(".jar") && pathname.isFile();
+        }
+    };
+
+    /**
+     * The NAR for which this <tt>ClassLoader</tt> is responsible.
+     */
+    private final File narWorkingDirectory;
+
+    private static final String TMP_DIR_PREFIX = "pulsar-nar";
+
+    private static final File NAR_CACHE_DIR = new File(System.getProperty("java.io.tmpdir") + "/" + TMP_DIR_PREFIX);
+
+    public static NarClassLoader getFromArchive(File narPath, Set<String> additionalJars) throws IOException {
+        File unpacked = NarUnpacker.unpackNar(narPath, NAR_CACHE_DIR);
+        try {
+            return new NarClassLoader(unpacked, additionalJars);
+        } catch (ClassNotFoundException e) {
+            throw new IOException(e);
+        }
+    }
+
+    /**
+     * Construct a nar class loader.
+     *
+     * @param narWorkingDirectory
+     *            directory to explode nar contents to
+     * @throws IllegalArgumentException
+     *             if the NAR is missing the Java Services API file for <tt>FlowFileProcessor</tt> implementations.
+     * @throws ClassNotFoundException
+     *             if any of the <tt>FlowFileProcessor</tt> implementations defined by the Java Services API cannot be
+     *             loaded.
+     * @throws IOException
+     *             if an error occurs while loading the NAR.
+     */
+    private NarClassLoader(final File narWorkingDirectory, Set<String> additionalJars)
+            throws ClassNotFoundException, IOException {
+        super(new URL[0]);
+        this.narWorkingDirectory = narWorkingDirectory;
+
+        // process the classpath
+        updateClasspath(narWorkingDirectory);
+
+        for (String jar : additionalJars) {
+            if (jar.startsWith("/")) {
+                addURL(new URL("file://" + jar));
+            } else {
+                Path currentRelativePath = Paths.get("");
+                String cwd = currentRelativePath.toAbsolutePath().toString();
+                addURL(new URL("file://" + cwd + "/" + jar));
+            }
+        }
+
+        if (log.isDebugEnabled()) {
+            log.info("Created class loader with paths: {}", Arrays.toString(getURLs()));
+        }
+    }
+
+    public File getWorkingDirectory() {
+        return narWorkingDirectory;
+    }
+
+    /**
+     * Read a service definition as a String
+     */
+    public String getServiceDefinition(String serviceName) throws IOException {
+        String serviceDefPath = narWorkingDirectory + "/META-INF/services/" + serviceName;
+        return new String(Files.readAllBytes(Paths.get(serviceDefPath)));
+    }
+
+    public List<String> getServiceImplementation(String serviceName) throws IOException {
+        List<String> impls = new ArrayList<>();
+
+        String serviceDefPath = narWorkingDirectory + "/META-INF/services/" + serviceName;
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(serviceDefPath))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                line = line.trim();
+                if (!line.isEmpty() && !line.startsWith("#")) {
+                    final int indexOfPound = line.indexOf("#");
+                    final String effectiveLine = (indexOfPound > 0) ? line.substring(0, indexOfPound) : line;
+                    impls.add(effectiveLine);
+                }
+            }
+        }
+
+        return impls;
+    }
+
+    /**
+     * Adds URLs for the resources unpacked from this NAR:
+     * <ul>
+     * <li>the root: for classes, <tt>META-INF</tt>, etc.</li>
+     * <li><tt>META-INF/dependencies</tt>: for config files, <tt>.so</tt>s, etc.</li>
+     * <li><tt>META-INF/dependencies/*.jar</tt>: for dependent libraries</li>
+     * </ul>
+     *
+     * @param root
+     *            the root directory of the unpacked NAR.
+     * @throws IOException
+     *             if the URL list could not be updated.
+     */
+    private void updateClasspath(File root) throws IOException {
+        addURL(root.toURI().toURL()); // for compiled classes, META-INF/, etc.
+
+        File dependencies = new File(root, "META-INF/bundled-dependencies");
+        if (!dependencies.isDirectory()) {
+            log.warn("{} does not contain META-INF/bundled-dependencies!", narWorkingDirectory);
+        }
+        addURL(dependencies.toURI().toURL());
+        if (dependencies.isDirectory()) {
+            final File[] jarFiles = dependencies.listFiles(JAR_FILTER);
+            if (jarFiles != null) {
+                Arrays.sort(jarFiles, Comparator.comparing(File::getName));
+                for (File libJar : jarFiles) {
+                    addURL(libJar.toURI().toURL());
+                }
+            }
+        }
+    }
+
+    @Override
+    protected String findLibrary(final String libname) {
+        File dependencies = new File(narWorkingDirectory, "META-INF/bundled-dependencies");
+        if (!dependencies.isDirectory()) {
+            log.warn("{} does not contain META-INF/bundled-dependencies!", narWorkingDirectory);
+        }
+
+        final File nativeDir = new File(dependencies, "native");
+        final File libsoFile = new File(nativeDir, "lib" + libname + ".so");
+        final File dllFile = new File(nativeDir, libname + ".dll");
+        final File soFile = new File(nativeDir, libname + ".so");
+        if (libsoFile.exists()) {
+            return libsoFile.getAbsolutePath();
+        } else if (dllFile.exists()) {
+            return dllFile.getAbsolutePath();
+        } else if (soFile.exists()) {
+            return soFile.getAbsolutePath();
+        }
+
+        // not found in the nar. try system native dir
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return NarClassLoader.class.getName() + "[" + narWorkingDirectory.getPath() + "]";
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/nar/NarUnpacker.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/nar/NarUnpacker.java
@@ -1,0 +1,162 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * This class was adapted from NiFi NAR Utils
+ * https://github.com/apache/nifi/tree/master/nifi-nar-bundles/nifi-framework-bundle/nifi-framework/nifi-nar-utils
+ */
+
+package org.apache.pulsar.common.nar;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class NarUnpacker {
+
+    private static String HASH_FILENAME = "nar-md5sum";
+
+    /**
+     * Unpacks the specified nar into the specified base working directory.
+     *
+     * @param nar
+     *            the nar to unpack
+     * @param baseWorkingDirectory
+     *            the directory to unpack to
+     * @return the directory to the unpacked NAR
+     * @throws IOException
+     *             if unable to explode nar
+     */
+    public static File unpackNar(final File nar, final File baseWorkingDirectory) throws IOException {
+        final File narWorkingDirectory = new File(baseWorkingDirectory, nar.getName() + "-unpacked");
+
+        // if the working directory doesn't exist, unpack the nar
+        if (!narWorkingDirectory.exists()) {
+            unpack(nar, narWorkingDirectory, calculateMd5sum(nar));
+        } else {
+            // the working directory does exist. Run MD5 sum against the nar
+            // file and check if the nar has changed since it was deployed.
+            final byte[] narMd5 = calculateMd5sum(nar);
+            final File workingHashFile = new File(narWorkingDirectory, HASH_FILENAME);
+            if (!workingHashFile.exists()) {
+                FileUtils.deleteFile(narWorkingDirectory, true);
+                unpack(nar, narWorkingDirectory, narMd5);
+            } else {
+                final byte[] hashFileContents = Files.readAllBytes(workingHashFile.toPath());
+                if (!Arrays.equals(hashFileContents, narMd5)) {
+                    log.info("Contents of nar {} have changed. Reloading.", nar.getAbsolutePath());
+                    FileUtils.deleteFile(narWorkingDirectory, true);
+                    unpack(nar, narWorkingDirectory, narMd5);
+                }
+            }
+        }
+
+        return narWorkingDirectory;
+    }
+
+    /**
+     * Unpacks the NAR to the specified directory. Creates a checksum file that used to determine if future expansion is
+     * necessary.
+     *
+     * @param workingDirectory
+     *            the root directory to which the NAR should be unpacked.
+     * @throws IOException
+     *             if the NAR could not be unpacked.
+     */
+    private static void unpack(final File nar, final File workingDirectory, final byte[] hash) throws IOException {
+
+        try (JarFile jarFile = new JarFile(nar)) {
+            Enumeration<JarEntry> jarEntries = jarFile.entries();
+            while (jarEntries.hasMoreElements()) {
+                JarEntry jarEntry = jarEntries.nextElement();
+                String name = jarEntry.getName();
+                File f = new File(workingDirectory, name);
+                if (jarEntry.isDirectory()) {
+                    FileUtils.ensureDirectoryExistAndCanReadAndWrite(f);
+                } else {
+                    makeFile(jarFile.getInputStream(jarEntry), f);
+                }
+            }
+        }
+
+        final File hashFile = new File(workingDirectory, HASH_FILENAME);
+        try (final FileOutputStream fos = new FileOutputStream(hashFile)) {
+            fos.write(hash);
+        }
+    }
+
+    /**
+     * Creates the specified file, whose contents will come from the <tt>InputStream</tt>.
+     *
+     * @param inputStream
+     *            the contents of the file to create.
+     * @param file
+     *            the file to create.
+     * @throws IOException
+     *             if the file could not be created.
+     */
+    private static void makeFile(final InputStream inputStream, final File file) throws IOException {
+        try (final InputStream in = inputStream; final FileOutputStream fos = new FileOutputStream(file)) {
+            byte[] bytes = new byte[65536];
+            int numRead;
+            while ((numRead = in.read(bytes)) != -1) {
+                fos.write(bytes, 0, numRead);
+            }
+        }
+    }
+
+    /**
+     * Calculates an md5 sum of the specified file.
+     *
+     * @param file
+     *            to calculate the md5sum of
+     * @return the md5sum bytes
+     * @throws IOException
+     *             if cannot read file
+     */
+    private static byte[] calculateMd5sum(final File file) throws IOException {
+        try (final FileInputStream inputStream = new FileInputStream(file)) {
+            final MessageDigest md5 = MessageDigest.getInstance("md5");
+
+            final byte[] buffer = new byte[1024];
+            int read = inputStream.read(buffer);
+
+            while (read > -1) {
+                md5.update(buffer, 0, read);
+                read = inputStream.read(buffer);
+            }
+
+            return md5.digest();
+        } catch (NoSuchAlgorithmException nsae) {
+            throw new IllegalArgumentException(nsae);
+        }
+    }
+}

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/util/ObjectMapperFactory.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/util/ObjectMapperFactory.java
@@ -21,7 +21,7 @@ package org.apache.pulsar.common.util;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 import io.netty.util.concurrent.FastThreadLocal;
 
@@ -35,15 +35,35 @@ public class ObjectMapperFactory {
         return mapper;
     }
 
-    private static final FastThreadLocal<ObjectMapper> mapper = new FastThreadLocal<ObjectMapper>() {
+    public static ObjectMapper createYaml() {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        // forward compatibility for the properties may go away in the future
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
+        mapper.setSerializationInclusion(Include.NON_NULL);
+        return mapper;
+    }
+
+    private static final FastThreadLocal<ObjectMapper> JSON_MAPPER = new FastThreadLocal<ObjectMapper>() {
         @Override
         protected ObjectMapper initialValue() throws Exception {
-            return ObjectMapperFactory.create();
+            return create();
+        }
+    };
+
+    private static final FastThreadLocal<ObjectMapper> YAML_MAPPER = new FastThreadLocal<ObjectMapper>() {
+        @Override
+        protected ObjectMapper initialValue() throws Exception {
+            return createYaml();
         }
     };
 
     public static ObjectMapper getThreadLocal() {
-        return mapper.get();
+        return JSON_MAPPER.get();
+    }
+
+    public static ObjectMapper getThreadLocalYaml() {
+        return YAML_MAPPER.get();
     }
 
 }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
@@ -23,6 +23,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.jodah.typetools.TypeResolver;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerEventListener;
 import org.apache.pulsar.client.api.Message;
@@ -242,6 +244,10 @@ public class PulsarSink<T> implements Sink<T> {
 
     @VisibleForTesting
     void setupSerDe() throws ClassNotFoundException {
+        if (StringUtils.isEmpty(this.pulsarSinkConfig.getTypeClassName())) {
+            this.outputSerDe = InstanceUtils.initializeDefaultSerDe(byte[].class);
+            return;
+        }
 
         Class<?> typeArg = Reflections.loadClass(this.pulsarSinkConfig.getTypeClassName(),
                 Thread.currentThread().getContextClassLoader());

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntime.java
@@ -38,6 +38,7 @@ import org.apache.pulsar.functions.proto.Function;
 import org.apache.pulsar.functions.proto.InstanceCommunication;
 import org.apache.pulsar.functions.proto.InstanceCommunication.FunctionStatus;
 import org.apache.pulsar.functions.proto.InstanceControlGrpc;
+import org.apache.pulsar.functions.utils.functioncache.FunctionCacheEntry;
 
 import java.io.InputStream;
 import java.util.*;
@@ -59,7 +60,7 @@ class ProcessRuntime implements Runtime {
     private List<String> processArgs;
     private int instancePort;
     @Getter
-    private Exception deathException;
+    private Throwable deathException;
     private ManagedChannel channel;
     private InstanceControlGrpc.InstanceControlFutureStub stub;
     private ScheduledExecutorService timer;
@@ -90,6 +91,10 @@ class ProcessRuntime implements Runtime {
             args.add("java");
             args.add("-cp");
             args.add(instanceFile);
+
+            // Keep the same env property pointing to the Java instance file so that it can be picked up
+            // by the child process and manually added to classpath
+            args.add(String.format("-D%s=%s", FunctionCacheEntry.JAVA_INSTANCE_JAR_PROPERTY, instanceFile));
             args.add("-Dlog4j.configurationFile=java_instance_log4j2.yml");
             args.add("-Dpulsar.log.dir=" + logDirectory);
             args.add("-Dpulsar.log.file=" + instanceConfig.getFunctionDetails().getName());

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntimeFactory.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntimeFactory.java
@@ -24,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.apache.pulsar.functions.instance.AuthenticationConfig;
 import org.apache.pulsar.functions.instance.InstanceConfig;
+import org.apache.pulsar.functions.utils.functioncache.FunctionCacheEntry;
 
 import java.nio.file.Paths;
 
@@ -56,7 +57,7 @@ public class ProcessRuntimeFactory implements RuntimeFactory {
 
         // if things are not specified, try to figure out by env properties
         if (this.javaInstanceJarFile == null) {
-            String envJavaInstanceJarLocation = System.getProperty("pulsar.functions.java.instance.jar");
+            String envJavaInstanceJarLocation = System.getProperty(FunctionCacheEntry.JAVA_INSTANCE_JAR_PROPERTY);
             if (null != envJavaInstanceJarLocation) {
                 log.info("Java instance jar location is not defined,"
                         + " using the location defined in system environment : {}", envJavaInstanceJarLocation);

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeSpawner.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeSpawner.java
@@ -49,7 +49,7 @@ public class RuntimeSpawner implements AutoCloseable {
     private Timer processLivenessCheckTimer;
     private int numRestarts;
     private long instanceLivenessCheckFreqMs;
-    private Exception runtimeDeathException;
+    private Throwable runtimeDeathException;
 
 
     public RuntimeSpawner(InstanceConfig instanceConfig,
@@ -65,7 +65,7 @@ public class RuntimeSpawner implements AutoCloseable {
     public void start() throws Exception {
         log.info("RuntimeSpawner starting function {} - {}", this.instanceConfig.getFunctionDetails().getName(),
                 this.instanceConfig.getInstanceId());
-        
+
         if (instanceConfig.getFunctionDetails().getRuntime() == PYTHON
                 && instanceConfig.getFunctionDetails().getSource() != null
                 && StringUtils.isNotBlank(instanceConfig.getFunctionDetails().getSource().getTopicsPattern())) {

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ThreadRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ThreadRuntime.java
@@ -124,7 +124,7 @@ class ThreadRuntime implements Runtime {
     }
 
     @Override
-    public Exception getDeathException() {
+    public Throwable getDeathException() {
         if (isAlive()) {
             return null;
         } else if (null != javaInstanceRunnable) {

--- a/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/ProcessRuntimeTest.java
+++ b/pulsar-functions/runtime/src/test/java/org/apache/pulsar/functions/runtime/ProcessRuntimeTest.java
@@ -25,6 +25,7 @@ import org.apache.pulsar.functions.api.utils.DefaultSerDe;
 import org.apache.pulsar.functions.instance.InstanceConfig;
 import org.apache.pulsar.functions.proto.Function;
 import org.apache.pulsar.functions.proto.Function.FunctionDetails;
+import org.apache.pulsar.functions.utils.functioncache.FunctionCacheEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
@@ -117,8 +118,10 @@ public class ProcessRuntimeTest {
 
         ProcessRuntime container = factory.createContainer(config, userJarFile);
         List<String> args = container.getProcessArgs();
-        assertEquals(args.size(), 55);
-        String expectedArgs = "java -cp " + javaInstanceJarFile + " -Dlog4j.configurationFile=java_instance_log4j2.yml "
+        assertEquals(args.size(), 56);
+        String expectedArgs = "java -cp " + javaInstanceJarFile
+                + " -Dpulsar.functions.java.instance.jar=" + javaInstanceJarFile
+                + " -Dlog4j.configurationFile=java_instance_log4j2.yml "
                 + "-Dpulsar.log.dir=" + logDirectory + "/functions" + " -Dpulsar.log.file=" + config.getFunctionDetails().getName()
                 + " org.apache.pulsar.functions.runtime.JavaInstanceMain"
                 + " --jar " + userJarFile + " --instance_id "
@@ -131,7 +134,7 @@ public class ProcessRuntimeTest {
                 + " --auto_ack false"
                 + " --processing_guarantees ATLEAST_ONCE"
                 + " --pulsar_serviceurl " + pulsarServiceUrl
-                + " --max_buffered_tuples 1024 --port " + args.get(34)
+                + " --max_buffered_tuples 1024 --port " + args.get(35)
                 + " --source_classname " + config.getFunctionDetails().getSource().getClassName()
                 + " --source_type_classname " + config.getFunctionDetails().getSource().getTypeClassName()
                 + " --source_subscription_type " + config.getFunctionDetails().getSource().getSubscriptionType().name()

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfig.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfig.java
@@ -48,8 +48,7 @@ public class SinkConfig {
     private String namespace;
     @NotNull
     private String name;
-    @NotNull
-    private String className;
+
     @isMapEntryCustom(keyValidatorClasses = { ValidatorImpls.TopicNameValidator.class },
             valueValidatorClasses = { ValidatorImpls.SerdeValidator.class })
     private Map<String, String> topicToSerdeClassName;
@@ -61,6 +60,7 @@ public class SinkConfig {
     private FunctionConfig.ProcessingGuarantees processingGuarantees;
     @isValidResources
     private Resources resources;
+
     @isFileExists
-    private String jar;
+    private String archive;
 }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfig.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfig.java
@@ -31,7 +31,6 @@ import org.apache.pulsar.functions.utils.validation.ConfigValidationAnnotations.
 import org.apache.pulsar.functions.utils.validation.ConfigValidationAnnotations.isValidResources;
 import org.apache.pulsar.functions.utils.validation.ConfigValidationAnnotations.isValidSourceConfig;
 import org.apache.pulsar.functions.utils.validation.ConfigValidationAnnotations.isValidTopicName;
-import org.apache.pulsar.io.core.Source;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -49,8 +48,7 @@ public class SourceConfig {
     private String namespace;
     @NotNull
     private String name;
-    @NotNull
-    private String className;
+
     @NotNull
     @isValidTopicName
     private String topicName;
@@ -62,6 +60,7 @@ public class SourceConfig {
     private FunctionConfig.ProcessingGuarantees processingGuarantees;
     @isValidResources
     private Resources resources;
+
     @isFileExists
-    private String jar;
+    private String archive;
 }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Utils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Utils.java
@@ -55,7 +55,7 @@ public class Utils {
 
     public static String HTTP = "http";
     public static String FILE = "file";
-    
+
     public static final long getSequenceId(MessageId messageId) {
         MessageIdImpl msgId = (MessageIdImpl) ((messageId instanceof TopicMessageIdImpl)
                 ? ((TopicMessageIdImpl) messageId).getInnerMessageId()
@@ -182,8 +182,12 @@ public class Utils {
     }
 
     public static Class<?> getSourceType(String className) {
+        return getSourceType(className, Thread.currentThread().getContextClassLoader());
+    }
 
-        Object userClass = Reflections.createInstance(className, Thread.currentThread().getContextClassLoader());
+    public static Class<?> getSourceType(String className, ClassLoader classloader) {
+
+        Object userClass = Reflections.createInstance(className, classloader);
         Class<?> typeArg;
         Source source = (Source) userClass;
         if (source == null) {
@@ -196,8 +200,12 @@ public class Utils {
     }
 
     public static Class<?> getSinkType(String className) {
+        return getSinkType(className, Thread.currentThread().getContextClassLoader());
+    }
 
-        Object userClass = Reflections.createInstance(className, Thread.currentThread().getContextClassLoader());
+    public static Class<?> getSinkType(String className, ClassLoader classLoader) {
+
+        Object userClass = Reflections.createInstance(className, classLoader);
         Class<?> typeArg;
         Sink sink = (Sink) userClass;
         if (sink == null) {
@@ -212,7 +220,7 @@ public class Utils {
     public static boolean fileExists(String file) {
         return new File(file).exists();
     }
-    
+
     public static boolean isFunctionPackageUrlSupported(String functionPkgUrl) {
         return isNotBlank(functionPkgUrl)
                 && (functionPkgUrl.startsWith(Utils.HTTP) || functionPkgUrl.startsWith(Utils.FILE));

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/functioncache/FunctionCacheManager.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/functioncache/FunctionCacheManager.java
@@ -60,6 +60,8 @@ public interface FunctionCacheManager extends AutoCloseable {
                                   List<URL> requiredClasspaths)
         throws IOException;
 
+    void registerFunctionInstanceWithArchive(String fid, String eid, String narArchive) throws IOException;
+
     /**
      * Unregisters a job from the function cache manager.
      *

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/functioncache/FunctionCacheManagerImpl.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/functioncache/FunctionCacheManagerImpl.java
@@ -24,6 +24,7 @@ import org.apache.pulsar.functions.utils.Exceptions;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -101,6 +102,29 @@ public class FunctionCacheManagerImpl implements FunctionCacheManager {
                     eid,
                     requiredJarFiles,
                     requiredClasspaths);
+            }
+        }
+    }
+
+    @Override
+    public void registerFunctionInstanceWithArchive(String fid, String eid, String narArchive) throws IOException {
+        if (fid == null) {
+            throw new NullPointerException("FunctionID not set");
+        }
+
+        synchronized (cacheFunctions) {
+            FunctionCacheEntry entry = cacheFunctions.get(fid);
+
+            if (null != entry) {
+                entry.register(eid, Collections.singleton(narArchive), Collections.emptyList());
+                return;
+            }
+
+            // Create new cache entry
+            try {
+                cacheFunctions.put(fid, new FunctionCacheEntry(narArchive, eid));
+            } catch (Throwable cause) {
+                Exceptions.rethrowIOException(cause);
             }
         }
     }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/io/ConnectorDefinition.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/io/ConnectorDefinition.java
@@ -16,30 +16,36 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.apache.pulsar.functions.utils.io;
 
-package org.apache.pulsar.functions.runtime;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-import org.apache.pulsar.functions.proto.InstanceCommunication;
+@Data
+@NoArgsConstructor
+public class ConnectorDefinition {
 
-import java.util.concurrent.CompletableFuture;
+    /**
+     * The name of the connector type
+     */
+    private String name;
 
-/**
- * A function container is an environment for invoking functions.
- */
-public interface Runtime {
+    /**
+     * Description to be used for user help
+     */
+    private String description;
 
-    void start();
+    /**
+     * The class name for the connector source implementation.
+     * <p>
+     * If not defined, it will be assumed this connector cannot act as a data source
+     */
+    private String sourceClass;
 
-    void join() throws Exception;
-
-    void stop();
-
-    boolean isAlive();
-
-    Throwable getDeathException();
-
-    CompletableFuture<InstanceCommunication.FunctionStatus> getFunctionStatus();
-
-    CompletableFuture<InstanceCommunication.MetricsData> getAndResetMetrics();
-
+    /**
+     * The class name for the connector sink implementation.
+     * <p>
+     * If not defined, it will be assumed this connector cannot act as a data si
+     */
+    private String sinkClass;
 }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/io/ConnectorUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/io/ConnectorUtils.java
@@ -1,0 +1,104 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.utils.io;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+
+import lombok.experimental.UtilityClass;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.common.nar.NarClassLoader;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
+import org.apache.pulsar.functions.utils.Exceptions;
+import org.apache.pulsar.io.core.Sink;
+import org.apache.pulsar.io.core.Source;
+
+@UtilityClass
+public class ConnectorUtils {
+
+    private static final String PULSAR_IO_SERVICE_NAME = "pulsar-io.yaml";
+
+    /**
+     * Extract the Pulsar IO Source class from a connector archive.
+     */
+    public static String getIOSourceClass(String narPath) throws IOException {
+        try (NarClassLoader ncl = NarClassLoader.getFromArchive(new File(narPath), Collections.emptySet())) {
+            String configStr = ncl.getServiceDefinition(PULSAR_IO_SERVICE_NAME);
+
+            ConnectorDefinition conf = ObjectMapperFactory.getThreadLocalYaml().readValue(configStr,
+                    ConnectorDefinition.class);
+            if (StringUtils.isEmpty(conf.getSourceClass())) {
+                throw new IOException(
+                        String.format("The '%s' connector does not provide a source implementation", conf.getName()));
+            }
+
+            try {
+                // Try to load source class and check it implements Source interface
+                Object instance = ncl.loadClass(conf.getSourceClass()).newInstance();
+                if (!(instance instanceof Source)) {
+                    throw new IOException("Class " + conf.getSourceClass() + " does not implement interface "
+                            + Source.class.getName());
+                }
+            } catch (Throwable t) {
+                Exceptions.rethrowIOException(t);
+            }
+
+            return conf.getSourceClass();
+        }
+    }
+
+    /**
+     * Extract the Pulsar IO Sink class from a connector archive.
+     */
+    public static String getIOSinkClass(String narPath) throws IOException {
+        try (NarClassLoader ncl = NarClassLoader.getFromArchive(new File(narPath), Collections.emptySet())) {
+            String configStr = ncl.getServiceDefinition(PULSAR_IO_SERVICE_NAME);
+
+            ConnectorDefinition conf = ObjectMapperFactory.getThreadLocalYaml().readValue(configStr,
+                    ConnectorDefinition.class);
+            if (StringUtils.isEmpty(conf.getSinkClass())) {
+                throw new IOException(
+                        String.format("The '%s' connector does not provide a sink implementation", conf.getName()));
+            }
+
+            try {
+                // Try to load source class and check it implements Sink interface
+                Object instance = ncl.loadClass(conf.getSinkClass()).newInstance();
+                if (!(instance instanceof Sink)) {
+                    throw new IOException(
+                            "Class " + conf.getSinkClass() + " does not implement interface " + Sink.class.getName());
+                }
+            } catch (Throwable t) {
+                Exceptions.rethrowIOException(t);
+            }
+
+            return conf.getSinkClass();
+        }
+    }
+
+    public static ConnectorDefinition getConnectorDefinition(String narPath) throws IOException {
+        try (NarClassLoader ncl = NarClassLoader.getFromArchive(new File(narPath), Collections.emptySet())) {
+            String configStr = ncl.getServiceDefinition(PULSAR_IO_SERVICE_NAME);
+
+            return ObjectMapperFactory.getThreadLocalYaml().readValue(configStr, ConnectorDefinition.class);
+        }
+    }
+}

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/validation/ValidatorImpls.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/validation/ValidatorImpls.java
@@ -18,11 +18,25 @@
  */
 package org.apache.pulsar.functions.utils.validation;
 
+import static org.apache.pulsar.functions.utils.Utils.fileExists;
+import static org.apache.pulsar.functions.utils.Utils.getSinkType;
+import static org.apache.pulsar.functions.utils.Utils.getSourceType;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import net.jodah.typetools.TypeResolver;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.nar.NarClassLoader;
 import org.apache.pulsar.functions.api.SerDe;
 import org.apache.pulsar.functions.api.utils.DefaultSerDe;
 import org.apache.pulsar.functions.utils.FunctionConfig;
@@ -32,18 +46,9 @@ import org.apache.pulsar.functions.utils.SinkConfig;
 import org.apache.pulsar.functions.utils.SourceConfig;
 import org.apache.pulsar.functions.utils.Utils;
 import org.apache.pulsar.functions.utils.WindowConfig;
+import org.apache.pulsar.functions.utils.io.ConnectorUtils;
 
-import java.io.File;
-import java.lang.reflect.InvocationTargetException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Map;
-
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.apache.pulsar.functions.utils.Utils.fileExists;
-import static org.apache.pulsar.functions.utils.Utils.getSinkType;
-import static org.apache.pulsar.functions.utils.Utils.getSourceType;
+import net.jodah.typetools.TypeResolver;
 
 @Slf4j
 public class ValidatorImpls {
@@ -219,7 +224,7 @@ public class ValidatorImpls {
         public ImplementsClassesValidator(Map<String, Object> params) {
             this.classesImplements = (Class<?>[]) params.get(ConfigValidationAnnotations.ValidatorParams.IMPLEMENTS_CLASSES);
         }
-        
+
         public ImplementsClassesValidator(Class<?>... classesImplements) {
             this.classesImplements = classesImplements;
         }
@@ -452,7 +457,7 @@ public class ValidatorImpls {
             if (functionConfig.getWindowConfig() != null) {
                 throw new IllegalArgumentException("There is currently no support windowing in python");
             }
-            
+
             if (StringUtils.isNotBlank(functionConfig.getTopicsPattern())) {
                 throw new IllegalArgumentException("Topic-patterns is not supported for python runtime");
             }
@@ -639,59 +644,69 @@ public class ValidatorImpls {
         @Override
         public void validateField(String name, Object o) {
             SourceConfig sourceConfig = (SourceConfig) o;
-            Class<?> typeArg = getSourceType(sourceConfig.getClassName());
-            String serdeClassname = sourceConfig.getSerdeClassName();
-
-            ClassLoader clsLoader = Thread.currentThread().getContextClassLoader();
-
-            if (StringUtils.isEmpty(serdeClassname)) {
-                serdeClassname = DefaultSerDe.class.getName();
-            }
-
+            String sourceClassName;
             try {
-                loadClass(serdeClassname);
-            } catch (ClassNotFoundException e) {
-                throw new IllegalArgumentException(
-                        String.format("The input serialization/deserialization class %s does not exist", serdeClassname));
-
+                sourceClassName = ConnectorUtils.getIOSourceClass(sourceConfig.getArchive());
+            } catch (IOException e1) {
+                throw new IllegalArgumentException("Failed to extract source class from archive", e1);
             }
 
-            try {
-                new ValidatorImpls.ImplementsClassValidator(SerDe.class).validateField(name, serdeClassname);
-            } catch (IllegalArgumentException ex) {
-                throw new IllegalArgumentException(
-                        String.format("The input serialization/deserialization class %s does not not implement %s",
-                                serdeClassname, SerDe.class.getCanonicalName()));
-            }
+            try (NarClassLoader clsLoader = NarClassLoader.getFromArchive(new File(sourceConfig.getArchive()),
+                    Collections.emptySet())) {
 
-            if (serdeClassname.equals(DefaultSerDe.class.getName())) {
-                if (!DefaultSerDe.IsSupportedType(typeArg)) {
-                    throw new IllegalArgumentException("The default Serializer does not support type " + typeArg);
-                }
-            } else {
-                SerDe serDe = (SerDe) Reflections.createInstance(serdeClassname, clsLoader);
-                if (serDe == null) {
-                    throw new IllegalArgumentException(String.format("The SerDe class %s does not exist",
-                            serdeClassname));
-                }
-                Class<?>[] serDeTypes = TypeResolver.resolveRawArguments(SerDe.class, serDe.getClass());
+                Class<?> typeArg = getSourceType(sourceClassName, clsLoader);
+                String serdeClassname = sourceConfig.getSerdeClassName();
 
-                // type inheritance information seems to be lost in generic type
-                // load the actual type class for verification
-                Class<?> fnInputClass;
-                Class<?> serdeInputClass;
+                if (StringUtils.isEmpty(serdeClassname)) {
+                    serdeClassname = DefaultSerDe.class.getName();
+                }
+
                 try {
-                    fnInputClass = Class.forName(typeArg.getName(), true, clsLoader);
-                    // get output serde
-                    serdeInputClass = Class.forName(serDeTypes[1].getName(), true, clsLoader);
+                    loadClass(serdeClassname);
                 } catch (ClassNotFoundException e) {
-                    throw new IllegalArgumentException("Failed to load type class", e);
+                    throw new IllegalArgumentException(String
+                            .format("The input serialization/deserialization class %s does not exist", serdeClassname));
                 }
 
-                if (!fnInputClass.isAssignableFrom(serdeInputClass)) {
-                    throw new IllegalArgumentException("Serializer type mismatch " + typeArg + " vs " +
-                            serDeTypes[1]);
+                try {
+                    new ValidatorImpls.ImplementsClassValidator(SerDe.class).validateField(name, serdeClassname);
+                } catch (IllegalArgumentException ex) {
+                    throw new IllegalArgumentException(
+                            String.format("The input serialization/deserialization class %s does not not implement %s",
+                                    serdeClassname, SerDe.class.getCanonicalName()));
                 }
+
+                if (serdeClassname.equals(DefaultSerDe.class.getName())) {
+                    if (!DefaultSerDe.IsSupportedType(typeArg)) {
+                        throw new IllegalArgumentException("The default Serializer does not support type " + typeArg);
+                    }
+                } else {
+                    SerDe serDe = (SerDe) Reflections.createInstance(serdeClassname, clsLoader);
+                    if (serDe == null) {
+                        throw new IllegalArgumentException(
+                                String.format("The SerDe class %s does not exist", serdeClassname));
+                    }
+                    Class<?>[] serDeTypes = TypeResolver.resolveRawArguments(SerDe.class, serDe.getClass());
+
+                    // type inheritance information seems to be lost in generic type
+                    // load the actual type class for verification
+                    Class<?> fnInputClass;
+                    Class<?> serdeInputClass;
+                    try {
+                        fnInputClass = Class.forName(typeArg.getName(), true, clsLoader);
+                        // get output serde
+                        serdeInputClass = Class.forName(serDeTypes[1].getName(), true, clsLoader);
+                    } catch (ClassNotFoundException e) {
+                        throw new IllegalArgumentException("Failed to load type class", e);
+                    }
+
+                    if (!fnInputClass.isAssignableFrom(serdeInputClass)) {
+                        throw new IllegalArgumentException(
+                                "Serializer type mismatch " + typeArg + " vs " + serDeTypes[1]);
+                    }
+                }
+            } catch (IOException e) {
+                throw new IllegalArgumentException(e);
             }
         }
     }
@@ -702,65 +717,69 @@ public class ValidatorImpls {
             SinkConfig sinkConfig = (SinkConfig) o;
             // if function-pkg url is present eg: file://xyz.jar then admin-tool might not have access of the file at
             // the same location so, need to rely on server side validation.
-            if (Utils.isFunctionPackageUrlSupported(sinkConfig.getJar())) {
+            if (Utils.isFunctionPackageUrlSupported(sinkConfig.getArchive())) {
                 return;
             }
-            Class<?> typeArg = getSinkType(sinkConfig.getClassName());
 
-            ClassLoader clsLoader = Thread.currentThread().getContextClassLoader();
 
-            sinkConfig.getTopicToSerdeClassName().forEach((topicName, serdeClassname) -> {
-                if (StringUtils.isEmpty(serdeClassname)) {
-                    serdeClassname = DefaultSerDe.class.getName();
-                }
+            try (NarClassLoader clsLoader = NarClassLoader.getFromArchive(new File(sinkConfig.getArchive()),
+                    Collections.emptySet())) {
+                String sinkClassName = ConnectorUtils.getIOSinkClass(sinkConfig.getArchive());
+                Class<?> typeArg = getSinkType(sinkClassName, clsLoader);
 
-                try {
-                    loadClass(serdeClassname);
-                } catch (ClassNotFoundException e) {
-                    throw new IllegalArgumentException(
-                            String.format("The input serialization/deserialization class %s does not exist", serdeClassname));
-                }
-
-                try {
-                    new ValidatorImpls.ImplementsClassValidator(SerDe.class).validateField(name, serdeClassname);
-                } catch (IllegalArgumentException ex) {
-                    throw new IllegalArgumentException(
-                            String.format("The input serialization/deserialization class %s does not not " +
-                                            "implement %s",
-                                    serdeClassname, SerDe.class.getCanonicalName()));
-                }
-
-                if (serdeClassname.equals(DefaultSerDe.class.getName())) {
-                    if (!DefaultSerDe.IsSupportedType(typeArg)) {
-                        throw new IllegalArgumentException("The default Serializer does not support type " +
-                                typeArg);
+                sinkConfig.getTopicToSerdeClassName().forEach((topicName, serdeClassname) -> {
+                    if (StringUtils.isEmpty(serdeClassname)) {
+                        serdeClassname = DefaultSerDe.class.getName();
                     }
-                } else {
-                    SerDe serDe = (SerDe) Reflections.createInstance(serdeClassname, clsLoader);
-                    if (serDe == null) {
-                        throw new IllegalArgumentException(String.format("The SerDe class %s does not exist",
-                                serdeClassname));
-                    }
-                    Class<?>[] serDeTypes = TypeResolver.resolveRawArguments(SerDe.class, serDe.getClass());
 
-                    // type inheritance information seems to be lost in generic type
-                    // load the actual type class for verification
-                    Class<?> fnInputClass;
-                    Class<?> serdeInputClass;
                     try {
-                        fnInputClass = Class.forName(typeArg.getName(), true, clsLoader);
-                        // get input serde
-                        serdeInputClass = Class.forName(serDeTypes[0].getName(), true, clsLoader);
+                        loadClass(serdeClassname);
                     } catch (ClassNotFoundException e) {
-                        throw new IllegalArgumentException("Failed to load type class", e);
+                        throw new IllegalArgumentException(String.format(
+                                "The input serialization/deserialization class %s does not exist", serdeClassname));
                     }
 
-                    if (!fnInputClass.isAssignableFrom(serdeInputClass)) {
-                        throw new IllegalArgumentException("Serializer type mismatch " + typeArg + " vs " +
-                                serDeTypes[0]);
+                    try {
+                        new ValidatorImpls.ImplementsClassValidator(SerDe.class).validateField(name, serdeClassname);
+                    } catch (IllegalArgumentException ex) {
+                        throw new IllegalArgumentException(String.format(
+                                "The input serialization/deserialization class %s does not not " + "implement %s",
+                                serdeClassname, SerDe.class.getCanonicalName()));
                     }
-                }
-            });
+
+                    if (serdeClassname.equals(DefaultSerDe.class.getName())) {
+                        if (!DefaultSerDe.IsSupportedType(typeArg)) {
+                            throw new IllegalArgumentException("The default Serializer does not support type " + typeArg);
+                        }
+                    } else {
+                        SerDe serDe = (SerDe) Reflections.createInstance(serdeClassname, clsLoader);
+                        if (serDe == null) {
+                            throw new IllegalArgumentException(
+                                    String.format("The SerDe class %s does not exist", serdeClassname));
+                        }
+                        Class<?>[] serDeTypes = TypeResolver.resolveRawArguments(SerDe.class, serDe.getClass());
+
+                        // type inheritance information seems to be lost in generic type
+                        // load the actual type class for verification
+                        Class<?> fnInputClass;
+                        Class<?> serdeInputClass;
+                        try {
+                            fnInputClass = Class.forName(typeArg.getName(), true, clsLoader);
+                            // get input serde
+                            serdeInputClass = Class.forName(serDeTypes[0].getName(), true, clsLoader);
+                        } catch (ClassNotFoundException e) {
+                            throw new IllegalArgumentException("Failed to load type class", e);
+                        }
+
+                        if (!fnInputClass.isAssignableFrom(serdeInputClass)) {
+                            throw new IllegalArgumentException(
+                                    "Serializer type mismatch " + typeArg + " vs " + serDeTypes[0]);
+                        }
+                    }
+                });
+            } catch (IOException e) {
+                throw new IllegalArgumentException(e);
+            }
         }
     }
 
@@ -773,7 +792,7 @@ public class ValidatorImpls {
             new StringValidator().validateField(name, o);
 
             String path = (String) o;
-            
+
             if(!Utils.isFunctionPackageUrlSupported(path)) {
                 // check file existence if path is not url and local path
                 if (!fileExists(path)) {

--- a/pulsar-io/aerospike/src/main/resources/META-INF/services/pulsar-io.yaml
+++ b/pulsar-io/aerospike/src/main/resources/META-INF/services/pulsar-io.yaml
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: aerospike
+description: Aerospike database sink
+sinkClass: org.apache.pulsar.io.aerospike.AerospikeStringSink

--- a/pulsar-io/cassandra/src/main/resources/META-INF/services/pulsar-io.yaml
+++ b/pulsar-io/cassandra/src/main/resources/META-INF/services/pulsar-io.yaml
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: cassandra
+description: Writes data into Cassandra
+sinkClass: org.apache.pulsar.io.cassandra.CassandraStringSink

--- a/pulsar-io/kafka/src/main/resources/META-INF/services/pulsar-io.yaml
+++ b/pulsar-io/kafka/src/main/resources/META-INF/services/pulsar-io.yaml
@@ -1,0 +1,23 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: kafka
+description: Kafka source and sink connector
+sourceClass: org.apache.pulsar.io.kafka.KafkaStringSource
+sinkClass: org.apache.pulsar.io.kafka.KafkaStringSink

--- a/pulsar-io/kinesis/src/main/resources/META-INF/services/pulsar-io.yaml
+++ b/pulsar-io/kinesis/src/main/resources/META-INF/services/pulsar-io.yaml
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: kinesis
+description: Kinesis sink connector
+sinkClass: org.apache.pulsar.io.kinesis.KinesisSink

--- a/pulsar-io/rabbitmq/src/main/resources/META-INF/services/pulsar-io.yaml
+++ b/pulsar-io/rabbitmq/src/main/resources/META-INF/services/pulsar-io.yaml
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: rabbitmq
+description: RabbitMQ source connector
+sourceClass: org.apache.pulsar.io.rabbitmq.RabbitMQSource

--- a/pulsar-io/twitter/src/main/resources/META-INF/services/pulsar-io.yaml
+++ b/pulsar-io/twitter/src/main/resources/META-INF/services/pulsar-io.yaml
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: twitter
+description: Ingest data from Twitter firehose
+sourceClass: org.apache.pulsar.io.twitter.TwitterFireHose


### PR DESCRIPTION
### Motivation

Allow the connectors to be submitted as NAR bundles.

Each NAR bundle contains the classes for the connector code plus all of its dependencies packaged in a Zip file.

The bundle is unpacked before being used the first time and then the directory is cached unless the archive is changed.
