### PR TITLE
Inherit I/O streams in functions process runtime

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntime.java
@@ -415,7 +415,7 @@ class ProcessRuntime implements Runtime {
     private void startProcess() {
         deathException = null;
         try {
-            ProcessBuilder processBuilder = new ProcessBuilder(processArgs);
+            ProcessBuilder processBuilder = new ProcessBuilder(processArgs).inheritIO();
             log.info("ProcessBuilder starting the process with args {}", String.join(" ", processBuilder.command()));
             process = processBuilder.start();
         } catch (Exception ex) {


### PR DESCRIPTION
When running processes with the local runner, the output to stderr and
stdout go nowhere. This makes it hard to debug startup issues.

This patch modifies the process runtime to make the child process
inherit the streams from the parent process, so the output will be
visible to the runner.
