### PR TITLE
Fix an Argument of Wget in Pulsar Functions Getting Started

### DIFF
--- a/site/docs/latest/functions/quickstart.md
+++ b/site/docs/latest/functions/quickstart.md
@@ -17,9 +17,9 @@ In order to follow along with this tutorial, you'll need to have [Maven](https:/
 In order to run our Pulsar Functions, we'll need to run a Pulsar cluster locally first. The easiest way to do that is to run Pulsar in {% popover standalone %} mode. Follow these steps to start up a standalone cluster:
 
 ```bash
-$ wget https://repository.apache.org/content/repositories/snapshots/org/apache/pulsar/distribution/2.0.0-incubating-SNAPSHOT/distribution-2.0.0-incubating-{{ site.preview_version_id }}-bin.tar.gz
-$ tar xvf distribution-2.0.0-incubating-{{ site.preview_version_id }}-bin.tar.gz
-$ cd apache-pulsar-2.0.0-incubating-SNAPSHOT
+$ wget 'https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=incubator/pulsar/pulsar-{{ site.current_version }}/apache-pulsar-{{ site.current_version }}-bin.tar.gz' -O apache-pulsar-{{ site.current_version }}-bin.tar.gz
+$ tar xvf apache-pulsar-{{ site.current_version }}-bin.tar.gz
+$ cd apache-pulsar-{{ site.current_version }}
 $ bin/pulsar standalone \
   --advertised-address 127.0.0.1
 ```


### PR DESCRIPTION
### Motivation

In https://pulsar.incubator.apache.org/docs/latest/functions/quickstart ,

```
wget https://repository.apache.org/content/repositories/snapshots/org/apache/pulsar/distribution/2.0.0-incubating-SNAPSHOT/distribution-2.0.0-incubating-20180426.125800-32-bin.tar.gz
```
is wrong.

This is executed, then it returns 404.

```
$ wget https://repository.apache.org/content/repositories/snapshots/org/apache/pulsar/distribution/2.0.0-incubating-SNAPSHOT/distribution-2.0.0-incubating-20180426.125800-32-bin.tar.gz
--2018-07-11 12:25:49--  https://repository.apache.org/content/repositories/snapshots/org/apache/pulsar/distribution/2.0.0-incubating-SNAPSHOT/distribution-2.0.0-incubating-20180426.125800-32-bin.tar.gz
Resolving repository.apache.org... 207.244.88.140
Connecting to repository.apache.org|207.244.88.140|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2018-07-11 12:25:50 ERROR 404: Not Found.
```

### Modifications

I changed `distribution-2.0.0-incubating-20180426.125800-32-bin.tar.gz` to binary release of current version .

After Modification:
```
wget 'https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=incubator/pulsar/pulsar-2.0.1-incubating/apache-pulsar-2.0.1-incubating-bin.tar.gz' -O apache-pulsar-2.0.1-incubating-bin.tar.gz
```

### Result

This modified command can be downloaded successfully.

```
$ wget 'https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=incubator/pulsar/pulsar-2.0.1-incubating/apache-pulsar-2.0.1-incubating-bin.tar.gz' -O apache-pulsar-2.0.1-incubating-bin.tar.gz
--2018-07-11 12:31:08--  https://www.apache.org/dyn/mirrors/mirrors.cgi?action=download&filename=incubator/pulsar/pulsar-2.0.1-incubating/apache-pulsar-2.0.1-incubating-bin.tar.gz
Resolving www.apache.org... 95.216.24.32, 40.79.78.1, 2a01:4f9:2a:185f::2
Connecting to www.apache.org|95.216.24.32|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: http://ftp.riken.jp/net/apache/incubator/pulsar/pulsar-2.0.1-incubating/apache-pulsar-2.0.1-incubating-bin.tar.gz [following]
--2018-07-11 12:31:11--  http://ftp.riken.jp/net/apache/incubator/pulsar/pulsar-2.0.1-incubating/apache-pulsar-2.0.1-incubating-bin.tar.gz
Resolving ftp.riken.jp... 134.160.38.1
Connecting to ftp.riken.jp|134.160.38.1|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 186527350 (178M) [application/x-gzip]
Saving to: “apache-pulsar-2.0.1-incubating-bin.tar.gz”

100%[==================================================================================================================================================================>] 186,527,350 57.9M/s   in 3.7s

2018-07-11 12:31:14 (48.2 MB/s) - “apache-pulsar-2.0.1-incubating-bin.tar.gz” saved [186527350/186527350]
```
And all sample codes of `Getting started with Pulsar Functions` can be executed successfully.
