### PR TITLE
Schedule task to update function stats separately

### DIFF
--- a/conf/functions_worker.yml
+++ b/conf/functions_worker.yml
@@ -44,3 +44,4 @@ rescheduleTimeoutMs: 60000
 initialBrokerReconnectMaxRetries: 60
 assignmentWriteMaxRetries: 60
 instanceLivenessCheckFreqMs: 30000
+metricsSamplingPeriodSec: 60

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/FunctionStats.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/FunctionStats.java
@@ -102,13 +102,35 @@ public class FunctionStats {
                 return totalLatencyMs / totalSuccessfullyProcessed;
             }
         }
+        
+        public void update(Stats stats) {
+            if (stats == null) {
+                return;
+            }
+            this.totalProcessed = stats.totalProcessed;
+            this.totalSuccessfullyProcessed = stats.totalSuccessfullyProcessed;
+            this.totalUserExceptions = stats.totalUserExceptions;
+            this.latestUserExceptions.clear();
+            this.latestSystemExceptions.clear();
+            this.totalDeserializationExceptions.clear();
+            this.latestUserExceptions.addAll(stats.latestUserExceptions);
+            this.latestSystemExceptions.addAll(stats.latestSystemExceptions);
+            this.totalDeserializationExceptions.putAll(stats.totalDeserializationExceptions);
+            this.totalSystemExceptions = stats.totalSystemExceptions;
+            this.latestSystemExceptions = stats.latestSystemExceptions;
+            this.totalSerializationExceptions = stats.totalSerializationExceptions;
+            this.totalLatencyMs = stats.totalLatencyMs;
+            this.lastInvocationTime = stats.lastInvocationTime;
+        }
     }
 
     private Stats currentStats;
     private Stats totalStats;
-
+    private Stats stats;
+    
     public FunctionStats() {
         currentStats = new Stats();
+        stats = new Stats();
         totalStats = new Stats();
     }
 
@@ -138,6 +160,7 @@ public class FunctionStats {
         totalStats.incrementSerializationExceptions();
     }
     public void resetCurrent() {
+        stats.update(currentStats);
         currentStats.reset();
     }
 }

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstance.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstance.java
@@ -76,4 +76,12 @@ public class JavaInstance implements AutoCloseable {
     public InstanceCommunication.MetricsData getAndResetMetrics() {
         return context.getAndResetMetrics();
     }
+
+    public void resetMetrics() {
+        context.resetMetrics();
+    }
+
+    public InstanceCommunication.MetricsData getMetrics() {
+        return context.getMetrics();
+    }
 }

--- a/pulsar-functions/instance/src/main/python/InstanceCommunication_pb2.py
+++ b/pulsar-functions/instance/src/main/python/InstanceCommunication_pb2.py
@@ -39,7 +39,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='InstanceCommunication.proto',
   package='proto',
   syntax='proto3',
