### PR TITLE
 [website] Add versions page

### DIFF
--- a/site2/website/oldversions.json
+++ b/site2/website/oldversions.json
@@ -1,0 +1,8 @@
+[
+    "2.0.1-incubating",
+    "2.0.0-rc1-incubating",
+    "1.22.0-incubating",
+    "1.21.0-incubating",
+    "1.20.0-incubating",
+    "1.19.0-incubating"
+]

--- a/site2/website/pages/en/download.js
+++ b/site2/website/pages/en/download.js
@@ -89,15 +89,20 @@ class Download extends React.Component {
 
 
             <h2>Release notes</h2>
-            <MarkdownBlock>
-              [Release notes](/release-notes) for all Pulsar's versions
-            </MarkdownBlock>
+            <div>
+              <p>
+                <a href={`${siteConfig.baseUrl}/release-notes`}>Release notes</a> for all Pulsar's versions
+              </p>
+            </div>
 
             <h2>Getting started</h2>
-            <MarkdownBlock>
-              Once you've downloaded a Pulsar release, instructions on getting up and running with a standalone cluster 
-              that you can run on your laptop can be found in the [Run Pulsar locally](/docs/standalone) tutorial.
-            </MarkdownBlock>
+            <div>
+              <p>
+                Once you've downloaded a Pulsar release, instructions on getting up and running with a standalone cluster 
+                that you can run on your laptop can be found in the{' '}
+                <a href={`${siteConfig.baseUrl}docs/standalone`}>Run Pulsar locally</a> tutorial.
+              </p>
+            </div>
             <p>
               If you need to connect to an existing Pulsar cluster or instance using an officially supported client, 
               see the client docs for these languages:
@@ -160,7 +165,7 @@ class Download extends React.Component {
                             <a href={`${info.srcArchiveUrl}.sha512`}>sha512</a>)
                         </td>
                         <td>
-                          <a href={''}>Release Notes</a>
+                          <a href={`${siteConfig.baseUrl}release-notes#${info.version}`}>Release Notes</a>
                         </td>
                       </tr>
                     )

