### PR TITLE
Set correct exception if function runnable fails with Error

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/JavaInstanceRunnable.java
@@ -185,8 +185,10 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
      */
     @Override
     public void run() {
+        String functionName = null;
         try {
             ContextImpl contextImpl = setupContext();
+            functionName = String.format("%s-%s", contextImpl.getTenant(), contextImpl.getFunctionName());
             javaInstance = setupJavaInstance(contextImpl);
             if (null != stateTable) {
                 StateContextImpl stateContext = new StateContextImpl(stateTable);
@@ -233,8 +235,8 @@ public class JavaInstanceRunnable implements AutoCloseable, Runnable {
                 }
             }
         } catch (Throwable t) {
-            log.error("Uncaught exception in Java Instance", t);
-            deathException = (Exception) t;
+            log.error("[{}] Uncaught exception in Java Instance", functionName, t);
+            deathException = (t instanceof Exception) ? (Exception) t : t.getCause();
             return;
         } finally {
             log.info("Closing instance");


### PR DESCRIPTION
### Motivation

If instance-runnable init fails with Error `java.lang.NoClassDefFoundError`, it doesn't cast into `Exception` and `deathException` sets with null value. and casting also throws below exception
```
java.lang.NoClassDefFoundError cannot be cast to java.lang.Exception
```
