### PR TITLE
Derive source/sink arg-class name from function-class for file-url

### DIFF
--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Utils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/Utils.java
@@ -102,16 +102,21 @@ public class Utils {
     }
 
     public static Class<?>[] getFunctionTypes(FunctionConfig functionConfig) {
-
-        Object userClass = createInstance(functionConfig.getClassName(), Thread.currentThread().getContextClassLoader());
+        Object userClass = createInstance(functionConfig.getClassName(),
+                Thread.currentThread().getContextClassLoader());
+        boolean isWindowConfigPresent = functionConfig.getWindowConfig() != null;
+        return getFunctionTypes(userClass, isWindowConfigPresent);
+    }
+    
+    public static Class<?>[] getFunctionTypes(Object userClass, boolean isWindowConfigPresent) {
 
         Class<?>[] typeArgs;
         // if window function
-        if (functionConfig.getWindowConfig() != null) {
+        if (isWindowConfigPresent) {
             java.util.function.Function function = (java.util.function.Function) userClass;
             if (function == null) {
-                throw new IllegalArgumentException(String.format("The Java util function class %s could not be instantiated",
-                        functionConfig.getClassName()));
+                throw new IllegalArgumentException(
+                        String.format("The Java util function class %s could not be instantiated", userClass));
             }
             typeArgs = TypeResolver.resolveRawArguments(java.util.function.Function.class, function.getClass());
             if (!typeArgs[0].equals(Collection.class)) {

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
@@ -865,6 +865,8 @@ public class FunctionsImpl {
 
         // validate function class-type
         Object functionObject = createInstance(functionDetailsBuilder.getClassName(), classLoader);
+        Class<?>[] typeArgs = org.apache.pulsar.functions.utils.Utils.getFunctionTypes(functionObject, false);
+        
         if (!(functionObject instanceof org.apache.pulsar.functions.api.Function)
                 && !(functionObject instanceof java.util.function.Function)) {
             throw new RuntimeException("User class must either be Function or java.util.Function");
@@ -891,6 +893,9 @@ public class FunctionsImpl {
                 log.error("Failed to validate source class", e);
                 throw new IllegalArgumentException("Failed to validate source class-name", e);
             }
+        } else {
+            functionDetailsBuilder
+                    .setSource(functionDetailsBuilder.getSourceBuilder().setTypeClassName(typeArgs[0].getName()));
         }
 
         if (functionDetailsBuilder.hasSink() && functionDetailsBuilder.getSink() != null
@@ -913,7 +918,11 @@ public class FunctionsImpl {
                 log.error("Failed to validate sink class", e);
                 throw new IllegalArgumentException("Failed to validate sink class-name", e);
             }
+        } else {
+            functionDetailsBuilder
+                    .setSink(functionDetailsBuilder.getSinkBuilder().setTypeClassName(typeArgs[1].getName()));
         }
+
     }
 
     private Class<?> getTypeArg(String className, Class<?> funClass, URLClassLoader classLoader)


### PR DESCRIPTION
### Motivation

When user submits function with file-url, server loads jar and performs validation. In that case, server should also configures source/sink arg type-class if it's not configured in the function details.

### Modification

when user submits function with url using cli, it doesn't pass type-arg classname into the request, so, server will update it by loading jar and function-class name.

### Result

User can successfully submit function jar with file-url.