### PR TITLE
Make it possible to set idle WebSocket session timeout period

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -462,6 +462,8 @@ webSocketNumIoThreads=8
 # Number of connections per Broker in Pulsar Client used in WebSocket proxy
 webSocketConnectionsPerBroker=8
 
+# Time in milliseconds that idle WebSocket session times out
+webSocketSessionIdleTimeoutMillis=300000
 
 ### --- Metrics --- ###
 

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -393,6 +393,8 @@ webSocketNumIoThreads=8
 # Number of connections per Broker in Pulsar Client used in WebSocket proxy
 webSocketConnectionsPerBroker=8
 
+# Time in milliseconds that idle WebSocket session times out
+webSocketSessionIdleTimeoutMillis=300000
 
 ### --- Metrics --- ###
 

--- a/conf/websocket.conf
+++ b/conf/websocket.conf
@@ -52,6 +52,9 @@ numIoThreads=8
 # Number of connections per Broker in Pulsar Client used in WebSocket proxy
 connectionsPerBroker=8
 
+# Time in milliseconds that idle WebSocket session times out
+webSocketSessionIdleTimeoutMillis=300000
+
 ### --- Authentication --- ###
 
 # Enable authentication

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -464,6 +464,8 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private int webSocketNumIoThreads = Runtime.getRuntime().availableProcessors();
     // Number of connections per Broker in Pulsar Client used in WebSocket proxy
     private int webSocketConnectionsPerBroker = Runtime.getRuntime().availableProcessors();
+    // Time in milliseconds that idle WebSocket session times out
+    private int webSocketSessionIdleTimeoutMillis = 300000;
 
     /**** --- Metrics --- ****/
     // If true, export topic level metrics otherwise namespace level
@@ -1581,6 +1583,14 @@ public class ServiceConfiguration implements PulsarConfiguration {
     public int getWebSocketConnectionsPerBroker() { return webSocketConnectionsPerBroker; }
 
     public void setWebSocketConnectionsPerBroker(int webSocketConnectionsPerBroker) { this.webSocketConnectionsPerBroker = webSocketConnectionsPerBroker; }
+
+    public int getWebSocketSessionIdleTimeoutMillis() {
+        return webSocketSessionIdleTimeoutMillis;
+    }
+
+    public void setWebSocketSessionIdleTimeoutMillis(int webSocketSessionIdleTimeoutMillis) {
+        this.webSocketSessionIdleTimeoutMillis = webSocketSessionIdleTimeoutMillis;
+    }
 
     public boolean exposeTopicLevelMetricsInPrometheus() {
         return exposeTopicLevelMetricsInPrometheus;

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketConsumerServlet.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketConsumerServlet.java
@@ -37,7 +37,9 @@ public class WebSocketConsumerServlet extends WebSocketServlet {
     @Override
     public void configure(WebSocketServletFactory factory) {
         factory.getPolicy().setMaxTextMessageSize(WebSocketService.MaxTextFrameSize);
-
+        if (service.getConfig().getWebSocketSessionIdleTimeoutMillis() > 0) {
+            factory.getPolicy().setIdleTimeout(service.getConfig().getWebSocketSessionIdleTimeoutMillis());
+        }
         factory.setCreator(
                 (request, response) -> new ConsumerHandler(service, request.getHttpServletRequest(), response));
     }

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketProducerServlet.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketProducerServlet.java
@@ -36,6 +36,9 @@ public class WebSocketProducerServlet extends WebSocketServlet {
     @Override
     public void configure(WebSocketServletFactory factory) {
         factory.getPolicy().setMaxTextMessageSize(WebSocketService.MaxTextFrameSize);
+        if (service.getConfig().getWebSocketSessionIdleTimeoutMillis() > 0) {
+            factory.getPolicy().setIdleTimeout(service.getConfig().getWebSocketSessionIdleTimeoutMillis());
+        }
         factory.setCreator((request, response) -> new ProducerHandler(service, request.getHttpServletRequest(), response));
     }
 }

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketReaderServlet.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/WebSocketReaderServlet.java
@@ -37,7 +37,9 @@ public class WebSocketReaderServlet extends WebSocketServlet {
     @Override
     public void configure(WebSocketServletFactory factory) {
         factory.getPolicy().setMaxTextMessageSize(WebSocketService.MaxTextFrameSize);
-
+        if (service.getConfig().getWebSocketSessionIdleTimeoutMillis() > 0) {
+            factory.getPolicy().setIdleTimeout(service.getConfig().getWebSocketSessionIdleTimeoutMillis());
+        }
         factory.setCreator(
                 (request, response) -> new ReaderHandler(service, request.getHttpServletRequest(), response));
     }

--- a/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
+++ b/pulsar-websocket/src/main/java/org/apache/pulsar/websocket/service/WebSocketProxyConfiguration.java
@@ -92,6 +92,8 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
     private int numIoThreads = Runtime.getRuntime().availableProcessors();
     // Number of connections per Broker in Pulsar Client used in WebSocket proxy
     private int connectionsPerBroker = Runtime.getRuntime().availableProcessors();
+    // Time in milliseconds that idle WebSocket session times out
+    private int webSocketSessionIdleTimeoutMillis = 300000;
 
     // When this parameter is not empty, unauthenticated users perform as anonymousUserRole
     private String anonymousUserRole = null;
@@ -297,6 +299,14 @@ public class WebSocketProxyConfiguration implements PulsarConfiguration {
 
     public void setConnectionsPerBroker(int connectionsPerBroker) {
         this.connectionsPerBroker = connectionsPerBroker;
+    }
+
+    public int getWebSocketSessionIdleTimeoutMillis() {
+        return webSocketSessionIdleTimeoutMillis;
+    }
+
+    public void setWebSocketSessionIdleTimeoutMillis(int webSocketSessionIdleTimeoutMillis) {
+        this.webSocketSessionIdleTimeoutMillis = webSocketSessionIdleTimeoutMillis;
     }
 
     public String getAnonymousUserRole() {


### PR DESCRIPTION
### Motivation

WebSocket session is automatically closed when the idle state lasts 5 minutes (default value of jetty). It is useful to be provided a way to extend/shorten this timeout period as needed.

### Modifications

Added `webSocketSessionIdleTimeoutMillis` to the configuration files and set the value as WebSocketPolicy.

### Result

Users can change the timeout period of idle WebSocket sessions as needed.