### PR TITLE
unshade avro in pulsar-client-schema

### DIFF
--- a/pulsar-client-schema/pom.xml
+++ b/pulsar-client-schema/pom.xml
@@ -169,6 +169,14 @@
                                     <include>org.objenesis:*</include>
                                     <include>org.yaml:snakeyaml</include>
 
+                                    <include>org.apache.avro:*</include>
+                                    <!-- Avro transitive dependencies-->
+                                    <include>org.codehaus.jackson:jackson-core-asl</include>
+                                    <include>org.codehaus.jackson:jackson-mapper-asl</include>
+                                    <include>com.thoughtworks.paranamer:paranamer</include>
+                                    <include>org.xerial.snappy:snappy-java</include>
+                                    <include>org.apache.commons:commons-compress</include>
+                                    <include>org.tukaani:xz</include>
                                 </includes>
                             </artifactSet>
                             <filters>
@@ -279,6 +287,39 @@
                                 <relocation>
                                     <pattern>org.reactivestreams</pattern>
                                     <shadedPattern>org.apache.pulsar.shade.org.reactivestreams</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.avro</pattern>
+                                    <shadedPattern>org.apache.pulsar.shade.org.apache.avro</shadedPattern>
+                                    <excludes>
+                                        <exclude>org.apache.avro.reflect.AvroAlias</exclude>
+                                        <exclude>org.apache.avro.reflect.AvroDefault</exclude>
+                                        <exclude>org.apache.avro.reflect.AvroEncode</exclude>
+                                        <exclude>org.apache.avro.reflect.AvroIgnore</exclude>
+                                        <exclude>org.apache.avro.reflect.AvroMeta</exclude>
+                                        <exclude>org.apache.avro.reflect.AvroName</exclude>
+                                        <exclude>org.apache.avro.reflect.AvroSchema</exclude>
+                                        <exclude>org.apache.avro.reflect.Nullable</exclude>
+                                        <exclude>org.apache.avro.reflect.Stringable</exclude>
+                                        <exclude>org.apache.avro.reflect.Union</exclude>
+                                    </excludes>
+                                </relocation>
+                                 <!--Avro transitive dependencies-->
+                                <relocation>
+                                    <pattern>org.codehaus.jackson</pattern>
+                                    <shadedPattern>org.apache.pulsar.shade.org.codehaus.jackson</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.thoughtworks.paranamer</pattern>
+                                    <shadedPattern>org.apache.pulsar.shade.com.thoughtworks.paranamer</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.xerial.snappy</pattern>
+                                    <shadedPattern>org.apache.pulsar.shade.org.xerial.snappy</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.tukaani</pattern>
+                                    <shadedPattern>org.apache.pulsar.shade.org.tukaani</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>io.grpc</pattern>

--- a/pulsar-client-schema/pom.xml
+++ b/pulsar-client-schema/pom.xml
@@ -50,6 +50,12 @@
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
             <version>${avro.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -163,14 +169,6 @@
                                     <include>org.objenesis:*</include>
                                     <include>org.yaml:snakeyaml</include>
 
-                                    <include>org.apache.avro:*</include>
-                                    <!-- Avro transitive dependencies-->
-                                    <include>org.codehaus.jackson:jackson-core-asl</include>
-                                    <include>org.codehaus.jackson:jackson-mapper-asl</include>
-                                    <include>com.thoughtworks.paranamer:paranamer</include>
-                                    <include>org.xerial.snappy:snappy-java</include>
-                                    <include>org.apache.commons:commons-compress</include>
-                                    <include>org.tukaani:xz</include>
                                 </includes>
                             </artifactSet>
                             <filters>
@@ -281,27 +279,6 @@
                                 <relocation>
                                     <pattern>org.reactivestreams</pattern>
                                     <shadedPattern>org.apache.pulsar.shade.org.reactivestreams</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.apache.avro</pattern>
-                                    <shadedPattern>org.apache.pulsar.shade.org.apache.avro</shadedPattern>
-                                </relocation>
-                                <!-- Avro transitive dependencies-->
-                                <relocation>
-                                    <pattern>org.codehaus.jackson</pattern>
-                                    <shadedPattern>org.apache.pulsar.shade.org.codehaus.jackson</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>com.thoughtworks.paranamer</pattern>
-                                    <shadedPattern>org.apache.pulsar.shade.com.thoughtworks.paranamer</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.xerial.snappy</pattern>
-                                    <shadedPattern>org.apache.pulsar.shade.org.xerial.snappy</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.tukaani</pattern>
-                                    <shadedPattern>org.apache.pulsar.shade.org.tukaani</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>io.grpc</pattern>

--- a/pulsar-client-schema/pom.xml
+++ b/pulsar-client-schema/pom.xml
@@ -50,12 +50,6 @@
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
             <version>${avro.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-compress</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### Motivation

If users want to use Avro annotations with their POJOs, currently they would have to use the our shaded version of avro because we shade avro which is not the best user experience.  Ideally they should just use the original avro annotations

For example users want to something like this:
@org.apache.avro.reflect.AvroSchema(“{ \“type\“: \“long\“, \“logicalType\“: \“timestamp-millis\” }“)
       private long date;

but since we shade avro the user would need to specify like this:
@org.apache.pulsar.shade.org.apache.avro.reflect.AvroSchema(“{ \“type\“: \“long\“, \“logicalType\“: \“timestamp-millis\” }“)
       private long date;

### Modifications
Unshade avro in pulsar-client-schema
