### PR TITLE
Add worker specific system and jvm metrics

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/WorkerStats.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/WorkerStats.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.broker.admin.v2;
 
 import java.io.IOException;
+import java.util.Collection;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -41,7 +42,15 @@ public class WorkerStats extends FunctionApiResource {
     @ApiOperation(value = "Get metrics for all functions owned by worker", notes = "Requested should be executed by Monitoring agent on each worker to fetch the metrics", response = Metrics.class)
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 503, message = "Worker service is not running") })
-    public Response getMetrics() throws IOException {
+    public Response getStats() throws IOException {
         return functions.getFunctionsMetrcis(clientAppId());
+    }
+    
+    @GET
+    @Path("/metrics")
+    @ApiOperation(value = "Gets the metrics for Monitoring", notes = "Request should be executed by Monitoring agent on each worker to fetch the worker-metrics", response = org.apache.pulsar.common.stats.Metrics.class, responseContainer = "List")
+    @ApiResponses(value = { @ApiResponse(code = 401, message = "Don't have admin permission") })
+    public Collection<org.apache.pulsar.common.stats.Metrics> getMetrics() throws Exception {
+        return functions.getWorkerMetrcis(clientAppId());
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
@@ -41,7 +41,7 @@ import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.loadbalance.BrokerHostUsage;
 import org.apache.pulsar.broker.loadbalance.LoadData;
-import org.apache.pulsar.broker.stats.metrics.JvmMetrics;
+import static org.apache.pulsar.common.stats.JvmMetrics.getJvmDirectMemoryUsed;
 import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.ServiceUnitId;
@@ -230,7 +230,7 @@ public class LoadManagerShared {
         systemResourceUsage.memory.limit = (double) maxHeapMemoryInBytes / MIBI;
 
         // Collect JVM direct memory
-        systemResourceUsage.directMemory.usage = (double) (JvmMetrics.getJvmDirectMemoryUsed() / MIBI);
+        systemResourceUsage.directMemory.usage = (double) (getJvmDirectMemoryUsed() / MIBI);
         systemResourceUsage.directMemory.limit = (double) (PlatformDependent.maxDirectMemory() / MIBI);
 
         return systemResourceUsage;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/MetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/MetricsGenerator.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.pulsar.broker.PulsarService;
-import org.apache.pulsar.broker.stats.metrics.JvmMetrics;
+import org.apache.pulsar.common.stats.JvmMetrics;
 import org.apache.pulsar.broker.stats.metrics.ManagedLedgerCacheMetrics;
 import org.apache.pulsar.broker.stats.metrics.ManagedLedgerMetrics;
 import org.apache.pulsar.common.stats.Metrics;
@@ -38,7 +38,7 @@ public class MetricsGenerator {
 
     public MetricsGenerator(PulsarService pulsar) {
         this.pulsar = pulsar;
-        this.jvmMetrics = new JvmMetrics(pulsar);
+        this.jvmMetrics = new JvmMetrics(pulsar.getExecutor(), "brk");
     }
 
     public Collection<Metrics> generate() {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/stats/prometheus/PrometheusMetricsGenerator.java
@@ -23,7 +23,7 @@ import java.io.OutputStream;
 import java.util.Enumeration;
 
 import org.apache.pulsar.broker.PulsarService;
-import org.apache.pulsar.broker.stats.metrics.JvmMetrics;
+import static org.apache.pulsar.common.stats.JvmMetrics.getJvmDirectMemoryUsed;
 import org.apache.pulsar.common.util.SimpleTextOutputStream;
 
 import io.netty.buffer.ByteBuf;
@@ -51,7 +51,7 @@ public class PrometheusMetricsGenerator {
         Gauge.build("jvm_memory_direct_bytes_used", "-").create().setChild(new Child() {
             @Override
             public double get() {
-                return JvmMetrics.getJvmDirectMemoryUsed();
+                return getJvmDirectMemoryUsed();
             }
         }).register(CollectorRegistry.defaultRegistry);
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/BookieClientsStatsGeneratorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/BookieClientsStatsGeneratorTest.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import org.apache.bookkeeper.mledger.proto.PendingBookieOpsStats;
 import org.apache.pulsar.broker.service.BrokerTestBase;
 import org.apache.pulsar.broker.stats.BookieClientStatsGenerator;
-import org.apache.pulsar.broker.stats.metrics.JvmMetrics;
+import org.apache.pulsar.common.stats.JvmMetrics;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/WorkerStatsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/WorkerStatsImpl.java
@@ -18,15 +18,20 @@
  */
 package org.apache.pulsar.client.admin.internal;
 
+import static org.apache.pulsar.client.admin.internal.FunctionsImpl.mergeJson;
+
+import java.util.Collection;
+import java.util.List;
+
 import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.admin.WorkerStats;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.functions.proto.InstanceCommunication.Metrics;
-import static org.apache.pulsar.client.admin.internal.FunctionsImpl.mergeJson;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -55,4 +60,15 @@ public class WorkerStatsImpl extends BaseResource implements WorkerStats {
            throw getApiException(e);
        }
    }
+
+    @Override
+    public Collection<org.apache.pulsar.common.stats.Metrics> getMetrics() throws PulsarAdminException {
+        try {
+            return request(workerStats.path("metrics"))
+                    .get(new GenericType<List<org.apache.pulsar.common.stats.Metrics>>() {
+                    });
+        } catch (Exception e) {
+            throw getApiException(e);
+        }
+    }
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctionWorkerStats.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctionWorkerStats.java
@@ -24,6 +24,7 @@ import org.apache.pulsar.functions.utils.Utils;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
+import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonParser;
 
@@ -33,8 +34,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Parameters(commandDescription = "Operations to collect function-worker statistics")
 public class CmdFunctionWorkerStats extends CmdBase {
-
-    private final FunctionsStats functionsStats;
 
     /**
      * Base command
@@ -70,10 +69,27 @@ public class CmdFunctionWorkerStats extends CmdBase {
         }
     }
 
+    @Parameters(commandDescription = "dump metrics for Monitoring")
+    class CmdMonitoringMetrics extends BaseCommand {
+
+        @Parameter(names = { "-i", "--indent" }, description = "Indent JSON output", required = false)
+        boolean indent = false;
+
+        @Override
+        void runCmd() throws Exception {
+            String json = new Gson().toJson(admin.workerStats().getMetrics());
+            GsonBuilder gsonBuilder = new GsonBuilder();
+            if (indent) {
+                gsonBuilder.setPrettyPrinting();
+            }
+            System.out.println(gsonBuilder.create().toJson(new JsonParser().parse(json)));
+        }
+    }
+
     public CmdFunctionWorkerStats(PulsarAdmin admin) throws PulsarClientException {
         super("functions", admin);
-        functionsStats = new FunctionsStats();
-        jcommander.addCommand("functions", functionsStats);
+        jcommander.addCommand("functions", new FunctionsStats());
+        jcommander.addCommand("monitoring-metrics", new CmdMonitoringMetrics());
     }
 
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/stats/Metrics.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/stats/Metrics.java
@@ -43,6 +43,11 @@ public class Metrics {
     @JsonInclude(content=Include.NON_EMPTY)
     final Map<String, String> dimensions;
 
+    public Metrics() {
+        metrics = Maps.newTreeMap();
+        dimensions = Maps.newHashMap();
+    }
+    
     // hide constructor
     protected Metrics(Map<String, String> unmodifiableDimensionMap) {
         this.metrics = Maps.newTreeMap();

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/MetricsGenerator.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/MetricsGenerator.java
@@ -16,29 +16,29 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.client.admin;
+package org.apache.pulsar.functions.worker;
 
-import java.util.Collection;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
 
-import org.apache.pulsar.functions.proto.InstanceCommunication.Metrics;
+import org.apache.pulsar.common.stats.JvmMetrics;
+import org.apache.pulsar.common.stats.Metrics;
 
-/**
- * Admin interface for worker stats management.
- */
-public interface WorkerStats {
-    
-    
-    /**
-     * Get all functions stats on a worker
-     * @return
-     * @throws PulsarAdminException 
-     */
-    Metrics getFunctionsStats() throws PulsarAdminException;
-    
-    /**
-     * Get worker metrics.
-     * @return
-     * @throws PulsarAdminException
-     */
-    Collection<org.apache.pulsar.common.stats.Metrics> getMetrics() throws PulsarAdminException;
+public class MetricsGenerator {
+
+    private final JvmMetrics jvmMetrics;
+
+    public MetricsGenerator(ScheduledExecutorService executor) {
+        this.jvmMetrics = new JvmMetrics(executor, "fun");
+    }
+
+    public List<Metrics> generate() {
+        List<Metrics> metricsCollection = new ArrayList<Metrics>();
+        metricsCollection.addAll(jvmMetrics.generate());
+        // add more metrics here..
+
+        return metricsCollection;
+    }
+
 }

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerService.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerService.java
@@ -41,6 +41,7 @@ import org.apache.pulsar.client.api.ClientBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.configuration.PulsarConfigurationLoader;
+import org.apache.pulsar.common.stats.JvmMetrics;
 
 /**
  * A service component contains everything to run a worker except rest server.
@@ -63,11 +64,13 @@ public class WorkerService {
     private AuthenticationService authenticationService;
     private ConnectorsManager connectorsManager;
     private PulsarAdmin admin;
+    private final MetricsGenerator metricsGenerator;
 
     public WorkerService(WorkerConfig workerConfig) {
         this.workerConfig = workerConfig;
         this.statsUpdater = Executors
                 .newSingleThreadScheduledExecutor(new DefaultThreadFactory("worker-stats-updater"));
+        this.metricsGenerator = new MetricsGenerator(this.statsUpdater);
     }
 
     public void start(URI dlogUri) throws InterruptedException {

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v2/WorkerStats.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/v2/WorkerStats.java
@@ -19,6 +19,7 @@
 package org.apache.pulsar.functions.worker.rest.api.v2;
 
 import java.io.IOException;
+import java.util.Collection;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -27,6 +28,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import org.apache.pulsar.functions.proto.InstanceCommunication.Metrics;
 import org.apache.pulsar.functions.worker.rest.FunctionApiResource;
 
 import io.swagger.annotations.Api;
@@ -34,7 +36,6 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.pulsar.functions.proto.InstanceCommunication.Metrics;
 
 @Slf4j
 @Path("/worker-stats")
@@ -45,10 +46,18 @@ public class WorkerStats extends FunctionApiResource {
 
     @GET
     @Path("/functions")
-    @ApiOperation(value = "Get metrics for all functions owned by worker", notes = "Requested should be executed by Monitoring agent on each worker to fetch the metrics", response = Metrics.class)
-    @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
+    @ApiOperation(value = "Get stats for all functions owned by worker", notes = "Request should be executed by Monitoring agent on each worker to fetch the function-metrics", response = Metrics.class)
+    @ApiResponses(value = { @ApiResponse(code = 401, message = "Don't have admin permission"),
             @ApiResponse(code = 503, message = "Worker service is not running") })
-    public Response getMetrics() throws IOException {
+    public Response getStats() throws IOException {
         return functions.getFunctionsMetrcis(clientAppId());
+    }
+    
+    @GET
+    @Path("/metrics")
+    @ApiOperation(value = "Gets the metrics for Monitoring", notes = "Request should be executed by Monitoring agent on each worker to fetch the worker-metrics", response = org.apache.pulsar.common.stats.Metrics.class, responseContainer = "List")
+    @ApiResponses(value = { @ApiResponse(code = 401, message = "Don't have admin permission") })
+    public Collection<org.apache.pulsar.common.stats.Metrics> getMetrics() throws Exception {
+        return functions.getWorkerMetrcis(clientAppId());
     }
 }


### PR DESCRIPTION
### Motivation

Adding worker system metrics, REST-CLI api to get system/jvm metrics.

### Result

Admin can get worker metrics using cli command:

```
./pulsar-admin functions-worker-stats monitoring-metrics  -i
[
  {
    "metrics": {
      "fun_default_pool_allocated": 33554432,
      "fun_default_pool_used": 172032,
      "jvm_direct_memory_used": 33554432,
      "jvm_gc_old_count": 0,
      "jvm_gc_old_pause": 0,
      "jvm_gc_young_count": 0,
      "jvm_gc_young_pause": 0,
      "jvm_heap_used": 163529544,
      "jvm_max_direct_memory": 4294967296,
      "jvm_max_memory": 2147483648,
      "jvm_thread_cnt": 37,
      "jvm_total_memory": 2147483648
    },
    "dimensions": {
      "metric": "jvm_metrics"
    }
  }
]
```