### PR TITLE
Cpp client: add PatternMultiTopicsConsumerImpl to support regex subscribe

### DIFF
--- a/pulsar-client-cpp/include/pulsar/Client.h
+++ b/pulsar-client-cpp/include/pulsar/Client.h
@@ -99,6 +99,9 @@ class Client {
     void subscribeAsync(const std::string& topic, const std::string& consumerName,
                         const ConsumerConfiguration& conf, SubscribeCallback callback);
 
+    /**
+     * subscribe for multiple topics under the same namespace.
+     */
     Result subscribe(const std::vector<std::string>& topics, const std::string& subscriptionName,
                      Consumer& consumer);
     Result subscribe(const std::vector<std::string>& topics, const std::string& subscriptionName,
@@ -107,6 +110,19 @@ class Client {
                         SubscribeCallback callback);
     void subscribeAsync(const std::vector<std::string>& topics, const std::string& subscriptionName,
                         const ConsumerConfiguration& conf, SubscribeCallback callback);
+
+    /**
+     * subscribe for multiple topics, which match given regexPattern, under the same namespace.
+     */
+    Result subscribe(const std::string& regexPattern, const std::string& consumerName, Consumer& consumer,
+                     bool useRegex);
+    Result subscribe(const std::string& regexPattern, const std::string& consumerName,
+                     const ConsumerConfiguration& conf, Consumer& consumer, bool useRegex);
+
+    void subscribeAsync(const std::string& regexPattern, const std::string& consumerName, bool useRegex,
+                        SubscribeCallback callback);
+    void subscribeAsync(const std::string& regexPattern, const std::string& consumerName,
+                        const ConsumerConfiguration& conf, bool useRegex, SubscribeCallback callback);
 
     /**
      * Create a topic reader with given {@code ReaderConfiguration} for reading messages from the specified

--- a/pulsar-client-cpp/include/pulsar/Client.h
+++ b/pulsar-client-cpp/include/pulsar/Client.h
@@ -114,15 +114,15 @@ class Client {
     /**
      * subscribe for multiple topics, which match given regexPattern, under the same namespace.
      */
-    Result subscribe(const std::string& regexPattern, const std::string& consumerName, Consumer& consumer,
-                     bool useRegex);
-    Result subscribe(const std::string& regexPattern, const std::string& consumerName,
-                     const ConsumerConfiguration& conf, Consumer& consumer, bool useRegex);
+    Result subscribeWithRegex(const std::string& regexPattern, const std::string& consumerName,
+                              Consumer& consumer);
+    Result subscribeWithRegex(const std::string& regexPattern, const std::string& consumerName,
+                              const ConsumerConfiguration& conf, Consumer& consumer);
 
-    void subscribeAsync(const std::string& regexPattern, const std::string& consumerName, bool useRegex,
-                        SubscribeCallback callback);
-    void subscribeAsync(const std::string& regexPattern, const std::string& consumerName,
-                        const ConsumerConfiguration& conf, bool useRegex, SubscribeCallback callback);
+    void subscribeWithRegexAsync(const std::string& regexPattern, const std::string& consumerName,
+                                 SubscribeCallback callback);
+    void subscribeWithRegexAsync(const std::string& regexPattern, const std::string& consumerName,
+                                 const ConsumerConfiguration& conf, SubscribeCallback callback);
 
     /**
      * Create a topic reader with given {@code ReaderConfiguration} for reading messages from the specified

--- a/pulsar-client-cpp/include/pulsar/ConsumerConfiguration.h
+++ b/pulsar-client-cpp/include/pulsar/ConsumerConfiguration.h
@@ -152,6 +152,16 @@ class ConsumerConfiguration {
     bool isReadCompacted() const;
     void setReadCompacted(bool compacted);
 
+    /**
+     * Set the time duration in minutes, for which the PatternMultiTopicsConsumer will do a pattern auto
+     * discovery.
+     * The default value is 60 seconds. less than 0 will disable auto discovery.
+     *
+     * @param periodInSeconds       period in seconds to do an auto discovery
+     */
+    void setPatternAutoDiscoveryPeriod(int periodInSeconds);
+    int getPatternAutoDiscoveryPeriod() const;
+
     friend class PulsarWrapper;
 
    private:

--- a/pulsar-client-cpp/lib/BinaryProtoLookupService.h
+++ b/pulsar-client-cpp/lib/BinaryProtoLookupService.h
@@ -40,6 +40,8 @@ class BinaryProtoLookupService : public LookupService {
 
     Future<Result, LookupDataResultPtr> getPartitionMetadataAsync(const TopicNamePtr& topicName);
 
+    Future<Result, NamespaceTopicsPtr> getTopicsOfNamespaceAsync(const NamespaceNamePtr& nsName);
+
    private:
     boost::mutex mutex_;
     uint64_t requestIdGenerator_;
@@ -60,6 +62,13 @@ class BinaryProtoLookupService : public LookupService {
     void handlePartitionMetadataLookup(const std::string& topicName, Result result, LookupDataResultPtr data,
                                        const ClientConnectionWeakPtr& clientCnx,
                                        LookupDataResultPromisePtr promise);
+
+    void sendGetTopicsOfNamespaceRequest(const std::string& nsName, Result result,
+                                         const ClientConnectionWeakPtr& clientCnx,
+                                         NamespaceTopicsPromisePtr promise);
+
+    void getTopicsOfNamespaceListener(Result result, NamespaceTopicsPtr topicsPtr,
+                                      NamespaceTopicsPromisePtr promise);
 
     uint64_t newRequestId();
 };

--- a/pulsar-client-cpp/lib/Client.cc
+++ b/pulsar-client-cpp/lib/Client.cc
@@ -114,6 +114,30 @@ void Client::subscribeAsync(const std::vector<std::string>& topics, const std::s
     impl_->subscribeAsync(topics, subscriptionName, conf, callback);
 }
 
+Result Client::subscribe(const std::string& regexPattern, const std::string& subscriptionName,
+                         Consumer& consumer, bool useRegex) {
+    return subscribe(regexPattern, subscriptionName, ConsumerConfiguration(), consumer, useRegex);
+}
+
+Result Client::subscribe(const std::string& regexPattern, const std::string& subscriptionName,
+                         const ConsumerConfiguration& conf, Consumer& consumer, bool useRegex) {
+    Promise<Result, Consumer> promise;
+    subscribeAsync(regexPattern, subscriptionName, conf, useRegex, WaitForCallbackValue<Consumer>(promise));
+    Future<Result, Consumer> future = promise.getFuture();
+
+    return future.get(consumer);
+}
+
+void Client::subscribeAsync(const std::string& regexPattern, const std::string& subscriptionName,
+                            bool useRegex, SubscribeCallback callback) {
+    subscribeAsync(regexPattern, subscriptionName, ConsumerConfiguration(), useRegex, callback);
+}
+
+void Client::subscribeAsync(const std::string& regexPattern, const std::string& subscriptionName,
+                            const ConsumerConfiguration& conf, bool useRegex, SubscribeCallback callback) {
+    impl_->subscribeAsync(regexPattern, subscriptionName, conf, useRegex, callback);
+}
+
 Result Client::createReader(const std::string& topic, const MessageId& startMessageId,
                             const ReaderConfiguration& conf, Reader& reader) {
     Promise<Result, Reader> promise;

--- a/pulsar-client-cpp/lib/Client.cc
+++ b/pulsar-client-cpp/lib/Client.cc
@@ -114,28 +114,28 @@ void Client::subscribeAsync(const std::vector<std::string>& topics, const std::s
     impl_->subscribeAsync(topics, subscriptionName, conf, callback);
 }
 
-Result Client::subscribe(const std::string& regexPattern, const std::string& subscriptionName,
-                         Consumer& consumer, bool useRegex) {
-    return subscribe(regexPattern, subscriptionName, ConsumerConfiguration(), consumer, useRegex);
+Result Client::subscribeWithRegex(const std::string& regexPattern, const std::string& subscriptionName,
+                                  Consumer& consumer) {
+    return subscribeWithRegex(regexPattern, subscriptionName, ConsumerConfiguration(), consumer);
 }
 
-Result Client::subscribe(const std::string& regexPattern, const std::string& subscriptionName,
-                         const ConsumerConfiguration& conf, Consumer& consumer, bool useRegex) {
+Result Client::subscribeWithRegex(const std::string& regexPattern, const std::string& subscriptionName,
+                                  const ConsumerConfiguration& conf, Consumer& consumer) {
     Promise<Result, Consumer> promise;
-    subscribeAsync(regexPattern, subscriptionName, conf, useRegex, WaitForCallbackValue<Consumer>(promise));
+    subscribeWithRegexAsync(regexPattern, subscriptionName, conf, WaitForCallbackValue<Consumer>(promise));
     Future<Result, Consumer> future = promise.getFuture();
 
     return future.get(consumer);
 }
 
-void Client::subscribeAsync(const std::string& regexPattern, const std::string& subscriptionName,
-                            bool useRegex, SubscribeCallback callback) {
-    subscribeAsync(regexPattern, subscriptionName, ConsumerConfiguration(), useRegex, callback);
+void Client::subscribeWithRegexAsync(const std::string& regexPattern, const std::string& subscriptionName,
+                                     SubscribeCallback callback) {
+    subscribeWithRegexAsync(regexPattern, subscriptionName, ConsumerConfiguration(), callback);
 }
 
-void Client::subscribeAsync(const std::string& regexPattern, const std::string& subscriptionName,
-                            const ConsumerConfiguration& conf, bool useRegex, SubscribeCallback callback) {
-    impl_->subscribeAsync(regexPattern, subscriptionName, conf, useRegex, callback);
+void Client::subscribeWithRegexAsync(const std::string& regexPattern, const std::string& subscriptionName,
+                                     const ConsumerConfiguration& conf, SubscribeCallback callback) {
+    impl_->subscribeWithRegexAsync(regexPattern, subscriptionName, conf, callback);
 }
 
 Result Client::createReader(const std::string& topic, const MessageId& startMessageId,

--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -219,7 +219,7 @@ void ClientConnection::handlePulsarConnected(const CommandConnected& cmdConnecte
 }
 
 void ClientConnection::startConsumerStatsTimer(std::vector<uint64_t> consumerStatsRequests) {
-    std::vector<Promise<Result, BrokerConsumerStatsImpl> > consumerStatsPromises;
+    std::vector<Promise<Result, BrokerConsumerStatsImpl>> consumerStatsPromises;
     Lock lock(mutex_);
 
     for (int i = 0; i < consumerStatsRequests.size(); i++) {
@@ -856,28 +856,35 @@ void ClientConnection::handleIncomingCommand() {
                                         << " -- req_id: " << error.request_id());
 
                     Lock lock(mutex_);
-                    PendingRequestsMap::iterator it = pendingRequests_.find(error.request_id());
-                    if (it != pendingRequests_.end()) {
+                    if (pendingRequests_.find(error.request_id()) != pendingRequests_.end()) {
+                        PendingRequestsMap::iterator it = pendingRequests_.find(error.request_id());
                         PendingRequestData requestData = it->second;
                         pendingRequests_.erase(it);
                         lock.unlock();
 
                         requestData.promise.setFailed(getResult(error.error()));
                         requestData.timer->cancel();
-                    } else {
-                        PendingGetLastMessageIdRequestsMap::iterator it2 =
+                    } else if (pendingGetLastMessageIdRequests_.find(error.request_id()) !=
+                               pendingGetLastMessageIdRequests_.end()) {
+                        PendingGetLastMessageIdRequestsMap::iterator it =
                             pendingGetLastMessageIdRequests_.find(error.request_id());
-                        if (it2 != pendingGetLastMessageIdRequests_.end()) {
-                            Promise<Result, MessageId> getLastMessageIdPromise = it2->second;
-                            pendingGetLastMessageIdRequests_.erase(it2);
-                            lock.unlock();
+                        Promise<Result, MessageId> getLastMessageIdPromise = it->second;
+                        pendingGetLastMessageIdRequests_.erase(it);
+                        lock.unlock();
 
-                            getLastMessageIdPromise.setFailed(getResult(error.error()));
-                        } else {
-                            lock.unlock();
-                        }
+                        getLastMessageIdPromise.setFailed(getResult(error.error()));
+                    } else if (pendingGetNamespaceTopicsRequests_.find(error.request_id()) !=
+                               pendingGetNamespaceTopicsRequests_.end()) {
+                        PendingGetNamespaceTopicsMap::iterator it =
+                            pendingGetNamespaceTopicsRequests_.find(error.request_id());
+                        Promise<Result, NamespaceTopicsPtr> getNamespaceTopicsPromise = it->second;
+                        pendingGetNamespaceTopicsRequests_.erase(it);
+                        lock.unlock();
+
+                        getNamespaceTopicsPromise.setFailed(getResult(error.error()));
+                    } else {
+                        lock.unlock();
                     }
-
                     break;
                 }
 
@@ -974,6 +981,51 @@ void ClientConnection::handleIncomingCommand() {
                         LOG_WARN(
                             "getLastMessageIdResponse command - Received unknown request id from server: "
                             << getLastMessageIdResponse.request_id());
+                    }
+                    break;
+                }
+
+                case BaseCommand::GET_TOPICS_OF_NAMESPACE_RESPONSE: {
+                    const CommandGetTopicsOfNamespaceResponse& response =
+                        incomingCmd_.gettopicsofnamespaceresponse();
+
+                    LOG_DEBUG(cnxString_ << "Received GetTopicsOfNamespaceResponse from server. req_id: "
+                                         << response.request_id() << " topicsSize" << response.topics_size());
+
+                    Lock lock(mutex_);
+                    PendingGetNamespaceTopicsMap::iterator it =
+                        pendingGetNamespaceTopicsRequests_.find(response.request_id());
+
+                    if (it != pendingGetNamespaceTopicsRequests_.end()) {
+                        Promise<Result, NamespaceTopicsPtr> getTopicsPromise = it->second;
+                        pendingGetNamespaceTopicsRequests_.erase(it);
+                        lock.unlock();
+
+                        int numTopics = response.topics_size();
+                        NamespaceTopicsPtr topicsPtr =
+                            boost::make_shared<std::vector<std::string>>(numTopics);
+                        topicsPtr->clear();
+
+                        // get all topics
+                        for (int i = 0; i < numTopics; i++) {
+                            // remove partition part
+                            const std::string& topicName = response.topics(i);
+                            int pos = topicName.find("-partition-");
+                            std::string filteredName = topicName.substr(0, pos);
+
+                            // filter duped topic name
+                            if (std::find(topicsPtr->begin(), topicsPtr->end(), filteredName) ==
+                                topicsPtr->end()) {
+                                topicsPtr->push_back(filteredName);
+                            }
+                        }
+
+                        getTopicsPromise.setValue(topicsPtr);
+                    } else {
+                        lock.unlock();
+                        LOG_WARN(
+                            "GetTopicsOfNamespaceResponse command - Received unknown request id from server: "
+                            << response.request_id());
                     }
                     break;
                 }
@@ -1278,6 +1330,23 @@ Future<Result, MessageId> ClientConnection::newGetLastMessageId(uint64_t consume
     pendingGetLastMessageIdRequests_.insert(std::make_pair(requestId, promise));
     lock.unlock();
     sendCommand(Commands::newGetLastMessageId(consumerId, requestId));
+    return promise.getFuture();
+}
+
+Future<Result, NamespaceTopicsPtr> ClientConnection::newGetTopicsOfNamespace(const std::string& nsName,
+                                                                             uint64_t requestId) {
+    Lock lock(mutex_);
+    Promise<Result, NamespaceTopicsPtr> promise;
+    if (isClosed()) {
+        lock.unlock();
+        LOG_ERROR(cnxString_ << "Client is not connected to the broker");
+        promise.setFailed(ResultNotConnected);
+        return promise.getFuture();
+    }
+
+    pendingGetNamespaceTopicsRequests_.insert(std::make_pair(requestId, promise));
+    lock.unlock();
+    sendCommand(Commands::newGetTopicsOfNamespace(nsName, requestId));
     return promise.getFuture();
 }
 

--- a/pulsar-client-cpp/lib/ClientConnection.cc
+++ b/pulsar-client-cpp/lib/ClientConnection.cc
@@ -1021,7 +1021,7 @@ void ClientConnection::handleIncomingCommand() {
 
                         NamespaceTopicsPtr topicsPtr =
                             boost::make_shared<std::vector<std::string>>(topicSet.begin(), topicSet.end());
-                        
+
                         getTopicsPromise.setValue(topicsPtr);
                     } else {
                         lock.unlock();

--- a/pulsar-client-cpp/lib/ClientConnection.h
+++ b/pulsar-client-cpp/lib/ClientConnection.h
@@ -70,6 +70,8 @@ struct OpSendMsg;
 
 typedef std::pair<std::string, int64_t> ResponseData;
 
+typedef boost::shared_ptr<std::vector<std::string>> NamespaceTopicsPtr;
+
 class ClientConnection : public boost::enable_shared_from_this<ClientConnection> {
     enum State
     {
@@ -81,7 +83,7 @@ class ClientConnection : public boost::enable_shared_from_this<ClientConnection>
 
    public:
     typedef boost::shared_ptr<boost::asio::ip::tcp::socket> SocketPtr;
-    typedef boost::shared_ptr<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&> > TlsSocketPtr;
+    typedef boost::shared_ptr<boost::asio::ssl::stream<boost::asio::ip::tcp::socket&>> TlsSocketPtr;
     typedef boost::shared_ptr<ClientConnection> ConnectionPtr;
     typedef boost::function<void(const boost::system::error_code&, ConnectionPtr)> ConnectionListener;
     typedef std::vector<ConnectionListener>::iterator ListenerIterator;
@@ -143,6 +145,8 @@ class ClientConnection : public boost::enable_shared_from_this<ClientConnection>
     Future<Result, BrokerConsumerStatsImpl> newConsumerStats(uint64_t consumerId, uint64_t requestId);
 
     Future<Result, MessageId> newGetLastMessageId(uint64_t consumerId, uint64_t requestId);
+
+    Future<Result, NamespaceTopicsPtr> newGetTopicsOfNamespace(const std::string& nsName, uint64_t requestId);
 
    private:
     struct PendingRequestData {
@@ -264,11 +268,14 @@ class ClientConnection : public boost::enable_shared_from_this<ClientConnection>
     typedef std::map<long, ConsumerImplWeakPtr> ConsumersMap;
     ConsumersMap consumers_;
 
-    typedef std::map<uint64_t, Promise<Result, BrokerConsumerStatsImpl> > PendingConsumerStatsMap;
+    typedef std::map<uint64_t, Promise<Result, BrokerConsumerStatsImpl>> PendingConsumerStatsMap;
     PendingConsumerStatsMap pendingConsumerStatsMap_;
 
-    typedef std::map<long, Promise<Result, MessageId> > PendingGetLastMessageIdRequestsMap;
+    typedef std::map<long, Promise<Result, MessageId>> PendingGetLastMessageIdRequestsMap;
     PendingGetLastMessageIdRequestsMap pendingGetLastMessageIdRequests_;
+
+    typedef std::map<long, Promise<Result, NamespaceTopicsPtr>> PendingGetNamespaceTopicsMap;
+    PendingGetNamespaceTopicsMap pendingGetNamespaceTopicsRequests_;
 
     boost::mutex mutex_;
     typedef boost::unique_lock<boost::mutex> Lock;

--- a/pulsar-client-cpp/lib/ClientImpl.cc
+++ b/pulsar-client-cpp/lib/ClientImpl.cc
@@ -217,9 +217,8 @@ void ClientImpl::handleReaderMetadataLookup(const Result result, const LookupDat
     consumers_.push_back(reader->getConsumer());
 }
 
-void ClientImpl::subscribeAsync(const std::string& regexPattern, const std::string& consumerName,
-                                const ConsumerConfiguration& conf, bool useRegex,
-                                SubscribeCallback callback) {
+void ClientImpl::subscribeWithRegexAsync(const std::string& regexPattern, const std::string& consumerName,
+                                         const ConsumerConfiguration& conf, SubscribeCallback callback) {
     TopicNamePtr topicNamePtr = TopicName::get(regexPattern);
 
     Lock lock(mutex_);
@@ -232,11 +231,6 @@ void ClientImpl::subscribeAsync(const std::string& regexPattern, const std::stri
         if (!topicNamePtr) {
             LOG_ERROR("Topic pattern not valid: " << regexPattern);
             callback(ResultInvalidTopicName, Consumer());
-            return;
-        }
-        if (!useRegex) {
-            LOG_ERROR("Topic pattern subscribe only support regex now");
-            callback(ResultInvalidConfiguration, Consumer());
             return;
         }
     }

--- a/pulsar-client-cpp/lib/ClientImpl.h
+++ b/pulsar-client-cpp/lib/ClientImpl.h
@@ -60,6 +60,9 @@ class ClientImpl : public boost::enable_shared_from_this<ClientImpl> {
     void subscribeAsync(const std::vector<std::string>& topics, const std::string& consumerName,
                         const ConsumerConfiguration& conf, SubscribeCallback callback);
 
+    void subscribeAsync(const std::string& regexPattern, const std::string& consumerName,
+                        const ConsumerConfiguration& conf, bool useRegex, SubscribeCallback callback);
+
     void createReaderAsync(const std::string& topic, const MessageId& startMessageId,
                            const ReaderConfiguration& conf, ReaderCallback callback);
 
@@ -82,6 +85,7 @@ class ClientImpl : public boost::enable_shared_from_this<ClientImpl> {
     ExecutorServiceProviderPtr getIOExecutorProvider();
     ExecutorServiceProviderPtr getListenerExecutorProvider();
     ExecutorServiceProviderPtr getPartitionListenerExecutorProvider();
+    LookupServicePtr getLookup();
     friend class PulsarFriend;
 
    private:
@@ -105,6 +109,10 @@ class ClientImpl : public boost::enable_shared_from_this<ClientImpl> {
     typedef boost::shared_ptr<int> SharedInt;
 
     void handleClose(Result result, SharedInt remaining, ResultCallback callback);
+
+    void createPatternMultiTopicsConsumer(const Result result, const NamespaceTopicsPtr topics,
+                                          const std::string& regexPattern, const std::string& consumerName,
+                                          const ConsumerConfiguration& conf, SubscribeCallback callback);
 
     enum State
     {

--- a/pulsar-client-cpp/lib/ClientImpl.h
+++ b/pulsar-client-cpp/lib/ClientImpl.h
@@ -60,8 +60,8 @@ class ClientImpl : public boost::enable_shared_from_this<ClientImpl> {
     void subscribeAsync(const std::vector<std::string>& topics, const std::string& consumerName,
                         const ConsumerConfiguration& conf, SubscribeCallback callback);
 
-    void subscribeAsync(const std::string& regexPattern, const std::string& consumerName,
-                        const ConsumerConfiguration& conf, bool useRegex, SubscribeCallback callback);
+    void subscribeWithRegexAsync(const std::string& regexPattern, const std::string& consumerName,
+                                 const ConsumerConfiguration& conf, SubscribeCallback callback);
 
     void createReaderAsync(const std::string& topic, const MessageId& startMessageId,
                            const ReaderConfiguration& conf, ReaderCallback callback);

--- a/pulsar-client-cpp/lib/Commands.cc
+++ b/pulsar-client-cpp/lib/Commands.cc
@@ -324,6 +324,18 @@ SharedBuffer Commands::newGetLastMessageId(uint64_t consumerId, uint64_t request
     return buffer;
 }
 
+SharedBuffer Commands::newGetTopicsOfNamespace(const std::string& nsName, uint64_t requestId) {
+    BaseCommand cmd;
+    cmd.set_type(BaseCommand::GET_TOPICS_OF_NAMESPACE);
+    CommandGetTopicsOfNamespace* getTopics = cmd.mutable_gettopicsofnamespace();
+    getTopics->set_request_id(requestId);
+    getTopics->set_namespace_(nsName);
+
+    const SharedBuffer buffer = writeMessageWithSize(cmd);
+    cmd.clear_gettopicsofnamespace();
+    return buffer;
+}
+
 std::string Commands::messageType(BaseCommand_Type type) {
     switch (type) {
         case BaseCommand::CONNECT:
@@ -415,6 +427,12 @@ std::string Commands::messageType(BaseCommand_Type type) {
             break;
         case BaseCommand::GET_LAST_MESSAGE_ID_RESPONSE:
             return "GET_LAST_MESSAGE_ID_RESPONSE";
+            break;
+        case BaseCommand::GET_TOPICS_OF_NAMESPACE:
+            return "GET_TOPICS_OF_NAMESPACE";
+            break;
+        case BaseCommand::GET_TOPICS_OF_NAMESPACE_RESPONSE:
+            return "GET_TOPICS_OF_NAMESPACE_RESPONSE";
             break;
     };
 }

--- a/pulsar-client-cpp/lib/Commands.h
+++ b/pulsar-client-cpp/lib/Commands.h
@@ -112,6 +112,7 @@ class Commands {
 
     static SharedBuffer newSeek(uint64_t consumerId, uint64_t requestId, const MessageId& messageId);
     static SharedBuffer newGetLastMessageId(uint64_t consumerId, uint64_t requestId);
+    static SharedBuffer newGetTopicsOfNamespace(const std::string& nsName, uint64_t requestId);
 
    private:
     Commands();

--- a/pulsar-client-cpp/lib/ConsumerConfiguration.cc
+++ b/pulsar-client-cpp/lib/ConsumerConfiguration.cc
@@ -105,4 +105,10 @@ bool ConsumerConfiguration::isReadCompacted() const { return impl_->readCompacte
 
 void ConsumerConfiguration::setReadCompacted(bool compacted) { impl_->readCompacted = compacted; }
 
+void ConsumerConfiguration::setPatternAutoDiscoveryPeriod(int periodInSeconds) {
+    impl_->patternAutoDiscoveryPeriod = periodInSeconds;
+}
+
+int ConsumerConfiguration::getPatternAutoDiscoveryPeriod() const { return impl_->patternAutoDiscoveryPeriod; }
+
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/ConsumerConfigurationImpl.h
+++ b/pulsar-client-cpp/lib/ConsumerConfigurationImpl.h
@@ -35,6 +35,7 @@ struct ConsumerConfigurationImpl {
     CryptoKeyReaderPtr cryptoKeyReader;
     ConsumerCryptoFailureAction cryptoFailureAction;
     bool readCompacted;
+    int patternAutoDiscoveryPeriod;
     ConsumerConfigurationImpl()
         : unAckedMessagesTimeoutMs(0),
           consumerType(ConsumerExclusive),
@@ -45,7 +46,8 @@ struct ConsumerConfigurationImpl {
           maxTotalReceiverQueueSizeAcrossPartitions(50000),
           cryptoKeyReader(),
           cryptoFailureAction(ConsumerCryptoFailureAction::FAIL),
-          readCompacted(false) {}
+          readCompacted(false),
+          patternAutoDiscoveryPeriod(60) {}
 };
 }  // namespace pulsar
 #endif /* LIB_CONSUMERCONFIGURATIONIMPL_H_ */

--- a/pulsar-client-cpp/lib/HTTPLookupService.cc
+++ b/pulsar-client-cpp/lib/HTTPLookupService.cc
@@ -68,8 +68,9 @@ Future<Result, LookupDataResultPtr> HTTPLookupService::lookupAsync(const std::st
                           << topicName->getEncodedLocalName();
     }
 
-    executorProvider_->get()->postWork(boost::bind(&HTTPLookupService::sendHTTPRequest, shared_from_this(),
-                                                   promise, completeUrlStream.str(), Lookup));
+    executorProvider_->get()->postWork(boost::bind(&HTTPLookupService::handleLookupHTTPRequest,
+                                                   shared_from_this(), promise, completeUrlStream.str(),
+                                                   Lookup));
     return promise.getFuture();
 }
 
@@ -89,8 +90,27 @@ Future<Result, LookupDataResultPtr> HTTPLookupService::getPartitionMetadataAsync
                           << '/' << PARTITION_METHOD_NAME;
     }
 
-    executorProvider_->get()->postWork(boost::bind(&HTTPLookupService::sendHTTPRequest, shared_from_this(),
-                                                   promise, completeUrlStream.str(), PartitionMetaData));
+    executorProvider_->get()->postWork(boost::bind(&HTTPLookupService::handleLookupHTTPRequest,
+                                                   shared_from_this(), promise, completeUrlStream.str(),
+                                                   PartitionMetaData));
+    return promise.getFuture();
+}
+
+Future<Result, NamespaceTopicsPtr> HTTPLookupService::getTopicsOfNamespaceAsync(
+    const NamespaceNamePtr &nsName) {
+    NamespaceTopicsPromise promise;
+    std::stringstream completeUrlStream;
+
+    if (nsName->isV2()) {
+        completeUrlStream << adminUrl_ << ADMIN_PATH_V2 << "namespaces" << '/' << nsName->toString() << '/'
+                          << "topics";
+    } else {
+        completeUrlStream << adminUrl_ << ADMIN_PATH_V1 << "namespaces" << '/' << nsName->toString() << '/'
+                          << "destinations";
+    }
+
+    executorProvider_->get()->postWork(boost::bind(&HTTPLookupService::handleNamespaceTopicsHTTPRequest,
+                                                   shared_from_this(), promise, completeUrlStream.str()));
     return promise.getFuture();
 }
 
@@ -99,19 +119,28 @@ static size_t curlWriteCallback(void *contents, size_t size, size_t nmemb, void 
     return size * nmemb;
 }
 
-void HTTPLookupService::sendHTTPRequest(LookupPromise promise, const std::string completeUrl,
-                                        RequestType requestType) {
+void HTTPLookupService::handleNamespaceTopicsHTTPRequest(NamespaceTopicsPromise promise,
+                                                         const std::string completeUrl) {
+    std::string responseData;
+    Result result = sendHTTPRequest(completeUrl, responseData);
+
+    if (result != ResultOk) {
+        promise.setFailed(result);
+    } else {
+        promise.setValue(parseNamespaceTopicsData(responseData));
+    }
+}
+
+Result HTTPLookupService::sendHTTPRequest(const std::string completeUrl, std::string &responseData) {
     CURL *handle;
     CURLcode res;
-    std::string responseData;
     std::string version = std::string("Pulsar-CPP-v") + _PULSAR_VERSION_;
     handle = curl_easy_init();
 
     if (!handle) {
         LOG_ERROR("Unable to curl_easy_init for url " << completeUrl);
-        promise.setFailed(ResultLookupError);
         // No curl_easy_cleanup required since handle not initialized
-        return;
+        return ResultLookupError;
     }
     // set URL
     curl_easy_setopt(handle, CURLOPT_URL, completeUrl.c_str());
@@ -148,9 +177,8 @@ void HTTPLookupService::sendHTTPRequest(LookupPromise promise, const std::string
             "All Authentication methods should have AuthenticationData and return true on getAuthData for "
             "url "
             << completeUrl);
-        promise.setFailed(authResult);
         curl_easy_cleanup(handle);
-        return;
+        return authResult;
     }
     struct curl_slist *list = NULL;
     if (authDataContent->hasDataForHttp()) {
@@ -158,7 +186,7 @@ void HTTPLookupService::sendHTTPRequest(LookupPromise promise, const std::string
     }
     curl_easy_setopt(handle, CURLOPT_HTTPHEADER, list);
 
-    LOG_INFO("Curl Lookup Request sent for" << completeUrl);
+    LOG_INFO("Curl Lookup Request sent for " << completeUrl);
 
     // Make get call to server
     res = curl_easy_perform(handle);
@@ -166,16 +194,17 @@ void HTTPLookupService::sendHTTPRequest(LookupPromise promise, const std::string
     // Free header list
     curl_slist_free_all(list);
 
+    Result retResult = ResultOk;
+
     switch (res) {
         case CURLE_OK:
             long response_code;
             curl_easy_getinfo(handle, CURLINFO_RESPONSE_CODE, &response_code);
             LOG_INFO("Response received for url " << completeUrl << " code " << response_code);
             if (response_code == 200) {
-                promise.setValue((requestType == PartitionMetaData) ? parsePartitionData(responseData)
-                                                                    : parseLookupData(responseData));
+                retResult = ResultOk;
             } else {
-                promise.setFailed(ResultLookupError);
+                retResult = ResultLookupError;
             }
             break;
         case CURLE_COULDNT_CONNECT:
@@ -183,22 +212,23 @@ void HTTPLookupService::sendHTTPRequest(LookupPromise promise, const std::string
         case CURLE_COULDNT_RESOLVE_HOST:
         case CURLE_HTTP_RETURNED_ERROR:
             LOG_ERROR("Response failed for url " << completeUrl << ". Error Code " << res);
-            promise.setFailed(ResultConnectError);
+            retResult = ResultConnectError;
             break;
         case CURLE_READ_ERROR:
             LOG_ERROR("Response failed for url " << completeUrl << ". Error Code " << res);
-            promise.setFailed(ResultReadError);
+            retResult = ResultReadError;
             break;
         case CURLE_OPERATION_TIMEDOUT:
             LOG_ERROR("Response failed for url " << completeUrl << ". Error Code " << res);
-            promise.setFailed(ResultTimeout);
+            retResult = ResultTimeout;
             break;
         default:
             LOG_ERROR("Response failed for url " << completeUrl << ". Error Code " << res);
-            promise.setFailed(ResultLookupError);
+            retResult = ResultLookupError;
             break;
     }
     curl_easy_cleanup(handle);
+    return retResult;
 }
 
 LookupDataResultPtr HTTPLookupService::parsePartitionData(const std::string &json) {
@@ -243,4 +273,47 @@ LookupDataResultPtr HTTPLookupService::parseLookupData(const std::string &json) 
     LOG_INFO("parseLookupData = " << *lookupDataResultPtr);
     return lookupDataResultPtr;
 }
+
+NamespaceTopicsPtr HTTPLookupService::parseNamespaceTopicsData(const std::string &json) {
+    Json::Value root;
+    Json::Reader reader;
+    if (!reader.parse(json, root, false)) {
+        LOG_ERROR("Failed to parse json of Topics of Namespace: " << reader.getFormatedErrorMessages()
+                                                                  << "\nInput Json = " << json);
+        return NamespaceTopicsPtr();
+    }
+
+    NamespaceTopicsPtr topicsResultPtr = boost::make_shared<std::vector<std::string>>();
+    Json::Value topicsArray = root["topics"];
+
+    // get all topics
+    for (int i = 0; i < topicsArray.size(); i++) {
+        // remove partition part
+        const std::string &topicName = topicsArray[i].asString();
+        int pos = topicName.find("-partition-");
+        std::string filteredName = topicName.substr(0, pos);
+
+        // filter duped topic name
+        if (std::find(topicsResultPtr->begin(), topicsResultPtr->end(), filteredName) ==
+            topicsResultPtr->end()) {
+            topicsResultPtr->push_back(filteredName);
+        }
+    }
+
+    return topicsResultPtr;
+}
+
+void HTTPLookupService::handleLookupHTTPRequest(LookupPromise promise, const std::string completeUrl,
+                                                RequestType requestType) {
+    std::string responseData;
+    Result result = sendHTTPRequest(completeUrl, responseData);
+
+    if (result != ResultOk) {
+        promise.setFailed(result);
+    } else {
+        promise.setValue((requestType == PartitionMetaData) ? parsePartitionData(responseData)
+                                                            : parseLookupData(responseData));
+    }
+}
+
 }  // namespace pulsar

--- a/pulsar-client-cpp/lib/HTTPLookupService.cc
+++ b/pulsar-client-cpp/lib/HTTPLookupService.cc
@@ -283,9 +283,8 @@ NamespaceTopicsPtr HTTPLookupService::parseNamespaceTopicsData(const std::string
         return NamespaceTopicsPtr();
     }
 
-    NamespaceTopicsPtr topicsResultPtr = boost::make_shared<std::vector<std::string>>();
     Json::Value topicsArray = root["topics"];
-
+    std::set<std::string> topicSet;
     // get all topics
     for (int i = 0; i < topicsArray.size(); i++) {
         // remove partition part
@@ -294,11 +293,13 @@ NamespaceTopicsPtr HTTPLookupService::parseNamespaceTopicsData(const std::string
         std::string filteredName = topicName.substr(0, pos);
 
         // filter duped topic name
-        if (std::find(topicsResultPtr->begin(), topicsResultPtr->end(), filteredName) ==
-            topicsResultPtr->end()) {
-            topicsResultPtr->push_back(filteredName);
+        if (topicSet.find(filteredName) == topicSet.end()) {
+            topicSet.insert(filteredName);
         }
     }
+
+    NamespaceTopicsPtr topicsResultPtr =
+        boost::make_shared<std::vector<std::string>>(topicSet.begin(), topicSet.end());
 
     return topicsResultPtr;
 }

--- a/pulsar-client-cpp/lib/HTTPLookupService.h
+++ b/pulsar-client-cpp/lib/HTTPLookupService.h
@@ -52,7 +52,12 @@ class HTTPLookupService : public LookupService, public boost::enable_shared_from
 
     static LookupDataResultPtr parsePartitionData(const std::string&);
     static LookupDataResultPtr parseLookupData(const std::string&);
-    void sendHTTPRequest(LookupPromise, const std::string, RequestType);
+    static NamespaceTopicsPtr parseNamespaceTopicsData(const std::string&);
+
+    void handleLookupHTTPRequest(LookupPromise, const std::string, RequestType);
+    void handleNamespaceTopicsHTTPRequest(NamespaceTopicsPromise promise, const std::string completeUrl);
+
+    Result sendHTTPRequest(const std::string completeUrl, std::string& responseData);
 
    public:
     HTTPLookupService(const std::string&, const ClientConfiguration&, const AuthenticationPtr&);
@@ -60,6 +65,8 @@ class HTTPLookupService : public LookupService, public boost::enable_shared_from
     Future<Result, LookupDataResultPtr> lookupAsync(const std::string&);
 
     Future<Result, LookupDataResultPtr> getPartitionMetadataAsync(const TopicNamePtr&);
+
+    Future<Result, NamespaceTopicsPtr> getTopicsOfNamespaceAsync(const NamespaceNamePtr& nsName);
 };
 }  // namespace pulsar
 

--- a/pulsar-client-cpp/lib/LookupService.h
+++ b/pulsar-client-cpp/lib/LookupService.h
@@ -26,6 +26,10 @@
 #include <lib/TopicName.h>
 
 namespace pulsar {
+typedef boost::shared_ptr<std::vector<std::string>> NamespaceTopicsPtr;
+typedef Promise<Result, NamespaceTopicsPtr> NamespaceTopicsPromise;
+typedef boost::shared_ptr<Promise<Result, NamespaceTopicsPtr>> NamespaceTopicsPromisePtr;
+
 class LookupService {
    public:
     /*
@@ -41,6 +45,13 @@ class LookupService {
      * Gets Partition metadata
      */
     virtual Future<Result, LookupDataResultPtr> getPartitionMetadataAsync(const TopicNamePtr& topicName) = 0;
+
+    /**
+     * @param   namespace - namespace-name
+     *
+     * Returns all the topics name for a given namespace.
+     */
+    virtual Future<Result, NamespaceTopicsPtr> getTopicsOfNamespaceAsync(const NamespaceNamePtr& nsName) = 0;
 
     virtual ~LookupService() {}
 };

--- a/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.h
+++ b/pulsar-client-cpp/lib/MultiTopicsConsumerImpl.h
@@ -80,7 +80,7 @@ class MultiTopicsConsumerImpl : public ConsumerImplBase,
     // not supported
     virtual void seekAsync(const MessageId& msgId, ResultCallback callback);
 
-   private:
+   protected:
     const ClientImplPtr client_;
     const std::string subscriptionName_;
     std::string consumerStr_;

--- a/pulsar-client-cpp/lib/PatternMultiTopicsConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/PatternMultiTopicsConsumerImpl.cc
@@ -1,0 +1,235 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "PatternMultiTopicsConsumerImpl.h"
+
+DECLARE_LOG_OBJECT()
+
+using namespace pulsar;
+
+PatternMultiTopicsConsumerImpl::PatternMultiTopicsConsumerImpl(ClientImplPtr client,
+                                                               const std::string pattern,
+                                                               const std::vector<std::string>& topics,
+                                                               const std::string& subscriptionName,
+                                                               const ConsumerConfiguration& conf,
+                                                               const LookupServicePtr lookupServicePtr_)
+    : MultiTopicsConsumerImpl(client, topics, subscriptionName, TopicName::get(pattern), conf,
+                              lookupServicePtr_),
+      patternString_(pattern),
+      pattern_(std::regex(pattern)),
+      autoDiscoveryTimer_(),
+      autoDiscoveryRunning_(false) {}
+
+const std::regex PatternMultiTopicsConsumerImpl::getPattern() { return pattern_; }
+
+void PatternMultiTopicsConsumerImpl::resetAutoDiscoveryTimer() {
+    autoDiscoveryRunning_ = false;
+    autoDiscoveryTimer_->expires_from_now(seconds(conf_.getPatternAutoDiscoveryPeriod()));
+    autoDiscoveryTimer_->async_wait(
+        boost::bind(&PatternMultiTopicsConsumerImpl::autoDiscoveryTimerTask, this, _1));
+}
+
+void PatternMultiTopicsConsumerImpl::autoDiscoveryTimerTask(const boost::system::error_code& err) {
+    if (err == boost::asio::error::operation_aborted) {
+        LOG_DEBUG(getName() << "Timer cancelled: " << err.message());
+        return;
+    } else if (err) {
+        LOG_ERROR(getName() << "Timer error: " << err.message());
+        return;
+    }
+
+    if (state_ != Ready) {
+        LOG_ERROR("Error in autoDiscoveryTimerTask consumer state not ready: " << state_);
+        resetAutoDiscoveryTimer();
+        return;
+    }
+
+    if (autoDiscoveryRunning_) {
+        LOG_DEBUG("autoDiscoveryTimerTask still running, cancel this running. ");
+        return;
+    }
+
+    autoDiscoveryRunning_ = true;
+
+    // already get namespace from pattern.
+    assert(namespaceName_);
+
+    lookupServicePtr_->getTopicsOfNamespaceAsync(namespaceName_)
+        .addListener(boost::bind(&PatternMultiTopicsConsumerImpl::timerGetTopicsOfNamespace, this, _1, _2));
+}
+
+void PatternMultiTopicsConsumerImpl::timerGetTopicsOfNamespace(const Result result,
+                                                               const NamespaceTopicsPtr topics) {
+    if (result != ResultOk) {
+        LOG_ERROR("Error in Getting topicsOfNameSpace. result: " << result);
+        resetAutoDiscoveryTimer();
+        return;
+    }
+
+    NamespaceTopicsPtr newTopics = PatternMultiTopicsConsumerImpl::topicsPatternFilter(*topics, pattern_);
+    // get old topics in consumer:
+    NamespaceTopicsPtr oldTopics = boost::make_shared<std::vector<std::string>>();
+    for (std::map<std::string, int>::iterator it = topicsPartitions_.begin(); it != topicsPartitions_.end();
+         it++) {
+        oldTopics->push_back(it->first);
+    }
+    NamespaceTopicsPtr topicsAdded = topicsListsMinus(*newTopics, *oldTopics);
+    NamespaceTopicsPtr topicsRemoved = topicsListsMinus(*oldTopics, *newTopics);
+
+    // callback method when removed topics all un-subscribed.
+    ResultCallback topicsRemovedCallback = [this](Result result) {
+        if (result != ResultOk) {
+            LOG_ERROR("Failed to unsubscribe topics: " << result);
+        }
+        resetAutoDiscoveryTimer();
+    };
+
+    // callback method when added topics all subscribed.
+    ResultCallback topicsAddedCallback = [this, topicsRemoved, topicsRemovedCallback](Result result) {
+        if (result == ResultOk) {
+            // call to unsubscribe all removed topics.
+            onTopicsRemoved(topicsRemoved, topicsRemovedCallback);
+        } else {
+            resetAutoDiscoveryTimer();
+        }
+    };
+
+    // call to subscribe new added topics, then in its callback do unsubscribe
+    onTopicsAdded(topicsListsMinus(*newTopics, *oldTopics), topicsAddedCallback);
+}
+
+void PatternMultiTopicsConsumerImpl::onTopicsAdded(NamespaceTopicsPtr addedTopics, ResultCallback callback) {
+    // start call subscribeOneTopicAsync for each single topic
+
+    if (addedTopics->empty()) {
+        LOG_DEBUG("no topics need subscribe");
+        callback(ResultOk);
+        return;
+    }
+    int topicsNumber = addedTopics->size();
+
+    boost::shared_ptr<std::atomic<int>> topicsNeedCreate = boost::make_shared<std::atomic<int>>(topicsNumber);
+    // subscribe for each passed in topic
+    for (std::vector<std::string>::const_iterator itr = addedTopics->begin(); itr != addedTopics->end();
+         itr++) {
+        MultiTopicsConsumerImpl::subscribeOneTopicAsync(*itr).addListener(
+            boost::bind(&PatternMultiTopicsConsumerImpl::handleOneTopicAdded, this, _1, *itr,
+                        topicsNeedCreate, callback));
+    }
+}
+
+void PatternMultiTopicsConsumerImpl::handleOneTopicAdded(const Result result, const std::string& topic,
+                                                         boost::shared_ptr<std::atomic<int>> topicsNeedCreate,
+                                                         ResultCallback callback) {
+    int previous = topicsNeedCreate->fetch_sub(1);
+    assert(previous > 0);
+
+    if (result != ResultOk) {
+        LOG_ERROR("Failed when subscribed to topic " << topic << "  Error - " << result);
+        callback(result);
+        return;
+    }
+
+    if (topicsNeedCreate->load() == 0) {
+        LOG_DEBUG("Subscribed all new added topics");
+        callback(result);
+    }
+}
+
+void PatternMultiTopicsConsumerImpl::onTopicsRemoved(NamespaceTopicsPtr removedTopics,
+                                                     ResultCallback callback) {
+    // start call subscribeOneTopicAsync for each single topic
+    if (removedTopics->empty()) {
+        LOG_DEBUG("no topics need unsubscribe");
+        callback(ResultOk);
+        return;
+    }
+    int topicsNumber = removedTopics->size();
+
+    boost::shared_ptr<std::atomic<int>> topicsNeedUnsub = boost::make_shared<std::atomic<int>>(topicsNumber);
+    ResultCallback oneTopicUnsubscribedCallback = [this, topicsNeedUnsub, callback](Result result) {
+        int previous = topicsNeedUnsub->fetch_sub(1);
+        assert(previous > 0);
+
+        if (result != ResultOk) {
+            LOG_ERROR("Failed when unsubscribe to one topic.  Error - " << result);
+            callback(result);
+            return;
+        }
+
+        if (topicsNeedUnsub->load() == 0) {
+            LOG_DEBUG("unSubscribed all needed topics");
+            callback(result);
+        }
+    };
+
+    // unsubscribe for each passed in topic
+    for (std::vector<std::string>::const_iterator itr = removedTopics->begin(); itr != removedTopics->end();
+         itr++) {
+        MultiTopicsConsumerImpl::unsubscribeOneTopicAsync(*itr, oneTopicUnsubscribedCallback);
+    }
+}
+
+NamespaceTopicsPtr PatternMultiTopicsConsumerImpl::topicsPatternFilter(const std::vector<std::string>& topics,
+                                                                       const std::regex& pattern) {
+    NamespaceTopicsPtr topicsResultPtr = boost::make_shared<std::vector<std::string>>();
+
+    for (std::vector<std::string>::const_iterator itr = topics.begin(); itr != topics.end(); itr++) {
+        if (std::regex_match(*itr, pattern)) {
+            topicsResultPtr->push_back(*itr);
+        }
+    }
+    return topicsResultPtr;
+}
+
+NamespaceTopicsPtr PatternMultiTopicsConsumerImpl::topicsListsMinus(std::vector<std::string>& list1,
+                                                                    std::vector<std::string>& list2) {
+    NamespaceTopicsPtr topicsResultPtr = boost::make_shared<std::vector<std::string>>();
+    std::remove_copy_if(list1.begin(), list1.end(), std::back_inserter(*topicsResultPtr),
+                        [&list2](const std::string& arg) {
+                            return (std::find(list2.begin(), list2.end(), arg) != list2.end());
+                        });
+
+    return topicsResultPtr;
+}
+
+void PatternMultiTopicsConsumerImpl::start() {
+    MultiTopicsConsumerImpl::start();
+
+    LOG_DEBUG("PatternMultiTopicsConsumerImpl start autoDiscoveryTimer_.");
+
+    // Init autoDiscoveryTimer task only once, wait for the timeout to happen
+    if (!autoDiscoveryTimer_ && conf_.getPatternAutoDiscoveryPeriod() > 0) {
+        autoDiscoveryTimer_ = client_->getIOExecutorProvider()->get()->createDeadlineTimer();
+        autoDiscoveryTimer_->expires_from_now(seconds(conf_.getPatternAutoDiscoveryPeriod()));
+        autoDiscoveryTimer_->async_wait(
+            boost::bind(&PatternMultiTopicsConsumerImpl::autoDiscoveryTimerTask, this, _1));
+    }
+}
+
+void PatternMultiTopicsConsumerImpl::shutdown() {
+    Lock lock(mutex_);
+    state_ = Closed;
+    autoDiscoveryTimer_->cancel();
+    multiTopicsConsumerCreatedPromise_.setFailed(ResultAlreadyClosed);
+}
+
+void PatternMultiTopicsConsumerImpl::closeAsync(ResultCallback callback) {
+    MultiTopicsConsumerImpl::closeAsync(callback);
+    autoDiscoveryTimer_->cancel();
+}

--- a/pulsar-client-cpp/lib/PatternMultiTopicsConsumerImpl.cc
+++ b/pulsar-client-cpp/lib/PatternMultiTopicsConsumerImpl.cc
@@ -110,7 +110,7 @@ void PatternMultiTopicsConsumerImpl::timerGetTopicsOfNamespace(const Result resu
     };
 
     // call to subscribe new added topics, then in its callback do unsubscribe
-    onTopicsAdded(topicsListsMinus(*newTopics, *oldTopics), topicsAddedCallback);
+    onTopicsAdded(topicsAdded, topicsAddedCallback);
 }
 
 void PatternMultiTopicsConsumerImpl::onTopicsAdded(NamespaceTopicsPtr addedTopics, ResultCallback callback) {

--- a/pulsar-client-cpp/lib/PatternMultiTopicsConsumerImpl.h
+++ b/pulsar-client-cpp/lib/PatternMultiTopicsConsumerImpl.h
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#ifndef PULSAR_PATTERN_MULTI_TOPICS_CONSUMER_HEADER
+#define PULSAR_PATTERN_MULTI_TOPICS_CONSUMER_HEADER
+#include "ConsumerImpl.h"
+#include "ClientImpl.h"
+#include <regex>
+#include "boost/enable_shared_from_this.hpp"
+#include <lib/TopicName.h>
+#include <lib/NamespaceName.h>
+#include "MultiTopicsConsumerImpl.h"
+
+namespace pulsar {
+
+class PatternMultiTopicsConsumerImpl;
+
+class PatternMultiTopicsConsumerImpl : public MultiTopicsConsumerImpl {
+   public:
+    // currently we support topics under same namespace, so `patternString` is a regex,
+    // which only contains after namespace part.
+    // when subscribe, client will first get all topics that match given pattern.
+    // `topics` contains the topics that match `patternString`.
+    PatternMultiTopicsConsumerImpl(ClientImplPtr client, const std::string patternString,
+                                   const std::vector<std::string>& topics,
+                                   const std::string& subscriptionName, const ConsumerConfiguration& conf,
+                                   const LookupServicePtr lookupServicePtr_);
+
+    const std::regex getPattern();
+
+    void autoDiscoveryTimerTask(const boost::system::error_code& err);
+
+    // filter input `topics` with given `pattern`, return matched topics
+    static NamespaceTopicsPtr topicsPatternFilter(const std::vector<std::string>& topics,
+                                                  const std::regex& pattern);
+
+    // Find out topics, which are in `list1` but not in `list2`.
+    static NamespaceTopicsPtr topicsListsMinus(std::vector<std::string>& list1,
+                                               std::vector<std::string>& list2);
+
+    virtual void closeAsync(ResultCallback callback);
+    virtual void start();
+    virtual void shutdown();
+
+   private:
+    const std::string patternString_;
+    const std::regex pattern_;
+    typedef boost::shared_ptr<boost::asio::deadline_timer> TimerPtr;
+    TimerPtr autoDiscoveryTimer_;
+    bool autoDiscoveryRunning_;
+
+    void resetAutoDiscoveryTimer();
+    void timerGetTopicsOfNamespace(const Result result, const NamespaceTopicsPtr topics);
+    void onTopicsAdded(NamespaceTopicsPtr addedTopics, ResultCallback callback);
+    void onTopicsRemoved(NamespaceTopicsPtr removedTopics, ResultCallback callback);
+    void handleOneTopicAdded(const Result result, const std::string& topic,
+                             boost::shared_ptr<std::atomic<int>> topicsNeedCreate, ResultCallback callback);
+};
+
+}  // namespace pulsar
+#endif  // PULSAR_PATTERN_MULTI_TOPICS_CONSUMER_HEADER

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -1690,16 +1690,9 @@ TEST(BasicEndToEndTest, testPatternTopicsConsumerInvalid) {
 
     Consumer consumer;
     Promise<Result, Consumer> consumerPromise;
-    client.subscribeAsync(pattern, subName, true, WaitForCallbackValue<Consumer>(consumerPromise));
+    client.subscribeWithRegexAsync(pattern, subName, WaitForCallbackValue<Consumer>(consumerPromise));
     Future<Result, Consumer> consumerFuture = consumerPromise.getFuture();
     Result result = consumerFuture.get(consumer);
-    ASSERT_EQ(ResultInvalidTopicName, result);
-
-    // invalid parameter (useRegex = false)
-    pattern = "persistent://prop/unit/ns/patternMultiTopicsConsumerInvalid.*";
-    client.subscribeAsync(pattern, subName, false, WaitForCallbackValue<Consumer>(consumerPromise));
-    consumerFuture = consumerPromise.getFuture();
-    result = consumerFuture.get(consumer);
     ASSERT_EQ(ResultInvalidTopicName, result);
 
     client.shutdown();
@@ -1759,8 +1752,8 @@ TEST(BasicEndToEndTest, testPatternMultiTopicsConsumerPubSub) {
     consConfig.setReceiverQueueSize(10);  // size for each sub-consumer
     Consumer consumer;
     Promise<Result, Consumer> consumerPromise;
-    client.subscribeAsync(pattern, subName, consConfig, true,
-                          WaitForCallbackValue<Consumer>(consumerPromise));
+    client.subscribeWithRegexAsync(pattern, subName, consConfig,
+                                   WaitForCallbackValue<Consumer>(consumerPromise));
     Future<Result, Consumer> consumerFuture = consumerPromise.getFuture();
     result = consumerFuture.get(consumer);
     ASSERT_EQ(ResultOk, result);
@@ -1837,8 +1830,8 @@ TEST(BasicEndToEndTest, testPatternMultiTopicsConsumerAutoDiscovery) {
     consConfig.setPatternAutoDiscoveryPeriod(1);  // set waiting time for auto discovery
     Consumer consumer;
     Promise<Result, Consumer> consumerPromise;
-    client.subscribeAsync(pattern, subName, consConfig, true,
-                          WaitForCallbackValue<Consumer>(consumerPromise));
+    client.subscribeWithRegexAsync(pattern, subName, consConfig,
+                                   WaitForCallbackValue<Consumer>(consumerPromise));
     Future<Result, Consumer> consumerFuture = consumerPromise.getFuture();
     result = consumerFuture.get(consumer);
     ASSERT_EQ(ResultOk, result);

--- a/pulsar-client-cpp/tests/BasicEndToEndTest.cc
+++ b/pulsar-client-cpp/tests/BasicEndToEndTest.cc
@@ -34,6 +34,7 @@
 #include <set>
 #include <vector>
 #include <lib/MultiTopicsConsumerImpl.h>
+#include <lib/PatternMultiTopicsConsumerImpl.h>
 #include "lib/Future.h"
 #include "lib/Utils.h"
 DECLARE_LOG_OBJECT()
@@ -1674,6 +1675,269 @@ TEST(BasicEndToEndTest, testMultiTopicsConsumerPubSub) {
     }
 
     LOG_INFO("Consumed and acked 300 messages by multiTopicsConsumer");
+
+    ASSERT_EQ(ResultOk, consumer.unsubscribe());
+
+    client.shutdown();
+}
+
+TEST(BasicEndToEndTest, testPatternTopicsConsumerInvalid) {
+    Client client(lookupUrl);
+
+    // invalid namespace
+    std::string pattern = "invalidDomain://prop/unit/ns/patternMultiTopicsConsumerInvalid.*";
+    std::string subName = "testPatternMultiTopicsConsumerInvalid";
+
+    Consumer consumer;
+    Promise<Result, Consumer> consumerPromise;
+    client.subscribeAsync(pattern, subName, true, WaitForCallbackValue<Consumer>(consumerPromise));
+    Future<Result, Consumer> consumerFuture = consumerPromise.getFuture();
+    Result result = consumerFuture.get(consumer);
+    ASSERT_EQ(ResultInvalidTopicName, result);
+
+    // invalid parameter (useRegex = false)
+    pattern = "persistent://prop/unit/ns/patternMultiTopicsConsumerInvalid.*";
+    client.subscribeAsync(pattern, subName, false, WaitForCallbackValue<Consumer>(consumerPromise));
+    consumerFuture = consumerPromise.getFuture();
+    result = consumerFuture.get(consumer);
+    ASSERT_EQ(ResultInvalidTopicName, result);
+
+    client.shutdown();
+}
+
+// create 4 topics, in which 3 topics match the pattern,
+// verify PatternMultiTopicsConsumer subscribed matched topics,
+// and only receive messages from matched topics.
+TEST(BasicEndToEndTest, testPatternMultiTopicsConsumerPubSub) {
+    Client client(lookupUrl);
+    std::string pattern = "persistent://prop/unit/ns1/patternMultiTopicsConsumer.*";
+
+    std::string subName = "testPatternMultiTopicsConsumer";
+    std::string topicName1 = "persistent://prop/unit/ns1/patternMultiTopicsConsumerPubSub1";
+    std::string topicName2 = "persistent://prop/unit/ns1/patternMultiTopicsConsumerPubSub2";
+    std::string topicName3 = "persistent://prop/unit/ns1/patternMultiTopicsConsumerPubSub3";
+    // This will not match pattern
+    std::string topicName4 = "persistent://prop/unit/ns1/patternMultiTopicsNotMatchPubSub4";
+
+    // call admin api to make topics partitioned
+    std::string url1 =
+        adminUrl + "admin/persistent/prop/unit/ns1/patternMultiTopicsConsumerPubSub1/partitions";
+    std::string url2 =
+        adminUrl + "admin/persistent/prop/unit/ns1/patternMultiTopicsConsumerPubSub2/partitions";
+    std::string url3 =
+        adminUrl + "admin/persistent/prop/unit/ns1/patternMultiTopicsConsumerPubSub3/partitions";
+    std::string url4 =
+        adminUrl + "admin/persistent/prop/unit/ns1/patternMultiTopicsNotMatchPubSub4/partitions";
+
+    int res = makePutRequest(url1, "2");
+    ASSERT_FALSE(res != 204 && res != 409);
+    res = makePutRequest(url2, "3");
+    ASSERT_FALSE(res != 204 && res != 409);
+    res = makePutRequest(url3, "4");
+    ASSERT_FALSE(res != 204 && res != 409);
+    res = makePutRequest(url4, "4");
+    ASSERT_FALSE(res != 204 && res != 409);
+
+    Producer producer1;
+    Result result = client.createProducer(topicName1, producer1);
+    ASSERT_EQ(ResultOk, result);
+    Producer producer2;
+    result = client.createProducer(topicName2, producer2);
+    ASSERT_EQ(ResultOk, result);
+    Producer producer3;
+    result = client.createProducer(topicName3, producer3);
+    ASSERT_EQ(ResultOk, result);
+    Producer producer4;
+    result = client.createProducer(topicName4, producer4);
+    ASSERT_EQ(ResultOk, result);
+
+    LOG_INFO("created 3 producers that match, with partitions: 2, 3, 4, and 1 producer not match");
+
+    int messageNumber = 100;
+    ConsumerConfiguration consConfig;
+    consConfig.setConsumerType(ConsumerShared);
+    consConfig.setReceiverQueueSize(10);  // size for each sub-consumer
+    Consumer consumer;
+    Promise<Result, Consumer> consumerPromise;
+    client.subscribeAsync(pattern, subName, consConfig, true,
+                          WaitForCallbackValue<Consumer>(consumerPromise));
+    Future<Result, Consumer> consumerFuture = consumerPromise.getFuture();
+    result = consumerFuture.get(consumer);
+    ASSERT_EQ(ResultOk, result);
+    ASSERT_EQ(consumer.getSubscriptionName(), subName);
+    LOG_INFO("created topics consumer on a pattern that match 3 topics");
+
+    std::string msgContent = "msg-content";
+    LOG_INFO("Publishing 100 messages by producer 1 synchronously");
+    for (int msgNum = 0; msgNum < messageNumber; msgNum++) {
+        std::stringstream stream;
+        stream << msgContent << msgNum;
+        Message msg = MessageBuilder().setContent(stream.str()).build();
+        ASSERT_EQ(ResultOk, producer1.send(msg));
+    }
+
+    msgContent = "msg-content2";
+    LOG_INFO("Publishing 100 messages by producer 2 synchronously");
+    for (int msgNum = 0; msgNum < messageNumber; msgNum++) {
+        std::stringstream stream;
+        stream << msgContent << msgNum;
+        Message msg = MessageBuilder().setContent(stream.str()).build();
+        ASSERT_EQ(ResultOk, producer2.send(msg));
+    }
+
+    msgContent = "msg-content3";
+    LOG_INFO("Publishing 100 messages by producer 3 synchronously");
+    for (int msgNum = 0; msgNum < messageNumber; msgNum++) {
+        std::stringstream stream;
+        stream << msgContent << msgNum;
+        Message msg = MessageBuilder().setContent(stream.str()).build();
+        ASSERT_EQ(ResultOk, producer3.send(msg));
+    }
+
+    msgContent = "msg-content4";
+    LOG_INFO("Publishing 100 messages by producer 4 synchronously");
+    for (int msgNum = 0; msgNum < messageNumber; msgNum++) {
+        std::stringstream stream;
+        stream << msgContent << msgNum;
+        Message msg = MessageBuilder().setContent(stream.str()).build();
+        ASSERT_EQ(ResultOk, producer4.send(msg));
+    }
+
+    LOG_INFO("Consuming and acking 300 messages by multiTopicsConsumer");
+    for (int i = 0; i < 3 * messageNumber; i++) {
+        Message m;
+        ASSERT_EQ(ResultOk, consumer.receive(m, 1000));
+        ASSERT_EQ(ResultOk, consumer.acknowledge(m));
+    }
+    LOG_INFO("Consumed and acked 300 messages by multiTopicsConsumer");
+
+    // verify no more to receive, because producer4 not match pattern
+    Message m;
+    ASSERT_EQ(ResultTimeout, consumer.receive(m, 1000));
+
+    ASSERT_EQ(ResultOk, consumer.unsubscribe());
+
+    client.shutdown();
+}
+
+// create a pattern consumer, which contains no match topics at beginning.
+// create 4 topics, in which 3 topics match the pattern.
+// verify PatternMultiTopicsConsumer subscribed matched topics, after a while,
+// and only receive messages from matched topics.
+TEST(BasicEndToEndTest, testPatternMultiTopicsConsumerAutoDiscovery) {
+    Client client(lookupUrl);
+    std::string pattern = "persistent://prop/unit/ns2/patternTopicsAutoConsumer.*";
+    Result result;
+    std::string subName = "testPatternTopicsAutoConsumer";
+
+    // 1.  create a pattern consumer, which contains no match topics at beginning.
+    ConsumerConfiguration consConfig;
+    consConfig.setConsumerType(ConsumerShared);
+    consConfig.setReceiverQueueSize(10);          // size for each sub-consumer
+    consConfig.setPatternAutoDiscoveryPeriod(1);  // set waiting time for auto discovery
+    Consumer consumer;
+    Promise<Result, Consumer> consumerPromise;
+    client.subscribeAsync(pattern, subName, consConfig, true,
+                          WaitForCallbackValue<Consumer>(consumerPromise));
+    Future<Result, Consumer> consumerFuture = consumerPromise.getFuture();
+    result = consumerFuture.get(consumer);
+    ASSERT_EQ(ResultOk, result);
+    ASSERT_EQ(consumer.getSubscriptionName(), subName);
+    LOG_INFO("created pattern consumer with not match topics at beginning");
+
+    // 2. create 4 topics, in which 3 match the pattern.
+    std::string topicName1 = "persistent://prop/unit/ns2/patternTopicsAutoConsumerPubSub1";
+    std::string topicName2 = "persistent://prop/unit/ns2/patternTopicsAutoConsumerPubSub2";
+    std::string topicName3 = "persistent://prop/unit/ns2/patternTopicsAutoConsumerPubSub3";
+    // This will not match pattern
+    std::string topicName4 = "persistent://prop/unit/ns2/patternMultiTopicsNotMatchPubSub4";
+
+    // call admin api to make topics partitioned
+    std::string url1 =
+        adminUrl + "admin/persistent/prop/unit/ns2/patternTopicsAutoConsumerPubSub1/partitions";
+    std::string url2 =
+        adminUrl + "admin/persistent/prop/unit/ns2/patternTopicsAutoConsumerPubSub2/partitions";
+    std::string url3 =
+        adminUrl + "admin/persistent/prop/unit/ns2/patternTopicsAutoConsumerPubSub3/partitions";
+    std::string url4 =
+        adminUrl + "admin/persistent/prop/unit/ns2/patternMultiTopicsNotMatchPubSub4/partitions";
+
+    int res = makePutRequest(url1, "2");
+    ASSERT_FALSE(res != 204 && res != 409);
+    res = makePutRequest(url2, "3");
+    ASSERT_FALSE(res != 204 && res != 409);
+    res = makePutRequest(url3, "4");
+    ASSERT_FALSE(res != 204 && res != 409);
+    res = makePutRequest(url4, "4");
+    ASSERT_FALSE(res != 204 && res != 409);
+
+    Producer producer1;
+    result = client.createProducer(topicName1, producer1);
+    ASSERT_EQ(ResultOk, result);
+    Producer producer2;
+    result = client.createProducer(topicName2, producer2);
+    ASSERT_EQ(ResultOk, result);
+    Producer producer3;
+    result = client.createProducer(topicName3, producer3);
+    ASSERT_EQ(ResultOk, result);
+    Producer producer4;
+    result = client.createProducer(topicName4, producer4);
+    ASSERT_EQ(ResultOk, result);
+    LOG_INFO("created 3 producers that match, with partitions: 2, 3, 4, and 1 producer not match");
+
+    // 3. wait enough time to trigger auto discovery
+    usleep(2 * 1000 * 1000);
+
+    // 4. produce data.
+    int messageNumber = 100;
+    std::string msgContent = "msg-content";
+    LOG_INFO("Publishing 100 messages by producer 1 synchronously");
+    for (int msgNum = 0; msgNum < messageNumber; msgNum++) {
+        std::stringstream stream;
+        stream << msgContent << msgNum;
+        Message msg = MessageBuilder().setContent(stream.str()).build();
+        ASSERT_EQ(ResultOk, producer1.send(msg));
+    }
+
+    msgContent = "msg-content2";
+    LOG_INFO("Publishing 100 messages by producer 2 synchronously");
+    for (int msgNum = 0; msgNum < messageNumber; msgNum++) {
+        std::stringstream stream;
+        stream << msgContent << msgNum;
+        Message msg = MessageBuilder().setContent(stream.str()).build();
+        ASSERT_EQ(ResultOk, producer2.send(msg));
+    }
+
+    msgContent = "msg-content3";
+    LOG_INFO("Publishing 100 messages by producer 3 synchronously");
+    for (int msgNum = 0; msgNum < messageNumber; msgNum++) {
+        std::stringstream stream;
+        stream << msgContent << msgNum;
+        Message msg = MessageBuilder().setContent(stream.str()).build();
+        ASSERT_EQ(ResultOk, producer3.send(msg));
+    }
+
+    msgContent = "msg-content4";
+    LOG_INFO("Publishing 100 messages by producer 4 synchronously");
+    for (int msgNum = 0; msgNum < messageNumber; msgNum++) {
+        std::stringstream stream;
+        stream << msgContent << msgNum;
+        Message msg = MessageBuilder().setContent(stream.str()).build();
+        ASSERT_EQ(ResultOk, producer4.send(msg));
+    }
+
+    // 5. pattern consumer already subscribed 3 topics
+    LOG_INFO("Consuming and acking 300 messages by pattern topics consumer");
+    for (int i = 0; i < 3 * messageNumber; i++) {
+        Message m;
+        ASSERT_EQ(ResultOk, consumer.receive(m, 1000));
+        ASSERT_EQ(ResultOk, consumer.acknowledge(m));
+    }
+    LOG_INFO("Consumed and acked 300 messages by pattern topics consumer");
+
+    // verify no more to receive, because producer4 not match pattern
+    Message m;
+    ASSERT_EQ(ResultTimeout, consumer.receive(m, 1000));
 
     ASSERT_EQ(ResultOk, consumer.unsubscribe());
 


### PR DESCRIPTION
In PR #1279 and #1298 we added regex based subscription. This is a catch up work to add PatternMultiTopicsConsumerImpl in cpp client.