### PR TITLE
Include Python-3.7 compatible client lib for linux

### DIFF
--- a/pulsar-client-cpp/CMakeLists.txt
+++ b/pulsar-client-cpp/CMakeLists.txt
@@ -110,7 +110,7 @@ if (PYTHONLIBS_VERSION_STRING MATCHES "^3.+$")
     list(GET PYTHONLIBS_VERSION_NO_LIST 1 PYTHONLIBS_VERSION_MINOR)
     set(BOOST_PYTHON_NAME_POSTFIX ${PYTHONLIBS_VERSION_MAJOR}${PYTHONLIBS_VERSION_MINOR})
     # For python3 the lib name is boost_python3
-    set(BOOST_PYTHON_NAME_LIST python3;python3-mt;python-py${BOOST_PYTHON_NAME_POSTFIX};python${BOOST_PYTHON_NAME_POSTFIX}-mt)
+    set(BOOST_PYTHON_NAME_LIST python3;python3-mt;python-py${BOOST_PYTHON_NAME_POSTFIX};python${BOOST_PYTHON_NAME_POSTFIX}-mt;python${BOOST_PYTHON_NAME_POSTFIX})
 else ()
     # Regular boost_python
     set(BOOST_PYTHON_NAME_LIST python;python-mt;python-py27;python27-mt)

--- a/pulsar-client-cpp/docker/Dockerfile
+++ b/pulsar-client-cpp/docker/Dockerfile
@@ -54,12 +54,12 @@ RUN curl -O -L https://github.com/openssl/openssl/archive/OpenSSL_1_0_2l.tar.gz 
     rm -rf /OpenSSL_1_0_2l.tar.gz /openssl-OpenSSL_1_0_2l
 
 # Download and compile boost
-RUN curl -O -L https://dl.bintray.com/boostorg/release/1.64.0/source/boost_1_64_0.tar.gz && \
-    tar xvfz boost_1_64_0.tar.gz && \
-    cd /boost_1_64_0 && \
+RUN curl -O -L https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.gz && \
+    tar xvfz boost_1_68_0.tar.gz && \
+    cd /boost_1_68_0 && \
     ./bootstrap.sh --with-libraries=program_options,filesystem,regex,thread,system,python && \
     ./b2 address-model=64 cxxflags=-fPIC link=static threading=multi variant=release install && \
-    rm -rf /boost_1_64_0.tar.gz /boost_1_64_0
+    rm -rf /boost_1_68_0.tar.gz /boost_1_68_0
 
 # Download and copile protoubf
 RUN curl -O -L  https://github.com/google/protobuf/releases/download/v3.3.0/protobuf-cpp-3.3.0.tar.gz && \
@@ -110,12 +110,12 @@ RUN curl -O -L  https://github.com/libexpat/libexpat/archive/R_2_2_0.tar.gz && \
     make && make installlib && \
     rm -rf /R_2_2_0.tar.gz /libexpat-R_2_2_0
 
-RUN curl -O -L https://github.com/Kitware/CMake/archive/v3.8.2.tar.gz && \
-    tar xvfz v3.8.2.tar.gz && \
-    cd CMake-3.8.2 && \
+RUN curl -O -L https://github.com/Kitware/CMake/archive/v3.12.1.tar.gz && \
+    tar xvfz v3.12.1.tar.gz && \
+    cd CMake-3.12.1 && \
     ./configure && \
     make && make install && \
-    rm -rf /v3.8.2.tar.gz /CMake-3.8.2
+    rm -rf /v3.12.1.tar.gz /CMake-3.12.1
 
 # Compile JSON CPP
 RUN curl -O -L  https://github.com/open-source-parsers/jsoncpp/archive/1.8.0.tar.gz && \

--- a/pulsar-client-cpp/docker/create-images.sh
+++ b/pulsar-client-cpp/docker/create-images.sh
@@ -30,6 +30,7 @@ PYTHON_VERSIONS=(
    '3.4 cp34-cp34m'
    '3.5 cp35-cp35m'
    '3.6 cp36-cp36m'
+   '3.7 cp37-cp37m'
 )
 
 for line in "${PYTHON_VERSIONS[@]}"; do

--- a/pulsar-client-cpp/python/CMakeLists.txt
+++ b/pulsar-client-cpp/python/CMakeLists.txt
@@ -35,9 +35,20 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "${CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS} -undefined dynamic_lookup")
 endif()
 
+# Newer boost versions don't use the -mt suffix
+if (NOT DEFINED ${Boost_PYTHON27-MT_LIBRARY})
+  set(Boost_PYTHON27-MT_LIBRARY ${Boost_PYTHON27_LIBRARY})
+endif()
+
+if (NOT DEFINED ${Boost_PYTHON37-MT_LIBRARY})
+  set(Boost_PYTHON37-MT_LIBRARY ${Boost_PYTHON37_LIBRARY})
+endif()
+
 # Try all possible boost-python variable namings
 set(PYTHON_WRAPPER_LIBS ${Boost_PYTHON_LIBRARY} ${Boost_PYTHON3_LIBRARY}
                         ${Boost_PYTHON27-MT_LIBRARY} ${Boost_PYTHON37-MT_LIBRARY})
+
+message(STATUS "Using Boost Python libs: ${PYTHON_WRAPPER_LIBS}")
 
 if (APPLE)
     target_link_libraries(_pulsar -Wl,-all_load pulsarStatic ${PYTHON_WRAPPER_LIBS})

--- a/site2/docs/client-libraries-python.md
+++ b/site2/docs/client-libraries-python.md
@@ -22,8 +22,8 @@ Installation via PyPi is available for the following Python versions:
 
 Platform | Supported Python versions
 :--------|:-------------------------
-MacOS 10.12 (Sierra) and 10.13 (High Sierra) | 2.7, 3.6
-Linux | 2.7, 3.3, 3.4, 3.5, 3.6
+MacOS <br /> 10.11 (El Capitan) &mdash; 10.12 (Sierra) &mdash; 10.13 (High Sierra) | 2.7, 3.7
+Linux | 2.7, 3.3, 3.4, 3.5, 3.6, 3.7
 
 ### Installing from source
 


### PR DESCRIPTION
### Motivation

Adding build file to provide Python-3.7 wheel files for linux.