### PR TITLE
Provide API and CLI to access list of connectors supported by system

### DIFF
--- a/conf/functions_worker.yml
+++ b/conf/functions_worker.yml
@@ -20,6 +20,9 @@
 workerId: standalone
 workerHostname: localhost
 workerPort: 6750
+
+connectorsDirectory: ./connectors
+
 functionMetadataTopicName: metadata
 functionMetadataSnapshotsTopicPath: snapshots
 clusterCoordinationTopicName: coordinate
@@ -33,7 +36,7 @@ downloadDirectory: /tmp/pulsar_functions
 #  threadGroupName: "Thread Function Container Group"
 processContainerFactory:
   logDirectory:
-  
+
 schedulerClassName: "org.apache.pulsar.functions.worker.scheduler.RoundRobinScheduler"
 functionAssignmentTopicName: "assignments"
 failureCheckFreqMs: 30000

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/FunctionsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/FunctionsBase.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.broker.admin.impl;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 import java.util.function.Supplier;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -37,6 +38,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.apache.pulsar.broker.admin.AdminResource;
 import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.common.io.ConnectorDefinition;
 import org.apache.pulsar.functions.proto.Function.Assignment;
 import org.apache.pulsar.functions.proto.Function.FunctionMetaData;
 import org.apache.pulsar.functions.proto.InstanceCommunication.FunctionStatus;
@@ -268,6 +270,21 @@ public class FunctionsBase extends AdminResource implements Supplier<WorkerServi
     @Path("/download")
     public Response downloadFunction(final @QueryParam("path") String path) {
         return functions.downloadFunction(path);
+    }
+
+    @GET
+    @ApiOperation(
+            value = "Fetches a list of supported Pulsar IO connectors currently running in cluster mode",
+            response = List.class
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 403, message = "The requester doesn't have admin permissions"),
+            @ApiResponse(code = 400, message = "Invalid request"),
+            @ApiResponse(code = 408, message = "Request timeout")
+    })
+    @Path("/connectors")
+    public List<ConnectorDefinition> getConnectorsList() throws IOException {
+        return functions.getListOfConnectors();
     }
 
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Functions.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Functions.java
@@ -19,10 +19,17 @@
 package org.apache.pulsar.broker.admin.v2;
 
 import com.wordnik.swagger.annotations.Api;
+
+import javax.ws.rs.Consumes;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
 import org.apache.pulsar.broker.admin.impl.FunctionsBase;
 
 @Path("/functions")
 @Api(value = "/functions", description = "Functions admin apis", tags = "functions")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
 public class Functions extends FunctionsBase {
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Functions.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/Functions.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.apache.pulsar.client.admin.PulsarAdminException.NotAuthorizedException;
 import org.apache.pulsar.client.admin.PulsarAdminException.NotFoundException;
 import org.apache.pulsar.client.admin.PulsarAdminException.PreconditionFailedException;
+import org.apache.pulsar.common.io.ConnectorDefinition;
 import org.apache.pulsar.functions.proto.Function.FunctionDetails;
 import org.apache.pulsar.functions.proto.InstanceCommunication.FunctionStatusList;
 
@@ -76,7 +77,7 @@ public interface Functions {
     FunctionDetails getFunction(String tenant, String namespace, String function) throws PulsarAdminException;
 
     /**
-     * Create a new function. 
+     * Create a new function.
      *
      * @param functionDetails
      *            the function configuration object
@@ -85,7 +86,7 @@ public interface Functions {
      *             Unexpected error
      */
     void createFunction(FunctionDetails functionDetails, String fileName) throws PulsarAdminException;
-    
+
     /**
      * <pre>
      * Create a new function by providing url from which fun-pkg can be downloaded. supported url: http/file
@@ -93,7 +94,7 @@ public interface Functions {
      * File: file:/dir/fileName.jar
      * Http: http://www.repo.com/fileName.jar
      * </pre>
-     * 
+     *
      * @param functionDetails
      *            the function configuration object
      * @param pkgUrl
@@ -117,7 +118,7 @@ public interface Functions {
      *             Unexpected error
      */
     void updateFunction(FunctionDetails functionDetails, String fileName) throws PulsarAdminException;
-    
+
     /**
      * Update the configuration for a function.
      * <pre>
@@ -126,7 +127,7 @@ public interface Functions {
      * File: file:/dir/fileName.jar
      * Http: http://www.repo.com/fileName.jar
      * </pre>
-     * 
+     *
      * @param functionDetails
      *            the function configuration object
      * @param pkgUrl
@@ -222,4 +223,13 @@ public interface Functions {
      *             Unexpected error
      */
     void downloadFunction(String destinationFile, String path) throws PulsarAdminException;
+
+    /**
+     * Fetches a list of supported Pulsar IO connectors currently running in cluster mode
+     *
+     * @throws PulsarAdminException
+     *             Unexpected error
+     *
+     */
+    List<ConnectorDefinition> getConnectorsList() throws PulsarAdminException;
 }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/FunctionsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/FunctionsImpl.java
@@ -40,6 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.admin.Functions;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.common.io.ConnectorDefinition;
 import org.apache.pulsar.common.policies.data.ErrorData;
 import org.apache.pulsar.functions.proto.Function.FunctionDetails;
 import org.apache.pulsar.functions.proto.InstanceCommunication.FunctionStatusList;
@@ -137,7 +138,7 @@ public class FunctionsImpl extends BaseResource implements Functions {
             throw getApiException(e);
         }
     }
