### PR TITLE
Kinesis-sink consider topic-name as partition-key if record key empty

### DIFF
--- a/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSink.java
+++ b/pulsar-io/kinesis/src/main/java/org/apache/pulsar/io/kinesis/KinesisSink.java
@@ -114,7 +114,7 @@ public class KinesisSink implements Sink<byte[]> {
                     record.getRecordSequence());
             throw new IllegalStateException("kinesis queue has publish failure");
         }
-        String partitionedKey = record.getKey().orElse(defaultPartitionedKey);
+        String partitionedKey = record.getKey().orElse(record.getTopicName().orElse(defaultPartitionedKey));
         partitionedKey = partitionedKey.length() > maxPartitionedKeyLength
                 ? partitionedKey.substring(0, maxPartitionedKeyLength - 1)
                 : partitionedKey; // partitionedKey Length must be at least one, and at most 256


### PR DESCRIPTION
### Motivation

#2116 refactored to pass record-key as partition-key to the configured sink. However, old pulsar-client (< 2.0) are not sending partitioned-key in the message which makes this key empty all the time. So, in that case, we should consider topic-name as partitioned-key to manage ordering for that partition.

### Modifications

Consider topic-name as partitioned-key if record-key is not available.
