### PR TITLE
handle subscription-already-exist exception on partitioned-topic for create-sub admin-api

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/CreateSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/CreateSubscriptionTest.java
@@ -103,4 +103,30 @@ public class CreateSubscriptionTest extends ProducerConsumerBase {
                     Lists.newArrayList("sub-1"));
         }
     }
+    
+    @Test
+    public void createSubscriptionOnPartitionedTopicWithPartialFailure() throws Exception {
+        String topic = "persistent://my-property/my-ns/my-partitioned-topic";
+        admin.topics().createPartitionedTopic(topic, 10);
+        
+        // create subscription for one partition
+        final String partitionedTopic0 = topic+"-partition-0";
+        admin.topics().createSubscription(partitionedTopic0, "sub-1", MessageId.latest);
+
+        admin.topics().createSubscription(topic, "sub-1", MessageId.latest);
+
+        // Create should fail if the subscription already exists
+        try {
+            admin.topics().createSubscription(topic, "sub-1", MessageId.latest);
+            fail("Should have failed");
+        } catch (Exception e) {
+            // Expected
+        }
+
+        for (int i = 0; i < 10; i++) {
+            assertEquals(
+                    admin.topics().getSubscriptions(TopicName.get(topic).getPartition(i).toString()),
+                    Lists.newArrayList("sub-1"));
+        }
+    }
 }


### PR DESCRIPTION
### Motivation

right now, application uses admin api to create subscription on partitioned topic. if subscription creation fails for one of the partition then it gives error to application. so, if application retries to create subscription again then admin api always gives `subscription-already-exist` exception (because previous call has partially created subscription on some of the partitions) and user/application will never be able to handle this scenario correctly.

### Modifications

handle partially failed request for create-subscription api.
admin api fails request only if
- subscription is created for all partitions


### Result

server handles and sends correct error-response for partially failed create subscription request.
