### PR TITLE
add function-name reference with function failure log

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeSpawner.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/RuntimeSpawner.java
@@ -82,7 +82,9 @@ public class RuntimeSpawner implements AutoCloseable {
                 @Override
                 public void run() {
                     if (!runtime.isAlive()) {
-                        log.error("Function Container is dead with exception", runtime.getDeathException());
+                        log.error("[{}-{}] Function Container is dead with exception",
+                                instanceConfig.getFunctionDetails().getName(), instanceConfig.getInstanceId(),
+                                runtime.getDeathException());
                         log.error("Restarting...");
                         // Just for the sake of sanity, just destroy the runtime
                         runtime.stop();


### PR DESCRIPTION
### Motivation

Right now, on function runtime failure, log shows exception but it's hard to figure out for which function is happens so, adding function-reference along with exception.
