### PR TITLE
Add a new docker image to include all pulsar io connectors

### DIFF
--- a/distribution/io/pom.xml
+++ b/distribution/io/pom.xml
@@ -53,7 +53,7 @@
               <goal>single</goal>
             </goals>
             <configuration>
-              <attach>false</attach>
+              <attach>true</attach>
               <tarLongFileMode>posix</tarLongFileMode>
               <finalName>apache-pulsar-io-connectors-${project.version}</finalName>
               <descriptors>

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -37,5 +37,6 @@
   <modules>
     <module>pulsar</module>
     <module>grafana</module>
+    <module>pulsar-all</module>
   </modules>
 </project>

--- a/docker/pulsar-all/Dockerfile
+++ b/docker/pulsar-all/Dockerfile
@@ -22,4 +22,4 @@ FROM apachepulsar/pulsar:latest
 ARG PULSAR_IO_TARBALL
 
 ADD ${PULSAR_IO_TARBALL} /
-RUN mv /apache-pulsar-io-connectors-* /pulsar/io
+RUN mv /apache-pulsar-io-connectors-*/connectors /pulsar/connectors

--- a/docker/pulsar-all/Dockerfile
+++ b/docker/pulsar-all/Dockerfile
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+FROM apachepulsar/pulsar:latest
+
+ARG PULSAR_IO_TARBALL
+
+ADD ${PULSAR_IO_TARBALL} /
+RUN mv /apache-pulsar-io-connectors-* /pulsar/io

--- a/docker/pulsar-all/pom.xml
+++ b/docker/pulsar-all/pom.xml
@@ -1,0 +1,110 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.apache.pulsar</groupId>
+    <artifactId>docker-images</artifactId>
+    <version>2.2.0-incubating-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.pulsar</groupId>
+  <artifactId>pulsar-all-docker-image</artifactId>
+  <name>Apache Pulsar :: Docker Images :: Pulsar Latest Version (Include All Components)</name>
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.pulsar</groupId>
+      <artifactId>pulsar-io-distribution</artifactId>
+      <version>${project.parent.version}</version>
+      <classifier>bin</classifier>
+      <type>tar.gz</type>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pulsar</groupId>
+      <artifactId>pulsar-docker-image</artifactId>
+      <version>${project.parent.version}</version>
+      <classifier>docker-info</classifier>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>docker</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>copy-io-tarball</id>
+                <goals>
+                  <goal>copy-dependencies</goal>
+                </goals>
+                <phase>generate-resources</phase>
+                <configuration>
+                  <outputDirectory>${project.build.directory}/</outputDirectory>
+                  <includeArtifactIds>pulsar-io-distribution</includeArtifactIds>
+                  <excludeTransitive>true</excludeTransitive>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>dockerfile-maven-plugin</artifactId>
+            <version>${dockerfile-maven.version}</version>
+            <executions>
+              <execution>
+                <id>default</id>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>tag-and-push-latest</id>
+                <goals>
+                  <goal>tag</goal>
+                  <goal>push</goal>
+                </goals>
+                <configuration>
+                  <repository>${docker.organization}/pulsar-all</repository>
+                  <tag>latest</tag>
+                </configuration>
+              </execution>
+            </executions>
+            <configuration>
+              <repository>${docker.organization}/pulsar-all</repository>
+              <pullNewerImage>false</pullNewerImage>
+              <tag>${project.version}</tag>
+              <buildArgs>
+                <PULSAR_IO_TARBALL>target/pulsar-io-distribution-${project.version}-bin.tar.gz</PULSAR_IO_TARBALL>
+              </buildArgs>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/docker/pulsar-all/pom.xml
+++ b/docker/pulsar-all/pom.xml
@@ -40,17 +40,20 @@
       <type>tar.gz</type>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.pulsar</groupId>
-      <artifactId>pulsar-docker-image</artifactId>
-      <version>${project.parent.version}</version>
-      <classifier>docker-info</classifier>
-    </dependency>
   </dependencies>
 
   <profiles>
     <profile>
       <id>docker</id>
+      <!-- include the docker image only when docker profile is active -->
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.pulsar</groupId>
+          <artifactId>pulsar-docker-image</artifactId>
+          <version>${project.parent.version}</version>
+          <classifier>docker-info</classifier>
+        </dependency>
+      </dependencies>
       <build>
         <plugins>
           <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -97,8 +97,6 @@ flexible messaging model and an intuitive client API.</description>
     <module>pulsar-client-auth-athenz</module>
     <module>pulsar-client-kafka-compat</module>
     <module>pulsar-zookeeper</module>
-    <module>docker</module>
-    <module>tests</module>
     <module>pulsar-log4j2-appender</module>
     <module>protobuf-shaded</module>
 
@@ -108,7 +106,10 @@ flexible messaging model and an intuitive client API.</description>
     <!-- connector-related modules -->
     <module>pulsar-io</module>
 
+    <!-- all these 3 modules should be put at the end in this exact sequence -->
     <module>distribution</module>
+    <module>docker</module>
+    <module>tests</module>
   </modules>
 
   <issueManagement>

--- a/tests/docker-images/latest-version-image/Dockerfile
+++ b/tests/docker-images/latest-version-image/Dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-FROM apachepulsar/pulsar:latest
+FROM apachepulsar/pulsar-all:latest
 
 RUN apt-get update && apt-get install -y supervisor python-pip
 

--- a/tests/docker-images/latest-version-image/pom.xml
+++ b/tests/docker-images/latest-version-image/pom.xml
@@ -42,7 +42,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.pulsar</groupId>
-          <artifactId>pulsar-docker-image</artifactId>
+          <artifactId>pulsar-all-docker-image</artifactId>
           <version>${project.parent.version}</version>
           <classifier>docker-info</classifier>
         </dependency>


### PR DESCRIPTION
*Motivation*

We shipped two distributions : server & io-connectors. For people who
run pulsar in docker, we need to put all the built-in connectors into
the docker, so that all built-in connectors are available to be used.

*Solution*

Introduce a `pulsar-all` image to include built-in connectors.

Named it as `pulsar-all` to allow include more pluggable components later, for example, offloaders.

