### PR TITLE
Increased default brokerShutdownTimeout to 60 seconds

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -53,7 +53,7 @@ failureDomainsEnabled=false
 zooKeeperSessionTimeoutMillis=30000
 
 # Time to wait for broker graceful shutdown. After this time elapses, the process will be killed
-brokerShutdownTimeoutMs=3000
+brokerShutdownTimeoutMs=60000
 
 # Enable backlog quota check. Enforces action on topic when the quota is reached
 backlogQuotaCheckEnabled=true

--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -46,7 +46,7 @@ failureDomainsEnabled=false
 zooKeeperSessionTimeoutMillis=30000
 
 # Time to wait for broker graceful shutdown. After this time elapses, the process will be killed
-brokerShutdownTimeoutMs=3000
+brokerShutdownTimeoutMs=60000
 
 # Enable backlog quota check. Enforces action on topic when the quota is reached
 backlogQuotaCheckEnabled=true

--- a/deployment/terraform-ansible/templates/broker.conf
+++ b/deployment/terraform-ansible/templates/broker.conf
@@ -53,7 +53,7 @@ failureDomainsEnabled=false
 zooKeeperSessionTimeoutMillis=30000
 
 # Time to wait for broker graceful shutdown. After this time elapses, the process will be killed
-brokerShutdownTimeoutMs=3000
+brokerShutdownTimeoutMs=60000
 
 # Enable backlog quota check. Enforces action on topic when the quota is reached
 backlogQuotaCheckEnabled=true

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -78,7 +78,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     // Time to wait for broker graceful shutdown. After this time elapses, the
     // process will be killed
     @FieldContext(dynamic = true)
-    private long brokerShutdownTimeoutMs = 3000;
+    private long brokerShutdownTimeoutMs = 60000;
     // Enable backlog quota check. Enforces action on topic when the quota is
     // reached
     private boolean backlogQuotaCheckEnabled = true;

--- a/site2/docs/reference-configuration.md
+++ b/site2/docs/reference-configuration.md
@@ -122,7 +122,7 @@ Pulsar brokers are responsible for handling incoming messages from producers, di
 |brokerDeduplicationEntriesInterval|  The number of entries after which a deduplication informational snapshot is taken. A larger interval will lead to fewer snapshots being taken, though this would also lengthen the topic recovery time (the time required for entries published after the snapshot to be replayed). |1000|
 |brokerDeduplicationProducerInactivityTimeoutMinutes| The time of inactivity (in minutes) after which the broker will discard deduplication information related to a disconnected producer. |360|
 |zooKeeperSessionTimeoutMillis| Zookeeper session timeout in milliseconds |30000|
-|brokerShutdownTimeoutMs| Time to wait for broker graceful shutdown. After this time elapses, the process will be killed  |3000|
+|brokerShutdownTimeoutMs| Time to wait for broker graceful shutdown. After this time elapses, the process will be killed  |60000|
 |backlogQuotaCheckEnabled|  Enable backlog quota check. Enforces action on topic when the quota is reached  |true|
 |backlogQuotaCheckIntervalInSeconds|  How often to check for topics that have reached the quota |60|
 |backlogQuotaDefaultLimitGB|  Default per-topic backlog quota limit |10|
@@ -303,7 +303,7 @@ The [`pulsar-client`](reference-cli-tools.md#pulsar-client) CLI tool can be used
 |advertisedAddress| The hostname or IP address that the standalone service advertises to the outside world. If not set, the value of `InetAddress.getLocalHost().getHostName()` is used.  ||
 |clusterName| The name of the cluster that this broker belongs to. |standalone|
 |zooKeeperSessionTimeoutMillis| The ZooKeeper session timeout, in milliseconds. |30000|
-|brokerShutdownTimeoutMs| The time to wait for graceful broker shutdown. After this time elapses, the process will be killed. |3000|
+|brokerShutdownTimeoutMs| The time to wait for graceful broker shutdown. After this time elapses, the process will be killed. |60000|
 |backlogQuotaCheckEnabled|  Enable the backlog quota check, which enforces a specified action when the quota is reached.  |true|
 |backlogQuotaCheckIntervalInSeconds|  How often to check for topics that have reached the backlog quota.  |60|
 |backlogQuotaDefaultLimitGB|  The default per-topic backlog quota limit.  |10|


### PR DESCRIPTION
### Motivation

The default timeout for broker graceful shutdown is set to 3 seconds. This can give little room to do graceful shutdown when the broker is serving a lot of topics.

There is no big downside in increasing the timeout to a much bigger value.