-  serialized_pb=_b('\n\x1bInstanceCommunication.proto\x12\x05proto\x1a\x1bgoogle/protobuf/empty.proto\"\xa1\x05\n\x0e\x46unctionStatus\x12\x0f\n\x07running\x18\x01 \x01(\x08\x12\x18\n\x10\x66\x61ilureException\x18\x02 \x01(\t\x12\x13\n\x0bnumRestarts\x18\x03 \x01(\x03\x12\x14\n\x0cnumProcessed\x18\x04 \x01(\x03\x12 \n\x18numSuccessfullyProcessed\x18\x05 \x01(\x03\x12\x19\n\x11numUserExceptions\x18\x06 \x01(\x03\x12H\n\x14latestUserExceptions\x18\x07 \x03(\x0b\x32*.proto.FunctionStatus.ExceptionInformation\x12\x1b\n\x13numSystemExceptions\x18\x08 \x01(\x03\x12J\n\x16latestSystemExceptions\x18\t \x03(\x0b\x32*.proto.FunctionStatus.ExceptionInformation\x12W\n\x19\x64\x65serializationExceptions\x18\n \x03(\x0b\x32\x34.proto.FunctionStatus.DeserializationExceptionsEntry\x12\x1f\n\x17serializationExceptions\x18\x0b \x01(\x03\x12\x16\n\x0e\x61verageLatency\x18\x0c \x01(\x01\x12\x1a\n\x12lastInvocationTime\x18\r \x01(\x03\x12\x12\n\ninstanceId\x18\x0e \x01(\t\x1a\x45\n\x14\x45xceptionInformation\x12\x17\n\x0f\x65xceptionString\x18\x01 \x01(\t\x12\x14\n\x0cmsSinceEpoch\x18\x02 \x01(\x03\x1a@\n\x1e\x44\x65serializationExceptionsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x03:\x02\x38\x01\"G\n\x12\x46unctionStatusList\x12\x31\n\x12\x66unctionStatusList\x18\x01 \x03(\x0b\x32\x15.proto.FunctionStatus\"\xd2\x01\n\x0bMetricsData\x12\x30\n\x07metrics\x18\x01 \x03(\x0b\x32\x1f.proto.MetricsData.MetricsEntry\x1a\x42\n\nDataDigest\x12\r\n\x05\x63ount\x18\x01 \x01(\x01\x12\x0b\n\x03sum\x18\x02 \x01(\x01\x12\x0b\n\x03max\x18\x03 \x01(\x01\x12\x0b\n\x03min\x18\x04 \x01(\x01\x1aM\n\x0cMetricsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12,\n\x05value\x18\x02 \x01(\x0b\x32\x1d.proto.MetricsData.DataDigest:\x02\x38\x01\"$\n\x11HealthCheckResult\x12\x0f\n\x07success\x18\x01 \x01(\x08\x32\xde\x01\n\x0fInstanceControl\x12\x44\n\x11GetFunctionStatus\x12\x16.google.protobuf.Empty\x1a\x15.proto.FunctionStatus\"\x00\x12\x42\n\x12GetAndResetMetrics\x12\x16.google.protobuf.Empty\x1a\x12.proto.MetricsData\"\x00\x12\x41\n\x0bHealthCheck\x12\x16.google.protobuf.Empty\x1a\x18.proto.HealthCheckResult\"\x00\x42:\n!org.apache.pulsar.functions.protoB\x15InstanceCommunicationb\x06proto3')
+  serialized_pb=_b('\n\x1bInstanceCommunication.proto\x12\x05proto\x1a\x1bgoogle/protobuf/empty.proto\"\xa1\x05\n\x0e\x46unctionStatus\x12\x0f\n\x07running\x18\x01 \x01(\x08\x12\x18\n\x10\x66\x61ilureException\x18\x02 \x01(\t\x12\x13\n\x0bnumRestarts\x18\x03 \x01(\x03\x12\x14\n\x0cnumProcessed\x18\x04 \x01(\x03\x12 \n\x18numSuccessfullyProcessed\x18\x05 \x01(\x03\x12\x19\n\x11numUserExceptions\x18\x06 \x01(\x03\x12H\n\x14latestUserExceptions\x18\x07 \x03(\x0b\x32*.proto.FunctionStatus.ExceptionInformation\x12\x1b\n\x13numSystemExceptions\x18\x08 \x01(\x03\x12J\n\x16latestSystemExceptions\x18\t \x03(\x0b\x32*.proto.FunctionStatus.ExceptionInformation\x12W\n\x19\x64\x65serializationExceptions\x18\n \x03(\x0b\x32\x34.proto.FunctionStatus.DeserializationExceptionsEntry\x12\x1f\n\x17serializationExceptions\x18\x0b \x01(\x03\x12\x16\n\x0e\x61verageLatency\x18\x0c \x01(\x01\x12\x1a\n\x12lastInvocationTime\x18\r \x01(\x03\x12\x12\n\ninstanceId\x18\x0e \x01(\t\x1a\x45\n\x14\x45xceptionInformation\x12\x17\n\x0f\x65xceptionString\x18\x01 \x01(\t\x12\x14\n\x0cmsSinceEpoch\x18\x02 \x01(\x03\x1a@\n\x1e\x44\x65serializationExceptionsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x03:\x02\x38\x01\"G\n\x12\x46unctionStatusList\x12\x31\n\x12\x66unctionStatusList\x18\x01 \x03(\x0b\x32\x15.proto.FunctionStatus\"\xd2\x01\n\x0bMetricsData\x12\x30\n\x07metrics\x18\x01 \x03(\x0b\x32\x1f.proto.MetricsData.MetricsEntry\x1a\x42\n\nDataDigest\x12\r\n\x05\x63ount\x18\x01 \x01(\x01\x12\x0b\n\x03sum\x18\x02 \x01(\x01\x12\x0b\n\x03max\x18\x03 \x01(\x01\x12\x0b\n\x03min\x18\x04 \x01(\x01\x1aM\n\x0cMetricsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12,\n\x05value\x18\x02 \x01(\x0b\x32\x1d.proto.MetricsData.DataDigest:\x02\x38\x01\"$\n\x11HealthCheckResult\x12\x0f\n\x07success\x18\x01 \x01(\x08\x32\xdc\x02\n\x0fInstanceControl\x12\x44\n\x11GetFunctionStatus\x12\x16.google.protobuf.Empty\x1a\x15.proto.FunctionStatus\"\x00\x12\x42\n\x12GetAndResetMetrics\x12\x16.google.protobuf.Empty\x1a\x12.proto.MetricsData\"\x00\x12@\n\x0cResetMetrics\x12\x16.google.protobuf.Empty\x1a\x16.google.protobuf.Empty\"\x00\x12:\n\nGetMetrics\x12\x16.google.protobuf.Empty\x1a\x12.proto.MetricsData\"\x00\x12\x41\n\x0bHealthCheck\x12\x16.google.protobuf.Empty\x1a\x18.proto.HealthCheckResult\"\x00\x42:\n!org.apache.pulsar.functions.protoB\x15InstanceCommunicationb\x06proto3')
   ,
   dependencies=[google_dot_protobuf_dot_empty__pb2.DESCRIPTOR,])
 
