### PR TITLE
Fix Creation of ClientOptions in Go Documentation

### DIFF
--- a/site/docs/latest/clients/go.md
+++ b/site/docs/latest/clients/go.md
@@ -69,7 +69,7 @@ import (
 )
 
 func main() {
-    client, err := pulsar.NewClient(pulsar.ClientOptions
+    client, err := pulsar.NewClient(pulsar.ClientOptions{
         URL: "pulsar://localhost:6650",
         OperationTimeoutSeconds: 5,
         MessageListenerThreads: runtime.NumCPU(),


### PR DESCRIPTION
### Motivation

In https://pulsar.incubator.apache.org/docs/latest/clients/go/#Creatingaclient ,

```
import (
    "log"
    "runtime"

    "github.com/apache/incubator-pulsar/pulsar-client-go/pulsar"
)

func main() {
    client, err := pulsar.NewClient(pulsar.ClientOptions
        URL: "pulsar://localhost:6650",
        OperationTimeoutSeconds: 5,
        MessageListenerThreads: runtime.NumCPU(),
    })

    if err != nil {
        log.Fatalf("Could not instantiate Pulsar client: %v", err)
    }
}
```

cannot be compiled because creation of ClientOptions is wrong.

### Modifications

I added `{` in creation of ClientOptions.

```
client, err := pulsar.NewClient(pulsar.ClientOptions{
        URL: "pulsar://localhost:6650",
        OperationTimeoutSeconds: 5,
        MessageListenerThreads: runtime.NumCPU(),
    })
```

### Result

This modified  code can complied successfully.