--- a/site2/website/pages/en/release-notes.js
+++ b/site2/website/pages/en/release-notes.js
@@ -19,7 +19,7 @@ class ReleaseNotes extends React.Component {
         <Container className="mainContainer documentContainer postContainer">
           <div className="post">
             <header className="postHeader">
-              <h1>Apache Pulsar downloads</h1>
+              <h1>Apache Pulsar Release Notes</h1>
               <hr />
             </header>
             <MarkdownBlock>

--- a/site2/website/pages/en/versions.js
+++ b/site2/website/pages/en/versions.js
@@ -8,90 +8,99 @@ const GridBlock = CompLibrary.GridBlock;
 const CWD = process.cwd();
 
 const siteConfig = require(`${CWD}/siteConfig.js`);
-//const versions = require(CWD + '/versions.json');
+// versions post docusaurus
+// const versions = require(`${CWD}/versions.json`);
+// versions pre docusaurus
+const oldversions = require(`${CWD}/oldversions.json`);
 
-/*
-class Versions extends React.Component {
-  render() {
-    const latestVersion = versions[0];
+function Versions(props) {
+    const latestStableVersion = oldversions[0];
+    const repoUrl = `https://github.com/${siteConfig.organizationName}/${
+      siteConfig.projectName
+    }`;
     return (
-      <div className="docMainWrapper wrapper">
-        <Container className="mainContainer versionsContainer">
-          <div className="post">
-            <header className="postHeader">
-              <h2>{siteConfig.title + ' Versions'}</h2>
-            </header>
-            <p>New versions of this project are released every so often.</p>
-            <h3 id="latest">Current version (Stable)</h3>
-            <table className="versions">
-              <tbody>
-                <tr>
-                  <th>{latestVersion}</th>
-                  <td>
-                    <a href={''}>Documentation</a>
-                  </td>
-                  <td>
-                    <a href={''}>Release Notes</a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <p>
-              This is the version that is configured automatically when you
-              first install this project.
-            </p>
-            <h3 id="rc">Pre-release versions</h3>
-            <table className="versions">
-              <tbody>
-                <tr>
-                  <th>master</th>
-                  <td>
-                    <a href={''}>Documentation</a>
-                  </td>
-                  <td>
-                    <a href={''}>Release Notes</a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <p>Other text describing this section.</p>
-            <h3 id="archive">Past Versions</h3>
-            <table className="versions">
-              <tbody>
-                {versions.map(
-                  version =>
-                    version !== latestVersion && (
-                      <tr>
-                        <th>{version}</th>
-                        <td>
-                          <a href={''}>Documentation</a>
-                        </td>
-                        <td>
-                          <a href={''}>Release Notes</a>
-                        </td>
-                      </tr>
-                    )
-                )}
-              </tbody>
-            </table>
-            <p>
-              You can find past versions of this project{' '}
-              <a href="https://github.com/"> on GitHub </a>.
-            </p>
-          </div>
-        </Container>
-      </div>
-    );
-  }
+    <div className="pageContainer">
+      <Container className="mainContainer documentContainer postContainer">
+        <div className="post">
+          <header className="postHeader">
+            <h1>{siteConfig.title} Versions</h1>
+          </header>
+          <h3 id="latest">Latest Stable Version</h3>
+          <p>Latest stable release of Apache Pulsar.</p>
+          <table className="versions">
+            <tbody>
+              <tr>
+                <th>{latestStableVersion}</th>
+                <td>
+                  <a
+                    href={`${siteConfig.url}/docs/v${latestStableVersion}/getting-started/LocalCluster/`}>
+                    Documentation
+                  </a>
+                </td>
+                <td>
+                  <a href={`${siteConfig.baseUrl}release-notes#${latestStableVersion}`}>
+                    Release Notes
+                  </a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h3 id="rc">Latest Version</h3>
+          Here you can find the latest documentation and unreleased code.
+          <table className="versions">
+            <tbody>
+              <tr>
+                <th>master</th>
+                <td>
+                  <a
+                    href={`${siteConfig.baseUrl}docs/standalone`}>
+                    Documentation
+                  </a>
+                </td>
+                <td>
+                  <a href={repoUrl}>Source Code</a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <h3 id="archive">Past Versions</h3>
+          <p>
+            Here you can find documentation for previous versions of Apache Pulsar.
+          </p>
+          <table className="versions">
+            <tbody>
+              {oldversions.map(
+                version =>
+                  version !== latestStableVersion && (
+                    <tr key={version}>
+                      <th>{version}</th>
+                      <td>
+                        <a
+                          href={`${siteConfig.url}/docs/v${version}/getting-started/LocalCluster/`}>
+                          Documentation
+                        </a>
+                      </td>
+                      <td>
+                        <a href={`${siteConfig.baseUrl}/release-notes#${version}`}>
+                          Release Notes
+                        </a>
+                      </td>
+                    </tr>
+                  )
+              )}
+            </tbody>
+          </table>
+          <p>
+            You can find past versions of this project on{' '}
+            <a href={`${repoUrl}/releases`}>GitHub</a> or download from{' '}
+            <a href={`${siteConfig.baseUrl}download`}>Apache</a>.
+          </p>
+        </div>
+      </Container>
+    </div>
+  );
 }
-*/
 
-class Versions extends React.Component {
-  render() {
-    return (
-      <h3>versions</h3>
-    );
-  }
-}
+Versions.title = 'Versions';
 
 module.exports = Versions;

--- a/site2/website/siteConfig.js
+++ b/site2/website/siteConfig.js
@@ -66,7 +66,7 @@ const siteConfig = {
 
   // Used for publishing and more
   projectName: 'pulsar',
-  //organizationName: '',
+  organizationName: 'apache',
   // For top-level user or org sites, the organization is still the same.
   // e.g., for the https://JoelMarcey.github.io site, it would be set like...
   //   organizationName: 'JoelMarcey'


### PR DESCRIPTION
 ### Motivation

We need to link back to the documentation for the old versions.

 ### Changes

Update `versions` page to include links back to old versions.

 ### NOTES

This change doesn't include cutting a version for 2.1.0 release.
This will be done after 2.1.0 release is released.