### PR TITLE
Issue 2283: Improve error message if authorization is not enabled

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v1/Namespaces.java
@@ -218,7 +218,8 @@ public class Namespaces extends NamespacesBase {
     @ApiOperation(hidden = true, value = "Grant a new permission to a role on a namespace.")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Property or cluster or namespace doesn't exist"),
-            @ApiResponse(code = 409, message = "Concurrent modification") })
+            @ApiResponse(code = 409, message = "Concurrent modification"),
+            @ApiResponse(code = 501, message = "Authorization is not enabled")})
     public void grantPermissionOnNamespace(@PathParam("property") String property, @PathParam("cluster") String cluster,
             @PathParam("namespace") String namespace, @PathParam("role") String role, Set<AuthAction> actions) {
         validateNamespaceName(property, cluster, namespace);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/Namespaces.java
@@ -160,7 +160,8 @@ public class Namespaces extends NamespacesBase {
     @ApiOperation(value = "Grant a new permission to a role on a namespace.")
     @ApiResponses(value = { @ApiResponse(code = 403, message = "Don't have admin permission"),
             @ApiResponse(code = 404, message = "Tenant or cluster or namespace doesn't exist"),
-            @ApiResponse(code = 409, message = "Concurrent modification") })
+            @ApiResponse(code = 409, message = "Concurrent modification"),
+            @ApiResponse(code = 501, message = "Authorization is not enabled")})
     public void grantPermissionOnNamespace(@PathParam("tenant") String tenant,
             @PathParam("namespace") String namespace, @PathParam("role") String role, Set<AuthAction> actions) {
         validateNamespaceName(tenant, namespace);

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PulsarAdminException.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/PulsarAdminException.java
@@ -47,25 +47,25 @@ public class PulsarAdminException extends Exception {
 
     public PulsarAdminException(ClientErrorException e) {
         super(getReasonFromServer(e), e);
-        this.httpError = e.getMessage();
+        this.httpError = getReasonFromServer(e);
         this.statusCode = e.getResponse().getStatus();
     }
 
     public PulsarAdminException(ClientErrorException e, String message) {
         super(message, e);
-        this.httpError = e.getMessage();
+        this.httpError = getReasonFromServer(e);
         this.statusCode = e.getResponse().getStatus();
     }
 
     public PulsarAdminException(ServerErrorException e) {
         super(getReasonFromServer(e), e);
-        this.httpError = e.getMessage();
+        this.httpError = getReasonFromServer(e);
         this.statusCode = e.getResponse().getStatus();
     }
 
     public PulsarAdminException(ServerErrorException e, String message) {
         super(message, e);
-        this.httpError = e.getMessage();
+        this.httpError = getReasonFromServer(e);
         this.statusCode = e.getResponse().getStatus();
     }
 
@@ -73,6 +73,12 @@ public class PulsarAdminException extends Exception {
         super(t);
         httpError = null;
         statusCode = DEFAULT_STATUS_CODE;
+    }
+
+    public PulsarAdminException(WebApplicationException e) {
+        super(getReasonFromServer(e), e);
+        this.httpError = getReasonFromServer(e);
+        this.statusCode = e.getResponse().getStatus();
     }
 
     public PulsarAdminException(String message, Throwable t) {
@@ -124,6 +130,10 @@ public class PulsarAdminException extends Exception {
     }
 
     public static class ServerSideErrorException extends PulsarAdminException {
+        public ServerSideErrorException(ServerErrorException e, String msg) {
+            super(e, msg);
+        }
+
         public ServerSideErrorException(ServerErrorException e) {
             super(e, "Some error occourred on the server");
         }

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BaseResource.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/BaseResource.java
@@ -159,7 +159,7 @@ public abstract class BaseResource {
             // Handle 5xx exceptions
             if (e instanceof ServerErrorException) {
                 ServerErrorException see = (ServerErrorException) e;
-                return new ServerSideErrorException(see);
+                return new ServerSideErrorException(see, e.getMessage());
             } else if (e instanceof ClientErrorException) {
                 // Handle 4xx exceptions
                 ClientErrorException cee = (ClientErrorException) e;
@@ -176,12 +176,11 @@ public abstract class BaseResource {
                         return new ConflictException(cee);
                     case 412:
                         return new PreconditionFailedException(cee);
-
                     default:
                         return new PulsarAdminException(cee);
                 }
             } else {
-                return new PulsarAdminException(e);
+                return new PulsarAdminException((WebApplicationException) e);
             }
         } else {
             return new PulsarAdminException(e);

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/CLITest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/cli/CLITest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.tests.integration.cli;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -206,6 +207,29 @@ public class CLITest extends PulsarTestSuite {
         assertTrue(
             result.getStdout().contains("\"retentionSizeInMB\" : -1"),
             result.getStdout());
+    }
+
+    // authorization related tests
+
+    @Test
+    public void testGrantPermissionsAuthorizationDisabled() throws Exception {
+        ContainerExecResult result;
+
+        String namespace = "grant-permissions-" + randomName(8);
+        result = pulsarCluster.createNamespace(namespace);
+        assertEquals(0, result.getExitCode());
+
+        String[] grantCommand = {
+            "namespaces", "grant-permission", "public/" + namespace,
+            "--actions", "produce",
+            "--role", "test-role"
+        };
+        try {
+            pulsarCluster.runAdminCommandOnAnyBroker(grantCommand);
+        } catch (ContainerExecException cee) {
+            result = cee.getResult();
+            assertTrue(result.getStderr().contains("HTTP 501 Not Implemented"), result.getStderr());
+        }
     }
 
 }


### PR DESCRIPTION
 ### Motivation

 Fixes #2283.

 If authorizationEnabled is not enabled, authorization service is not set. All the accesses to this authorization service will throw NPE and clients will receive Internal Server Error. The message is meaningless. It is better to return a more meaningful message.

 ### Changes

 Return `Not implemented` if authorization is not enabled.


