### PR TITLE
Issue #1452: remove reachedEndOfTopic in addConsumer

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -103,11 +103,6 @@ public class PersistentSubscription implements Subscription {
             throw new SubscriptionFencedException("Subscription is fenced");
         }
 
-        if (topic.getManagedLedger().isTerminated() && cursor.getNumberOfEntriesInBacklog() == 0) {
-            // Immediately notify the consumer that there are no more available messages
-            consumer.reachedEndOfTopic();
-        }
-
         if (dispatcher == null || !dispatcher.isConsumerConnected()) {
             switch (consumer.subType()) {
             case Exclusive:


### PR DESCRIPTION
### Motivation

Fixes #1452 

In issue #1452 , reachedEndOfTopic was called twice if a topic has been terminated before subscription.
It may be better to call `reachedEndOfTopic`, when real read/ack happened to the subscription, so delete the calling in `addConsumer` to avoid dup calling.

### Modifications

remove dup calling in `addConsumer` .
add related ut.

### Result

Expected all ut passed.