### PR TITLE
[build] pin protobuf-shaded version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,6 @@ flexible messaging model and an intuitive client API.</description>
     <module>pulsar-client-kafka-compat</module>
     <module>pulsar-zookeeper</module>
     <module>pulsar-log4j2-appender</module>
-    <module>protobuf-shaded</module>
     <!-- jclouds shaded for gson conflict: https://issues.apache.org/jira/browse/JCLOUDS-1166 -->
     <module>jclouds-shaded</module>
 
@@ -126,6 +125,9 @@ flexible messaging model and an intuitive client API.</description>
     <redirectTestOutputToFile>true</redirectTestOutputToFile>
     <testRealAWS>false</testRealAWS>
     <testRetryCount>1</testRetryCount>
+
+    <!-- pin the protobuf-shaded version to make the pulsar build friendly to intellij -->
+    <pulsar.protobuf.shaded.version>2.1.0-incubating</pulsar.protobuf.shaded.version>
 
     <!-- apache commons -->
     <commons-compress.version>1.15</commons-compress.version>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.apache.pulsar</groupId>
       <artifactId>protobuf-shaded</artifactId>
-      <version>${project.version}</version>
+      <version>${pulsar.protobuf.shaded.version}</version>
     </dependency>
 
     <dependency>

--- a/pulsar-common/pom.xml
+++ b/pulsar-common/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>protobuf-shaded</artifactId>
-      <version>${project.version}</version>
+      <version>${pulsar.protobuf.shaded.version}</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.protobuf</groupId>

--- a/pulsar-functions/utils/pom.xml
+++ b/pulsar-functions/utils/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>org.apache.pulsar</groupId>
       <artifactId>protobuf-shaded</artifactId>
-      <version>${project.version}</version>
+      <version>${pulsar.protobuf.shaded.version}</version>
     </dependency>
 
     <dependency>

--- a/pulsar-io/core/pom.xml
+++ b/pulsar-io/core/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>protobuf-shaded</artifactId>
-      <version>${project.version}</version>
+      <version>${pulsar.protobuf.shaded.version}</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
 ### Motivation

shading kills the development experiences in IDEs like intellij.
since protobuf-shaded is a module that is rarely changed, we should
pin the version of `protobuf-shaded` to make IDEs work well with
shaded depenencies

 ### Changes

Pin `protobuf-shaded` to `2.1.0-incubating`

