### PR TITLE
 bin/bookkeeper doesn't output the result to the console

### DIFF
--- a/bin/bookkeeper
+++ b/bin/bookkeeper
@@ -175,6 +175,7 @@ BOOKIE_LOG_FILE=${BOOKIE_LOG_FILE:-"bookkeeper-server.log"}
 
 #Configure log configuration system properties
 OPTS="$OPTS -Dpulsar.log.appender=$BOOKIE_LOG_APPENDER"
+OPTS="$OPTS -Dbk.log.appender=$BOOKIE_LOG_APPENDER"
 OPTS="$OPTS -Dbookkeeper.log.dir=$BOOKIE_LOG_DIR"
 OPTS="$OPTS -Dbookkeeper.log.file=$BOOKIE_LOG_FILE"
 

--- a/bin/bookkeeper
+++ b/bin/bookkeeper
@@ -176,8 +176,9 @@ BOOKIE_LOG_FILE=${BOOKIE_LOG_FILE:-"bookkeeper-server.log"}
 #Configure log configuration system properties
 OPTS="$OPTS -Dpulsar.log.appender=$BOOKIE_LOG_APPENDER"
 OPTS="$OPTS -Dbk.log.appender=$BOOKIE_LOG_APPENDER"
-OPTS="$OPTS -Dbookkeeper.log.dir=$BOOKIE_LOG_DIR"
-OPTS="$OPTS -Dbookkeeper.log.file=$BOOKIE_LOG_FILE"
+OPTS="$OPTS -Dbk.log.level=error"
+OPTS="$OPTS -Dpulsar.log.dir=$BOOKIE_LOG_DIR"
+OPTS="$OPTS -Dpulsar.log.file=$BOOKIE_LOG_FILE"
 
 #Change to BK_HOME to support relative paths
 cd "$BK_HOME"

--- a/conf/log4j2.yaml
+++ b/conf/log4j2.yaml
@@ -167,6 +167,12 @@ Configuration:
           level: "${sys:pulsar.log.level}"
 
     Logger:
+      - name: org.apache.bookkeeper.bookie.BookieShell
+        level: info
+        additivity: false
+        AppenderRef:
+          - ref: Console
+
       - name: org.apache.bookkeeper
         level: "${sys:bk.log.level}"
         additivity: false
@@ -177,10 +183,16 @@ Configuration:
         level: "${sys:bk.log.level}"
         additivity: false
         AppenderRef:
-          - ref: BkRollingFile
+          - ref: "${sys:bk.log.appender}"
+
+      - name: org.apache.zookeeper
+        level: "${sys:bk.log.level}"
+        additivity: false
+        AppenderRef:
+          - ref: "${sys:bk.log.appender}"
 
       - name: verbose
-        level: "${sys:bk.log.level}"
+        level: info
         additivity: false
         AppenderRef:
           - ref: Console

--- a/conf/log4j2.yaml
+++ b/conf/log4j2.yaml
@@ -37,6 +37,8 @@ Configuration:
         value: "Console"
       - name: "bk.log.level"
         value: "info"
+      - name: "bk.log.appender"
+        value: "BkRollingFile"
 
   # Example: logger-filter script
   Scripts:
@@ -169,13 +171,19 @@ Configuration:
         level: "${sys:bk.log.level}"
         additivity: false
         AppenderRef:
-          - ref: BkRollingFile
+          - ref: "${sys:bk.log.appender}"
 
       - name: org.apache.distributedlog
         level: "${sys:bk.log.level}"
         additivity: false
         AppenderRef:
           - ref: BkRollingFile
+
+      - name: verbose
+        level: "${sys:bk.log.level}"
+        additivity: false
+        AppenderRef:
+          - ref: Console
     
     # Logger to inject filter script
 #     - name: org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl


### PR DESCRIPTION
### Motivation

the change from log4j to log4j2 in 2.0 changes the logging behavior for `bin/bookkeeper`. some of the results of BookieShell is not showed up in Console, and other loggings (e.g. zookeeper) are showed up.

### Modifications

- add a logger for `BookieShell` and set its log level to INFO and appender to Console.
- make other loggers parameterized. and turn them off in `bin/bookkeeper`

### Result

This achieves the same behavior as in 1.2x releases.
