### PR TITLE
Don't dirty the tree when building in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,4 +64,6 @@ pulsar-client-cpp/python/pkg/osx/**/*.whl
 pulsar-client-cpp/python/pkg/osx/**/*.template2
 pulsar-client-cpp/python/wheelhouse
 
-
+# CI generated files
+.repository
+docker.debug-info


### PR DESCRIPTION
When we build a package, mvn inserts the sha of the commit we are
building from into the tarball. If there have been any changes to the
work tree, it will add the suffix "(dirty)".

CI makes a couple of modifications to the worktree. It creates its own
.repository for maven artifacts. And it create a docker debugging
logfile.

This patch adds these to .gitignore so that they won't be picked up by
git status and won't cause the tree to be 'dirty'.

