### PR TITLE
Fix NPE when splitting and unloading bundle

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -593,7 +593,7 @@ public class NamespaceService {
                                        boolean unload,
                                        AtomicInteger counter,
                                        CompletableFuture<Void> unloadFuture) {
-        CompletableFuture<NamespaceBundles> updateFuture = new CompletableFuture<>();
+        CompletableFuture<List<NamespaceBundle>> updateFuture = new CompletableFuture<>();
 
         final Pair<NamespaceBundles, List<NamespaceBundle>> splittedBundles = bundleFactory.splitBundles(bundle,
             2 /* by default split into 2 */);
@@ -622,7 +622,7 @@ public class NamespaceService {
                             // namespace bundle
                             bundleFactory.invalidateBundleCache(bundle.getNamespaceObject());
 
-                            updateFuture.complete(splittedBundles.getLeft());
+                            updateFuture.complete(splittedBundles.getRight());
                         } else if (rc == Code.BADVERSION.intValue()) {
                             KeeperException keeperException = KeeperException.create(KeeperException.Code.get(rc));
                             String msg = format("failed to update namespace policies [%s], NamespaceBundle: %s " +
@@ -680,7 +680,7 @@ public class NamespaceService {
 
                 if (unload) {
                     // unload new split bundles
-                    r.getBundles().forEach(splitBundle -> {
+                    r.forEach(splitBundle -> {
                         try {
                             unloadNamespaceBundle(splitBundle);
                         } catch (Exception e) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/namespace/NamespaceServiceTest.java
@@ -429,6 +429,48 @@ public class NamespaceServiceTest extends BrokerTestBase {
 
     }
 
+    @Test
+    public void testRemoveOwnershipAndSplitBundle() throws Exception {
+        OwnershipCache ownershipCache = spy(pulsar.getNamespaceService().getOwnershipCache());
+        doNothing().when(ownershipCache).disableOwnership(any(NamespaceBundle.class));
+
+        Field ownership = NamespaceService.class.getDeclaredField("ownershipCache");
+        ownership.setAccessible(true);
+        ownership.set(pulsar.getNamespaceService(), ownershipCache);
+
+        NamespaceService namespaceService = pulsar.getNamespaceService();
+        NamespaceName nsname = NamespaceName.get("pulsar/global/ns1");
+        TopicName topicName = TopicName.get("persistent://pulsar/global/ns1/topic-1");
+        NamespaceBundles bundles = namespaceService.getNamespaceBundleFactory().getBundles(nsname);
+        NamespaceBundle originalBundle = bundles.findBundle(topicName);
+
+        CompletableFuture<Void> result1 = namespaceService.splitAndOwnBundle(originalBundle, false);
+        try {
+            result1.get();
+        } catch (Exception e) {
+            fail("split bundle faild", e);
+        }
+
+        NamespaceBundles updatedNsBundles = namespaceService.getNamespaceBundleFactory().getBundles(nsname);
+        assertNotNull(updatedNsBundles);
+        NamespaceBundle splittedBundle = updatedNsBundles.findBundle(topicName);
+
+        updatedNsBundles.getBundles().stream().filter(bundle -> !bundle.equals(splittedBundle)).forEach(bundle -> {
+            try {
+                ownershipCache.removeOwnership(bundle).get();
+            } catch (Exception e) {
+                fail("faild to remove ownership", e);
+            }
+        });
+
+        CompletableFuture<Void> result2 = namespaceService.splitAndOwnBundle(splittedBundle, true);
+        try {
+            result2.get();
+        } catch (Exception e) {
+            // make sure: NPE does not occur
+            fail("split bundle faild", e);
+        }
+    }
 
     @SuppressWarnings("unchecked")
     private Pair<NamespaceBundles, List<NamespaceBundle>> splitBundles(NamespaceBundleFactory utilityFactory,


### PR DESCRIPTION
### Motivation

In v1.22.1 or later, NPE often occurs when a bundle is splitted and unloaded.
https://gist.github.com/massakam/39b10ab273771924e8ccc458fa83b7e0

NPE occurs in the following line. It means that the bundle is not included in `ownershipCache`.
https://github.com/apache/incubator-pulsar/blob/e548aa28505c3e0d40944751c85fbc9360cfcb7d/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java#L506

I think that what we should pass to `updateFuture` is not the left element of `splittedBundles` but the right one.
https://github.com/apache/incubator-pulsar/blob/e548aa28505c3e0d40944751c85fbc9360cfcb7d/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java#L625

The left element seems to be all bundles under the namespace. Some of them are not owned by the broker and not included in `ownershipCache`.

cf. https://github.com/apache/incubator-pulsar/pull/1428

### Modifications

Fixed `NamespaceService` to pass the left element of `splittedBundles` (list of bundles owened by the broker) to `updateFuture`.

### Result

NPE will no longer occur and the splitted bundle will be unloaded properly.