### PR TITLE
Fix TestS3Offload

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/impl/BlobStoreManagedLedgerOffloader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/impl/BlobStoreManagedLedgerOffloader.java
@@ -185,7 +185,6 @@ public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
             } catch (Exception e) {
                 // allowed, some mock s3 service not need credential
                 log.error("Exception when get credentials for s3 ", e);
-                throw new PulsarServerException(e);
             }
 
             String id = "accesskey";

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/impl/BlobStoreManagedLedgerOffloader.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/offload/impl/BlobStoreManagedLedgerOffloader.java
@@ -184,7 +184,7 @@ public class BlobStoreManagedLedgerOffloader implements LedgerOffloader {
                 credentials = creds.getCredentials();
             } catch (Exception e) {
                 // allowed, some mock s3 service not need credential
-                log.error("Exception when get credentials for s3 ", e);
+                log.warn("Exception when get credentials for s3 ", e);
             }
 
             String id = "accesskey";


### PR DESCRIPTION
 ### Motivation

s3 mock service doesn't need credential. so we will fail to load credentials on s3 integration tests.
that is expected. However there is a regression when introducing GCS support in #2151:
https://github.com/apache/incubator-pulsar/pull/2151/files#diff-9160ffc9df7afcf42a8335f214393c6dR188

 ### Changes

Don't throw exception when failed to load aws credentials
