### PR TITLE
[tiered storage] Pulsar standalone hangs when s3 offloader is enabled

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/PulsarService.java
@@ -663,21 +663,25 @@ public class PulsarService implements AutoCloseable {
 
     public synchronized LedgerOffloader createManagedLedgerOffloader(ServiceConfiguration conf)
             throws PulsarServerException {
-        if (conf.getManagedLedgerOffloadDriver() != null
-            && BlobStoreManagedLedgerOffloader.driverSupported(conf.getManagedLedgerOffloadDriver())) {
-            try {
-                return BlobStoreManagedLedgerOffloader.create(
-                    getTieredStorageConf(conf),
-                    ImmutableMap.of(
-                        METADATA_SOFTWARE_VERSION_KEY.toLowerCase(), PulsarBrokerVersionStringUtils.getNormalizedVersionString(),
-                        METADATA_SOFTWARE_GITSHA_KEY.toLowerCase(), PulsarBrokerVersionStringUtils.getGitSha()
-                    ),
-                    getOffloaderScheduler(conf));
-            } catch (IOException ioe) {
-                throw new PulsarServerException(ioe.getMessage(), ioe.getCause());
+        try {
+            if (conf.getManagedLedgerOffloadDriver() != null
+                && BlobStoreManagedLedgerOffloader.driverSupported(conf.getManagedLedgerOffloadDriver())) {
+                try {
+                    return BlobStoreManagedLedgerOffloader.create(
+                        getTieredStorageConf(conf),
+                        ImmutableMap.of(
+                            METADATA_SOFTWARE_VERSION_KEY.toLowerCase(), PulsarBrokerVersionStringUtils.getNormalizedVersionString(),
+                            METADATA_SOFTWARE_GITSHA_KEY.toLowerCase(), PulsarBrokerVersionStringUtils.getGitSha()
+                        ),
+                        getOffloaderScheduler(conf));
+                } catch (IOException ioe) {
+                    throw new PulsarServerException(ioe.getMessage(), ioe.getCause());
+                }
+            } else {
+                return NullLedgerOffloader.INSTANCE;
             }
-        } else {
-            return NullLedgerOffloader.INSTANCE;
+        } catch (Throwable t) {
+            throw new PulsarServerException(t);
         }
     }
 

--- a/tiered-storage/jcloud/pom.xml
+++ b/tiered-storage/jcloud/pom.xml
@@ -67,18 +67,6 @@
           <groupId>org.apache.jclouds.provider</groupId>
           <artifactId>*</artifactId>
         </exclusion>
-        <exclusion>
-          <groupId>com.google.inject</groupId>
-          <artifactId>guice</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.inject.extensions</groupId>
-          <artifactId>guice-assistedinject</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.inject.extensions</groupId>
-          <artifactId>guice-multibindings</artifactId>
-        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/tiered-storage/jcloud/pom.xml
+++ b/tiered-storage/jcloud/pom.xml
@@ -42,6 +42,44 @@
       <groupId>org.apache.pulsar</groupId>
       <artifactId>jclouds-shaded</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.gson</groupId>
+          <artifactId>gson</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.jclouds</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.jclouds.api</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.jclouds.common</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.jclouds.provider</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.inject</groupId>
+          <artifactId>guice</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.inject.extensions</groupId>
+          <artifactId>guice-assistedinject</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.inject.extensions</groupId>
+          <artifactId>guice-multibindings</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>

--- a/tiered-storage/jcloud/pom.xml
+++ b/tiered-storage/jcloud/pom.xml
@@ -80,5 +80,51 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+
+    <!-- we excluded the transitive dependencies above to make it work for standalone.
+         however it will cause test failures. bring following dependencies back for testing.
+         all these should be gone once we introduce NAR package for offloaders. -->
+    <dependency>
+      <groupId>com.jamesmurty.utils</groupId>
+      <artifactId>java-xmlbuilder</artifactId>
+      <version>1.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.iharder</groupId>
+      <artifactId>base64</artifactId>
+      <version>2.3.8</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <version>2.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>aopalliance</groupId>
+      <artifactId>aopalliance</artifactId>
+      <version>1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <version>1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>jsr250-api</artifactId>
+      <version>1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_annotations</artifactId>
+      <version>2.1.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
 ### Motivation

 #2371 introduced a regression on starting pulsar standalone with s3 offloader enabled.

 ```
org.apache.pulsar.broker.PulsarServerException: java.util.ServiceConfigurationError: org.jclouds.providers.ProviderMetadata: Provider org.jclouds.aws.s3.AWSS3ProviderMetadata could not be instantiated
	at org.apache.pulsar.broker.PulsarService.createManagedLedgerOffloader(PulsarService.java:684) ~[pulsar-broker.jar:2.2.0-incubating-SNAPSHOT]
	at org.apache.pulsar.broker.PulsarService.start(PulsarService.java:346) [pulsar-broker.jar:2.2.0-incubating-SNAPSHOT]
	at org.apache.pulsar.PulsarStandalone.start(PulsarStandalone.java:289) [pulsar-broker.jar:2.2.0-incubating-SNAPSHOT]
	at org.apache.pulsar.PulsarStandaloneStarter.main(PulsarStandaloneStarter.java:102) [pulsar-broker.jar:2.2.0-incubating-SNAPSHOT]
Caused by: java.util.ServiceConfigurationError: org.jclouds.providers.ProviderMetadata: Provider org.jclouds.aws.s3.AWSS3ProviderMetadata could not be instantiated
	at java.util.ServiceLoader.fail(ServiceLoader.java:232) ~[?:1.8.0_144]
	at java.util.ServiceLoader.access$100(ServiceLoader.java:185) ~[?:1.8.0_144]
	at java.util.ServiceLoader$LazyIterator.nextService(ServiceLoader.java:384) ~[?:1.8.0_144]
	at java.util.ServiceLoader$LazyIterator.next(ServiceLoader.java:404) ~[?:1.8.0_144]
	at java.util.ServiceLoader$1.next(ServiceLoader.java:480) ~[?:1.8.0_144]
	at com.google.common.collect.ImmutableCollection$Builder.addAll(ImmutableCollection.java:416) ~[guava-21.0.jar:?]
	at com.google.common.collect.ImmutableCollection$ArrayBasedBuilder.addAll(ImmutableCollection.java:500) ~[guava-21.0.jar:?]
	at com.google.common.collect.ImmutableSet$Builder.addAll(ImmutableSet.java:518) ~[guava-21.0.jar:?]
	at org.jclouds.providers.Providers.all(Providers.java:83) ~[jclouds-core-2.2.0-SNAPSHOT.jar:2.2.0-SNAPSHOT]
	at org.jclouds.providers.Providers.withId(Providers.java:99) ~[jclouds-core-2.2.0-SNAPSHOT.jar:2.2.0-SNAPSHOT]
	at org.jclouds.ContextBuilder.newBuilder(ContextBuilder.java:167) ~[jclouds-core-2.2.0-SNAPSHOT.jar:2.2.0-SNAPSHOT]
	at org.apache.pulsar.broker.offload.impl.BlobStoreManagedLedgerOffloader.<init>(BlobStoreManagedLedgerOffloader.java:233) ~[tiered-storage-jcloud.jar:2.2.0-incubating-SNAPSHOT]
	at org.apache.pulsar.broker.offload.impl.BlobStoreManagedLedgerOffloader.create(BlobStoreManagedLedgerOffloader.java:163) ~[tiered-storage-jcloud.jar:2.2.0-incubating-SNAPSHOT]
	at org.apache.pulsar.broker.PulsarService.createManagedLedgerOffloader(PulsarService.java:670) ~[pulsar-broker.jar:2.2.0-incubating-SNAPSHOT]
	... 3 more
Caused by: java.lang.NoSuchMethodError: org.jclouds.reflect.Reflection2.typeToken(Ljava/lang/Class;)Lorg/apache/pulsar/shaded/com/google/common/reflect/TypeToken;
	at org.jclouds.aws.s3.AWSS3ApiMetadata$Builder.<init>(AWSS3ApiMetadata.java:63) ~[jclouds-shaded.jar:2.2.0-incubating-SNAPSHOT]
	at org.jclouds.aws.s3.AWSS3ApiMetadata.<init>(AWSS3ApiMetadata.java:43) ~[jclouds-shaded.jar:2.2.0-incubating-SNAPSHOT]
	at org.jclouds.aws.s3.AWSS3ProviderMetadata$Builder.<init>(AWSS3ProviderMetadata.java:106) ~[jclouds-shaded.jar:2.2.0-incubating-SNAPSHOT]
	at org.jclouds.aws.s3.AWSS3ProviderMetadata.builder(AWSS3ProviderMetadata.java:56) ~[jclouds-shaded.jar:2.2.0-incubating-SNAPSHOT]
	at org.jclouds.aws.s3.AWSS3ProviderMetadata.<init>(AWSS3ProviderMetadata.java:65) ~[jclouds-shaded.jar:2.2.0-incubating-SNAPSHOT]
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:1.8.0_144]
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) ~[?:1.8.0_144]
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:1.8.0_144]
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423) ~[?:1.8.0_144]
	at java.lang.Class.newInstance(Class.java:442) ~[?:1.8.0_144]
	at java.util.ServiceLoader$LazyIterator.nextService(ServiceLoader.java:380) ~[?:1.8.0_144]
	at java.util.ServiceLoader$LazyIterator.next(ServiceLoader.java:404) ~[?:1.8.0_144]
	at java.util.ServiceLoader$1.next(ServiceLoader.java:480) ~[?:1.8.0_144]
	at com.google.common.collect.ImmutableCollection$Builder.addAll(ImmutableCollection.java:416) ~[guava-21.0.jar:?]
	at com.google.common.collect.ImmutableCollection$ArrayBasedBuilder.addAll(ImmutableCollection.java:500) ~[guava-21.0.jar:?]
	at com.google.common.collect.ImmutableSet$Builder.addAll(ImmutableSet.java:518) ~[guava-21.0.jar:?]
	at org.jclouds.providers.Providers.all(Providers.java:83) ~[jclouds-core-2.2.0-SNAPSHOT.jar:2.2.0-SNAPSHOT]
	at org.jclouds.providers.Providers.withId(Providers.java:99) ~[jclouds-core-2.2.0-SNAPSHOT.jar:2.2.0-SNAPSHOT]
	at org.jclouds.ContextBuilder.newBuilder(ContextBuilder.java:167) ~[jclouds-core-2.2.0-SNAPSHOT.jar:2.2.0-SNAPSHOT]
	at org.apache.pulsar.broker.offload.impl.BlobStoreManagedLedgerOffloader.<init>(BlobStoreManagedLedgerOffloader.java:233) ~[tiered-storage-jcloud.jar:2.2.0-incubating-SNAPSHOT]
	at org.apache.pulsar.broker.offload.impl.BlobStoreManagedLedgerOffloader.create(BlobStoreManagedLedgerOffloader.java:163) ~[tiered-storage-jcloud.jar:2.2.0-incubating-SNAPSHOT]
	at org.apache.pulsar.broker.PulsarService.createManagedLedgerOffloader(PulsarService.java:670) ~[pulsar-broker.jar:2.2.0-incubating-SNAPSHOT]
	... 3 more
 ```

The problem is unshaded dependencies introduced in the classpath.

 ### Changes

- Catch runtime exception on starting up and fail explicityly
- Exclude transitive dependencies from shaded artifact


