### PR TITLE
adding tiered storage confs to endpoint

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/BrokersBase.java
@@ -193,7 +193,7 @@ public class BrokersBase extends AdminResource {
         return new InternalConfigurationData(
             pulsar().getConfiguration().getZookeeperServers(),
             pulsar().getConfiguration().getConfigurationStoreServers(),
-            conf.getZkLedgersRootPath());
+            conf.getZkLedgersRootPath(), pulsar().getTieredStorageConf());
     }
 
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminTest.java
@@ -66,6 +66,7 @@ import org.apache.pulsar.broker.web.PulsarWebResource;
 import org.apache.pulsar.broker.web.RestException;
 import org.apache.pulsar.common.conf.InternalConfigurationData;
 import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.offload.TieredStorageConfigurationData;
 import org.apache.pulsar.common.policies.data.AuthAction;
 import org.apache.pulsar.common.policies.data.AutoFailoverPolicyData;
 import org.apache.pulsar.common.policies.data.AutoFailoverPolicyType;
@@ -209,7 +210,7 @@ public class AdminTest extends MockedPulsarServiceBaseTest {
         InternalConfigurationData expectedData = new InternalConfigurationData(
             pulsar.getConfiguration().getZookeeperServers(),
             pulsar.getConfiguration().getConfigurationStoreServers(),
-            new ClientConfiguration().getZkLedgersRootPath());
+            new ClientConfiguration().getZkLedgersRootPath(), new TieredStorageConfigurationData());
 
         assertEquals(brokers.getInternalConfigurationData(), expectedData);
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
@@ -770,7 +770,7 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
      *
      * @throws Exception
      */
