### PR TITLE
Fix the sample code in Metrics for Pulsar Functions document

### DIFF
--- a/site/docs/latest/functions/metrics.md
+++ b/site/docs/latest/functions/metrics.md
@@ -27,7 +27,7 @@ import org.apache.pulsar.functions.api.Function;
 
 public class MetricRecordingFunction implements Function<String, Void> {
     @Override
-    public void apply(String input, Context context) {
+    public Void process(String input, Context context) {
         context.recordMetric("number-of-characters", input.length());
         return null;
     }


### PR DESCRIPTION
### Motivation
In https://pulsar.incubator.apache.org/docs/latest/functions/metrics/
introducing the sample code of using metric.
```
import org.apache.pulsar.functions.api.Context;
import org.apache.pulsar.functions.api.Function;

public class MetricRecordingFunction implements Function<String, Void> {
    @Override
    public void apply(String input, Context context) {
        context.recordMetric("number-of-characters", input.length());
        return null;
    }
}
```
I cannot compile the code because override method is different.

### Modifications

I changed method `apply` method to `process` method.
I also change `void` to `Void`.

```
@Override
public Void process(String input, Context context) {
    context.recordMetric("number-of-characters", input.length());
    return null;
}
```
### Result

We can compile the code.
