### PR TITLE
Fixed mem leak when receiving unrecoverable fencing errors in managed ledger

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -1327,7 +1327,6 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
     void clearPendingAddEntries(ManagedLedgerException e) {
         while (!pendingAddEntries.isEmpty()) {
             OpAddEntry op = pendingAddEntries.poll();
-            op.data.release();
             op.failed(e);
         }
     }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/OpAddEntry.java
@@ -96,6 +96,7 @@ class OpAddEntry extends SafeRunnable implements AddCallback, CloseCallback {
 
     public void failed(ManagedLedgerException e) {
         AddEntryCallback cb = callbackUpdater.getAndSet(this, null);
+        data.release();
         if (cb != null) {
             cb.addFailed(e, ctx);
             ml.mbean.recordAddEntryError();


### PR DESCRIPTION
### Motivation

In the code handling the fenced and terminated exception, we are calling `OpAddEntry` but the `op.data.release()` was not being invoked. 

### Modifications

Moved `op.data.release()` into `OpAddEntry.failed()`