### PR TITLE
Fix: function-cli avoid arg-type check and class-loading for file url

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -545,7 +545,14 @@ public class CmdFunctions extends CmdBase {
 
             Class<?>[] typeArgs = null;
             if (functionConfig.getRuntime() == FunctionConfig.Runtime.JAVA) {
-                typeArgs = Utils.getFunctionTypes(functionConfig);
+                if (functionConfig.getJar().startsWith(Utils.FILE)) {
+                    // server derives the arg-type by loading a class
+                    if (isBlank(functionConfig.getClassName())) {
+                        throw new ParameterException("Class-name must be present for jar with file-url");
+                    }
+                } else {
+                    typeArgs = Utils.getFunctionTypes(functionConfig);
+                }
             }
 
             FunctionDetails.Builder functionDetailsBuilder = FunctionDetails.newBuilder();

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfig.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfig.java
@@ -69,7 +69,6 @@ public class FunctionConfig {
     @NotNull
     private String name;
     @NotNull
-    @isImplementationOfClasses(implementsClasses = {Function.class, java.util.function.Function.class})
     private String className;
     @isListEntryCustom(entryValidatorClasses = {ValidatorImpls.TopicNameValidator.class})
     private Collection<String> inputs;

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/validation/ValidatorImpls.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/validation/ValidatorImpls.java
@@ -502,7 +502,9 @@ public class ValidatorImpls {
             FunctionConfig functionConfig = (FunctionConfig) o;
             doCommonChecks(functionConfig);
             if (functionConfig.getRuntime() == FunctionConfig.Runtime.JAVA) {
-                doJavaChecks(functionConfig, name);
+                if (!functionConfig.getJar().startsWith(Utils.FILE)) {
+                    doJavaChecks(functionConfig, name);
+                }
             } else {
                 doPythonChecks(functionConfig, name);
             }


### PR DESCRIPTION
### Motivation

While function-registration, Function does server side validation for function-jar with url (http/file). So, cli can't load jar for file-url protocol and validate classname of the function. 

### Modifications

[Skip class-name validation](https://github.com/apache/incubator-pulsar/blob/master/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java#L447) for jar with file url.

### Result

user can submit function with file-url using cli.
