### PR TITLE
Issue #2330: change getTopicName in MultiTopicsConsumer

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -131,6 +131,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
     private final SubscriptionInitialPosition subscriptionInitialPosition;
     private final ConnectionHandler connectionHandler;
 
+    private final String topicNameWithoutPartition;
+
     enum SubscriptionMode {
         // Make the subscription to be backed by a durable cursor that will retain messages and persist the current
         // position
@@ -202,6 +204,8 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             this.acknowledgmentsGroupingTracker =
                 NonPersistentAcknowledgmentGroupingTracker.of();
         }
+
+        topicNameWithoutPartition = topicName.getPartitionedTopicName();
 
         grabCnx();
     }
@@ -1456,6 +1460,10 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
 
     void grabCnx() {
         this.connectionHandler.grabCnx();
+    }
+
+    public String getTopicNameWithoutPartition() {
+        return topicNameWithoutPartition;
     }
 
     private static final Logger log = LoggerFactory.getLogger(ConsumerImpl.class);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -511,7 +511,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         }
         removeExpiredMessagesFromQueue(messageIds);
         messageIds.stream().map(messageId -> (TopicMessageIdImpl)messageId)
-            .collect(Collectors.groupingBy(TopicMessageIdImpl::getTopicName, Collectors.toSet()))
+            .collect(Collectors.groupingBy(TopicMessageIdImpl::getTopicPartitionName, Collectors.toSet()))
             .forEach((topicName, messageIds1) ->
                 consumers.get(topicName)
                     .redeliverUnacknowledgedMessages(messageIds1.stream()

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MultiTopicsConsumerImpl.java
@@ -231,7 +231,8 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         checkArgument(message instanceof MessageImpl);
         lock.writeLock().lock();
         try {
-            TopicMessageImpl<T> topicMessage = new TopicMessageImpl<>(consumer.getTopic(), message);
+            TopicMessageImpl<T> topicMessage = new TopicMessageImpl<>(
+                consumer.getTopic(), consumer.getTopicNameWithoutPartition(), message);
             unAckedMessageTracker.add(topicMessage.getMessageId());
 
             if (log.isDebugEnabled()) {
@@ -370,7 +371,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
         }
 
         if (ackType == AckType.Cumulative) {
-            Consumer individualConsumer = consumers.get(topicMessageId.getTopicName());
+            Consumer individualConsumer = consumers.get(topicMessageId.getTopicPartitionName());
             if (individualConsumer != null) {
                 MessageId innerId = topicMessageId.getInnerMessageId();
                 return individualConsumer.acknowledgeCumulativeAsync(innerId);
@@ -378,7 +379,7 @@ public class MultiTopicsConsumerImpl<T> extends ConsumerBase<T> {
                 return FutureUtil.failedFuture(new PulsarClientException.NotConnectedException());
             }
         } else {
-            ConsumerImpl<T> consumer = consumers.get(topicMessageId.getTopicName());
+            ConsumerImpl<T> consumer = consumers.get(topicMessageId.getTopicPartitionName());
 
             MessageId innerId = topicMessageId.getInnerMessageId();
             return consumer.doAcknowledge(innerId, ackType, properties)

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageIdImpl.java
@@ -31,16 +31,10 @@ public class TopicMessageIdImpl implements MessageId {
     private final String topicName;
     private final MessageId messageId;
 
-    TopicMessageIdImpl(String topicPartitionName, MessageId messageId) {
+    TopicMessageIdImpl(String topicPartitionName, String topicName, MessageId messageId) {
         this.messageId = messageId;
         this.topicPartitionName = topicPartitionName;
-
-        int position = topicPartitionName.lastIndexOf(PARTITIONED_TOPIC_SUFFIX);
-        if (position != -1) {
-            this.topicName = topicPartitionName.substring(0, position);
-        } else {
-            this.topicName = topicPartitionName;
-        }
+        this.topicName = topicName;
     }
 
     /**

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageIdImpl.java
@@ -26,13 +26,21 @@ import org.apache.pulsar.client.api.MessageId;
 
 public class TopicMessageIdImpl implements MessageId {
 
-    /** This topicName is get from ConsumerImpl, it contains partition part. */
+    /** This topicPartitionName is get from ConsumerImpl, it contains partition part. */
+    private final String topicPartitionName;
     private final String topicName;
     private final MessageId messageId;
 
-    TopicMessageIdImpl(String topicName, MessageId messageId) {
-        this.topicName = topicName;
+    TopicMessageIdImpl(String topicPartitionName, MessageId messageId) {
         this.messageId = messageId;
+        this.topicPartitionName = topicPartitionName;
+
+        int position = topicPartitionName.lastIndexOf(PARTITIONED_TOPIC_SUFFIX);
+        if (position != -1) {
+            this.topicName = topicPartitionName.substring(0, position);
+        } else {
+            this.topicName = topicPartitionName;
+        }
     }
 
     /**
@@ -40,9 +48,7 @@ public class TopicMessageIdImpl implements MessageId {
      * @return the name of the topic on which this message was published
      */
     public String getTopicName() {
-        int position = topicName.lastIndexOf(PARTITIONED_TOPIC_SUFFIX);
-        checkState(position != -1, "Topic Name not contains partition part. " + topicName);
-        return topicName.substring(0, position);
+        return this.topicName;
     }
 
     /**
@@ -50,7 +56,7 @@ public class TopicMessageIdImpl implements MessageId {
      * @return the topic name which contains Partition part
      */
     public String getTopicPartitionName() {
-        return topicName;
+        return this.topicPartitionName;
     }
 
     public MessageId getInnerMessageId() {
@@ -68,7 +74,7 @@ public class TopicMessageIdImpl implements MessageId {
             return false;
         }
         TopicMessageIdImpl other = (TopicMessageIdImpl) obj;
-        return Objects.equals(topicName, other.topicName)
+        return Objects.equals(topicPartitionName, other.topicPartitionName)
             && Objects.equals(messageId, other.messageId);
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageIdImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageIdImpl.java
@@ -18,10 +18,15 @@
  */
 package org.apache.pulsar.client.impl;
 
+import static com.google.common.base.Preconditions.checkState;
+import static org.apache.pulsar.common.naming.TopicName.PARTITIONED_TOPIC_SUFFIX;
+
 import java.util.Objects;
 import org.apache.pulsar.client.api.MessageId;
 
 public class TopicMessageIdImpl implements MessageId {
+
+    /** This topicName is get from ConsumerImpl, it contains partition part. */
     private final String topicName;
     private final MessageId messageId;
 
@@ -30,7 +35,21 @@ public class TopicMessageIdImpl implements MessageId {
         this.messageId = messageId;
     }
 
+    /**
+     * Get the topic name without partition part of this message.
+     * @return the name of the topic on which this message was published
+     */
     public String getTopicName() {
+        int position = topicName.lastIndexOf(PARTITIONED_TOPIC_SUFFIX);
+        checkState(position != -1, "Topic Name not contains partition part. " + topicName);
+        return topicName.substring(0, position);
+    }
+
+    /**
+     * Get the topic name which contains partition part for this message.
+     * @return the topic name which contains Partition part
+     */
+    public String getTopicPartitionName() {
         return topicName;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageImpl.java
@@ -19,6 +19,9 @@
 
 package org.apache.pulsar.client.impl;
 
+import static com.google.common.base.Preconditions.checkState;
+import static org.apache.pulsar.common.naming.TopicName.PARTITIONED_TOPIC_SUFFIX;
+
 import java.util.Map;
 import java.util.Optional;
 
@@ -28,6 +31,7 @@ import org.apache.pulsar.common.api.EncryptionContext;
 
 public class TopicMessageImpl<T> implements Message<T> {
 
+    /** This topicName is get from ConsumerImpl, it contains partition part. */
     private final String topicName;
     private final Message<T> msg;
     private final TopicMessageIdImpl messageId;
@@ -40,10 +44,20 @@ public class TopicMessageImpl<T> implements Message<T> {
     }
 
     /**
-     * Get the topic name of this message.
+     * Get the topic name without partition part of this message.
      * @return the name of the topic on which this message was published
      */
     public String getTopicName() {
+        int position = topicName.lastIndexOf(PARTITIONED_TOPIC_SUFFIX);
+        checkState(position != -1, "Topic Name not contains partition part. " + topicName);
+        return topicName.substring(0, position);
+    }
+
+    /**
+     * Get the topic name which contains partition part for this message.
+     * @return the topic name which contains Partition part
+     */
+    public String getTopicPartitionName() {
         return topicName;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageImpl.java
@@ -31,16 +31,24 @@ import org.apache.pulsar.common.api.EncryptionContext;
 
 public class TopicMessageImpl<T> implements Message<T> {
 
-    /** This topicName is get from ConsumerImpl, it contains partition part. */
+    /** This topicPartitionName is get from ConsumerImpl, it contains partition part. */
+    private final String topicPartitionName;
     private final String topicName;
     private final Message<T> msg;
     private final TopicMessageIdImpl messageId;
 
-    TopicMessageImpl(String topicName,
+    TopicMessageImpl(String topicPartitionName,
                      Message<T> msg) {
-        this.topicName = topicName;
+        this.topicPartitionName = topicPartitionName;
+        int position = topicPartitionName.lastIndexOf(PARTITIONED_TOPIC_SUFFIX);
+        if (position != -1) {
+            this.topicName = topicPartitionName.substring(0, position);
+        } else {
+            this.topicName = topicPartitionName;
+        }
+
         this.msg = msg;
-        this.messageId = new TopicMessageIdImpl(topicName, msg.getMessageId());
+        this.messageId = new TopicMessageIdImpl(topicPartitionName, msg.getMessageId());
     }
 
     /**
@@ -48,9 +56,7 @@ public class TopicMessageImpl<T> implements Message<T> {
      * @return the name of the topic on which this message was published
      */
     public String getTopicName() {
-        int position = topicName.lastIndexOf(PARTITIONED_TOPIC_SUFFIX);
-        checkState(position != -1, "Topic Name not contains partition part. " + topicName);
-        return topicName.substring(0, position);
+        return topicName;
     }
 
     /**
@@ -58,7 +64,7 @@ public class TopicMessageImpl<T> implements Message<T> {
      * @return the topic name which contains Partition part
      */
     public String getTopicPartitionName() {
-        return topicName;
+        return topicPartitionName;
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageImpl.java
@@ -19,12 +19,8 @@
 
 package org.apache.pulsar.client.impl;
 
-import static com.google.common.base.Preconditions.checkState;
-import static org.apache.pulsar.common.naming.TopicName.PARTITIONED_TOPIC_SUFFIX;
-
 import java.util.Map;
 import java.util.Optional;
-
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.common.api.EncryptionContext;
@@ -38,17 +34,13 @@ public class TopicMessageImpl<T> implements Message<T> {
     private final TopicMessageIdImpl messageId;
 
     TopicMessageImpl(String topicPartitionName,
+                     String topicName,
                      Message<T> msg) {
         this.topicPartitionName = topicPartitionName;
-        int position = topicPartitionName.lastIndexOf(PARTITIONED_TOPIC_SUFFIX);
-        if (position != -1) {
-            this.topicName = topicPartitionName.substring(0, position);
-        } else {
-            this.topicName = topicPartitionName;
-        }
+        this.topicName = topicName;
 
         this.msg = msg;
-        this.messageId = new TopicMessageIdImpl(topicPartitionName, msg.getMessageId());
+        this.messageId = new TopicMessageIdImpl(topicPartitionName, topicName, msg.getMessageId());
     }
 
     /**

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedTopicMessageTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/UnAckedTopicMessageTracker.java
@@ -32,12 +32,12 @@ public class UnAckedTopicMessageTracker extends UnAckedMessageTracker {
             int currentSetRemovedMsgCount = currentSet.removeIf(m -> {
                 checkState(m instanceof TopicMessageIdImpl,
                     "message should be of type TopicMessageIdImpl");
-                return ((TopicMessageIdImpl)m).getTopicName().contains(topicName);
+                return ((TopicMessageIdImpl)m).getTopicPartitionName().contains(topicName);
             });
             int oldSetRemovedMsgCount = oldOpenSet.removeIf(m -> {
                 checkState(m instanceof TopicMessageIdImpl,
                     "message should be of type TopicMessageIdImpl");
-                return ((TopicMessageIdImpl)m).getTopicName().contains(topicName);
+                return ((TopicMessageIdImpl)m).getTopicPartitionName().contains(topicName);
             });
 
             return currentSetRemovedMsgCount + oldSetRemovedMsgCount;

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageIdCompareToTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageIdCompareToTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pulsar.client.impl;
 
-import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import org.testng.annotations.Test;
@@ -123,12 +122,15 @@ public class MessageIdCompareToTest  {
         MessageIdImpl messageIdImpl = new MessageIdImpl(123L, 345L, 567);
         TopicMessageIdImpl topicMessageId1 = new TopicMessageIdImpl(
             "test-topic-partition-0",
+            "test-topic",
             new BatchMessageIdImpl(123L, 345L, 566, 789));
         TopicMessageIdImpl topicMessageId2 = new TopicMessageIdImpl(
             "test-topic-partition-0",
+            "test-topic",
             new BatchMessageIdImpl(123L, 345L, 567, 789));
         TopicMessageIdImpl topicMessageId3 = new TopicMessageIdImpl(
             "test-topic-partition-0",
+            "test-topic",
             new BatchMessageIdImpl(messageIdImpl));
         assertTrue(messageIdImpl.compareTo(topicMessageId1) > 0, "Expected to be greater than");
         assertTrue(messageIdImpl.compareTo(topicMessageId2) == 0, "Expected to be equal");
@@ -145,9 +147,11 @@ public class MessageIdCompareToTest  {
         BatchMessageIdImpl messageIdImpl3 = new BatchMessageIdImpl(123L, 345L, 567, -1);
         TopicMessageIdImpl topicMessageId1 = new TopicMessageIdImpl(
             "test-topic-partition-0",
+            "test-topic",
             new MessageIdImpl(123L, 345L, 566));
         TopicMessageIdImpl topicMessageId2 = new TopicMessageIdImpl(
             "test-topic-partition-0",
+            "test-topic",
             new MessageIdImpl(123L, 345L, 567));
         assertTrue(messageIdImpl1.compareTo(topicMessageId1) > 0, "Expected to be greater than");
         assertTrue(messageIdImpl1.compareTo(topicMessageId2) > 0, "Expected to be greater than");

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageIdCompareToTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/MessageIdCompareToTest.java
@@ -122,13 +122,13 @@ public class MessageIdCompareToTest  {
     public void testMessageIdImplCompareToTopicMessageId() {
         MessageIdImpl messageIdImpl = new MessageIdImpl(123L, 345L, 567);
         TopicMessageIdImpl topicMessageId1 = new TopicMessageIdImpl(
-            "test-topic",
+            "test-topic-partition-0",
             new BatchMessageIdImpl(123L, 345L, 566, 789));
         TopicMessageIdImpl topicMessageId2 = new TopicMessageIdImpl(
-            "test-topic",
+            "test-topic-partition-0",
             new BatchMessageIdImpl(123L, 345L, 567, 789));
         TopicMessageIdImpl topicMessageId3 = new TopicMessageIdImpl(
-            "test-topic",
+            "test-topic-partition-0",
             new BatchMessageIdImpl(messageIdImpl));
         assertTrue(messageIdImpl.compareTo(topicMessageId1) > 0, "Expected to be greater than");
         assertTrue(messageIdImpl.compareTo(topicMessageId2) == 0, "Expected to be equal");
@@ -144,10 +144,10 @@ public class MessageIdCompareToTest  {
         BatchMessageIdImpl messageIdImpl2 = new BatchMessageIdImpl(123L, 345L, 567, 0);
         BatchMessageIdImpl messageIdImpl3 = new BatchMessageIdImpl(123L, 345L, 567, -1);
         TopicMessageIdImpl topicMessageId1 = new TopicMessageIdImpl(
-            "test-topic",
+            "test-topic-partition-0",
             new MessageIdImpl(123L, 345L, 566));
         TopicMessageIdImpl topicMessageId2 = new TopicMessageIdImpl(
-            "test-topic",
+            "test-topic-partition-0",
             new MessageIdImpl(123L, 345L, 567));
         assertTrue(messageIdImpl1.compareTo(topicMessageId1) > 0, "Expected to be greater than");
         assertTrue(messageIdImpl1.compareTo(topicMessageId2) > 0, "Expected to be greater than");

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/semantics/SemanticsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/semantics/SemanticsTest.java
@@ -245,7 +245,7 @@ public class SemanticsTest extends PulsarClusterTestBase {
                     Message<String> m = consumer.receive();
                     int topicIdx;
                     if (numTopics > 1) {
-                        String topic = ((TopicMessageIdImpl) m.getMessageId()).getTopicName();
+                        String topic = ((TopicMessageIdImpl) m.getMessageId()).getTopicPartitionName();
 
                         String[] topicParts = StringUtils.split(topic, '-');
                         topicIdx = Integer.parseInt(topicParts[topicParts.length - 1]);


### PR DESCRIPTION
### Motivation

`getTopicName` in `TopicMessageIdImpl` and `TopicMessageImpl` is some kind of confusing. 
Developer may mis-use it.  

### Modifications

change method `getTopicName` to let it return topic name without partition.
add method `getTopicPartitionName`, which return topic name with partition part.

### Result

More clear of the method names.
Unit-Tests all pass.
Issue #2330 get fixed.