### PR TITLE
Rename Netty native libs to reflect shading prefix

### DIFF
--- a/pulsar-broker-shaded/pom.xml
+++ b/pulsar-broker-shaded/pom.xml
@@ -345,6 +345,30 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <!-- This plugin is used to run a script after the package phase in order to rename
+            libnetty_transport_native_epoll_x86_64.so from Netty into
+            liborg_apache_pulsar_shade_netty_transport_native_epoll_x86_64.so
+            to reflect the shade that is being applied.
+         -->
+        <artifactId>exec-maven-plugin</artifactId>
+        <groupId>org.codehaus.mojo</groupId>
+        <executions>
+          <execution>
+            <id>rename-epoll-library</id>
+            <phase>package</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>${project.parent.basedir}/src/rename-netty-native-libs.sh</executable>
+              <arguments>
+                <argument>${project.artifactId}</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pulsar-client-kafka-compat/pulsar-client-kafka-shaded/pom.xml
+++ b/pulsar-client-kafka-compat/pulsar-client-kafka-shaded/pom.xml
@@ -223,6 +223,30 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <!-- This plugin is used to run a script after the package phase in order to rename
+            libnetty_transport_native_epoll_x86_64.so from Netty into
+            liborg_apache_pulsar_shade_netty_transport_native_epoll_x86_64.so
+            to reflect the shade that is being applied.
+         -->
+        <artifactId>exec-maven-plugin</artifactId>
+        <groupId>org.codehaus.mojo</groupId>
+        <executions>
+          <execution>
+            <id>rename-epoll-library</id>
+            <phase>package</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>${project.parent.basedir}/../src/rename-netty-native-libs.sh</executable>
+              <arguments>
+                <argument>${project.artifactId}</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pulsar-client-shaded/pom.xml
+++ b/pulsar-client-shaded/pom.xml
@@ -207,6 +207,31 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <!-- This plugin is used to run a script after the package phase in order to rename
+            libnetty_transport_native_epoll_x86_64.so from Netty into
+            liborg_apache_pulsar_shade_netty_transport_native_epoll_x86_64.so
+            to reflect the shade that is being applied.
+         -->
+        <artifactId>exec-maven-plugin</artifactId>
+        <groupId>org.codehaus.mojo</groupId>
+        <executions>
+          <execution>
+            <id>rename-epoll-library</id>
+            <phase>package</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>${project.parent.basedir}/src/rename-netty-native-libs.sh</executable>
+              <arguments>
+                <argument>${project.artifactId}</argument>
+              </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/src/rename-netty-native-libs.sh
+++ b/src/rename-netty-native-libs.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+set -e
+
+ARTIFACT_ID=$1
+JAR_PATH="$PWD/target/$ARTIFACT_ID.jar"
+
+FILE_PREFIX='META-INF/native'
+
+FILES_TO_RENAME=(
+    'libnetty_transport_native_epoll_x86_64.so liborg_apache_pulsar_shade_netty_transport_native_epoll_x86_64.so'
+    'libnetty_tcnative_linux_x86_64.so liborg_apache_pulsar_shade_netty_tcnative_linux_x86_64.so'
+)
+
+echo "----- Renaming epoll lib in $JAR_PATH ------"
+TMP_DIR=`mktemp -d`
+unzip -q $JAR_PATH -d $TMP_DIR
+
+pushd $TMP_DIR
+
+for line in "${FILES_TO_RENAME[@]}"; do
+    read -r -a A <<< "$line"
+    FROM=${A[0]}
+    TO=${A[1]}
+
+    if [ -f $FILE_PREFIX/$FROM ]; then
+        echo "Renaming $FROM -> $TO"
+        mv $FILE_PREFIX/$FROM $FILE_PREFIX/$TO
+    fi
+done
+
+# Overwrite the original ZIP archive
+zip -q -r $JAR_PATH .
+popd
+
+rm -rf $TMP_DIR


### PR DESCRIPTION
### Motivation

When using shaded artifacts, the Netty epoll and OpenSSL libraries are not being loaded correctly and it falls back to Java based implementations. 

The problem is that when the Java classes are shaded, Netty expects the native library also to be prefixed with the same name.

Since there is no easy way to do the renaming in Maven itself, I've added here a bash script that gets executed before the install phase.