### PR TITLE
[website] fix anchors in functions documentation pages and add `State` documentation

### DIFF
--- a/site2/docs/functions-deploying.md
+++ b/site2/docs/functions-deploying.md
@@ -25,7 +25,7 @@ If you're running a non-[standalone](reference-terminology.md#standalone) cluste
 
 ## Command-line interface
 
-Pulsar Functions are deployed and managed using the [`pulsar-admin functions`](reference-pulsar-admin.md#functions) interface, which contains commands such as [`create`](reference-pulsar-admin.md#functions-create) for deploying functions in [cluster mode](#cluster-mode), [`trigger`](reference-pulsar-admin.md#functions-trigger) for [triggering](#triggering) functions, [`list`](reference-pulsar-admin.md#functions-list) for listing deployed functions, and several others.
+Pulsar Functions are deployed and managed using the [`pulsar-admin functions`](reference-pulsar-admin.md#functions) interface, which contains commands such as [`create`](reference-pulsar-admin.md#functions-create) for deploying functions in [cluster mode](#cluster-mode), [`trigger`](reference-pulsar-admin.md#trigger) for [triggering](#triggering-pulsar-functions) functions, [`list`](reference-pulsar-admin.md#list-2) for listing deployed functions, and several others.
 
 ### Fully Qualified Function Name (FQFN)
 
@@ -47,8 +47,8 @@ Function name | Whichever value is specified for the class name (minus org, libr
 Tenant | Derived from the input topics' names. If the input topics are under the `marketing` tenant---i.e. the topic names have the form `persistent://marketing/{namespace}/{topicName}`---then the tenant will be `marketing`.
 Namespace | Derived from the input topics' names. If the input topics are under the `asia` namespace under the `marketing` tenant---i.e. the topic names have the form `persistent://marketing/asia/{topicName}`, then the namespace will be `asia`.
 Output topic | `{input topic}-{function name}-output`. A function with an input topic name of `incoming` and a function name of `exclamation`, for example, would have an output topic of `incoming-exclamation-output`.
-Subscription type | For at-least-once and at-most-once [processing guarantees](functions-gaurantees.md), the [`SHARED`](concepts-messaging.md#shared) is applied by default; for effectively-once guarantees, [`FAILOVER`](concepts-messaging.md#failover) is applied
-Processing guarantees | [`ATLEAST_ONCE`](functions-gaurantees.md)
+Subscription type | For at-least-once and at-most-once [processing guarantees](functions-guarantees.md), the [`SHARED`](concepts-messaging.md#shared) is applied by default; for effectively-once guarantees, [`FAILOVER`](concepts-messaging.md#failover) is applied
+Processing guarantees | [`ATLEAST_ONCE`](functions-guarantees.md)
 Pulsar service URL | `pulsar://localhost:6650`
 
 #### Example use of defaults
@@ -66,7 +66,7 @@ The created function would have default values supplied for the function name (`
 
 ## Local run mode
 
-If you run a Pulsar Function in **local run** mode, it will run on the machine from which the command is run (this could be your laptop, an [AWS EC2](https://aws.amazon.com/ec2/) instance, etc.). Here's an example [`localrun`](reference-pulsar-admin.md#functions-localrun) command:
+If you run a Pulsar Function in **local run** mode, it will run on the machine from which the command is run (this could be your laptop, an [AWS EC2](https://aws.amazon.com/ec2/) instance, etc.). Here's an example [`localrun`](reference-pulsar-admin.md#localrun) command:
 
 ```bash
 $ bin/pulsar-admin functions localrun \
@@ -86,7 +86,7 @@ $ bin/pulsar-admin functions localrun \
 
 ## Cluster mode
 
-When you run a Pulsar Function in **cluster mode**, the function code will be uploaded to a Pulsar broker and run *alongside the broker* rather than in your [local environment](#local-run). You can run a function in cluster mode using the [`create`](reference-pulsar-admin.md#functions-create) command. Here's an example:
+When you run a Pulsar Function in **cluster mode**, the function code will be uploaded to a Pulsar broker and run *alongside the broker* rather than in your [local environment](#local-run-mode). You can run a function in cluster mode using the [`create`](reference-pulsar-admin.md#create-1) command. Here's an example:
 
 ```bash
 $ bin/pulsar-admin functions create \
@@ -98,7 +98,7 @@ $ bin/pulsar-admin functions create \
 
 ### Updating cluster mode functions
 
-You can use the [`update`](reference-pulsar-admin.md#functions-update) command to update a Pulsar Function running in cluster mode. This command, for example, would update the function created in the section [above](#cluster-mode):
+You can use the [`update`](reference-pulsar-admin.md#update-1) command to update a Pulsar Function running in cluster mode. This command, for example, would update the function created in the section [above](#cluster-mode):
 
 ```bash
 $ bin/pulsar-admin functions update \
@@ -110,7 +110,7 @@ $ bin/pulsar-admin functions update \
 
 ### Parallelism
 
-Pulsar Functions run as processes called **instances**. When you run a Pulsar Function, it runs as a single instance by default (and in [local run mode](#local-run) you can *only* run a single instance of a function).
+Pulsar Functions run as processes called **instances**. When you run a Pulsar Function, it runs as a single instance by default (and in [local run mode](#local-run-mode) you can *only* run a single instance of a function).
 
 You can also specify the *parallelism* of a function, i.e. the number of instances to run, when you create the function. You can set the parallelism factor using the `--parallelism` flag of the [`create`](reference-pulsar-admin.md#functions-create) command. Here's an example:
 
@@ -120,7 +120,7 @@ $ bin/pulsar-admin functions create \
   # Other function info
 ```
 
-You can adjust the parallelism of an already created function using the [`update`](reference-pulsar-admin.md#functions-update) interface.
+You can adjust the parallelism of an already created function using the [`update`](reference-pulsar-admin.md#update-1) interface.
 
 ```bash
 $ bin/pulsar-admin functions update \
@@ -148,7 +148,7 @@ $ bin/pulsar-admin functions update \
 
 ### Function instance resources
 
-When you run Pulsar Functions in [cluster run](#cluster-run) mode, you can specify the resources that are assigned to each function [instance](#parallelism):
+When you run Pulsar Functions in [cluster run](#cluster-mode) mode, you can specify the resources that are assigned to each function [instance](#parallelism):
 
 Resource | Specified as... | Runtimes
 :--------|:----------------|:--------
@@ -174,9 +174,9 @@ $ bin/pulsar-admin functions create \
 
 If a Pulsar Function is running in [cluster mode](#cluster-mode), you can **trigger** it at any time using the command line. Triggering a function means that you send a message with a specific value to the function and get the function's output (if any) via the command line.
 
-> Triggering a function is ultimately no different from invoking a function by producing a message on one of the function's input topics. The [`pulsar-admin functions trigger`](reference-pulsar-admin.md#functions-trigger) command is essentially a convenient mechanism for sending messages to functions without needing to use the [`pulsar-client`](reference-cli-tools.md#pulsar-client) tool or a language-specific client library.
+> Triggering a function is ultimately no different from invoking a function by producing a message on one of the function's input topics. The [`pulsar-admin functions trigger`](reference-pulsar-admin.md#trigger) command is essentially a convenient mechanism for sending messages to functions without needing to use the [`pulsar-client`](reference-cli-tools.md#pulsar-client) tool or a language-specific client library.
 
-To show an example of function triggering, let's start with a simple [Python function](functions-api.md#python) that returns a simple string based on the input:
+To show an example of function triggering, let's start with a simple [Python function](functions-api.md#functions-for-python) that returns a simple string based on the input:
 
 ```python
 # myfunc.py
@@ -184,7 +184,7 @@ def process(input):
     return "This function has been triggered with a value of {0}".format(input)
 ```
 
-Let's run that function in [local run mode](functions-deploying.md#local-run):
+Let's run that function in [local run mode](functions-deploying.md#local-run-mode):
 
 ```bash
 $ bin/pulsar-admin functions create \
@@ -197,7 +197,7 @@ $ bin/pulsar-admin functions create \
   --output persistent://public/default/out
 ```
 
-Now let's make a consumer listen on the output topic for messages coming from the `myfunc` function using the [`pulsar-client consume`](reference-cli-tools.md#pulsar-client-consume) command:
+Now let's make a consumer listen on the output topic for messages coming from the `myfunc` function using the [`pulsar-client consume`](reference-cli-tools.md#consume) command:
 
 ```bash
 $ bin/pulsar-client consume persistent://public/default/out \
@@ -224,15 +224,3 @@ This function has been triggered with a value of hello world
 
 > #### Topic info not required
 > In the `trigger` command above, you may have noticed that you only need to specify basic information about the function (tenant, namespace, and name). To trigger the function, you didn't need to know the function's input topic(s).
-
-<!--
-## Subscription types
-
-Pulsar supports three different [subscription types](concepts-messaging.md#subscription-modes) (or subscription modes) for Pulsar clients:
-
-* With [exclusive](concepts-messaging.md#exclusive) subscriptions, only a single [consumer](reference-terminology.md#consumer) is allowed to attach to the subscription.
-* With [shared](concepts-messaging.md#shared) . Please note that strict message ordering is *not* guaranteed with shared subscriptions.
-* With [failover](concepts-messaging.md#failover) subscriptions
-
-Pulsar Functions can also be assigned a subscription type when you [create](#cluster-mode) them or run them [locally](#local-run). In cluster mode, the subscription can also be [updated](#updating) after the function has been created.
--->

--- a/site2/docs/functions-guarantees.md
+++ b/site2/docs/functions-guarantees.md
@@ -14,7 +14,7 @@ Delivery semantics | Description
 
 ## Applying processing guarantees to a function
 
-You can set the processing guarantees for a Pulsar Function when you create the Function. This [`pulsar-function create`](reference-pulsar-admin.md#pulsar-admin-functions-create) command, for example, would apply effectively-once guarantees to the Function:
+You can set the processing guarantees for a Pulsar Function when you create the Function. This [`pulsar-function create`](reference-pulsar-admin.md#create-1) command, for example, would apply effectively-once guarantees to the Function:
 
 ```bash
 $ bin/pulsar-admin functions create \
@@ -32,7 +32,7 @@ The available options are:
 
 ## Updating the processing guarantees of a function
 
-You can change the processing guarantees applied to a function once it's already been created using the [`update`](reference-pulsar-admin.md#pulsar-admin-functions-update) command. Here's an example:
+You can change the processing guarantees applied to a function once it's already been created using the [`update`](reference-pulsar-admin.md#update-1) command. Here's an example:
 
 ```bash
 $ bin/pulsar-admin functions update \

--- a/site2/docs/functions-metrics.md
+++ b/site2/docs/functions-metrics.md
@@ -7,7 +7,7 @@ sidebar_label: Metrics
 Pulsar Functions can publish arbitrary metrics to the metrics interface which can then be queried. This doc contains instructions for publishing metrics using the [Java](#java-sdk) and [Python](#python-sdk) Pulsar Functions SDKs.
 
 > #### Metrics and stats not available through language-native interfaces
-> If a Pulsar Function uses the language-native interface for [Java](functions-api.md#java-native) or [Python](#python-native), that function will not be able to publish metrics and stats to Pulsar.
+> If a Pulsar Function uses the language-native interface for [Java](functions-api.md#java-native-functions) or [Python](#python-native-functions), that function will not be able to publish metrics and stats to Pulsar.
 
 ## Accessing metrics
 
@@ -15,7 +15,7 @@ For a guide to accessing metrics created by Pulsar Functions, see the guide to [
 
 ## Java SDK
 
-If you're creating a Pulsar Function using the [Java SDK](functions-api.md#java-sdk), the {@inject: javadoc:Context:/client/org/apache/pulsar/functions/api/Context} object has a `recordMetric` method that you can use to register both a name for the metric and a value. Here's the signature for that method:
+If you're creating a Pulsar Function using the [Java SDK](functions-api.md#java-sdk-functions), the {@inject: javadoc:Context:/pulsar-functions/org/apache/pulsar/functions/api/Context} object has a `recordMetric` method that you can use to register both a name for the metric and a value. Here's the signature for that method:
 
 ```java
 void recordMetric(String metricName, double value);
@@ -40,4 +40,4 @@ This function counts the length of each incoming message (of type `String`) and 
 
 ## Python SDK
 
-Documentation for the [Python SDK](functions-api.md#python-sdk) is coming soon.
+Documentation for the [Python SDK](functions-api.md#python-sdk-functions) is coming soon.

--- a/site2/docs/functions-overview.md
+++ b/site2/docs/functions-overview.md
@@ -10,7 +10,7 @@ sidebar_label: Overview
 * apply a user-supplied processing logic to each message,
 * publish the results of the computation to another topic
 
-Here's an example Pulsar Function for Java (using the [native interface](functions-api.md#java-native)):
+Here's an example Pulsar Function for Java (using the [native interface](functions-api.md#java-native-functions)):
 
 ```java
 import java.util.Function;
@@ -21,7 +21,7 @@ public class ExclamationFunction implements Function<String, String> {
 }
 ```
 
-Here's an equivalent function in Python (also using the [native interface](functions-api.md#python-native)):
+Here's an equivalent function in Python (also using the [native interface](functions-api.md#python-native-functions)):
 
 ```python
 def process(input):
@@ -34,7 +34,7 @@ Functions are executed each time a message is published to the input topic. If a
 
 The core goal behind Pulsar Functions is to enable you to easily create processing logic of any level of complexity without needing to deploy a separate neighboring system (such as [Apache Storm](http://storm.apache.org/), [Apache Heron](https://apache.github.io/incubator-heron), [Apache Flink](https://flink.apache.org/), etc.). Pulsar Functions is essentially ready-made compute infrastructure at your disposal as part of your Pulsar messaging system. This core goal is tied to a series of other goals:
 
-* Developer productivity ([language-native](#native) vs. [Pulsar Functions SDK](#sdk) functions)
+* Developer productivity ([language-native](#language-native-functions) vs. [Pulsar Functions SDK](#the-pulsar-functions-sdk) functions)
 * Easy troubleshooting
 * Operational simplicity (no need for an external processing system)
 
@@ -54,12 +54,12 @@ Pulsar Functions could be described as
 
 The core programming model behind Pulsar Functions is very simple:
 
-* Functions receive messages from one or more **input [topics](reference-teminology.md#topic)**. Every time a message is received, the function can do a variety of things:
+* Functions receive messages from one or more **input [topics](reference-terminology.md#topic)**. Every time a message is received, the function can do a variety of things:
   * Apply some processing logic to the input and write output to:
     * An **output topic** in Pulsar
     * [Apache BookKeeper](#state-storage)
   * Write logs to a **log topic** (potentially for debugging purposes)
-  * Increment a [counter](#counters)
+  * Increment a [counter](#word-count-example)
 
 ![Pulsar Functions core programming model](assets/pulsar-functions-overview.png)
 
@@ -69,7 +69,7 @@ If you were to implement the classic word count example using Pulsar Functions, 
 
 ![Pulsar Functions word count example](assets/pulsar-functions-word-count.png)
 
-If you were writing the function in [Java](functions-api.md#java) using the [Pulsar Functions SDK for Java](functions-api.md#java-sdk), you could write the function like this...
+If you were writing the function in [Java](functions-api.md#functions-for-java) using the [Pulsar Functions SDK for Java](functions-api.md#java-sdk-functions), you could write the function like this...
 
 ```java
 package org.example.functions;
@@ -92,7 +92,7 @@ public class WordCountFunction implements Function<String, Void> {
 }
 ```
 
-...and then [deploy it](#cluster-mode) in your Pulsar cluster using the [command line](#cli) like this:
+...and then [deploy it](#cluster-run-mode) in your Pulsar cluster using the [command line](#command-line-interface) like this:
 
 ```bash
 $ bin/pulsar-admin functions create \
@@ -141,7 +141,7 @@ class RoutingFunction(Function):
 
 ## Command-line interface
 
-Pulsar Functions are managed using the [`pulsar-admin`](reference-pulsar-admin.md) CLI tool (in particular the [`functions`](reference-pulsar-admin.md#pulsar-admin-functions) command). Here's an example command that would run a function in [local run mode](#local-run):
+Pulsar Functions are managed using the [`pulsar-admin`](reference-pulsar-admin.md) CLI tool (in particular the [`functions`](reference-pulsar-admin.md#functions) command). Here's an example command that would run a function in [local run mode](#local-run-mode):
 
 ```bash
 $ bin/pulsar-functions localrun \
@@ -165,7 +165,7 @@ FQFNs enable you to, for example, create multiple functions with the same name p
 
 Pulsar Functions can be configured in two ways:
 
-* Via [command-line arguments](#cli) passed to the [`pulsar-admin functions`](reference-pulsar-admin.md#pulsar-admin-functions) interface
+* Via [command-line arguments](#command-line-interface) passed to the [`pulsar-admin functions`](reference-pulsar-admin.md#functions) interface
 * Via [YAML](http://yaml.org/) configuration files
 
 If you're supplying a YAML configuration, you must specify a path to the file on the command line. Here's an example:
@@ -192,7 +192,7 @@ You can also mix and match configuration methods by specifying some function att
 
 ## Supported languages
 
-Pulsar Functions can currently be written in [Java](functions-api.md#java) and [Python](functions-api.md#python). Support for additional languages is coming soon.
+Pulsar Functions can currently be written in [Java](functions-api.md#functions-for-java) and [Python](functions-api.md#functions-for-python). Support for additional languages is coming soon.
 
 ## The Pulsar Functions API
 
@@ -203,12 +203,12 @@ The Pulsar Functions API enables you to create processing logic that is:
 
 ### Function context
 
-Each Pulsar Function created using the [Pulsar Functions SDK](#sdk) has access to a context object that both provides:
+Each Pulsar Function created using the [Pulsar Functions SDK](#the-pulsar-functions-sdk) has access to a context object that both provides:
 
 1. A wide variety of information about the function, including:
   * The name of the function
   * The tenant and namespace of the function
-  * [User-supplied configuration](#user-config) values
+  * [User-supplied configuration](#user-configuration) values
 2. Special functionality, including:
   * The ability to produce [logs](#logging) to a specified logging topic
   * The ability to produce [metrics](#metrics)
@@ -217,11 +217,11 @@ Each Pulsar Function created using the [Pulsar Functions SDK](#sdk) has access t
 
 Both Java and Python support writing "native" functions, i.e. Pulsar Functions with no dependencies.
 
-The benefit of native functions is that they don't have any dependencies beyond what's already available in Java/Python "out of the box." The downside is that they don't provide access to the function's [context](#context), which is necessary for a variety of functionality, including [logging](#logging), [user configuration](#user-config), and more.
+The benefit of native functions is that they don't have any dependencies beyond what's already available in Java/Python "out of the box." The downside is that they don't provide access to the function's [context](#function-context), which is necessary for a variety of functionality, including [logging](#logging), [user configuration](#user-configuration), and more.
 
 ## The Pulsar Functions SDK
 
-If you'd like a Pulsar Function to have access to a [context object](#context), you can use the **Pulsar Functions SDK**, available for both [Java](functions-api.md#java-sdk) and [Pythnon](functions-api.md#python-sdk).
+If you'd like a Pulsar Function to have access to a [context object](#function-context), you can use the **Pulsar Functions SDK**, available for both [Java](functions-api.md#functions-for-java) and [Pythnon](functions-api.md#functions-for-python).
 
 ### Java
 
@@ -267,12 +267,12 @@ The Pulsar Functions feature was built to support a variety of deployment option
 
 Deployment mode | Description
 :---------------|:-----------
-[Local run mode](#local-run) | The function runs in your local environment, for example on your laptop
-[Cluster mode](#cluster-run) | The function runs *inside of* your Pulsar cluster, on the same machines as your Pulsar [brokers](reference-terminology.md#broker)
+[Local run mode](#local-run-mode) | The function runs in your local environment, for example on your laptop
+[Cluster mode](#cluster-run-mode) | The function runs *inside of* your Pulsar cluster, on the same machines as your Pulsar [brokers](reference-terminology.md#broker)
 
 ### Local run mode
 
-If you run a Pulsar Function in **local run** mode, it will run on the machine from which the command is run (this could be your laptop, an [AWS EC2](https://aws.amazon.com/ec2/) instance, etc.). Here's an example [`localrun`](reference-pulsar-admin.md#pulsar-admin-functions-localrun) command:
+If you run a Pulsar Function in **local run** mode, it will run on the machine from which the command is run (this could be your laptop, an [AWS EC2](https://aws.amazon.com/ec2/) instance, etc.). Here's an example [`localrun`](reference-pulsar-admin.md#localrun) command:
 
 ```bash
 $ bin/pulsar-admin functions localrun \
@@ -292,7 +292,7 @@ $ bin/pulsar-admin functions localrun \
 
 ### Cluster run mode
 
-When you run a Pulsar Function in **cluster mode**, the function code will be uploaded to a Pulsar broker and run *alongside the broker* rather than in your [local environment](#local-run). You can run a function in cluster mode using the [`create`](reference-pulsar-admin.md#pulsar-admin-functions-create) command. Here's an example:
+When you run a Pulsar Function in **cluster mode**, the function code will be uploaded to a Pulsar broker and run *alongside the broker* rather than in your [local environment](#local-run-mode). You can run a function in cluster mode using the [`create`](reference-pulsar-admin.md#create-1) command. Here's an example:
 
 ```bash
 $ bin/pulsar-admin functions create \
@@ -306,7 +306,7 @@ This command will upload `myfunc.py` to Pulsar, which will use the code to start
 
 ### Parallelism
 
-By default, only one **instance** of a Pulsar Function runs when you create and run it in [cluster run mode](#cluster-run). You can also, however, run multiple instances in parallel. You can specify the number of instances when you create the function, or update an existing single-instance function with a new parallelism factor.
+By default, only one **instance** of a Pulsar Function runs when you create and run it in [cluster run mode](#cluster-run-mode). You can also, however, run multiple instances in parallel. You can specify the number of instances when you create the function, or update an existing single-instance function with a new parallelism factor.
 
 This command, for example, would create and run a function with a parallelism of 5 (i.e. 5 instances):
 
@@ -322,7 +322,7 @@ $ bin/pulsar-admin functions create \
 
 ### Function instance resources
 
-When you run Pulsar Functions in [cluster run](#cluster-run) mode, you can specify the resources that are assigned to each function [instance](#parallelism):
+When you run Pulsar Functions in [cluster run](#cluster-run-mode) mode, you can specify the resources that are assigned to each function [instance](#parallelism):
 
 Resource | Specified as... | Runtimes
 :--------|:----------------|:--------
@@ -345,7 +345,7 @@ For more information on resources, see the [Deploying and Managing Pulsar Functi
 
 ### Logging
 
-Pulsar Functions created using the [Pulsar Functions SDK(#sdk) can send logs to a log topic that you specify as part of the function's configuration. The function created using the command below, for example, would produce all logs on the `persistent://public/default/my-func-1-log` topic:
+Pulsar Functions created using the [Pulsar Functions SDK](#the-pulsar-functions-sdk) can send logs to a log topic that you specify as part of the function's configuration. The function created using the command below, for example, would produce all logs on the `persistent://public/default/my-func-1-log` topic:
 
 ```bash
 $ bin/pulsar-admin functions create \
@@ -398,11 +398,11 @@ public class ConfigMapFunction implements Function<String, Void> {
 
 ### Triggering Pulsar Functions
 
-Pulsar Functions running in [cluster mode](#cluster-mode) can be [triggered](functions-deploying.md#triggering) via the [command line](#cli). With triggering you can easily pass a specific value to a function and get the function's return value *without* needing to worry about creating a client, sending a message to the right input topic, etc. Triggering can be very useful for---but is by no means limited to---testing and debugging purposes.
+Pulsar Functions running in [cluster mode](#cluster-run-mode) can be [triggered](functions-deploying.md#triggering-pulsar-functions) via the [command line](#command-line-interface). With triggering you can easily pass a specific value to a function and get the function's return value *without* needing to worry about creating a client, sending a message to the right input topic, etc. Triggering can be very useful for---but is by no means limited to---testing and debugging purposes.
 
-> Triggering a function is ultimately no different from invoking a function by producing a message on one of the function's input topics. The [`pulsar-admin functions trigger`](reference-pulsar-admin.md#pulsar-admin-functions-trigger) command is essentially a convenient mechanism for sending messages to functions without needing to use the [`pulsar-client`](reference-pulsar-admin.md#pulsar-client) tool or a language-specific client library.
+> Triggering a function is ultimately no different from invoking a function by producing a message on one of the function's input topics. The [`pulsar-admin functions trigger`](reference-pulsar-admin.md#trigger) command is essentially a convenient mechanism for sending messages to functions without needing to use the [`pulsar-client`](reference-cli-tools.md#pulsar-client) tool or a language-specific client library.
 
-Let's take an example Pulsar Function written in Python (using the [native interface](functions-api.md#python-native)) that simply reverses string inputs:
+Let's take an example Pulsar Function written in Python (using the [native interface](functions-api.md#python-native-functions)) that simply reverses string inputs:
 
 ```python
 def process(input):
@@ -433,7 +433,7 @@ Delivery semantics | Description
 **At-least-once** delivery | Each message that is sent to the function could be processed more than once (hence the "at least")
 **Effectively-once** delivery | Each message that is sent to the function will have one output associated with it
 
-This command, for example, would run a function in [cluster mode](#cluster-mode) with effectively-once guarantees applied:
+This command, for example, would run a function in [cluster mode](#cluster-run-mode) with effectively-once guarantees applied:
 
 ```bash
 $ bin/pulsar-admin functions create \
@@ -444,7 +444,7 @@ $ bin/pulsar-admin functions create \
 
 ## Metrics
 
-Pulsar Functions that use the [Pulsar Functions SDK](#sdk) can publish metrics to Pulsar. For more information, see [Metrics for Pulsar Functions](functions-metrics.md).
+Pulsar Functions that use the [Pulsar Functions SDK](#the-pulsar-functions-sdk) can publish metrics to Pulsar. For more information, see [Metrics for Pulsar Functions](functions-metrics.md).
 
 ## State storage
 

--- a/site2/docs/functions-quickstart.md
+++ b/site2/docs/functions-quickstart.md
@@ -4,7 +4,7 @@ title: Getting started with Pulsar Functions
 sidebar_label: Getting started
 ---
 
-This tutorial will walk you through running a [standalone](reference-teminology.md#standalone) Pulsar [cluster](reference-teminology.md#cluster) on your machine and then running your first Pulsar Functions using that cluster. The first function will run in local run mode (outside your Pulsar [cluster](reference-teminology.md#cluster)), while the second will run in cluster mode (inside your cluster).
+This tutorial will walk you through running a [standalone](reference-terminology.md#standalone) Pulsar [cluster](reference-terminology.md#cluster) on your machine and then running your first Pulsar Functions using that cluster. The first function will run in local run mode (outside your Pulsar [cluster](reference-terminology.md#cluster)), while the second will run in cluster mode (inside your cluster).
 
 > In local run mode, your Pulsar Function will communicate with your Pulsar cluster but will run outside of the cluster.
 
@@ -14,12 +14,12 @@ In order to follow along with this tutorial, you'll need to have [Maven](https:/
 
 ## Run a standalone Pulsar cluster
 
-In order to run our Pulsar Functions, we'll need to run a Pulsar cluster locally first. The easiest way to do that is to run Pulsar in [standalone](reference-teminology.md#standalone) mode. Follow these steps to start up a standalone cluster:
+In order to run our Pulsar Functions, we'll need to run a Pulsar cluster locally first. The easiest way to do that is to run Pulsar in [standalone](reference-terminology.md#standalone) mode. Follow these steps to start up a standalone cluster:
 
 ```bash
-$ wget https://repository.apache.org/content/repositories/snapshots/org/apache/pulsar/distribution/2.0.0-incubating-SNAPSHOT/distribution-2.0.0-incubating-{{ site.preview_version_id }}-bin.tar.gz
-$ tar xvf distribution-2.0.0-incubating-{{ site.preview_version_id }}-bin.tar.gz
-$ cd apache-pulsar-2.0.0-incubating-SNAPSHOT
+$ wget pulsar:binary_release_url
+$ tar xvfz apache-pulsar-{{pulsar:version}}-bin.tar.gz
+$ cd apache-pulsar-{{pulsar:version}}
 $ bin/pulsar standalone \
   --advertised-address 127.0.0.1
 ```
@@ -60,7 +60,7 @@ $ bin/pulsar-admin functions localrun \
 > --inputs topic1,topic2
 > ```
 
-We can open up another shell and use the [`pulsar-client`](reference-pulsar-admin.md#pulsar-client) tool to listen for messages on the output topic:
+We can open up another shell and use the [`pulsar-client`](reference-cli-tools.md#pulsar-client) tool to listen for messages on the output topic:
 
 ```bash
 $ bin/pulsar-client consume persistent://public/default/exclamation-output \
@@ -95,7 +95,7 @@ Here's what happened:
 
 ## Run a Pulsar Function in cluster mode
 
-[Local run mode](#local-run-mode) is useful for development and experimentation, but if you want to use Pulsar Functions in a real Pulsar deployment, you'll want to run them in **cluster mode**. In this mode, Pulsar Functions run *inside* your Pulsar cluster and are managed using the same [`pulsar-admin functions`](reference-pulsar-admin.md#pulsar-admin-functions) interface that we've been using thus far.
+[Local run mode](#run-a-pulsar-function-in-local-run-mode) is useful for development and experimentation, but if you want to use Pulsar Functions in a real Pulsar deployment, you'll want to run them in **cluster mode**. In this mode, Pulsar Functions run *inside* your Pulsar cluster and are managed using the same [`pulsar-admin functions`](reference-pulsar-admin.md#functions) interface that we've been using thus far.
 
 This command, for example, would deploy the same exclamation function we ran locally above *in our Pulsar cluster* (rather than outside it):
 
@@ -208,7 +208,7 @@ If you see `Deleted successfully` in the output, then you've succesfully run, up
 
 ## Writing and running a new function
 
-> In order to write and run the [Python](functions-api.md#python) function below, you'll need to install a few dependencies:
+> In order to write and run the [Python](functions-api.md#functions-for-python) function below, you'll need to install a few dependencies:
 > ```bash
 > $ pip install pulsar-client protobuf futures grpcio grpcio-tools
 > ```
@@ -241,7 +241,7 @@ $ bin/pulsar-admin functions create \
   --name reverse
 ```
 
-If you see `Created successfully`, the function is ready to accept incoming messages. Because the function is running in cluster mode, we can **trigger** the function using the [`trigger`](reference-pulsar-admin.md#pulsar-admin-functions-trigger) command. This command will send a message that we specify to the function and also give us the function's output. Here's an example:
+If you see `Created successfully`, the function is ready to accept incoming messages. Because the function is running in cluster mode, we can **trigger** the function using the [`trigger`](reference-pulsar-admin.md#trigger) command. This command will send a message that we specify to the function and also give us the function's output. Here's an example:
 
 ```bash
 $ bin/pulsar-admin functions trigger \
@@ -257,7 +257,7 @@ You should get this output:
 This string was backwards but is now forwards
 ```
 
-Once again, success! We created a brand new Pulsar Function, deployed it in our Pulsar standalone cluster in [cluster mode](#cluster-mode) and successfully triggered the function. If you're ready for more, check out one of these docs:
+Once again, success! We created a brand new Pulsar Function, deployed it in our Pulsar standalone cluster in [cluster mode](#run-a-pulsar-function-in-cluster-mode) and successfully triggered the function. If you're ready for more, check out one of these docs:
 
 * [The Pulsar Functions API](functions-api.md)
 * [Deploying Pulsar Functions](functions-deploying.md)

--- a/site2/docs/functions-state.md
+++ b/site2/docs/functions-state.md
@@ -1,0 +1,118 @@
+---
+id: functions-state
+title: Pulsar Functions State Storage (Developer Preview)
+sidebar_label: State Storage
+---
+
+Since Pulsar 2.1.0 release, Pulsar integrates with Apache BookKeeper [table service](https://docs.google.com/document/d/155xAwWv5IdOitHh1NVMEwCMGgB28M3FyMiQSxEpjE-Y/edit#heading=h.56rbh52koe3f)
+for storing the `State` for functions. For example, A `WordCount` function can store its `counters` state into BookKeeper's table service via Pulsar Functions [State API](#api).
+
+## API
+
+### Java API
+
+Currently Pulsar Functions expose following APIs for mutating and accessing State. These APIs are avaible in the [Context](functions-api.md#context) object when
+you are using [Java SDK](functions-api.md#java-sdk-functions) functions.
+
+#### incrCounter
+
+```java
+    /**
+     * Increment the builtin distributed counter refered by key
+     * @param key The name of the key
+     * @param amount The amount to be incremented
+     */
+    void incrCounter(String key, long amount);
+```
+
+Application can use `incrCounter` to change the counter of a given `key` by the given `amount`.
+
+#### getCounter
+
+```java
+    /**
+     * Retrieve the counter value for the key.
+     *
+     * @param key name of the key
+     * @return the amount of the counter value for this key
+     */
+    long getCounter(String key);
+```
+
+Application can use `getCounter` to retrieve the counter of a given `key` mutated by `incrCounter`.
+
+Besides the `counter` API, Pulsar also exposes a general key/value API for functions to store
+general key/value state.
+
+#### putState
+
+```java
+    /**
+     * Update the state value for the key.
+     *
+     * @param key name of the key
+     * @param value state value of the key
+     */
+    void putState(String key, ByteBuffer value);
+```
+
+#### getState
+
+```
+    /**
+     * Retrieve the state value for the key.
+     *
+     * @param key name of the key
+     * @return the state value for the key.
+     */
+    ByteBuffer getState(String key);
+```
+
+### Python API
+
+State currently is not supported at [Python SDK](functions-api.md#python-sdk-functions).
+
+## Query State
+
+A Pulsar Function can use the [State API](#api) for storing state into Pulsar's state storage
+and retrieving state back from Pulsar's state storage. Additionally Pulsar also provides
+CLI commands for querying its state.
+
+```shell
+$ bin/pulsar-admin functions querystate \
+    --tenant <tenant> \
+    --namespace <namespace> \
+    --name <function-name> \
+    --state-storage-url <bookkeeper-service-url> \
+    --key <state-key> \
+    [---watch]
+```
+
+If `--watch` is specified, the CLI will watch the value of the provided `state-key`.
+
+## Example
+
+### Java Example
+
+{@inject: github:`WordCountFunction`:/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/WordCountFunction.java} is a very good example
+demonstrating on how Application can easily store `state` in Pulsar Functions.
+
+```java
+public class WordCountFunction implements Function<String, Void> {
+    @Override
+    public Void process(String input, Context context) throws Exception {
+        Arrays.asList(input.split("\\.")).forEach(word -> context.incrCounter(word, 1));
+        return null;
+    }
+}
+```
+
+The logic of this `WordCount` function is pretty simple and straightforward:
+
+1. The function first splits the received `String` into multiple words using regex `\\.`.
+2. For each `word`, the function increments the corresponding `counter` by 1 (via `incrCounter(key, amount)`).
+
+### Python Example
+
+State currently is not supported at [Python SDK](functions-api.md#python-sdk-functions).
+

--- a/site2/website/sidebars.json
+++ b/site2/website/sidebars.json
@@ -24,6 +24,7 @@
       "functions-api",
       "functions-deploying",
       "functions-guarantees",
+      "functions-state",
       "functions-metrics"
     ],
     "Pulsar IO": [


### PR DESCRIPTION
 ### Changes

- fix anchors in functions' documentation pages
- add `functions-state` page on documentation state api
