### PR TITLE
Fix pulsar:version vars in site2 docs.

### DIFF
--- a/site2/docs/deploy-bare-metal.md
+++ b/site2/docs/deploy-bare-metal.md
@@ -48,20 +48,20 @@ For machines running a bookie and a Pulsar broker, we recommend using more power
 To get started deploying a Pulsar cluster on bare metal, you'll need to download a binary tarball release in one of the following ways:
 
 * By clicking on the link directly below, which will automatically trigger a download:
-  * <a href="pulsar:binary_release_url" download>Pulsar pulsar:version binary release</a>
+  * <a href="pulsar:binary_release_url" download>Pulsar {{pulsar:version}} binary release</a>
 * From the Pulsar [downloads page](pulsar:download_page_url)
 * From the Pulsar [releases page](https://github.com/apache/incubator-pulsar/releases/latest) on [GitHub](https://github.com)
 * Using [wget](https://www.gnu.org/software/wget):
 
 ```bash
-$ wget http://archive.apache.org/dist/incubator/pulsar/pulsar-pulsar:version/apache-pulsar-pulsar:version-bin.tar.gz
+$ wget pulsar:binary_release_url
 ```
 
 Once you've downloaded the tarball, untar it and `cd` into the resulting directory:
 
 ```bash
-$ tar xvzf apache-pulsar-pulsar:version-bin.tar.gz
-$ cd apache-pulsar-pulsar:version
+$ tar xvzf apache-pulsar-{{pulsar:version}}-bin.tar.gz
+$ cd apache-pulsar-{{pulsar:version}}
 ```
 
 The untarred directory contains the following subdirectories:

--- a/site2/docs/getting-started-standalone.md
+++ b/site2/docs/getting-started-standalone.md
@@ -20,7 +20,7 @@ To get started running Pulsar, download a binary tarball release in one of the f
 
 * by clicking the link below and downloading the release from an Apache mirror:
 
-  * <a href="pulsar:binary_release_url" download>Pulsar pulsar:version binary release</a>
+  * <a href="pulsar:binary_release_url" download>Pulsar {{pulsar:version}} binary release</a>
 
 * from the Pulsar [downloads page](pulsar:download_page_url)
 * from the Pulsar [releases page](https://github.com/apache/incubator-pulsar/releases/latest)
@@ -33,8 +33,8 @@ To get started running Pulsar, download a binary tarball release in one of the f
 Once the tarball is downloaded, untar it and `cd` into the resulting directory:
 
 ```bash
-$ tar xvfz apache-pulsar-pulsar:version-bin.tar.gz
-$ cd apache-pulsar-pulsar:version
+$ tar xvfz apache-pulsar-{{pulsar:version}}-bin.tar.gz
+$ cd apache-pulsar-{{pulsar:version}}
 ```
 
 ## What your package contains


### PR DESCRIPTION
### Motivation

pulsar:version shows up in the docs. http://pulsar.incubator.apache.org/staging/docs/standalone/#installing-pulsar

### Modifications

Update to the new variable format.

### Result

The correct version shows up.