### PR TITLE
Fix implementation of equals() for MessageId

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageIdImpl.java
@@ -92,7 +92,9 @@ public class BatchMessageIdImpl extends MessageIdImpl {
             return ledgerId == other.ledgerId && entryId == other.entryId && partitionIndex == other.partitionIndex
                     && batchIndex == other.batchIndex;
         } else if (obj instanceof MessageIdImpl) {
-            return batchIndex == NO_BATCH && obj.equals(this);
+            MessageIdImpl other = (MessageIdImpl) obj;
+            return ledgerId == other.ledgerId && entryId == other.entryId && partitionIndex == other.partitionIndex
+                    && batchIndex == NO_BATCH;
         }
         return false;
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageIdImpl.java
@@ -70,12 +70,12 @@ public class MessageIdImpl implements MessageId {
 
     @Override
     public boolean equals(Object obj) {
-        if (obj instanceof MessageIdImpl) {
-            MessageIdImpl other = (MessageIdImpl) obj;
-            return ledgerId == other.ledgerId && entryId == other.entryId && partitionIndex == other.partitionIndex;
-        } else if (obj instanceof BatchMessageIdImpl){
+        if (obj instanceof BatchMessageIdImpl) {
             BatchMessageIdImpl other = (BatchMessageIdImpl) obj;
             return other.equals(this);
+        } else if (obj instanceof MessageIdImpl) {
+            MessageIdImpl other = (MessageIdImpl) obj;
+            return ledgerId == other.ledgerId && entryId == other.entryId && partitionIndex == other.partitionIndex;
         }
         return false;
     }

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageIdImplTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/BatchMessageIdImplTest.java
@@ -44,4 +44,28 @@ public class BatchMessageIdImplTest {
         Assert.assertTrue(batchMsgId1.hashCode() != batchMsgId2.hashCode());
 
     }
+
+    @Test
+    public void equalsTest() {
+        BatchMessageIdImpl batchMsgId1 = new BatchMessageIdImpl(0, 0, 0, 0);
+        BatchMessageIdImpl batchMsgId2 = new BatchMessageIdImpl(1, 1, 1, 1);
+        BatchMessageIdImpl batchMsgId3 = new BatchMessageIdImpl(0, 0, 0, 1);
+        BatchMessageIdImpl batchMsgId4 = new BatchMessageIdImpl(0, 0, 0, -1);
+        MessageIdImpl msgId = new MessageIdImpl(0, 0, 0);
+
+        Assert.assertTrue(batchMsgId1.equals(batchMsgId1));
+        Assert.assertFalse(batchMsgId1.equals(batchMsgId2));
+        Assert.assertFalse(batchMsgId1.equals(batchMsgId3));
+        Assert.assertFalse(batchMsgId1.equals(batchMsgId4));
+        Assert.assertFalse(batchMsgId1.equals(msgId));
+
+        Assert.assertTrue(msgId.equals(msgId));
+        Assert.assertFalse(msgId.equals(batchMsgId1));
+        Assert.assertFalse(msgId.equals(batchMsgId2));
+        Assert.assertFalse(msgId.equals(batchMsgId3));
+        Assert.assertTrue(msgId.equals(batchMsgId4));
+
+        Assert.assertTrue(batchMsgId4.equals(msgId));
+    }
+
 }


### PR DESCRIPTION
### Motivation

When comparing MessageIdImpl and BatchMessageIdImpl using `equals()` method, the result may be incorrect. For example:

```java
MessageIdImpl m1 = new MessageIdImpl(0, 0, 0);
BatchMessageIdImpl m2 = new BatchMessageIdImpl(0, 0, 0, 1);
System.out.println(m1.equals(m2));
System.out.println(m2.equals(m1));
```

```
true
false
```
### Modifications

Fixed the implementation of `equals()` method.

### Result

MessageIdImpl and BatchMessageIdImpl will be compared correctly.