### PR TITLE
More detailed documentation to config file for TLS

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -211,15 +211,24 @@ tlsCertificateFilePath=
 # Path for the TLS private key file
 tlsKeyFilePath=
 
-# Path for the trusted TLS certificate file
+# Path for the trusted TLS certificate file.
+# This cert is used to verify that any certs presented by connecting clients
+# are signed by a certificate authority. If this verification
+# fails, then the certs are untrusted and the connections are dropped.
 tlsTrustCertsFilePath=
 
-# Accept untrusted TLS certificate from client
+# Accept untrusted TLS certificate from client.
+# If true, a client with a cert which cannot be verified with the
+# 'tlsTrustCertsFilePath' cert will allowed to connect to the server,
+# though the cert will not be used for client authentication.
 tlsAllowInsecureConnection=false
 
-# Specify whether Client certificates are required for TLS
+# Trusted client certificates are required for to connect TLS
 # Reject the Connection if the Client Certificate is not trusted.
+# In effect, this requires that all connecting clients perform TLS client
+# authentication.
 tlsRequireTrustedClientCertOnConnect=false
+
 ### --- Authentication --- ###
 
 # Enable authentication

--- a/conf/client.conf
+++ b/conf/client.conf
@@ -17,12 +17,45 @@
 # under the License.
 #
 
-# Pulsar Client and pulsar-admin configuration
+# Configuration for pulsar-client and pulsar-admin CLI tools
+
+# URL for Pulsar REST API (for admin operations)
+# For TLS:
+# webServiceUrl=https://localhost:8443/
 webServiceUrl=http://localhost:8080/
+
+# URL for Pulsar Binary Protocol (for produce and consume operations)
+# For TLS:
+# brokerServiceUrl=pulsar+ssl://localhost:6651/
 brokerServiceUrl=pulsar://localhost:6650/
-#authPlugin=
-#authParams=
-#useTls=
+
+# Authentication plugin to authenticate with servers
+# e.g. for TLS
+# authPlugin=org.apache.pulsar.client.impl.auth.AuthenticationTls
+authPlugin=
+
+# Parameters passed to authentication plugin.
+# A comma separated list of key:value pairs.
+# Keys depend on the configured authPlugin.
+# e.g. for TLS
+# authParams=tlsCertFile:/path/to/client-cert.pem,tlsKeyFile:/path/to/client-key.pem
+authParams=
+
+# Whether to use TLS. Defaults to false.
+useTls=
+
+# Allow TLS connections to servers whose certificate cannot be
+# be verified to have been signed by a trusted certificate
+# authority.
 tlsAllowInsecureConnection=false
+
+# Whether server hostname must match the common name of the certificate
+# the server is using.
 tlsEnableHostnameVerification=false
-#tlsTrustCertsFilePath
+
+# Path for the trusted TLS certificate file.
+# This cert is used to verify that any cert presented by a server
+# is signed by a certificate authority. If this verification
+# fails, then the cert is untrusted and the connection is dropped.
+tlsTrustCertsFilePath=
+

--- a/conf/proxy.conf
+++ b/conf/proxy.conf
@@ -97,6 +97,18 @@ tlsCertificateFilePath=
 # Path for the TLS private key file
 tlsKeyFilePath=
 
+# Path for the trusted TLS certificate file.
+# This cert is used to verify that any certs presented by connecting clients
+# are signed by a certificate authority. If this verification
+# fails, then the certs are untrusted and the connections are dropped.
+tlsTrustCertsFilePath=
+
+# Accept untrusted TLS certificate from client.
+# If true, a client with a cert which cannot be verified with the
+# 'tlsTrustCertsFilePath' cert will allowed to connect to the server,
+# though the cert will not be used for client authentication.
+tlsAllowInsecureConnection=false
+
 # Whether the hostname is validated when the proxy creates a TLS connection with brokers
 tlsHostnameVerificationEnabled=false
 


### PR DESCRIPTION
This patch adds more detail for TLS options in the broker, proxy, and
client configuration files which were previously ambiguous. It also
adds some options which were missing, and suggests some defaults in
the client configuration.
