### PR TITLE
Issue 2121: Improve logging around "Namespace not served by this instance"

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -934,8 +934,8 @@ public class BrokerService implements Closeable, ZooKeeperCacheListener<Policies
         }
 
         if (!ownedByThisInstance) {
-            String msg = String.format("Namespace not served by this instance. Please redo the lookup. "
-                    + "Request is denied: namespace=%s", topicName.getNamespace());
+            String msg = String.format("Namespace bundle for topic (%s) not served by this instance. Please redo the lookup. "
+                    + "Request is denied: namespace=%s", topic, topicName.getNamespace());
             log.warn(msg);
             throw new RuntimeException(new ServiceUnitNotReadyException(msg));
         }


### PR DESCRIPTION


 ### Motivation

Fixes #2121. Improve the logging around "namespace not served by this instance" to make things clearer.

 ### Changes

Improve the logging to say "namespace bundle for topic not served by", rahter than "namespace not served by"

