### PR TITLE
[website] fix `developing-binary-protocol` page

### DIFF
--- a/site2/docs/developing-binary-protocol.md
+++ b/site2/docs/developing-binary-protocol.md
@@ -549,9 +549,4 @@ message CommandPartitionedTopicMetadataResponse {
 
 ## Protobuf interface
 
-{% include protobuf.html %}
-
-
-
-
-
+All Pulsar's Protobuf definitions can be found {@inject: github:here:/pulsar-common/src/main/proto/PulsarApi.proto}.


### PR DESCRIPTION
 ### Motiviation

old website has a customized template on formating protobuf file
into website. it is hard to achieve in the new website.

 ### Changes

Changes to a hyperlink to point back to the protobuf definition file at github.

