### PR TITLE
Clean up sidebar menu under `Deployment`

### DIFF
--- a/site/_data/sidebar.yaml
+++ b/site/_data/sidebar.yaml
@@ -69,10 +69,6 @@ groups:
     endpoint: instance
   - title: Pulsar on Kubernetes
     endpoint: Kubernetes
-  - title: Pulsar on Google Kubernetes Engine
-    endpoint: Kubernetes/#pulsar-on-google-kubernetes-engine
-  - title: Pulsar on AWS
-    endpoint: Kubernetes/#pulsar-on-amazon-web-services
   - title: Pulsar on DC/OS
     endpoint: dcos
   - title: Monitoring


### PR DESCRIPTION
*Motivation*

There's "Deploy on Amazon Web Services" and "Pulsar on AWS" in the deployment section of the site. These are confused.

*Changes*

Remove sub-sections of "kubernetes" deployment from sidebard and only leave "Pulsar on Kubernetes" there.