### PR TITLE
[build] Add `yarn.lock` into gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,7 @@ pulsar-client-cpp/python/wheelhouse
 # CI generated files
 .repository
 docker.debug-info
+
+# Yarn
+
+**/yarn.lock


### PR DESCRIPTION
 ### Motivation

We introduced docusaurus in #2206 for building the new documentation site.
docusaurus is using [yarn](https://yarnpkg.com/en/docs/install#mac-stable) for building.
It will leave `yarn.lock` file after builds.

 ### Changes

Add `yarn.lock` into gitignore file

