### PR TITLE
fix Test: function-tls test stops server gracefully

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionTlsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarFunctionTlsTest.java
@@ -74,7 +74,6 @@ public class PulsarFunctionTlsTest {
     String pulsarFunctionsNamespace = tenant + "/use/pulsar-function-admin";
     String workerId;
     WorkerServer workerServer;
-    Thread serverThread;
     PulsarAdmin functionAdmin;
     private final int ZOOKEEPER_PORT = PortManager.nextFreePort();
     private final int workerServicePort = PortManager.nextFreePort();
@@ -128,8 +127,7 @@ public class PulsarFunctionTlsTest {
         when(functionsWorkerService.getFunctionMetaDataManager()).thenReturn(dataManager);
 
         workerServer = new WorkerServer(functionsWorkerService);
-        serverThread = new Thread(workerServer, workerServer.getThreadName());
-        serverThread.start();
+        workerServer.start();
         Thread.sleep(2000);
         String functionTlsUrl = String.format("https://%s:%s",
                 functionsWorkerService.getWorkerConfig().getWorkerHostname(), workerServicePortTls);
@@ -153,14 +151,6 @@ public class PulsarFunctionTlsTest {
         functionAdmin.close();
         bkEnsemble.stop();
         workerServer.stop();
-        if (null != serverThread) {
-            serverThread.interrupt();
-            try {
-                serverThread.join();
-            } catch (InterruptedException e) {
-                log.warn("Worker server thread is interrupted", e);
-            }
-        }
         functionsWorkerService.stop();
     }
 

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/WorkerServer.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/WorkerServer.java
@@ -76,42 +76,56 @@ public class WorkerServer implements Runnable {
         this.workerConfig = workerService.getWorkerConfig();
         this.workerService = workerService;
         this.webServerExecutor = Executors.newFixedThreadPool(NUM_ACCEPTORS, new DefaultThreadFactory("function-web"));
+        init();
     }
 
     @Override
     public void run() {
+        try {
+            start();
+            server.join();
+        } catch (Exception ex) {
+            log.error("ex: {}", ex, ex);
+            System.exit(1);
+            final String message = getErrorMessage(server, this.workerConfig.getWorkerPort(), ex);
+            log.error(message);
+        } finally {
+            server.destroy();
+        }
+    }
+
+    public void start() throws Exception {
+        server.start();
+        log.info("Worker Server started at {}", server.getURI());
+    }
+    
+    private void init() {
         server = new Server(new ExecutorThreadPool(webServerExecutor));
 
-        
         List<ServerConnector> connectors = new ArrayList<>();
         ServerConnector connector = new ServerConnector(server, 1, 1);
         connector.setPort(this.workerConfig.getWorkerPort());
         connector.setHost(this.workerConfig.getWorkerHostname());
         connectors.add(connector);
-        
+
         List<Handler> handlers = new ArrayList<>(3);
-        handlers.add(newServletContextHandler("/admin",
-                new ResourceConfig(Resources.getApiResources()), workerService));
-        handlers.add(newServletContextHandler("/admin/v2",
-                new ResourceConfig(Resources.getApiResources()), workerService));
-        handlers.add(newServletContextHandler("/",
-                new ResourceConfig(Resources.getRootResources()), workerService));
+        handlers.add(
+                newServletContextHandler("/admin", new ResourceConfig(Resources.getApiResources()), workerService));
+        handlers.add(
+                newServletContextHandler("/admin/v2", new ResourceConfig(Resources.getApiResources()), workerService));
+        handlers.add(newServletContextHandler("/", new ResourceConfig(Resources.getRootResources()), workerService));
 
         ContextHandlerCollection contexts = new ContextHandlerCollection();
         contexts.setHandlers(handlers.toArray(new Handler[handlers.size()]));
         HandlerCollection handlerCollection = new HandlerCollection();
-        handlerCollection.setHandlers(new Handler[] {
-            contexts, new DefaultHandler()
-        });
+        handlerCollection.setHandlers(new Handler[] { contexts, new DefaultHandler() });
         server.setHandler(handlerCollection);
-        
+
         if (this.workerConfig.isTlsEnabled()) {
             try {
                 SslContextFactory sslCtxFactory = SecurityUtility.createSslContextFactory(
-                        this.workerConfig.isTlsAllowInsecureConnection(),
-                        this.workerConfig.getTlsTrustCertsFilePath(),
-                        this.workerConfig.getTlsCertificateFilePath(),
-                        this.workerConfig.getTlsKeyFilePath(),
+                        this.workerConfig.isTlsAllowInsecureConnection(), this.workerConfig.getTlsTrustCertsFilePath(),
+                        this.workerConfig.getTlsCertificateFilePath(), this.workerConfig.getTlsKeyFilePath(),
                         this.workerConfig.isTlsRequireTrustedClientCertOnConnect());
                 ServerConnector tlsConnector = new ServerConnector(server, 1, 1, sslCtxFactory);
                 tlsConnector.setPort(this.workerConfig.getWorkerPortTls());
@@ -125,20 +139,6 @@ public class WorkerServer implements Runnable {
         // Limit number of concurrent HTTP connections to avoid getting out of file descriptors
         connectors.forEach(c -> c.setAcceptQueueSize(MAX_CONCURRENT_REQUESTS / connectors.size()));
         server.setConnectors(connectors.toArray(new ServerConnector[connectors.size()]));
-
-        try {
-            server.start();
-
-            log.info("Worker Server started at {}", server.getURI());
-
-            server.join();
-        } catch (Exception ex) {
-            log.error("ex: {}", ex, ex);
-            final String message = getErrorMessage(server, this.workerConfig.getWorkerPort(), ex);
-            log.error(message);
-        } finally {
-            server.destroy();
-        }
     }
 
     public String getThreadName() {

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/WorkerServer.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/WorkerServer.java
@@ -86,14 +86,14 @@ public class WorkerServer implements Runnable {
             server.join();
         } catch (Exception ex) {
             log.error("ex: {}", ex, ex);
-            System.exit(1);
             final String message = getErrorMessage(server, this.workerConfig.getWorkerPort(), ex);
             log.error(message);
+            System.exit(1);
         } finally {
+            server.destroy();
             if (this.webServerExecutor != null && !this.webServerExecutor.isShutdown()) {
                 this.webServerExecutor.shutdown();
             }
-            server.destroy();
         }
     }
 
@@ -169,13 +169,13 @@ public class WorkerServer implements Runnable {
     @VisibleForTesting
     public void stop() {
         if (this.server != null) {
-            if (this.webServerExecutor != null && !this.webServerExecutor.isShutdown()) {
-                this.webServerExecutor.shutdown();
-            }
             try {
                 this.server.stop();
             } catch (Exception e) {
                 log.error("Failed to stop function web-server ", e);
+            }
+            if (this.webServerExecutor != null && !this.webServerExecutor.isShutdown()) {
+                this.webServerExecutor.shutdown();
             }
         }
     }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/WorkerServer.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/WorkerServer.java
@@ -170,13 +170,13 @@ public class WorkerServer implements Runnable {
     public void stop() {
         if (this.server != null) {
             try {
-                this.server.stop();
+                this.server.destroy();
             } catch (Exception e) {
                 log.error("Failed to stop function web-server ", e);
             }
-            if (this.webServerExecutor != null && !this.webServerExecutor.isShutdown()) {
-                this.webServerExecutor.shutdown();
-            }
+        }
+        if (this.webServerExecutor != null && !this.webServerExecutor.isShutdown()) {
+            this.webServerExecutor.shutdown();
         }
     }
     

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/WorkerServer.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/WorkerServer.java
@@ -90,6 +90,9 @@ public class WorkerServer implements Runnable {
             final String message = getErrorMessage(server, this.workerConfig.getWorkerPort(), ex);
             log.error(message);
         } finally {
+            if (this.webServerExecutor != null && !this.webServerExecutor.isShutdown()) {
+                this.webServerExecutor.shutdown();
+            }
             server.destroy();
         }
     }
@@ -166,6 +169,9 @@ public class WorkerServer implements Runnable {
     @VisibleForTesting
     public void stop() {
         if (this.server != null) {
+            if (this.webServerExecutor != null && !this.webServerExecutor.isShutdown()) {
+                this.webServerExecutor.shutdown();
+            }
             try {
                 this.server.stop();
             } catch (Exception e) {


### PR DESCRIPTION
### Motivation

As discussed in #2214 , right now, integration test requires function-worker process to exit when worker-server thread is interrupted which was removed in #2214. so, revert back previous behavior to exit worker-server when server thread is interrupted. However, tls-test will not create a separate thread to start worker-server so, unit-test will not exist during testing. 


### Result

Fix integration test failure.
