### PR TITLE
[website] update downlink used for quickstart

### DIFF
--- a/site2/docs/functions-quickstart.md
+++ b/site2/docs/functions-quickstart.md
@@ -55,7 +55,9 @@ $ bin/pulsar-admin functions localrun \
 ```
 
 > #### Multiple input topics allowed
+>
 > In the example above, a single topic was specified using the `--inputs` flag. You can also specify multiple input topics as a comma-separated list using the same flag. Here's an example:
+>
 > ```bash
 > --inputs topic1,topic2
 > ```
@@ -210,7 +212,7 @@ If you see `Deleted successfully` in the output, then you've succesfully run, up
 
 > In order to write and run the [Python](functions-api.md#functions-for-python) function below, you'll need to install a few dependencies:
 > ```bash
-> $ pip install pulsar-client protobuf futures grpcio grpcio-tools
+> $ pip install pulsar-client
 > ```
 
 In the above examples, we ran and managed a pre-written Pulsar Function and saw how it worked. To really get our hands dirty, let's write and our own function from scratch, using the Python API. This simple function will also take a string as input but it will reverse the string and publish the resulting, reversed string to the specified topic.

--- a/site2/website/scripts/replace.js
+++ b/site2/website/scripts/replace.js
@@ -22,11 +22,11 @@ function downloadPageUrl() {
 }
 
 function binaryReleaseUrl(version) {
-  return `http://www.apache.org/dyn/closer.cgi/incubator/pulsar/pulsar-${version}/apache-pulsar-${version}-bin.tar.gz`
+  return `https://archive.apache.org/dist/incubator/pulsar/pulsar-${version}/apache-pulsar-${version}-bin.tar.gz`
 }
 
 function connectorReleaseUrl(version) {
-  return `http://www.apache.org/dyn/closer.cgi/incubator/pulsar/pulsar-${version}/apache-pulsar-io-connectors-${version}-bin.tar.gz`
+  return `https://archive.apache.org/dist/incubator/pulsar/pulsar-${version}/apache-pulsar-io-connectors-${version}-bin.tar.gz`
 }
 
 function rpmReleaseUrl(version, type) {

--- a/site2/website/versioned_docs/version-2.1.0-incubating/functions-quickstart.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/functions-quickstart.md
@@ -56,7 +56,9 @@ $ bin/pulsar-admin functions localrun \
 ```
 
 > #### Multiple input topics allowed
+>
 > In the example above, a single topic was specified using the `--inputs` flag. You can also specify multiple input topics as a comma-separated list using the same flag. Here's an example:
+>
 > ```bash
 > --inputs topic1,topic2
 > ```
@@ -211,7 +213,7 @@ If you see `Deleted successfully` in the output, then you've succesfully run, up
 
 > In order to write and run the [Python](functions-api.md#functions-for-python) function below, you'll need to install a few dependencies:
 > ```bash
-> $ pip install pulsar-client protobuf futures grpcio grpcio-tools
+> $ pip install pulsar-client
 > ```
 
 In the above examples, we ran and managed a pre-written Pulsar Function and saw how it worked. To really get our hands dirty, let's write and our own function from scratch, using the Python API. This simple function will also take a string as input but it will reverse the string and publish the resulting, reversed string to the specified topic.


### PR DESCRIPTION
 ### Changes

- Use archieve links to ensure all command line works with old releases
- Fix formatting
- Remove redundant pip dependencies

Also Fixes #2153 