### PR TITLE
Fix a few links in security pages

### DIFF
--- a/site/docs/latest/security/authorization.md
+++ b/site/docs/latest/security/authorization.md
@@ -24,11 +24,11 @@ tags: [admin, authentication, authorization, athenz, tls, java, cpp]
 
 -->
 
-In Pulsar, the [authentication provider](../../overview#authentication-providers) is charged with properly identifying clients and
-associating them with [role tokens](../../overview#role-tokens). *Authorization* is the process that determines *what* clients are able to do.
+In Pulsar, the [authentication provider](../overview#authentication-providers) is charged with properly identifying clients and
+associating them with [role tokens](../overview#role-tokens). *Authorization* is the process that determines *what* clients are able to do.
 
 Authorization in Pulsar is managed at the {% popover tenant %} level, which means that you can have multiple authorization schemes active
-in a single Pulsar instance. You could, for example, create a `shopping` tenant that has one set of [roles](../../overview#role-tokens)
+in a single Pulsar instance. You could, for example, create a `shopping` tenant that has one set of [roles](../overview#role-tokens)
 and applies to a shopping application used by your company, while an `inventory` tenant would be used only by an inventory application.
 
 {% include message.html id="properties_multiple_clusters" %}

--- a/site/docs/latest/security/extending.md
+++ b/site/docs/latest/security/extending.md
@@ -31,7 +31,7 @@ Pulsar provides a way to use custom authentication and authorization mechanisms
 ## Authentication
 
 Pulsar support mutual TLS and Athenz authentication plugins, and these can be used as described
-in [Security](../../overview).
+in [Security](../overview).
 
 It is possible to use a custom authentication mechanism by providing the implementation in the
 form of two plugins one for the Client library and the other for the Pulsar Broker to validate

--- a/site/docs/latest/security/tls.md
+++ b/site/docs/latest/security/tls.md
@@ -33,7 +33,7 @@ To encrypt communication, it is recommended to configure all the Apache Pulsar c
 
 TLS can be configured for encryption or authentication. You may configure just TLS encryption
 (by default TLS encryption includes certificate authentication of the server) and independently choose a separate mechanism
-for client authentication, e.g. TLS, [Athenz](../../athenz), etc. Note that TLS encryption, technically speaking, already enables
+for client authentication, e.g. TLS, [Athenz](../athenz), etc. Note that TLS encryption, technically speaking, already enables
 1-way authentication in which the client authenticates the server certificate. So when referring to TLS authentication, it is really
 referring to 2-way authentication in which the broker also authenticates the client certificate.
 
@@ -105,7 +105,7 @@ At this point, you should have a `broker-cert.pem` and `broker-key.pem` file. Th
 
 To create a client certificate, repeat the steps in the previous section, but did create `client-cert.pem` and `client-key.pem` files instead.
 
-For the client common name, you need to use a string that you intend to use as the [role token](#role-tokens) for this client, though it doesn't need to match the client hostname.
+For the client common name, you need to use a string that you intend to use as the [role token](../overview#role-tokens) for this client, though it doesn't need to match the client hostname.
 
 ## Configure the broker for TLS
 


### PR DESCRIPTION
*Motivation*

A few links use `../..` for locating pages in same `security` category, which are wrong.

*Solution*

Change `../..` to `..`

