### PR TITLE
kinesis-sink: manage msg ordering for publish callback failure

### DIFF
--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSinkConfig.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSinkConfig.java
@@ -45,6 +45,7 @@ public class KinesisSinkConfig implements Serializable {
     private String awsCredentialPluginName;
     private String awsCredentialPluginParam;
     private MessageFormat messageFormat = MessageFormat.ONLY_RAW_PAYLOAD; // default : ONLY_RAW_PAYLOAD
+    private boolean retainOrdering;
 
     public static KinesisSinkConfig load(String yamlFile) throws IOException {
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());


### PR DESCRIPTION
### Motivation

sometimes, kinesis async-publish fails and failure-callback is called on kpl thread which should not throw any exception rather function-thread should throw runtime-exception which can reinit consumer and function. so, kpl thread can capture publish-failure and next publish on function-thread can throw runtime-exception (if user wants to retain ordering)  to reinit the function.
