### PR TITLE
add stats entry for active consumer name and endpoint to get leader of functions cluster

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/FunctionsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/FunctionsBase.java
@@ -215,6 +215,20 @@ public class FunctionsBase extends AdminResource implements Supplier<WorkerServi
 
     @GET
     @ApiOperation(
+            value = "Fetches info about the leader node of the Pulsar cluster running Pulsar Functions",
+            response = WorkerInfo.class
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 403, message = "The requester doesn't have admin permissions")
+
+    })
+    @Path("/cluster/leader")
+    public WorkerInfo getClusterLeader() {
+        return functions.getClusterLeader();
+    }
+
+    @GET
+    @ApiOperation(
             value = "Fetches information about which Pulsar Functions are assigned to which Pulsar clusters",
             response = Assignment.class,
             responseContainer = "Map"

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -630,6 +630,10 @@ public class PersistentSubscription implements Subscription {
         }
 
         subStats.type = getType();
+        if (dispatcher instanceof PersistentDispatcherSingleActiveConsumer) {
+            subStats.activeConsumerName
+                    = ((PersistentDispatcherSingleActiveConsumer) dispatcher).getActiveConsumer().consumerName();
+        }
         if (SubType.Shared.equals(subStats.type)) {
             if (dispatcher instanceof PersistentDispatcherMultipleConsumers) {
                 subStats.unackedMessages = ((PersistentDispatcherMultipleConsumers) dispatcher)
@@ -640,6 +644,7 @@ public class PersistentSubscription implements Subscription {
         }
         subStats.msgBacklog = getNumberOfEntriesInBacklog();
         subStats.msgRateExpired = expiryMonitor.getMessageExpiryRate();
+
         return subStats;
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -631,8 +631,11 @@ public class PersistentSubscription implements Subscription {
 
         subStats.type = getType();
         if (dispatcher instanceof PersistentDispatcherSingleActiveConsumer) {
-            subStats.activeConsumerName
-                    = ((PersistentDispatcherSingleActiveConsumer) dispatcher).getActiveConsumer().consumerName();
+                    ((PersistentDispatcherSingleActiveConsumer) dispatcher).getActiveConsumer());
+            Consumer activeConsumer = ((PersistentDispatcherSingleActiveConsumer) dispatcher).getActiveConsumer();
+            if (activeConsumer != null) {
+                subStats.activeConsumerName = activeConsumer.consumerName();
+            }
         }
         if (SubType.Shared.equals(subStats.type)) {
             if (dispatcher instanceof PersistentDispatcherMultipleConsumers) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -631,7 +631,6 @@ public class PersistentSubscription implements Subscription {
 
         subStats.type = getType();
         if (dispatcher instanceof PersistentDispatcherSingleActiveConsumer) {
-                    ((PersistentDispatcherSingleActiveConsumer) dispatcher).getActiveConsumer());
             Consumer activeConsumer = ((PersistentDispatcherSingleActiveConsumer) dispatcher).getActiveConsumer();
             if (activeConsumer != null) {
                 subStats.activeConsumerName = activeConsumer.consumerName();

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/SubscriptionStats.java
@@ -47,8 +47,11 @@ public class SubscriptionStats {
     /** Number of unacknowledged messages for the subscription */
     public long unackedMessages;
 
-    /** whether this subscription is Exclusive or Shared or Failover */
+    /** Whether this subscription is Exclusive or Shared or Failover */
     public SubType type;
+
+    /** The name of the consumer that is active for single active consumer subscriptions i.e. failover or exclusive */
+    public String activeConsumerName;
 
     /** Total rate of messages expired on this subscription. msg/s */
     public double msgRateExpired;

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
@@ -508,6 +508,24 @@ public class FunctionsImpl {
         return Response.status(Status.OK).entity(new Gson().toJson(members)).build();
     }
 
+    public WorkerInfo getClusterLeader() {
+        if (!isWorkerServiceAvailable()) {
+            throw new WebApplicationException(
+                    Response.status(Status.SERVICE_UNAVAILABLE).type(MediaType.APPLICATION_JSON)
+                            .entity(new ErrorData("Function worker service is not avaialable")).build());
+        }
+
+        MembershipManager membershipManager = worker().getMembershipManager();
+        WorkerInfo leader = membershipManager.getLeader();
+
+        if (leader == null) {
+            throw new WebApplicationException(
+                    Response.status(Status.INTERNAL_SERVER_ERROR).type(MediaType.APPLICATION_JSON)
+                            .entity(new ErrorData("Leader cannot be determined")).build());}
+
+        return leader;
+    }
+
     public Response getAssignments() {
 
         if (!isWorkerServiceAvailable()) {

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2Resource.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v2/FunctionApiV2Resource.java
@@ -136,6 +136,13 @@ public class FunctionApiV2Resource extends FunctionApiResource {
     }
 
     @GET
+    @Path("/cluster/leader")
+    @Produces(MediaType.APPLICATION_JSON)
+    public WorkerInfo getClusterLeader() {
+        return functions.getClusterLeader();
+    }
+
+    @GET
     @Path("/assignments")
     public Response getAssignments() {
         return functions.getAssignments();


### PR DESCRIPTION
### Motivation

Currently there is no way to determine the active consumer of a topic (failover or exclusive).  It would be nice for debugging purposes to be able to see which consumer is the active consumer.

Also in a functions cluster, it would also be nice to now which worker is the leader

### Modifications

Added an entry in subscriptions stats for the active consumer name. 

Added an endpoint that returns the leader of the functions cluster
