### PR TITLE
Fixed refcounting when processing entries from sql

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageParser.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageParser.java
@@ -95,15 +95,10 @@ public class MessageParser {
             if (numMessages == 1 && !msgMetadata.hasNumMessagesInBatch()) {
                 final MessageImpl<?> message = new MessageImpl<>(msgId, msgMetadata, uncompressedPayload, null, null);
                 processor.process(msgId, message, uncompressedPayload);
-
-                uncompressedPayload.release();
-
             } else {
                 // handle batch message enqueuing; uncompressed payload has all messages in batch
                 receiveIndividualMessagesFromBatch(msgMetadata, uncompressedPayload, messageId, null, -1, processor);
-                uncompressedPayload.release();
             }
-
         } finally {
             if (uncompressedPayload != null) {
                 uncompressedPayload.release();


### PR DESCRIPTION
### Motivation

There were 2 issues with ref-count when parsing entries from SQL connector: 

 1. `entry.getData().length` is actually releasing the buffer after the invocation, so `entry.getDataBuffer()` was getting invalid buffer.
 2. `uncompressedPayload.release()` needs to be only invoked once, in the `finally` block