### PR TITLE
[docker] Publish pulsar-all image to docker hub

### DIFF
--- a/docker/publish.sh
+++ b/docker/publish.sh
@@ -63,18 +63,22 @@ set -x
 set -e
 
 docker tag pulsar:latest ${docker_registry_org}/pulsar:latest
+docker tag pulsar-all:latest ${docker_registry_org}/pulsar-all:latest
 docker tag pulsar-grafana:latest ${docker_registry_org}/pulsar-grafana:latest
 docker tag pulsar-dashboard:latest ${docker_registry_org}/pulsar-dashboard:latest
 
 docker tag pulsar:latest ${docker_registry_org}/pulsar:$MVN_VERSION
+docker tag pulsar-all:latest ${docker_registry_org}/pulsar-all:$MVN_VERSION
 docker tag pulsar-grafana:latest ${docker_registry_org}/pulsar-grafana:$MVN_VERSION
 docker tag pulsar-dashboard:latest ${docker_registry_org}/pulsar-dashboard:$MVN_VERSION
 
 # Push all images and tags
 docker push ${docker_registry_org}/pulsar:latest
+docker push ${docker_registry_org}/pulsar-all:latest
 docker push ${docker_registry_org}/pulsar-grafana:latest
 docker push ${docker_registry_org}/pulsar-dashboard:latest
 docker push ${docker_registry_org}/pulsar:$MVN_VERSION
+docker push ${docker_registry_org}/pulsar-all:$MVN_VERSION
 docker push ${docker_registry_org}/pulsar-grafana:$MVN_VERSION
 docker push ${docker_registry_org}/pulsar-dashboard:$MVN_VERSION
 


### PR DESCRIPTION
 ### Motivation

We have `pulsar-all` image since 2.1.0 release. However this image is not pushed to docker hub.

 ### Changes

Publish `pulsar-all` image to docker hub.

