### PR TITLE
Remove dependencies exclusions for org.apache.httpcomponents:httpclient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,12 +188,6 @@ flexible messaging model and an intuitive client API.</description>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
         <version>4.5.5</version>
-        <exclusions>
-          <exclusion>
-            <groupId>*</groupId>
-            <artifactId>*</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
### Motivation

In `pulsar-client` we have dependency on `org.apache.httpcomponents:httpclient` and we had exclusions since we don't need any of the dependencies. 

Since the exclusion is already set in `pulsar-client/pom.xml` we don't need it here. This blanket exclusion is causing problems for connectors that use this dependency, since Maven won't pull in any of the transitive dependencies.