### PR TITLE
derive worker-host and id at runtime if not provided

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -24,6 +24,10 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import org.apache.commons.lang3.StringUtils;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -69,7 +73,7 @@ public class WorkerConfig implements Serializable {
     private String tlsTrustCertsFilePath = "";
     private boolean tlsAllowInsecureConnection = false;
     private boolean tlsHostnameVerificationEnable = false;
-
+    
     @Data
     @Setter
     @Getter
@@ -107,5 +111,27 @@ public class WorkerConfig implements Serializable {
     public static WorkerConfig load(String yamlFile) throws IOException {
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         return mapper.readValue(new File(yamlFile), WorkerConfig.class);
+    }
+
+    public String getWorkerId() {
+        if (StringUtils.isBlank(this.workerId)) {
+            this.workerId = getWorkerHostname();
+        }
+        return this.workerId;
+    }
+
+    public String getWorkerHostname() {
+        if (StringUtils.isBlank(this.workerHostname)) {
+            this.workerHostname = unsafeLocalhostResolve();
+        }
+        return this.workerHostname;
+    }
+    
+    public static String unsafeLocalhostResolve() {
+        try {
+            return InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException ex) {
+            throw new IllegalStateException("Failed to resolve localhost name.", ex);
+        }
     }
 }


### PR DESCRIPTION
### Motivation

Sometimes, user can install function configuration file per environment but not per host. So, it might not be possible to configure settings per host level. Right now, function worker requires worker-id and host-name to be configured at host level which is difficult to manage.

### Modifications

Derive worker-id and hostname at runtime.

### Result

admin don't have to configure worker-id and hostname at host-level.
