### PR TITLE
C++ should default not allow insecure connections with TLS

### DIFF
--- a/pulsar-client-cpp/lib/ClientConfigurationImpl.h
+++ b/pulsar-client-cpp/lib/ClientConfigurationImpl.h
@@ -44,7 +44,7 @@ struct ClientConfigurationImpl {
           concurrentLookupRequest(50000),
           logConfFilePath(),
           useTls(false),
-          tlsAllowInsecureConnection(true),
+          tlsAllowInsecureConnection(false),
           statsIntervalInSeconds(600),  // 10 minutes
           loggerFactory() {}
 };


### PR DESCRIPTION
If tlsAllowInsecureConnection is true, then the client doesn't
validate the server's TLS cert, allowing for MITM attacks. This
shouldn't be the default option.
