### PR TITLE
Issue #2204: support v2 namespace in cpp client

### DIFF
--- a/pulsar-client-cpp/lib/NamespaceName.cc
+++ b/pulsar-client-cpp/lib/NamespaceName.cc
@@ -60,6 +60,34 @@ bool NamespaceName::validateNamespace(const std::string& property, const std::st
     }
 }
 
+boost::shared_ptr<NamespaceName> NamespaceName::get(const std::string& property,
+                                                    const std::string& namespaceName) {
+    if (validateNamespace(property, namespaceName)) {
+        boost::shared_ptr<NamespaceName> ptr(new NamespaceName(property, namespaceName));
+        return ptr;
+    } else {
+        LOG_DEBUG("Returning a null NamespaceName object");
+        return boost::shared_ptr<NamespaceName>();
+    }
+}
+
+NamespaceName::NamespaceName(const std::string& property, const std::string& namespaceName) {
+    std::ostringstream oss;
+    oss << property << "/" << namespaceName;
+    this->namespace_ = oss.str();
+    this->property_ = property;
+    this->localName_ = namespaceName;
+}
+
+bool NamespaceName::validateNamespace(const std::string& property, const std::string& namespaceName) {
+    if (!property.empty() && !namespaceName.empty()) {
+        return NamedEntity::checkName(property) && NamedEntity::checkName(namespaceName);
+    } else {
+        LOG_DEBUG("Empty parameters passed for validating namespace");
+        return false;
+    }
+}
+
 boost::shared_ptr<NamespaceName> NamespaceName::getNamespaceObject() {
     return boost::shared_ptr<NamespaceName>(this);
 }
@@ -73,3 +101,5 @@ std::string NamespaceName::getProperty() { return this->property_; }
 std::string NamespaceName::getCluster() { return this->cluster_; }
 
 std::string NamespaceName::getLocalName() { return this->localName_; }
+
+bool NamespaceName::isV2() { return this->cluster_.empty(); }

--- a/pulsar-client-cpp/lib/NamespaceName.h
+++ b/pulsar-client-cpp/lib/NamespaceName.h
@@ -34,7 +34,10 @@ class NamespaceName : public ServiceUnitId {
     std::string getLocalName();
     static boost::shared_ptr<NamespaceName> get(const std::string& property, const std::string& cluster,
                                                 const std::string& namespaceName);
+    static boost::shared_ptr<NamespaceName> get(const std::string& property,
+                                                const std::string& namespaceName);
     bool operator==(const NamespaceName& namespaceName);
+    bool isV2();
 
    private:
     std::string namespace_;
@@ -43,7 +46,9 @@ class NamespaceName : public ServiceUnitId {
     std::string localName_;
     static bool validateNamespace(const std::string& property, const std::string& cluster,
                                   const std::string& namespace_);
+    static bool validateNamespace(const std::string& property, const std::string& namespace_);
     NamespaceName(const std::string& property, const std::string& cluster, const std::string& namespace_);
+    NamespaceName(const std::string& property, const std::string& namespace_);
 };
 
 #pragma GCC visibility pop

--- a/pulsar-client-cpp/lib/TopicName.cc
+++ b/pulsar-client-cpp/lib/TopicName.cc
@@ -80,7 +80,11 @@ bool TopicName::init(const std::string& topicName) {
         LOG_ERROR("Topic name is not valid, topic name is empty - " << topicName_);
         return false;
     }
-    namespaceName_ = NamespaceName::get(property_, cluster_, namespacePortion_);
+    if (isV2Topic_ && cluster_.empty()) {
+        namespaceName_ = NamespaceName::get(property_, namespacePortion_);
+    } else {
+        namespaceName_ = NamespaceName::get(property_, cluster_, namespacePortion_);
+    }
     return true;
 }
 bool TopicName::parse(const std::string& topicName, std::string& domain, std::string& property,

--- a/pulsar-client-cpp/tests/NamespaceNameTest.cc
+++ b/pulsar-client-cpp/tests/NamespaceNameTest.cc
@@ -25,7 +25,19 @@ TEST(NamespaceNameTest, testNamespaceName) {
     ASSERT_EQ("property", nn1->getProperty());
     ASSERT_EQ("cluster", nn1->getCluster());
     ASSERT_EQ("namespace", nn1->getLocalName());
+    ASSERT_FALSE(nn1->isV2());
 
     boost::shared_ptr<NamespaceName> nn2 = NamespaceName::get("property", "cluster", "namespace");
+    ASSERT_TRUE(*nn1 == *nn2);
+}
+
+TEST(NamespaceNameTest, testNamespaceNameV2) {
+    boost::shared_ptr<NamespaceName> nn1 = NamespaceName::get("property", "namespace");
+    ASSERT_EQ("property", nn1->getProperty());
+    ASSERT_TRUE(nn1->getCluster().empty());
+    ASSERT_EQ("namespace", nn1->getLocalName());
+    ASSERT_TRUE(nn1->isV2());
+
+    boost::shared_ptr<NamespaceName> nn2 = NamespaceName::get("property", "namespace");
     ASSERT_TRUE(*nn1 == *nn2);
 }


### PR DESCRIPTION
### Motivation

In pulsar-client-cpp, TopicName support V2 type, and contains method isV2Topic(), but NamespaceName not support it.
We need to add support for NamespaceName to make it align with java client.

### Modifications

- add v2 support in NamespaceName
- add test case for it

### Result

old behaviour not changed.