### PR TITLE
Issue 2272: Fix git-commit-id-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1144,6 +1144,7 @@ flexible messaging model and an intuitive client API.</description>
           <verbose>false</verbose>
           <generateGitPropertiesFile>true</generateGitPropertiesFile>
           <generateGitPropertiesFilename>${project.build.outputDirectory}/${project.artifactId}-git.properties</generateGitPropertiesFilename>
+          <failOnNoGitDirectory>false</failOnNoGitDirectory>
           <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
           <format>properties</format>
           <gitDescribe>


### PR DESCRIPTION
 ### Motivation

Fixes #2272.

We are using git-commit-id plugin for generating a properties file containing all the build information.
However you have to skip git-commit-id-plugin when the source code is not in a git repo.

 ### Changes

add `<failOnNoGitDirectory>false</failOnNoGitDirectory>` to git-commit-plugin

