### PR TITLE
Removed GPL deps on gnu crypto from aerospike connector

### DIFF
--- a/pulsar-io/aerospike/pom.xml
+++ b/pulsar-io/aerospike/pom.xml
@@ -52,6 +52,12 @@
       <groupId>com.aerospike</groupId>
       <artifactId>aerospike-client</artifactId>
       <version>${aerospike-client.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.gnu</groupId>
+          <artifactId>gnu-crypto</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
### Motivation

There's an optional dependency on gnu-crypto for aerospike connector. We need to remove it to avoid license issue at release.