### PR TITLE
ack message for atmost processing guaranty

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/sink/PulsarSink.java
@@ -82,7 +82,14 @@ public class PulsarSink<T> implements Sink<T> {
         public void sendOutputMessage(MessageBuilder outputMsgBuilder,
                                       Record<T> recordContext) throws Exception {
             Message<byte[]> outputMsg = outputMsgBuilder.build();
-            this.producer.sendAsync(outputMsg);
+            this.producer.sendAsync(outputMsg).handle((messageId, e) -> {
+                if (log.isDebugEnabled()) {
+                    log.debug("[{}] failed to sink message {}", recordContext.getTopicName().orElseGet(() -> null),
+                            e.getMessage());
+                }
+                recordContext.ack();
+                return null;
+            });
         }
 
         @Override


### PR DESCRIPTION
### Motivation

[at-most-once](https://doc.akka.io/docs/akka/current/general/message-delivery-reliability.html?language=scala) delivery can't give delivery guaranteed. If function has pulsar as a source and sink both then right now, `PulsarSinkAtMostOnceProcessor` doesn't ack message to broker so, broker restart can redeliver all messages and user might not be expecting this behavior for `at-most-once`.

### Modifications

Pulsar sink acks messages regardless publish-result for `at-most-once` usecase.

### Result

Pulsar sink will not redeliver duplicate messages when it is consuming messages from pulsar-source for `at-most-once`.
