### PR TITLE
fix: conflicting jackson transitive dependency for worker

### DIFF
--- a/pulsar-functions/worker/pom.xml
+++ b/pulsar-functions/worker/pom.xml
@@ -101,12 +101,21 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
-    
-     <dependency>
+     
+    <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.dataformat</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
-    
 
   </dependencies>
 


### PR DESCRIPTION
### Motivation

Right now, swager-io brings  incompatible old-version transitive jackson dependencies which causes exception while using jackson dependencies:
![snip20180713_1](https://user-images.githubusercontent.com/2898254/42713804-949802ec-86a5-11e8-88e6-4774d61a4e7c.png)

```
@400000005b490d5d1a0d4214       at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:210)
@400000005b490d5d1a0dedf4       at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:177)
@400000005b490d5d1a0ead5c       at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.wrapAndThrow(BeanDeserializerBase.java:1428)
@400000005b490d5d1a0f5d24       at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:240)
@400000005b490d5d1a10051c       at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:118)
@400000005b490d5d1a10ad14       at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:3066)
@400000005b490d5d1a1160c4       at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2115)
@400000005b490d5d1a12473c       at org.apache.pulsar.functions.worker.WorkerConfig.load(WorkerConfig.java:115)
@400000005b490d5d1a1325e4       at org.apache.pulsar.functions.worker.FunctionWorkerStarter.main(FunctionWorkerStarter.java:59)
```

### Modifications

Exclude jackson transitive dependencies from swagger-io.

