### PR TITLE
Throw exception on non-zero command exit in integ tests

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/ChaosContainer.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/containers/ChaosContainer.java
@@ -106,8 +106,7 @@ public class ChaosContainer<SelfT extends ChaosContainer<SelfT>> extends Generic
     public ContainerExecResult execCmd(String... commands) throws Exception {
         DockerClient client = this.getDockerClient();
         String dockerId = this.getContainerId();
-        return DockerUtils.runCommand(
-            client, dockerId, true, commands);
+        return DockerUtils.runCommand(client, dockerId, commands);
     }
 
     @Override

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/docker/ContainerExecException.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/docker/ContainerExecException.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.tests.integration.docker;
+
+public class ContainerExecException extends Exception {
+    private final ContainerExecResult result;
+
+    public ContainerExecException(String cmd, String containerId, ContainerExecResult result) {
+        super(String.format("%s failed on %s with error code %d", cmd, containerId, result.getExitCode()));
+        this.result = result;
+    }
+
+    public ContainerExecResult getResult() {
+        return result;
+    }
+}


### PR DESCRIPTION
This patch replaces the boolean flag to ignore failure, and instead
always throws an exception if a command exits with non-zero. This
means that test code doesn't need to check the exit code for each
invokation. For non-zero exits, the ContainerExecResult is carried as
part of the exception, so the test can also assert on the contents of
stdout, stderr and the exit code.
