### PR TITLE
Fix string in popover-term

### DIFF
--- a/site/_data/popovers.yaml
+++ b/site/_data/popovers.yaml
@@ -94,7 +94,7 @@ pulsar-functions:
   def: Pulsar Functions are lightweight functions that can consume messages from Pulsar topics, apply custom processing logic, and, if desired, publish results to topics.
 reader:
   q: What is a Pulsar reader?
-  def: |
+  def:
     "Pulsar readers are message processors much like Pulsar consumers but with two crucial differences: (1) you can specify *where* on a topic readers begin processing messages (consumers always begin with the latest available unacked message); and (2) readers don't retain data or acknowledge messages."
 retention-policy:
   q: What is a retention policy?


### PR DESCRIPTION
### Motivation

In https://pulsar.incubator.apache.org/docs/latest/clients/go/#Readers ,
`span` tag is displayed as it is.

<img width="691" alt="before" src="https://user-images.githubusercontent.com/15376628/42494343-fb321c24-845a-11e8-9375-3ce0ee5851d4.png">

### Modifications

I removed `|` in `_data/popovers.yaml`.

### Result

`span` tag is working properly.

<img width="759" alt="after" src="https://user-images.githubusercontent.com/15376628/42494538-8c94e1e2-845b-11e8-886b-f20ab003dceb.png">

