### PR TITLE
[build][docker] Add zip and unzip to pulsar-build docker image

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && \
                 liblog4cxx-dev libprotobuf-dev libboost-all-dev google-mock libgtest-dev \
                 libjsoncpp-dev libxml2-utils protobuf-compiler wget \
                 curl doxygen openjdk-8-jdk-headless clang-format-5.0 \
-                gnupg2 golang-1.10-go
+                gnupg2 golang-1.10-go zip unzip
 
 # Compile and install gtest
 RUN cd /usr/src/gtest && cmake . && make && cp libgtest.a /usr/lib


### PR DESCRIPTION
 ### Motivation

zip and unzip are required for building pulsar project since #2192.

 ### Changes

add `zip` and `unzip` into `pulsar-build` docker image, so the docker
image can be used for building website

