### PR TITLE
Fix Copy Command in Pulsar IO Getting Started

### DIFF
--- a/site2/docs/io-quickstart.md
+++ b/site2/docs/io-quickstart.md
@@ -66,7 +66,7 @@ $ tar xvfz /path/to/apache-pulsar-io-connectors-{{pulsar:version}}-bin.tar.gz
 // you will find a directory named `apache-pulsar-io-connectors-{{pulsar:version}}` in the pulsar directory
 // then copy the connectors
 
-$ cd apache-pulsar-io-connectors-{{pulsar:version}}/connectors connectors
+$ cp -r apache-pulsar-io-connectors-{{pulsar:version}}/connectors connectors
 
 $ ls connectors
 pulsar-io-aerospike-{{pulsar.version}}.nar

--- a/site2/website/versioned_docs/version-2.1.0-incubating/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/io-quickstart.md
@@ -67,7 +67,7 @@ $ tar xvfz /path/to/apache-pulsar-io-connectors-{{pulsar:version}}-bin.tar.gz
 // you will find a directory named `apache-pulsar-io-connectors-{{pulsar:version}}` in the pulsar directory
 // then copy the connectors
 
-$ cd apache-pulsar-io-connectors-{{pulsar:version}}/connectors connectors
+$ cp -r apache-pulsar-io-connectors-{{pulsar:version}}/connectors connectors
 
 $ ls connectors
 pulsar-io-aerospike-{{pulsar.version}}.nar


### PR DESCRIPTION
### Motivation

In https://pulsar.incubator.apache.org/docs/en/io-quickstart/ ,
`connectors` directory cannot be copied because copy command is wrong.

> // you will find a directory named `apache-pulsar-io-connectors-2.1.0-incubating` in the pulsar directory
> // then copy the connectors
>
> $ cd apache-pulsar-io-connectors-2.1.0-incubating/connectors connectors

### Modifications

・Change `cd` to `cp -r`

### Result

`connectors` directory can be copied successfully.

```
$ cp -r apache-pulsar-io-connectors-2.1.0-incubating/connectors connectors
$ ls connectors
pulsar-io-aerospike-2.1.0-incubating.nar  pulsar-io-kinesis-2.1.0-incubating.nar
pulsar-io-cassandra-2.1.0-incubating.nar  pulsar-io-rabbitmq-2.1.0-incubating.nar
pulsar-io-kafka-2.1.0-incubating.nar      pulsar-io-twitter-2.1.0-incubating.nar
```
