### PR TITLE
Fixed linking of python wrapper to boost-python in MacOS build

### DIFF
--- a/pulsar-client-cpp/python/CMakeLists.txt
+++ b/pulsar-client-cpp/python/CMakeLists.txt
@@ -35,7 +35,9 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS} -undefined dynamic_lookup")
 endif()
 
-set(PYTHON_WRAPPER_LIBS ${Boost_PYTHON_LIBRARY} ${Boost_PYTHON3_LIBRARY})
+# Try all possible boost-python variable namings
+set(PYTHON_WRAPPER_LIBS ${Boost_PYTHON_LIBRARY} ${Boost_PYTHON3_LIBRARY}
+                        ${Boost_PYTHON27-MT_LIBRARY} ${Boost_PYTHON37-MT_LIBRARY})
 
 if (APPLE)
     target_link_libraries(_pulsar -Wl,-all_load pulsarStatic ${PYTHON_WRAPPER_LIBS})

--- a/pulsar-client-cpp/python/pkg/osx/build.sh.template
+++ b/pulsar-client-cpp/python/pkg/osx/build.sh.template
@@ -27,7 +27,7 @@ BOOST_VERSION=1.67
 
 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
-brew install openssl git boost@$BOOST_VERSION pkg-config jsoncpp cmake protobuf260 log4cxx
+brew install openssl git boost@$BOOST_VERSION pkg-config jsoncpp cmake protobuf260
 
 brew link --force boost@$BOOST_VERSION
 
@@ -40,8 +40,8 @@ fi
 
 if [ "$PYTHONVER" = "PYTHON3" ]
 then
-	brew install python boost-python3@BOOST_VERSION
-	brew link --force boost-python3@$BOOST_VERSION
+	brew install python boost-python3
+	brew link --force boost-python3
 fi
 
 brew link --force protobuf260
@@ -52,4 +52,10 @@ cd incubator-pulsar/pulsar-client-cpp
 cmake . -DBUILD_TESTS=OFF -DLINK_STATIC=ON
 make _pulsar -j8
 cd python
-python setup.py bdist_wheel
+
+if [ "$PYTHONVER" = "PYTHON2" ]
+then
+  python2 setup.py bdist_wheel
+else
+  python3 setup.py bdist_wheel
+fi


### PR DESCRIPTION
### Motivation

With newer cmake and boost versions from Homebrew, the variable for boost-python library name path had slightly changed. Adjusting to have successful build in all macos/python variants.

