### PR TITLE
Issue #2304: add encoding for WebTargets parts

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -620,11 +620,15 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
             // Ok, got the non authorized exception since usc cluster is not in the allowed clusters list.
         }
 
+        // test with url style role.
+        admin.namespaces().grantPermissionOnNamespace("prop-xyz/ns1",
+            "spiffe://developer/passport-role", EnumSet.allOf(AuthAction.class));
         admin.namespaces().grantPermissionOnNamespace("prop-xyz/ns1", "my-role", EnumSet.allOf(AuthAction.class));
 
         Policies policies = new Policies();
         policies.replication_clusters = Sets.newHashSet("test");
         policies.bundles = Policies.defaultBundle();
+        policies.auth_policies.namespace_auth.put("spiffe://developer/passport-role", EnumSet.allOf(AuthAction.class));
         policies.auth_policies.namespace_auth.put("my-role", EnumSet.allOf(AuthAction.class));
 
         assertEquals(admin.namespaces().getPolicies("prop-xyz/ns1"), policies);
@@ -632,7 +636,9 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
 
         assertEquals(admin.namespaces().getTopics("prop-xyz/ns1"), Lists.newArrayList());
 
+        admin.namespaces().revokePermissionsOnNamespace("prop-xyz/ns1", "spiffe://developer/passport-role");
         admin.namespaces().revokePermissionsOnNamespace("prop-xyz/ns1", "my-role");
+        policies.auth_policies.namespace_auth.remove("spiffe://developer/passport-role");
         policies.auth_policies.namespace_auth.remove("my-role");
         assertEquals(admin.namespaces().getPolicies("prop-xyz/ns1"), policies);
 

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/WebTargets.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/WebTargets.java
@@ -18,14 +18,26 @@
  */
 package org.apache.pulsar.client.admin.internal;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import javax.ws.rs.client.WebTarget;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 class WebTargets {
 
     static WebTarget addParts(WebTarget target, String[] parts) {
         if (parts != null && parts.length > 0) {
             for (String part : parts) {
-                target = target.path(part);
+                String encode;
+                try {
+                    encode = URLEncoder.encode(part, StandardCharsets.UTF_8.toString());
+                } catch (UnsupportedEncodingException e) {
+                    log.error(String.format("%s is Unknown", StandardCharsets.UTF_8.toString()) + "exception - [{}]", e);
+                    encode = part;
+                }
+                target = target.path(encode);
             }
         }
         return target;


### PR DESCRIPTION
### Motivation

Fixes #2304 

Issue #2304 reported that Pulsar admin commands will fail with some url style parts,
```
root@pulsar-admin:/pulsar# pulsar-admin namespaces grant-permission --actions produce,consume --role 'spiffe://developer/passport' core-platform/testing
HTTP 404 Not Found
Reason: HTTP 404 Not Found
```
This PR try to fix it.

### Modifications

- use URLEncoder to encode webTarget parts.
- add tests to verify

### Result

all UT passed