### PR TITLE
Exclude helm files from Apache Rat Check.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1113,6 +1113,10 @@ flexible messaging model and an intuitive client API.</description>
 
             <!-- Configuration Templates -->
             <exclude>conf/schema_example.conf</exclude>
+
+            <!-- helm files -->
+            <exclude>**/.helmignore</exclude>
+            <exclude>**/_helpers.tpl</exclude>
           </excludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
*Motivation*

Some of the helm files (e.g. helm ignore file and template file) doesn't have ASF license header.
It is tricky to add license headers for them. so exclude them from rat check.

*Changes*

Exclude two files from Apache Rat Check

