### PR TITLE
Avoid double executor on non-persistent topic send operation

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/nonpersistent/NonPersistentTopic.java
@@ -188,32 +188,24 @@ public class NonPersistentTopic implements Topic {
 
     @Override
     public void publishMessage(ByteBuf data, PublishContext callback) {
-        AtomicInteger msgDeliveryCount = new AtomicInteger(2);
+        callback.completed(null, 0L, 0L);
         ENTRIES_ADDED_COUNTER_UPDATER.incrementAndGet(this);
 
-        // retain data for sub/replication because io-thread will release actual payload
-        data.retain(2);
-        this.executor.executeOrdered(topic, SafeRun.safeRun(() -> {
-            subscriptions.forEach((name, subscription) -> {
-                ByteBuf duplicateBuffer = data.retainedDuplicate();
-                Entry entry = create(0L, 0L, duplicateBuffer);
-                // entry internally retains data so, duplicateBuffer should be release here
-                duplicateBuffer.release();
-                if (subscription.getDispatcher() != null) {
-                    subscription.getDispatcher().sendMessages(Lists.newArrayList(entry));
-                } else {
-                    // it happens when subscription is created but dispatcher is not created as consumer is not added
-                    // yet
-                    entry.release();
-                }
-            });
-            data.release();
-            if (msgDeliveryCount.decrementAndGet() == 0) {
-                callback.completed(null, 0L, 0L);
+        subscriptions.forEach((name, subscription) -> {
+            ByteBuf duplicateBuffer = data.retainedDuplicate();
+            Entry entry = create(0L, 0L, duplicateBuffer);
+            // entry internally retains data so, duplicateBuffer should be release here
+            duplicateBuffer.release();
+            if (subscription.getDispatcher() != null) {
+                subscription.getDispatcher().sendMessages(Collections.singletonList(entry));
+            } else {
+                // it happens when subscription is created but dispatcher is not created as consumer is not added
+                // yet
+                entry.release();
             }
-        }));
+        });
 
-        this.executor.executeOrdered(topic, SafeRun.safeRun(() -> {
+        if (!replicators.isEmpty()) {
             replicators.forEach((name, replicator) -> {
                 ByteBuf duplicateBuffer = data.retainedDuplicate();
                 Entry entry = create(0L, 0L, duplicateBuffer);
@@ -221,11 +213,7 @@ public class NonPersistentTopic implements Topic {
                 duplicateBuffer.release();
                 ((NonPersistentReplicator) replicator).sendMessage(entry);
             });
-            data.release();
-            if (msgDeliveryCount.decrementAndGet() == 0) {
-                callback.completed(null, 0L, 0L);
-            }
-        }));
+        }
     }
 
     @Override


### PR DESCRIPTION
### Motivation

Currently, the non-persistent topic publish handler is offloading twice to the same background thread. Both thread jumps are not really necessary, since we can do the same from existing io thread as the dispatch is itself non-blocking.