### PR TITLE
[website] Translation strings are not downloaded correctly

### DIFF
--- a/site2/tools/docker-build-site.sh
+++ b/site2/tools/docker-build-site.sh
@@ -44,4 +44,4 @@ CROWDIN_DOCUSAURUS_API_KEY=${CROWDIN_DOCUSAURUS_API_KEY:-UNSET}
 
 DOCKER_CMD="docker run -i -e CI_USER=$CI_USER -e CI_GROUP=$CI_GROUP -e CROWDIN_DOCUSAURUS_PROJECT_ID=${CROWDIN_DOCUSAURUS_PROJECT_ID} -e CROWDIN_DOCUSAURUS_API_KEY=${CROWDIN_DOCUSAURUS_API_KEY} -v $ROOT_DIR:/pulsar $IMAGE"
 
-$DOCKER_CMD bash -l -c 'cd /pulsar/site2/website && yarn && yarn run crowdin-upload && yarn run crowdin-download && yarn build && node ./scripts/replace.js && cp -R ./build/pulsar/* /pulsar/generated-site/content'
+$DOCKER_CMD bash -l -c 'cd /pulsar/site2/website && yarn && yarn write-translations && yarn run crowdin-upload && yarn run crowdin-download && yarn build && node ./scripts/replace.js && cp -R ./build/pulsar/* /pulsar/generated-site/content'

--- a/site2/website/pages/en/download.js
+++ b/site2/website/pages/en/download.js
@@ -108,8 +108,8 @@ class Download extends React.Component {
               <translate>
                 Once you've downloaded a Pulsar release, instructions on getting up and running with a standalone cluster
                 that you can run on your laptop can be found in the{' '}
-                <a href={`${siteConfig.baseUrl}docs/${this.props.language}/standalone`}>Run Pulsar locally</a> tutorial.
               </translate>
+                <a href={`${siteConfig.baseUrl}docs/${this.props.language}/standalone`}><translate>Run Pulsar locally</translate></a> <translate>tutorial</translate>.
               </p>
             </div>
             <p>


### PR DESCRIPTION
 ### Motivation

Noticed following warnings in website CI builds.

```
Warning: Downloaded translations do not match current project configuration. The following files will be omitted:
 - '/website/i18n/ja-JP.json'
```

The warnings were generated before `i18n/en.json` was not generated before downloading translations.

 ### Changes

add `yarn write-translations` before uploading/downloading translations.

additionaly fix `<translate>` location for download page

