### PR TITLE
Release resources for ZLib inflater/deflater when not used

### DIFF
--- a/pulsar-common/src/main/java/org/apache/pulsar/common/compression/CompressionCodecZLib.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/compression/CompressionCodecZLib.java
@@ -39,12 +39,22 @@ public class CompressionCodecZLib implements CompressionCodec {
         protected Deflater initialValue() throws Exception {
             return new Deflater();
         }
+
+        @Override
+        protected void onRemoval(Deflater deflater) throws Exception {
+            deflater.end();
+        }
     };
 
     private final FastThreadLocal<Inflater> inflater = new FastThreadLocal<Inflater>() {
         @Override
         protected Inflater initialValue() throws Exception {
             return new Inflater();
+        }
+
+        @Override
+        protected void onRemoval(Inflater inflater) throws Exception {
+            inflater.end();
         }
     };
 


### PR DESCRIPTION
### Motivation

While the ZLib Inflater/Deflater classes from JDK are not "Closable", they do have native resources to free. This is currently happening when the objects are finalized, though it would be better to free the memory as soon as possible.

This is not a big problem now since the instances of inflater/deflater are cached per thread.