### PR TITLE
Fix Output In Pulsar Go Client Documentation

### DIFF
--- a/site/docs/latest/clients/go.md
+++ b/site/docs/latest/clients/go.md
@@ -182,7 +182,7 @@ func main() {
         producer.SendAsync(ctx, asyncMsg, func(msg pulsar.ProducerMessage, err error) {
             if err != nil { log.Fatal(err) }
 
-            fmt.Printf("Message %s succesfully published", msg.ID())
+            fmt.Printf("Message %s successfully published", msg.Payload)
         })
     }
 }


### PR DESCRIPTION
### Motivation

In http://pulsar.incubator.apache.org/docs/latest/clients/go/#Produceroperations ,

```
producer.SendAsync(ctx, asyncMsg, func(msg pulsar.ProducerMessage, err error) {
	if err != nil {
		log.Fatal(err)
	}

	fmt.Printf("Message %s succesfully published\n", msg.ID())
})
```

cannot be compiled because `msg` doesn't have ID method.

```
$ go build producer.go
# command-line-arguments
./producer.go:54:56: msg.ID undefined (type pulsar.ProducerMessage has no field or method ID)
```

### Modifications

I changed `msg.ID()` to `msg.Payload`.

```
producer.SendAsync(ctx, asyncMsg, func(msg pulsar.ProducerMessage, err error) {
	if err != nil {
		log.Fatal(err)
	}

	fmt.Printf("Message %s succesfully published\n", msg.Payload)
})
``` 

### Result

This modified code can be compiled and executed successfully.

```
$ go build producer.go
$ ./producer
2018/07/09 16:22:17 INFO  | ConnectionPool:63 | Created connection for pulsar://localhost:6650
2018/07/09 16:22:17 INFO  | ClientConnection:279 | [[::1]:62559 -> [::1]:6650] Connected to broker
2018/07/09 16:22:17 INFO  | HandlerBase:53 | [persistent://public/default/my-topic, ] Getting connection from pool
2018/07/09 16:22:17 INFO  | ConnectionPool:63 | Created connection for pulsar://ac47a8d4f588:6650
2018/07/09 16:22:17 INFO  | ClientConnection:281 | [[::1]:62560 -> [::1]:6650] Connected to broker through proxy. Logical broker: pulsar://ac47a8d4f588:6650
2018/07/09 16:22:17 INFO  | ProducerImpl:154 | [persistent://public/default/my-topic, ] Created producer on broker [[::1]:62560 -> [::1]:6650]
Message async-message-0 successfully published
Message async-message-1 successfully published
Message async-message-2 successfully published
Message async-message-3 successfully published
Message async-message-4 successfully published
Message async-message-5 successfully published
Message async-message-6 successfully published
Message async-message-7 successfully published
Message async-message-8 successfully published
```
