### PR TITLE
If auth is badly configured in c++, close the connection

### DIFF
--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -160,6 +160,12 @@ ClientConnection::ClientConnection(const std::string& logicalAddress, const std:
             }
         }
 
+        if (!authentication_) {
+          LOG_ERROR("Invalid authentication plugin");
+          close();
+          return;
+        }
+
         AuthenticationDataPtr authData;
         if (authentication_->getAuthData(authData) == ResultOk && authData->hasDataForTls()) {
             std::string tlsCertificates = authData->getTlsCertificates();
@@ -354,6 +360,10 @@ void ClientConnection::handleSentPulsarConnect(const boost::system::error_code& 
  *
  */
 void ClientConnection::tcpConnectAsync() {
+    if (isClosed()) {
+        return;
+    }
+
     boost::system::error_code err;
     Url service_url;
     if (!Url::parse(physicalAddress_, service_url)) {

--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -161,9 +161,9 @@ ClientConnection::ClientConnection(const std::string& logicalAddress, const std:
         }
 
         if (!authentication_) {
-          LOG_ERROR("Invalid authentication plugin");
-          close();
-          return;
+            LOG_ERROR("Invalid authentication plugin");
+            close();
+            return;
         }
 
         AuthenticationDataPtr authData;

--- a/pulsar-client-cpp/python/pulsar_test.py
+++ b/pulsar-client-cpp/python/pulsar_test.py
@@ -24,7 +24,7 @@ import time
 import os
 from pulsar import Client, MessageId, \
             CompressionType, ConsumerType, PartitionsRoutingMode, \
-            AuthenticationTLS
+            AuthenticationTLS, Authentication
 
 from _pulsar import ProducerConfiguration, ConsumerConfiguration
 
@@ -151,6 +151,23 @@ class PulsarTest(TestCase):
             pass  # Exception is expected
 
         client.close()
+
+    def test_auth_junk_params(self):
+        certs_dir = '/pulsar/pulsar-broker/src/test/resources/authentication/tls/'
+        if not os.path.exists(certs_dir):
+            certs_dir = "../../pulsar-broker/src/test/resources/authentication/tls/"
+        authPlugin = "someoldjunk.so"
+        authParams = "blah"
+        client = Client(self.serviceUrlTls,
+                        tls_trust_certs_file_path=certs_dir + 'cacert.pem',
+                        tls_allow_insecure_connection=False,
+                        authentication=Authentication(authPlugin, authParams))
+        try:
+            client.subscribe('persistent://property/cluster/namespace/my-python-topic-producer-consumer',
+                             'my-sub',
+                             consumer_type=ConsumerType.Shared)
+        except:
+            pass  # Exception is expected
 
     def test_message_listener(self):
         client = Client(self.serviceUrl)


### PR DESCRIPTION
This patch fixes a segfault where, if auth was badly configured,
resulting in a null authentication pointer, the client would still try
to use it to connect, and as a result, segfault.

The patch adds a null check on the authentication object, and a check
that the connection object is still valid before initialization of the
tcp channel.