-    @Test
+    @Test(invocationCount=100, skipFailedInvocations=true)
     public void testMsgDropStat() throws Exception {
 
         int defaultNonPersistentMessageRate = conf.getMaxConcurrentNonPersistentMessagePerConnection();

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/conf/InternalConfigurationData.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/conf/InternalConfigurationData.java
@@ -19,6 +19,8 @@
 package org.apache.pulsar.common.conf;
 
 import com.google.common.base.MoreObjects;
+import org.apache.pulsar.common.offload.TieredStorageConfigurationData;
+
 import java.util.Objects;
 
 public class InternalConfigurationData {
@@ -26,16 +28,18 @@ public class InternalConfigurationData {
     private String zookeeperServers;
     private String configurationStoreServers;
     private String ledgersRootPath;
-
+    private TieredStorageConfigurationData tieredStorageConfigurationData;
     public InternalConfigurationData() {
     }
 
     public InternalConfigurationData(String zookeeperServers,
                                      String configurationStoreServers,
-                                     String ledgersRootPath) {
+                                     String ledgersRootPath,
+                                     TieredStorageConfigurationData tieredStorageConfigurationData) {
         this.zookeeperServers = zookeeperServers;
         this.configurationStoreServers = configurationStoreServers;
         this.ledgersRootPath = ledgersRootPath;
+        this.tieredStorageConfigurationData = tieredStorageConfigurationData;
     }
 
     public String getZookeeperServers() {
@@ -50,6 +54,10 @@ public class InternalConfigurationData {
         return ledgersRootPath;
     }
 
+    public TieredStorageConfigurationData getTieredStorageConfigurationData() {
+        return tieredStorageConfigurationData;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (!(obj instanceof InternalConfigurationData)) {
@@ -58,7 +66,8 @@ public class InternalConfigurationData {
         InternalConfigurationData other = (InternalConfigurationData) obj;
         return Objects.equals(zookeeperServers, other.zookeeperServers)
             && Objects.equals(configurationStoreServers, other.configurationStoreServers)
-            && Objects.equals(ledgersRootPath, other.ledgersRootPath);
+            && Objects.equals(ledgersRootPath, other.ledgersRootPath)
+            && Objects.equals(tieredStorageConfigurationData, other.tieredStorageConfigurationData);
     }
 
     @Override
@@ -72,6 +81,7 @@ public class InternalConfigurationData {
             .add("zookeeperServers", zookeeperServers)
             .add("configurationStoreServers", configurationStoreServers)
             .add("ledgersRootPath", ledgersRootPath)
+            .add("tieredStorageConfigurationData", tieredStorageConfigurationData)
             .toString();
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/conf/InternalConfigurationData.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/conf/InternalConfigurationData.java
@@ -18,17 +18,17 @@
  */
 package org.apache.pulsar.common.conf;
 
-import com.google.common.base.MoreObjects;
+import lombok.Data;
 import org.apache.pulsar.common.offload.TieredStorageConfigurationData;
 
-import java.util.Objects;
-
+@Data
 public class InternalConfigurationData {
 
     private String zookeeperServers;
     private String configurationStoreServers;
     private String ledgersRootPath;
     private TieredStorageConfigurationData tieredStorageConfigurationData;
+    
     public InternalConfigurationData() {
     }
 
@@ -41,48 +41,4 @@ public class InternalConfigurationData {
         this.ledgersRootPath = ledgersRootPath;
         this.tieredStorageConfigurationData = tieredStorageConfigurationData;
     }
-
-    public String getZookeeperServers() {
-        return zookeeperServers;
-    }
-
-    public String getConfigurationStoreServers() {
-        return configurationStoreServers;
-    }
-
-    public String getLedgersRootPath() {
-        return ledgersRootPath;
-    }
-
-    public TieredStorageConfigurationData getTieredStorageConfigurationData() {
-        return tieredStorageConfigurationData;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (!(obj instanceof InternalConfigurationData)) {
-            return false;
-        }
-        InternalConfigurationData other = (InternalConfigurationData) obj;
-        return Objects.equals(zookeeperServers, other.zookeeperServers)
-            && Objects.equals(configurationStoreServers, other.configurationStoreServers)
-            && Objects.equals(ledgersRootPath, other.ledgersRootPath)
-            && Objects.equals(tieredStorageConfigurationData, other.tieredStorageConfigurationData);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(zookeeperServers, configurationStoreServers, ledgersRootPath);
-    }
-
-    @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("zookeeperServers", zookeeperServers)
-            .add("configurationStoreServers", configurationStoreServers)
-            .add("ledgersRootPath", ledgersRootPath)
-            .add("tieredStorageConfigurationData", tieredStorageConfigurationData)
-            .toString();
-    }
-
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/offload/TieredStorageConfigurationData.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/offload/TieredStorageConfigurationData.java
@@ -19,6 +19,8 @@
 package org.apache.pulsar.common.offload;
 
 import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
 
 /**
@@ -64,6 +66,7 @@ public class TieredStorageConfigurationData implements Serializable, Cloneable{
 
     // For Google Cloud Storage, path to json file containing service account credentials.
     // For more details, see the "Service Accounts" section of https://support.google.com/googleapi/answer/6158849
+    @JsonIgnore
     private String gcsManagedLedgerOffloadServiceAccountKeyFile = null;
 
 }

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/offload/TieredStorageConfigurationData.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/offload/TieredStorageConfigurationData.java
@@ -66,6 +66,7 @@ public class TieredStorageConfigurationData implements Serializable, Cloneable{
 
     // For Google Cloud Storage, path to json file containing service account credentials.
     // For more details, see the "Service Accounts" section of https://support.google.com/googleapi/answer/6158849
+    // Add @JsonIgnore so that this field will not be serialized and returned via any endpoints e.g. {@link org.apache.pulsar.broker.admin.impl.BrokerBase#getInternalConfigurationData}
     @JsonIgnore
     private String gcsManagedLedgerOffloadServiceAccountKeyFile = null;
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/offload/TieredStorageConfigurationData.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/offload/TieredStorageConfigurationData.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pulsar.broker.offload;
+package org.apache.pulsar.common.offload;
 
 import java.io.Serializable;
 import lombok.Data;

--- a/tiered-storage/jcloud/src/main/java/org/apache/pulsar/broker/offload/impl/BlobStoreManagedLedgerOffloader.java
+++ b/tiered-storage/jcloud/src/main/java/org/apache/pulsar/broker/offload/impl/BlobStoreManagedLedgerOffloader.java
@@ -42,7 +42,7 @@ import org.apache.bookkeeper.mledger.LedgerOffloader;
 import org.apache.pulsar.broker.offload.BlockAwareSegmentInputStream;
 import org.apache.pulsar.broker.offload.OffloadIndexBlock;
 import org.apache.pulsar.broker.offload.OffloadIndexBlockBuilder;
-import org.apache.pulsar.broker.offload.TieredStorageConfigurationData;
+import org.apache.pulsar.common.offload.TieredStorageConfigurationData;
 import org.jclouds.Constants;
 import org.jclouds.ContextBuilder;
 import org.jclouds.blobstore.BlobStore;

--- a/tiered-storage/jcloud/src/test/java/org/apache/pulsar/broker/offload/impl/BlobStoreManagedLedgerOffloaderTest.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/pulsar/broker/offload/impl/BlobStoreManagedLedgerOffloaderTest.java
@@ -53,7 +53,7 @@ import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.bookkeeper.mledger.LedgerOffloader;
 import org.apache.bookkeeper.util.ZkUtils;
 import org.apache.pulsar.broker.offload.BlobStoreTestBase;
-import org.apache.pulsar.broker.offload.TieredStorageConfigurationData;
+import org.apache.pulsar.common.offload.TieredStorageConfigurationData;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.MockZooKeeper;
 import org.apache.zookeeper.data.ACL;


### PR DESCRIPTION
add tiered storage configuration information to the internal-confs endpoint so broker confs for tiered storage can be retrieved