@@ -513,7 +513,7 @@ _INSTANCECONTROL = _descriptor.ServiceDescriptor(
   index=0,
   options=None,
   serialized_start=1068,
-  serialized_end=1290,
+  serialized_end=1416,
   methods=[
   _descriptor.MethodDescriptor(
     name='GetFunctionStatus',
@@ -534,9 +534,27 @@ _INSTANCECONTROL = _descriptor.ServiceDescriptor(
     options=None,
   ),
   _descriptor.MethodDescriptor(
+    name='ResetMetrics',
+    full_name='proto.InstanceControl.ResetMetrics',
+    index=2,
+    containing_service=None,
+    input_type=google_dot_protobuf_dot_empty__pb2._EMPTY,
+    output_type=google_dot_protobuf_dot_empty__pb2._EMPTY,
+    options=None,
+  ),
+  _descriptor.MethodDescriptor(
+    name='GetMetrics',
+    full_name='proto.InstanceControl.GetMetrics',
+    index=3,
+    containing_service=None,
+    input_type=google_dot_protobuf_dot_empty__pb2._EMPTY,
+    output_type=_METRICSDATA,
+    options=None,
+  ),
+  _descriptor.MethodDescriptor(
     name='HealthCheck',
     full_name='proto.InstanceControl.HealthCheck',
-    index=2,
+    index=4,
     containing_service=None,
     input_type=google_dot_protobuf_dot_empty__pb2._EMPTY,
     output_type=_HEALTHCHECKRESULT,

--- a/pulsar-functions/instance/src/main/python/InstanceCommunication_pb2_grpc.py
+++ b/pulsar-functions/instance/src/main/python/InstanceCommunication_pb2_grpc.py
@@ -44,6 +44,16 @@ class InstanceControlStub(object):
         request_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
         response_deserializer=InstanceCommunication__pb2.MetricsData.FromString,
         )
+    self.ResetMetrics = channel.unary_unary(
+        '/proto.InstanceControl/ResetMetrics',
+        request_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
+        response_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+        )
+    self.GetMetrics = channel.unary_unary(
+        '/proto.InstanceControl/GetMetrics',
+        request_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
+        response_deserializer=InstanceCommunication__pb2.MetricsData.FromString,
+        )
     self.HealthCheck = channel.unary_unary(
         '/proto.InstanceControl/HealthCheck',
         request_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
@@ -69,6 +79,20 @@ class InstanceControlServicer(object):
     context.set_details('Method not implemented!')
     raise NotImplementedError('Method not implemented!')
 
+  def ResetMetrics(self, request, context):
+    # missing associated documentation comment in .proto file
+    pass
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def GetMetrics(self, request, context):
+    # missing associated documentation comment in .proto file
+    pass
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
   def HealthCheck(self, request, context):
     # missing associated documentation comment in .proto file
     pass
@@ -86,6 +110,16 @@ def add_InstanceControlServicer_to_server(servicer, server):
       ),
       'GetAndResetMetrics': grpc.unary_unary_rpc_method_handler(
           servicer.GetAndResetMetrics,
+          request_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+          response_serializer=InstanceCommunication__pb2.MetricsData.SerializeToString,
+      ),
+      'ResetMetrics': grpc.unary_unary_rpc_method_handler(
+          servicer.ResetMetrics,
+          request_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+          response_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
+      ),
+      'GetMetrics': grpc.unary_unary_rpc_method_handler(
+          servicer.GetMetrics,
           request_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
           response_serializer=InstanceCommunication__pb2.MetricsData.SerializeToString,
       ),

--- a/pulsar-functions/instance/src/main/python/contextimpl.py
+++ b/pulsar-functions/instance/src/main/python/contextimpl.py
@@ -54,6 +54,7 @@ class ContextImpl(pulsar.Context):
     self.pulsar_client = pulsar_client
     self.user_code_dir = os.path.dirname(user_code)
     self.consumers = consumers
+    self.current_accumulated_metrics = {}
     self.accumulated_metrics = {}
     self.publish_producers = {}
     self.publish_serializers = {}
@@ -107,9 +108,9 @@ class ContextImpl(pulsar.Context):
     return self.user_config
 
   def record_metric(self, metric_name, metric_value):
-    if not metric_name in self.accumulated_metrics:
-      self.accumulated_metrics[metric_name] = AccumulatedMetricDatum()
-    self.accumulated_metrics[metric_name].update(metric_value)
+    if not metric_name in self.current_accumulated_metrics:
+      self.current_accumulated_metrics[metric_name] = AccumulatedMetricDatum()
+    self.current_accumulated_metrics[metric_name].update(metric_value)
 
   def get_output_topic(self):
     return self.instance_config.function_details.output
@@ -146,6 +147,18 @@ class ContextImpl(pulsar.Context):
     self.consumers[topic].acknowledge(msgid)
 
   def get_and_reset_metrics(self):
+    metrics = self.get_metrics()
+    # TODO(sanjeev):- Make this thread safe
+    self.reset_metrics()
+    return metrics
+
+  def reset_metrics(self):
+    # TODO: Make it thread safe
+    self.accumulated_metrics.clear()
+    self.accumulated_metrics.update(self.current_accumulated_metrics)
+    self.current_accumulated_metrics.clear()
+
+  def get_metrics(self):
     metrics = InstanceCommunication_pb2.MetricsData()
     for metric_name, accumulated_metric in self.accumulated_metrics.items():
       m = InstanceCommunication_pb2.MetricsData.DataDigest()
@@ -154,6 +167,4 @@ class ContextImpl(pulsar.Context):
       m.max = accumulated_metric.max
       m.min = accumulated_metric.min
       metrics.metrics[metric_name] = m
-    # TODO(sanjeev):- Make this thread safe
-    self.accumulated_metrics.clear()
     return metrics

--- a/pulsar-functions/instance/src/main/python/python_instance.py
+++ b/pulsar-functions/instance/src/main/python/python_instance.py
@@ -97,6 +97,22 @@ class Stats(object):
     else:
       return self.latency / self.nsuccessfullyprocessed
 
+  def update(self, object):
+    self.nprocessed = object.nprocessed
+    self.nsuccessfullyprocessed = object.nsuccessfullyprocessed
+    self.nuserexceptions = object.nuserexceptions
+    self.nsystemexceptions = object.nsystemexceptions
+    self.nserialization_exceptions = object.nserialization_exceptions
+    self.latency = object.latency
+    self.lastinvocationtime = object.lastinvocationtime
+    self.latestuserexceptions = []
+    self.latestsystemexceptions = []
+    self.ndeserialization_exceptions.clear()
+    self.latestuserexceptions.append(object.latestuserexceptions)
+    self.latestsystemexceptions.append(object.latestsystemexceptions)
+    self.ndeserialization_exceptions.update(object.ndeserialization_exceptions)
+    
+
 class PythonInstance(object):
   def __init__(self, instance_id, function_id, function_version, function_details, max_buffered_tuples, user_code, log_topic, pulsar_client):
     self.instance_config = InstanceConfig(instance_id, function_id, function_version, function_details, max_buffered_tuples)
@@ -119,6 +135,7 @@ class PythonInstance(object):
     self.contextimpl = None
     self.total_stats = Stats()
     self.current_stats = Stats()
+    self.stats = Stats()
     self.last_health_check_ts = time.time()
     self.timeout_ms = function_details.source.timeoutMs if function_details.source.timeoutMs > 0 else None
 
@@ -278,18 +295,29 @@ class PythonInstance(object):
 
   def get_and_reset_metrics(self):
     # First get any user metrics
-    metrics = self.contextimpl.get_and_reset_metrics()
-    # Now add system metrics as well
-    self.add_system_metrics("__total_processed__", self.current_stats.nprocessed, metrics)
-    self.add_system_metrics("__total_successfully_processed__", self.current_stats.nsuccessfullyprocessed, metrics)
-    self.add_system_metrics("__total_system_exceptions__", self.current_stats.nsystemexceptions, metrics)
-    self.add_system_metrics("__total_user_exceptions__", self.current_stats.nuserexceptions, metrics)
-    for (topic, metric) in self.current_stats.ndeserialization_exceptions.items():
-      self.add_system_metrics("__total_deserialization_exceptions__" + topic, metric, metrics)
-    self.add_system_metrics("__total_serialization_exceptions__", self.current_stats.nserialization_exceptions, metrics)
-    self.add_system_metrics("__avg_latency_ms__", self.current_stats.compute_latency(), metrics)
-    self.current_stats.reset()
+    metrics = self.get_metrics()
+    self.reset_metrics()
     return metrics
+
+  def reset_metrics(self):
+    self.stats.update(self.current_stats)
+    self.current_stats.reset()
+    self.contextimpl.reset_metrics()
+
+  def get_metrics(self):
+    # First get any user metrics
+    metrics = self.contextimpl.get_metrics()
+    # Now add system metrics as well
+    self.add_system_metrics("__total_processed__", self.stats.nprocessed, metrics)
+    self.add_system_metrics("__total_successfully_processed__", self.stats.nsuccessfullyprocessed, metrics)
+    self.add_system_metrics("__total_system_exceptions__", self.stats.nsystemexceptions, metrics)
+    self.add_system_metrics("__total_user_exceptions__", self.stats.nuserexceptions, metrics)
+    for (topic, metric) in self.stats.ndeserialization_exceptions.items():
+      self.add_system_metrics("__total_deserialization_exceptions__" + topic, metric, metrics)
+    self.add_system_metrics("__total_serialization_exceptions__", self.stats.nserialization_exceptions, metrics)
+    self.add_system_metrics("__avg_latency_ms__", self.stats.compute_latency(), metrics)
+    return metrics
+
 
   def add_system_metrics(self, metric_name, value, metrics):
     metrics.metrics[metric_name].count = value

--- a/pulsar-functions/instance/src/main/python/server.py
+++ b/pulsar-functions/instance/src/main/python/server.py
@@ -42,6 +42,15 @@ class InstanceCommunicationServicer(InstanceCommunication_pb2_grpc.InstanceContr
     Log.info("Came in GetAndResetMetrics")
     return self.pyinstance.get_and_reset_metrics()
 
+  def ResetMetrics(self, request, context):
+    Log.info("Came in ResetMetrics")
+    self.pyinstance.reset_metrics()
+    return request
+
+  def GetMetrics(self, request, context):
+    Log.info("Came in GetMetrics")
+    return self.pyinstance.get_metrics()
+
   def HealthCheck(self, request, context):
     return self.pyinstance.health_check()
 

--- a/pulsar-functions/proto/src/main/proto/InstanceCommunication.proto
+++ b/pulsar-functions/proto/src/main/proto/InstanceCommunication.proto
@@ -72,5 +72,7 @@ message HealthCheckResult {
 service InstanceControl {
     rpc GetFunctionStatus(google.protobuf.Empty) returns (FunctionStatus) {}
     rpc GetAndResetMetrics(google.protobuf.Empty) returns (MetricsData) {}
+    rpc ResetMetrics(google.protobuf.Empty) returns (google.protobuf.Empty) {}
+    rpc GetMetrics(google.protobuf.Empty) returns (MetricsData) {}
     rpc HealthCheck(google.protobuf.Empty) returns (HealthCheckResult) {}
 }

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceMain.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceMain.java
@@ -349,6 +349,36 @@ public class JavaInstanceMain implements AutoCloseable {
         }
 
         @Override
+        public void getMetrics(com.google.protobuf.Empty request,
+                                       io.grpc.stub.StreamObserver<org.apache.pulsar.functions.proto.InstanceCommunication.MetricsData> responseObserver) {
+            Runtime runtime = runtimeSpawner.getRuntime();
+            if (runtime != null) {
+                try {
+                    InstanceCommunication.MetricsData metrics = runtime.getMetrics().get();
+                    responseObserver.onNext(metrics);
+                    responseObserver.onCompleted();
+                } catch (InterruptedException | ExecutionException e) {
+                    log.error("Exception in JavaInstance doing getAndResetMetrics", e);
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+
+        public void resetMetrics(com.google.protobuf.Empty request,
+                io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
+            Runtime runtime = runtimeSpawner.getRuntime();
+            if (runtime != null) {
+                try {
+                    runtime.resetMetrics().get();
+                    responseObserver.onCompleted();
+                } catch (InterruptedException | ExecutionException e) {
+                    log.error("Exception in JavaInstance doing getAndResetMetrics", e);
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+        
+        @Override
         public void healthCheck(com.google.protobuf.Empty request,
                                 io.grpc.stub.StreamObserver<org.apache.pulsar.functions.proto.InstanceCommunication.HealthCheckResult> responseObserver) {
             log.debug("Recieved health check request...");

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntime.java
@@ -347,6 +347,50 @@ class ProcessRuntime implements Runtime {
         return retval;
     }
 
+    @Override
+    public CompletableFuture<Void> resetMetrics() {
+        CompletableFuture<Void> retval = new CompletableFuture<>();
+        if (stub == null) {
+            retval.completeExceptionally(new RuntimeException("Not alive"));
+            return retval;
+        }
+        ListenableFuture<Empty> response = stub.resetMetrics(Empty.newBuilder().build());
+        Futures.addCallback(response, new FutureCallback<Empty>() {
+            @Override
+            public void onFailure(Throwable throwable) {
+                retval.completeExceptionally(throwable);
+            }
+
+            @Override
+            public void onSuccess(Empty t) {
+                retval.complete(null);
+            }
+        });
+        return retval;
+    }
+
+    @Override
+    public CompletableFuture<InstanceCommunication.MetricsData> getMetrics() {
+        CompletableFuture<InstanceCommunication.MetricsData> retval = new CompletableFuture<>();
+        if (stub == null) {
+            retval.completeExceptionally(new RuntimeException("Not alive"));
+            return retval;
+        }
+        ListenableFuture<InstanceCommunication.MetricsData> response = stub.getMetrics(Empty.newBuilder().build());
+        Futures.addCallback(response, new FutureCallback<InstanceCommunication.MetricsData>() {
+            @Override
+            public void onFailure(Throwable throwable) {
+                retval.completeExceptionally(throwable);
+            }
+
+            @Override
+            public void onSuccess(InstanceCommunication.MetricsData t) {
+                retval.complete(t);
+            }
+        });
+        return retval;
+    }
+    
     public CompletableFuture<InstanceCommunication.HealthCheckResult> healthCheck() {
         CompletableFuture<InstanceCommunication.HealthCheckResult> retval = new CompletableFuture<>();
         if (stub == null) {

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/Runtime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/Runtime.java
@@ -41,5 +41,9 @@ public interface Runtime {
     CompletableFuture<InstanceCommunication.FunctionStatus> getFunctionStatus();
 
     CompletableFuture<InstanceCommunication.MetricsData> getAndResetMetrics();
+    
+    CompletableFuture<Void> resetMetrics();
+    
+    CompletableFuture<InstanceCommunication.MetricsData> getMetrics();
 
 }

--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ThreadRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ThreadRuntime.java
@@ -113,6 +113,18 @@ class ThreadRuntime implements Runtime {
     public CompletableFuture<InstanceCommunication.MetricsData> getAndResetMetrics() {
         return CompletableFuture.completedFuture(javaInstanceRunnable.getAndResetMetrics());
     }
+    
+    
+    @Override
+    public CompletableFuture<InstanceCommunication.MetricsData> getMetrics() {
+        return CompletableFuture.completedFuture(javaInstanceRunnable.getMetrics());
+    }
+
+    @Override
+    public CompletableFuture<Void> resetMetrics() {
+        javaInstanceRunnable.resetMetrics();
+        return CompletableFuture.completedFuture(null);
+    }
 
     @Override
     public boolean isAlive() {

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
@@ -31,6 +31,7 @@ import org.apache.pulsar.functions.proto.InstanceCommunication;
 import org.apache.pulsar.functions.proto.Request.AssignmentsUpdate;
 import org.apache.pulsar.functions.runtime.RuntimeFactory;
 import org.apache.pulsar.functions.runtime.ProcessRuntimeFactory;
+import org.apache.pulsar.functions.runtime.Runtime;
 import org.apache.pulsar.functions.runtime.ThreadRuntimeFactory;
 import org.apache.pulsar.functions.runtime.RuntimeSpawner;
 
@@ -42,6 +43,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -437,6 +439,22 @@ public class FunctionRuntimeManager implements AutoCloseable{
 
     public Map<String, FunctionRuntimeInfo> getFunctionRuntimeInfos() {
         return this.functionRuntimeInfoMap;
+    }
+    
+    public void updateRates() {
+        for (Entry<String, FunctionRuntimeInfo> entry : this.functionRuntimeInfoMap.entrySet()) {
+            RuntimeSpawner functionRuntimeSpawner = entry.getValue().getRuntimeSpawner();
+            if (functionRuntimeSpawner != null) {
+                Runtime functionRuntime = functionRuntimeSpawner.getRuntime();
+                if (functionRuntime != null) {
+                    try {
+                        functionRuntime.resetMetrics().get();
+                    } catch (Exception e) {
+                        log.error("Failed to update stats for {}-{}", entry.getKey(), e.getMessage());
+                    }
+                }
+            }
+        }
     }
     /**
      * Private methods for internal use.  Should not be used outside of this class

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionsStatsGenerator.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionsStatsGenerator.java
@@ -49,7 +49,9 @@ public class FunctionsStatsGenerator {
                     Runtime functionRuntime = functionRuntimeSpawner.getRuntime();
                     if (functionRuntime != null) {
                         try {
-                            InstanceCommunication.MetricsData metrics = functionRuntime.getAndResetMetrics().get();
+                            InstanceCommunication.MetricsData metrics = workerService.getWorkerConfig()
+                                    .getMetricsSamplingPeriodSec() > 0 ? functionRuntime.getMetrics().get()
+                                            : functionRuntime.getAndResetMetrics().get();
                             for (Map.Entry<String, InstanceCommunication.MetricsData.DataDigest> metricsEntry
                                     : metrics.getMetricsMap().entrySet()) {
                                 String metricName = metricsEntry.getKey();

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -73,7 +73,8 @@ public class WorkerConfig implements Serializable {
     private String tlsTrustCertsFilePath = "";
     private boolean tlsAllowInsecureConnection = false;
     private boolean tlsHostnameVerificationEnable = false;
-    
+    private int metricsSamplingPeriodSec = 60;
+
     @Data
     @Setter
     @Getter

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionStatsGeneratorTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionStatsGeneratorTest.java
@@ -52,6 +52,7 @@ public class FunctionStatsGeneratorTest {
 
         WorkerService workerService = mock(WorkerService.class);
         doReturn(functionRuntimeManager).when(workerService).getFunctionRuntimeManager();
+        doReturn(new WorkerConfig()).when(workerService).getWorkerConfig();
 
         CompletableFuture<InstanceCommunication.MetricsData> metricsDataCompletableFuture = new CompletableFuture<>();
         InstanceCommunication.MetricsData metricsData = InstanceCommunication.MetricsData.newBuilder()
@@ -66,7 +67,7 @@ public class FunctionStatsGeneratorTest {
 
         metricsDataCompletableFuture.complete(metricsData);
         Runtime runtime = mock(Runtime.class);
-        doReturn(metricsDataCompletableFuture).when(runtime).getAndResetMetrics();
+        doReturn(metricsDataCompletableFuture).when(runtime).getMetrics();
 
         RuntimeSpawner runtimeSpawner = mock(RuntimeSpawner.class);
         doReturn(runtime).when(runtimeSpawner).getRuntime();


### PR DESCRIPTION
### Motivation

Right now, we have [metrics api](https://github.com/apache/incubator-pulsar/blob/master/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsMetricsResource.java#L48) which can be triggered by prometheus or monitoring system and it updates the metrics for functions. We also want a mechanism where
- function worker updates stats periodically and captures the metrics
- so, function metrics can be retrieved on demand by admin api eg: `pulsar-admin persistent stats <topic>` to check function metrics and same api can be used by monitoring system to capture metrics for functions.

### Modifications

- add task to update metrics periodically 
- capture and store one latest metrics-sample so, it can be retrieved on demand using admin-api

### Result

- we can build an admin-api to get function metrics on-demand.
Note: I will create a separate PR for admin-api to get function-metrics.
