### PR TITLE
Fix a command in Pulsar Function overview Document

### DIFF
--- a/site/docs/latest/functions/overview.md
+++ b/site/docs/latest/functions/overview.md
@@ -144,7 +144,7 @@ class RoutingFunction(Function):
 Pulsar Functions are managed using the [`pulsar-admin`](../../reference/CliTools#pulsar-admin) CLI tool (in particular the [`functions`](../../reference/CliTools#pulsar-admin-functions) command). Here's an example command that would run a function in [local run mode](#local-run):
 
 ```bash
-$ bin/pulsar-functions localrun \
+$ bin/pulsar-admin functions localrun \
   --inputs persistent://public/default/test_src \
   --output persistent://public/default/test_result \
   --jar examples/api-examples.jar \


### PR DESCRIPTION
### Motivation

In https://pulsar.incubator.apache.org/docs/latest/functions/overview/

```
$ bin/pulsar-functions localrun \
  --inputs persistent://public/default/test_src \
  --output persistent://public/default/test_result \
  --jar examples/api-examples.jar \
  --className org.apache.pulsar.functions.api.examples.ExclamationFunction
```

cannot run because `pulsar-functions` is not in bin.

```
-bash: bin/pulsar-functions: No such file or directory
```


### Modifications

I changed `pulsar-function` to `pulsar-admin functions`.

```
$ bin/pulsar-admin functions localrun \
   --inputs persistent://public/default/test_src \
   --output persistent://public/default/test_result \
   --jar examples/api-examples.jar \
   --className org.apache.pulsar.functions.api.examples.ExclamationFunction
```

### Result

We can run the process.