### PR TITLE
Set empty response to complete grpc txn

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceMain.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/JavaInstanceMain.java
@@ -370,9 +370,10 @@ public class JavaInstanceMain implements AutoCloseable {
             if (runtime != null) {
                 try {
                     runtime.resetMetrics().get();
+                    responseObserver.onNext(com.google.protobuf.Empty.getDefaultInstance());
                     responseObserver.onCompleted();
                 } catch (InterruptedException | ExecutionException e) {
-                    log.error("Exception in JavaInstance doing getAndResetMetrics", e);
+                    log.error("Exception in JavaInstance doing resetMetrics", e);
                     throw new RuntimeException(e);
                 }
             }


### PR DESCRIPTION
### Motivation

when function worker resets metrics for process running on grpc client, it doesn't send response back to server so, we can see below error when function-worker resets the metrics.
```
io.grpc.StatusRuntimeException: CANCELLED: HTTP/2 error code: CANCEL Received Rst Stream
```

### Modifications

send empty response to server to avoid error message for reset metrics call.

### Result

function worker will not have failure while reseting metrics.