-    
+
     @Override
     public void deleteFunction(String cluster, String namespace, String function) throws PulsarAdminException {
         try {
@@ -181,7 +182,7 @@ public class FunctionsImpl extends BaseResource implements Functions {
             throw getApiException(e);
         }
     }
-    
+
     @Override
     public String triggerFunction(String tenant, String namespace, String functionName, String topic, String triggerValue, String triggerFile) throws PulsarAdminException {
         try {
@@ -231,6 +232,20 @@ public class FunctionsImpl extends BaseResource implements Functions {
                         targetFile.toPath(),
                         StandardCopyOption.REPLACE_EXISTING);
             }
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
+
+    @Override
+    public List<ConnectorDefinition> getConnectorsList() throws PulsarAdminException {
+        try {
+            Response response = request(functions.path("connectors")).get();
+            if (!response.getStatusInfo().equals(Response.Status.OK)) {
+                throw new ClientErrorException(response);
+            }
+            return response.readEntity(new GenericType<List<ConnectorDefinition>>() {
+            });
         } catch (Exception e) {
             throw getApiException(e);
         }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSinks.java
@@ -46,9 +46,13 @@ import java.util.Map;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.text.WordUtils;
+import org.apache.pulsar.admin.cli.CmdSources.SourceCommand;
 import org.apache.pulsar.admin.cli.utils.CmdUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.internal.FunctionsImpl;
+import org.apache.pulsar.common.io.ConnectorDefinition;
 import org.apache.pulsar.common.nar.NarClassLoader;
 import org.apache.pulsar.functions.api.utils.IdentityFunction;
 import org.apache.pulsar.functions.instance.AuthenticationConfig;
@@ -61,7 +65,6 @@ import org.apache.pulsar.functions.utils.FunctionConfig;
 import org.apache.pulsar.functions.utils.Reflections;
 import org.apache.pulsar.functions.utils.SinkConfig;
 import org.apache.pulsar.functions.utils.Utils;
-import org.apache.pulsar.functions.utils.io.ConnectorDefinition;
 import org.apache.pulsar.functions.utils.io.ConnectorUtils;
 import org.apache.pulsar.functions.utils.validation.ConfigValidation;
 
@@ -86,6 +89,7 @@ public class CmdSinks extends CmdBase {
         jcommander.addCommand("update", updateSink);
         jcommander.addCommand("delete", deleteSink);
         jcommander.addCommand("localrun", localSinkRunner);
+        jcommander.addCommand("available-sinks", new ListSinks());
     }
 
     /**
@@ -441,6 +445,19 @@ public class CmdSinks extends CmdBase {
         void runCmd() throws Exception {
             admin.functions().deleteFunction(tenant, namespace, name);
             print("Deleted successfully");
+        }
+    }
+
+    @Parameters(commandDescription = "Get the list of Pulsar IO connector sinks supported by Pulsar cluster")
+    public class ListSinks extends SinkCommand {
+        @Override
+        void runCmd() throws Exception {
+            admin.functions().getConnectorsList().stream().filter(x -> !StringUtils.isEmpty(x.getSinkClass()))
+                    .forEach(connector -> {
+                        System.out.println(connector.getName());
+                        System.out.println(WordUtils.wrap(connector.getDescription(), 80));
+                        System.out.println("----------------------------------------");
+                    });
         }
     }
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdSources.java
@@ -43,9 +43,11 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.text.WordUtils;
 import org.apache.pulsar.admin.cli.utils.CmdUtils;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.internal.FunctionsImpl;
+import org.apache.pulsar.common.io.ConnectorDefinition;
 import org.apache.pulsar.common.nar.NarClassLoader;
 import org.apache.pulsar.functions.api.utils.IdentityFunction;
 import org.apache.pulsar.functions.instance.AuthenticationConfig;
@@ -56,7 +58,6 @@ import org.apache.pulsar.functions.proto.Function.SourceSpec;
 import org.apache.pulsar.functions.utils.FunctionConfig;
 import org.apache.pulsar.functions.utils.SourceConfig;
 import org.apache.pulsar.functions.utils.Utils;
-import org.apache.pulsar.functions.utils.io.ConnectorDefinition;
 import org.apache.pulsar.functions.utils.io.ConnectorUtils;
 import org.apache.pulsar.functions.utils.validation.ConfigValidation;
 
@@ -81,6 +82,7 @@ public class CmdSources extends CmdBase {
         jcommander.addCommand("update", updateSource);
         jcommander.addCommand("delete", deleteSource);
         jcommander.addCommand("localrun", localSourceRunner);
+        jcommander.addCommand("available-sources", new ListSources());
     }
 
     /**
@@ -426,4 +428,18 @@ public class CmdSources extends CmdBase {
             print("Delete source successfully");
         }
     }
+
+    @Parameters(commandDescription = "Get the list of Pulsar IO connector sources supported by Pulsar cluster")
+    public class ListSources extends SourceCommand {
+        @Override
+        void runCmd() throws Exception {
+            admin.functions().getConnectorsList().stream().filter(x -> !StringUtils.isEmpty(x.getSourceClass()))
+                    .forEach(connector -> {
+                        System.out.println(connector.getName());
+                        System.out.println(WordUtils.wrap(connector.getDescription(), 80));
+                        System.out.println("----------------------------------------");
+                    });
+        }
+    }
+
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/io/ConnectorDefinition.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/io/ConnectorDefinition.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.functions.utils.io;
+package org.apache.pulsar.common.io;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/io/ConnectorUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/io/ConnectorUtils.java
@@ -20,9 +20,14 @@ package org.apache.pulsar.functions.utils.io;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 
 import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.common.io.ConnectorDefinition;
@@ -33,6 +38,7 @@ import org.apache.pulsar.io.core.Sink;
 import org.apache.pulsar.io.core.Source;
 
 @UtilityClass
+@Slf4j
 public class ConnectorUtils {
 
     private static final String PULSAR_IO_SERVICE_NAME = "pulsar-io.yaml";
@@ -101,5 +107,47 @@ public class ConnectorUtils {
 
             return ObjectMapperFactory.getThreadLocalYaml().readValue(configStr, ConnectorDefinition.class);
         }
+    }
+
+    public static Connectors searchForConnectors(String connectorsDirectory) throws IOException {
+        Path path = Paths.get(connectorsDirectory).toAbsolutePath();
+        log.info("Searching for connectors in {}", path);
+
+        Connectors connectors = new Connectors();
+
+        if (!path.toFile().exists()) {
+            log.warn("Connectors archive directory not found");
+            return connectors;
+        }
+
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(path, "*.nar")) {
+            for (Path archive : stream) {
+                try {
+                    ConnectorDefinition cntDef = ConnectorUtils.getConnectorDefinition(archive.toString());
+                    log.info("Found connector {} from {}", cntDef, archive);
+
+                    if (!StringUtils.isEmpty(cntDef.getSourceClass())) {
+                        // Validate source class to be present and of the right type
+                        ConnectorUtils.getIOSourceClass(archive.toString());
+                        connectors.sources.put(cntDef.getName(), archive);
+                    }
+
+                    if (!StringUtils.isEmpty(cntDef.getSinkClass())) {
+                        // Validate sinkclass to be present and of the right type
+                        ConnectorUtils.getIOSinkClass(archive.toString());
+                        connectors.sinks.put(cntDef.getName(), archive);
+                    }
+
+                    connectors.connectors.add(cntDef);
+                } catch (Throwable t) {
+                    log.warn("Failed to load connector from {}", archive, t);
+                }
+            }
+        }
+
+        Collections.sort(connectors.connectors,
+                (c1, c2) -> String.CASE_INSENSITIVE_ORDER.compare(c1.getName(), c2.getName()));
+
+        return connectors;
     }
 }

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/io/ConnectorUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/io/ConnectorUtils.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import lombok.experimental.UtilityClass;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.common.io.ConnectorDefinition;
 import org.apache.pulsar.common.nar.NarClassLoader;
 import org.apache.pulsar.common.util.ObjectMapperFactory;
 import org.apache.pulsar.functions.utils.Exceptions;

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/io/Connectors.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/io/Connectors.java
@@ -16,33 +16,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.functions.worker;
+package org.apache.pulsar.functions.utils.io;
 
-import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import lombok.Data;
 
 import org.apache.pulsar.common.io.ConnectorDefinition;
-import org.apache.pulsar.functions.utils.io.ConnectorUtils;
-import org.apache.pulsar.functions.utils.io.Connectors;
 
-public class ConnectorsManager {
-
-    private final Connectors connectors;
-
-    public ConnectorsManager(WorkerConfig workerConfig) throws IOException {
-        this.connectors = ConnectorUtils.searchForConnectors(workerConfig.getConnectorsDirectory());
-    }
-
-    public List<ConnectorDefinition> getConnectors() {
-        return connectors.getConnectors();
-    }
-
-    public Path getSourceArchive(String sourceType) {
-        return connectors.getSources().get(sourceType);
-    }
-
-    public Path getSinkArchive(String sinkType) {
-        return connectors.getSinks().get(sinkType);
-    }
+@Data
+public class Connectors {
+    final List<ConnectorDefinition> connectors = new ArrayList<>();
+    final Map<String, Path> sources = new TreeMap<>();
+    final Map<String, Path> sinks = new TreeMap<>();
 }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/ConnectorsManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/ConnectorsManager.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.worker;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.common.io.ConnectorDefinition;
+import org.apache.pulsar.functions.utils.io.ConnectorUtils;
+
+@Slf4j
+public class ConnectorsManager {
+
+    private final List<ConnectorDefinition> connectors = new ArrayList<>();
+    private final Map<String, Path> sources = new TreeMap<>();
+    private final Map<String, Path> sinks = new TreeMap<>();
+
+    public ConnectorsManager(WorkerConfig workerConfig) throws IOException {
+        searchForConnectors(workerConfig.getConnectorsDirectory());
+    }
+
+    public List<ConnectorDefinition> getConnectors() {
+        return connectors;
+    }
+
+    public Path getSourceArchive(String sourceType) {
+        return sources.get(sourceType);
+    }
+
+    public Path getSinkArchive(String sinkType) {
+        return sinks.get(sinkType);
+    }
+
+    private void searchForConnectors(String connectorsDirectory) throws IOException {
+        Path path = Paths.get(connectorsDirectory).toAbsolutePath();
+        log.info("Searching for connectors in {}", path);
+
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(path, "*.nar")) {
+            for (Path archive : stream) {
+                try {
+                    ConnectorDefinition cntDef = ConnectorUtils.getConnectorDefinition(archive.toString());
+                    log.info("Found connector {} from {}", cntDef, archive);
+
+                    if (!StringUtils.isEmpty(cntDef.getSourceClass())) {
+                        // Validate source class to be present and of the right type
+                        ConnectorUtils.getIOSourceClass(archive.toString());
+                        sources.put(cntDef.getName(), archive);
+                    }
+
+                    if (!StringUtils.isEmpty(cntDef.getSinkClass())) {
+                        // Validate sinkclass to be present and of the right type
+                        ConnectorUtils.getIOSinkClass(archive.toString());
+                        sinks.put(cntDef.getName(), archive);
+                    }
+
+                    connectors.add(cntDef);
+                } catch (Throwable t) {
+                    log.warn("Failed to load connector from {}", archive, t);
+                }
+            }
+        }
+
+        Collections.sort(connectors, (c1, c2) -> String.CASE_INSENSITIVE_ORDER.compare(c1.getName(), c2.getName()));
+    }
+}

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -45,6 +45,7 @@ public class WorkerConfig implements Serializable {
     private String workerId;
     private String workerHostname;
     private int workerPort;
+    private String connectorsDirectory;
     private String functionMetadataTopicName;
     private String pulsarServiceUrl;
     private String pulsarWebServiceUrl;
@@ -68,7 +69,7 @@ public class WorkerConfig implements Serializable {
     private String tlsTrustCertsFilePath = "";
     private boolean tlsAllowInsecureConnection = false;
     private boolean tlsHostnameVerificationEnable = false;
-    
+
     @Data
     @Setter
     @Getter

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -45,7 +45,7 @@ public class WorkerConfig implements Serializable {
     private String workerId;
     private String workerHostname;
     private int workerPort;
-    private String connectorsDirectory;
+    private String connectorsDirectory = "./connectors";
     private String functionMetadataTopicName;
     private String pulsarServiceUrl;
     private String pulsarWebServiceUrl;

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerService.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerService.java
@@ -50,6 +50,8 @@ public class WorkerService {
     private SchedulerManager schedulerManager;
     private boolean isInitialized = false;
 
+    private ConnectorsManager connectorsManager;
+
     public WorkerService(WorkerConfig workerConfig) {
         this.workerConfig = workerConfig;
     }
@@ -134,9 +136,11 @@ public class WorkerService {
             // indicate function worker service is done intializing
             this.isInitialized = true;
 
-        } catch (Exception e) {
-            log.error("Error Starting up in worker", e);
-            throw new RuntimeException(e);
+            this.connectorsManager = new ConnectorsManager(workerConfig);
+
+        } catch (Throwable t) {
+            log.error("Error Starting up in worker", t);
+            throw new RuntimeException(t);
         }
     }
 

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
@@ -45,6 +45,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -56,6 +57,7 @@ import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.Reader;
+import org.apache.pulsar.common.io.ConnectorDefinition;
 import org.apache.pulsar.common.policies.data.ErrorData;
 import org.apache.pulsar.common.util.Codec;
 import org.apache.pulsar.functions.proto.Function;
@@ -417,6 +419,16 @@ public class FunctionsImpl {
         }
 
         return Response.status(Status.OK).build();
+    }
+
+    public List<ConnectorDefinition> getListOfConnectors() {
+        if (!isWorkerServiceAvailable()) {
+            throw new WebApplicationException(
+                    Response.status(Status.SERVICE_UNAVAILABLE).type(MediaType.APPLICATION_JSON)
+                            .entity(new ErrorData("Function worker service is not avaialable")).build());
+        }
+
+        return this.worker().getConnectorsManager().getConnectors();
     }
 
     public Response getCluster() {


### PR DESCRIPTION
### Motivation

Added API and CLI command for clients to discover list of supported connectors

### Modifications 

 * When `WorkerService` starts, it checks the "connectors" directory and compile the list of supported sources and sinks
 * Added API/CLI tools

Notes: 
 * Next PR will add the ability to submit connectors by referring to a pre-existing type
 * This is based on #2102, only last commit 
319a1fb  is relevant for this PR. I'll rebase once the 1st is merged