### PR TITLE
attach shaded artifact while deploying to maven-repo

### DIFF
--- a/pulsar-functions/runtime-all/pom.xml
+++ b/pulsar-functions/runtime-all/pom.xml
@@ -75,6 +75,7 @@
             <configuration>
               <finalName>java-instance</finalName>
               <minimizeJar>false</minimizeJar>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                 <transformer implementation="org.apache.maven.plugins.shade.resource.PluginXmlResourceTransformer" />


### PR DESCRIPTION
### Motivation

we have jenkins job with maven3.1 which doesn't upload shaded `java-instance.jar` on `mvn deploy` but with `<shadedArtifactAttached>true</shadedArtifactAttached>` it does upload `pulsar-functions-runtime-all` artifact with classifier `shaded` which can be downloaded while building function-package.

### Modifications

Attach shaded artifact for `pulsar-functions-runtime-all`

