### PR TITLE
Pull docker images before running integration tests

### DIFF
--- a/tests/scripts/pre-integ-tests.sh
+++ b/tests/scripts/pre-integ-tests.sh
@@ -26,4 +26,7 @@ df -h
 ps -eo euser,pid,ppid,pgid,start,pcpu,pmem,cmd
 docker network prune -f --filter name=pulsarnet_*
 docker system events > docker.debug-info & echo $! > docker-log.pid
-
+docker pull apachepulsar/s3mock:latest
+docker pull alpine/socat:latest
+docker pull cassandra:3
+docker pull confluentinc/cp-kafka:4.0.0


### PR DESCRIPTION
*Motivation*

Integration tests sometime failed with "No such image:".

*Changes*

This change attempts to pull docker images before running integration tests.
Hopefully it can improve the stability on running integration tests.
