### PR TITLE
V2 doc changes

### DIFF
--- a/site/docs/latest/admin-api/brokers.md
+++ b/site/docs/latest/admin-api/brokers.md
@@ -59,7 +59,7 @@ broker1.use.org.com:8080
 
 ###### REST
 
-{% endpoint GET /admin/brokers/:cluster %}
+{% endpoint GET /admin/v2/brokers/:cluster %}
 
 [More info](../../reference/RestApi#/admin/brokers/:cluster)
 
@@ -91,7 +91,7 @@ $ pulsar-admin brokers namespaces use \
 ```
 ###### REST
 
-{% endpoint GET /admin/brokers/:cluster/:broker:/ownedNamespaces %}
+{% endpoint GET /admin/v2/brokers/:cluster/:broker:/ownedNamespaces %}
 
 ###### Java
 
@@ -120,7 +120,7 @@ $ pulsar-admin brokers update-dynamic-config brokerShutdownTimeoutMs 100
 
 #### REST API
 
-{% endpoint POST /admin/brokers/configuration/:configName/:configValue %}
+{% endpoint POST /admin/v2/brokers/configuration/:configName/:configValue %}
 
 [More info](../../reference/RestApi#/admin/brokers/configuration/:configName/:configValue)
 
@@ -143,7 +143,7 @@ brokerShutdownTimeoutMs
 
 #### REST API
 
-{% endpoint GET /admin/brokers/configuration %}
+{% endpoint GET /admin/v2/brokers/configuration %}
 
 [More info](../../reference/RestApi#/admin/brokers/configuration)
 
@@ -166,7 +166,7 @@ brokerShutdownTimeoutMs:100
 
 #### REST API
 
-{% endpoint GET /admin/brokers/configuration/values %}
+{% endpoint GET /admin/v2/brokers/configuration/values %}
 
 [More info](../../reference/RestApi#/admin/brokers/configuration/values)
 

--- a/site/docs/latest/clients/WebSocket.md
+++ b/site/docs/latest/clients/WebSocket.md
@@ -79,7 +79,7 @@ All exchanges via the WebSocket API use JSON.
 
 The producer endpoint requires you to specify a {% popover tenant %}, {% popover namespace %}, and {% popover topic %} in the URL:
 
-{% endpoint ws://broker-service-url:8080/ws/producer/persistent/:tenant/:namespace/:topic %}
+{% endpoint ws://broker-service-url:8080/ws/v2/producer/persistent/:tenant/:namespace/:topic %}
 
 ##### Query param
 
@@ -146,7 +146,7 @@ Key | Type | Required? | Explanation
 
 The consumer endpoint requires you to specify a {% popover tenant %}, {% popover namespace %}, and {% popover topic %}, as well as a {% popover subscription %}, in the URL:
 
-{% endpoint ws://broker-service-url:8080/ws/consumer/persistent/:tenant/:namespace/:topic/:subscription %}
+{% endpoint ws://broker-service-url:8080/ws/v2/consumer/persistent/:tenant/:namespace/:topic/:subscription %}
 
 ##### Query param
 
@@ -199,7 +199,7 @@ Key | Type | Required? | Explanation
 
 The reader endpoint requires you to specify a {% popover tenant %}, {% popover namespace %}, and {% popover topic %} in the URL:
 
-{% endpoint ws://broker-service-url:8080/ws/reader/persistent/:tenant/:namespace/:topic %}
+{% endpoint ws://broker-service-url:8080/ws/v2/reader/persistent/:tenant/:namespace/:topic %}
 
 ##### Query param
 
@@ -286,7 +286,7 @@ Here's an example Python {% popover producer %} that sends a simple message to a
 ```python
 import websocket, base64, json
 
-TOPIC = 'ws://localhost:8080/ws/producer/persistent/public/default/my-topic'
+TOPIC = 'ws://localhost:8080/ws/v2/producer/persistent/public/default/my-topic'
 
 ws = websocket.create_connection(TOPIC)
 
@@ -315,7 +315,7 @@ Here's an example Python {% popover consumer %} that listens on a Pulsar {% popo
 ```python
 import websocket, base64, json
 
-TOPIC = 'ws://localhost:8080/ws/consumer/persistent/public/default/my-topic/my-sub'
+TOPIC = 'ws://localhost:8080/ws/v2/consumer/persistent/public/default/my-topic/my-sub'
 
 ws = websocket.create_connection(TOPIC)
 
@@ -338,7 +338,7 @@ Here's an example Python reader that listens on a Pulsar {% popover topic %} and
 ```python
 import websocket, base64, json
 
-TOPIC = 'ws://localhost:8080/ws/reader/persistent/public/default/my-topic'
+TOPIC = 'ws://localhost:8080/ws/v2/reader/persistent/public/default/my-topic'
 
 ws = websocket.create_connection(TOPIC)
 
@@ -368,7 +368,7 @@ Here's an example Node.js {% popover producer %} that sends a simple message to 
 
 ```javascript
 var WebSocket = require('ws'),
-    topic = "ws://localhost:8080/ws/producer/persistent/my-tenant/my-ns/my-topic1",
+    topic = "ws://localhost:8080/ws/v2/producer/persistent/my-tenant/my-ns/my-topic1",
     ws = new WebSocket(topic);
 
 var message = {
@@ -396,7 +396,7 @@ Here's an example Node.js {% popover consumer %} that listens on the same topic 
 
 ```javascript
 var WebSocket = require('ws'),
-    topic = "ws://localhost:8080/ws/consumer/persistent/my-tenant/my-ns/my-topic1/my-sub",
+    topic = "ws://localhost:8080/ws/v2/consumer/persistent/my-tenant/my-ns/my-topic1/my-sub",
     ws = new WebSocket(topic);
 
 ws.on('message', function(message) {
@@ -410,7 +410,7 @@ ws.on('message', function(message) {
 #### NodeJS reader
 ```javascript
 var WebSocket = require('ws'),
-    topic = "ws://localhost:8080/ws/reader/persistent/my-tenant/my-ns/my-topic1",
+    topic = "ws://localhost:8080/ws/v2/reader/persistent/my-tenant/my-ns/my-topic1",
     ws = new WebSocket(topic);
 
 ws.on('message', function(message) {


### PR DESCRIPTION
Apparently we've forgotten to add some v2s to the URLs.

NOTE: I think there will be more changes needed.   Also - should we note the availability of v1 of the API somewhere?

### Motivation

Docs are missing critical v2 URL component for APIs!

### Modifications

Add v2 to a bunch of URLs.

### Result

Docs will be more accurate.
