### PR TITLE
[website] fix css problem on languages menu

### DIFF
--- a/site2/website/static/css/custom.css
+++ b/site2/website/static/css/custom.css
@@ -62,25 +62,29 @@
 
 /* for drop down menus */
 #community-dropdown.hide,
-#apache-dropdown.hide {
+#apache-dropdown.hide,
+#languages-dropdown.hide {
   display: none;
 }
 
 
 #community-dropdown.visible,
-#apache-dropdown.visible {
+#apache-dropdown.visible,
+#languages-dropdown.visible {
   display: flex;
 }
 
 #community-dropdown,
-#apache-dropdown {
+#apache-dropdown,
+#languages-dropdown {
   pointer-events: none;
   position: absolute;
   width: 100%;
 }
 
 #community-dropdown-items,
-#apache-dropdown-items {
+#apache-dropdown-items,
+#languages-dropdown-items {
   background-color: white;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
### Problem

The languages menu is not displayed properly.

<img width="412" alt="screen shot 2018-08-03 at 1 44 04 pm" src="https://user-images.githubusercontent.com/1217863/43665010-a3231016-9723-11e8-97d5-c132d73c4485.png">

### Changes

Add language menu to custom css file.

### Results

<img width="375" alt="screen shot 2018-08-03 at 1 44 16 pm" src="https://user-images.githubusercontent.com/1217863/43665025-b8d987fa-9723-11e8-898e-b0813ff8e331.png">
