### PR TITLE
[website] Fix website docker build

### DIFF
--- a/site2/tools/docker-build-site.sh
+++ b/site2/tools/docker-build-site.sh
@@ -38,6 +38,7 @@ echo "---- Build Pulsar website using image $IMAGE"
 CI_USER=$(id -u)
 CI_GROUP=$(id -g)
 
+# crowdin keys
 CROWDIN_DOCUSAURUS_PROJECT_ID=${CROWDIN_DOCUSAURUS_PROJECT_ID:-"apache-pulsar"}
 CROWDIN_DOCUSAURUS_API_KEY=${CROWDIN_DOCUSAURUS_API_KEY:-UNSET}
 

--- a/site2/tools/docker-build-site.sh
+++ b/site2/tools/docker-build-site.sh
@@ -38,10 +38,9 @@ echo "---- Build Pulsar website using image $IMAGE"
 CI_USER=$(id -u)
 CI_GROUP=$(id -g)
 
-# crowdin keys
-CROWDIN_DOCUSAURUS_PROJECT_ID=${CROWDIN_DOCUSAURUS_PROJECT_ID:-apache-pulsar}
+CROWDIN_DOCUSAURUS_PROJECT_ID=${CROWDIN_DOCUSAURUS_PROJECT_ID:-"apache-pulsar"}
 CROWDIN_DOCUSAURUS_API_KEY=${CROWDIN_DOCUSAURUS_API_KEY:-UNSET}
 
-DOCKER_CMD="docker run -i -e CI_USER=$CI_USER -e CI_GROUP=$CI_GROUP -v $ROOT_DIR:/pulsar $IMAGE"
+DOCKER_CMD="docker run -i -e CI_USER=$CI_USER -e CI_GROUP=$CI_GROUP -e CROWDIN_DOCUSAURUS_PROJECT_ID=${CROWDIN_DOCUSAURUS_PROJECT_ID} -e CROWDIN_DOCUSAURUS_API_KEY=${CROWDIN_DOCUSAURUS_API_KEY} -v $ROOT_DIR:/pulsar $IMAGE"
 
 $DOCKER_CMD bash -l -c 'cd /pulsar/site2/website && yarn && yarn run crowdin-upload && yarn run crowdin-download && yarn build && node ./scripts/replace.js && cp -R ./build/pulsar /pulsar/generated-site/content/staging'


### PR DESCRIPTION
 ### Motivation

Crowdin integration requires API key. The API key is set at CI,
however it is not propagated into the docker image that we are
using for building the website. So Crowdin was not able to download
translations.

```shell
$ crowdin --config ../crowdin.yaml upload sources --auto-update -b master
Project identifier is empty
Project key is empty
Done in 0.46s.
yarn run v1.7.0
warning package.json: No license field
$ crowdin --config ../crowdin.yaml download -b master
Project identifier is empty
Project key is empty
Done in 0.47s.
yarn run v1.7.0
```

 ### Changes

Pass Crowdin related environment settings from host to docker.


