### PR TITLE
Remove connection state assertion in NonPersistentTopicTest#testMsgDropStat

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/NonPersistentTopicTest.java
@@ -814,8 +814,6 @@ public class NonPersistentTopicTest extends ProducerConsumerBase {
             assertTrue(npStats.msgDropRate > 0);
             assertTrue(sub1Stats.msgDropRate > 0);
             assertTrue(sub2Stats.msgDropRate > 0);
-            // make sure producer connection not disconnected due to unordered ack
-            assertEquals(firstTimeConnected, producer.getConnectedSince());
 
             producer.close();
             consumer.close();


### PR DESCRIPTION
 ### Motivation

(This is a worker around to fix master build. The real fix will be done in #2394)

NonPersistentTopicTest keeps failing with following errors: (https://builds.apache.org/job/pulsar_precommit_java8/ws/pulsar-broker/target/surefire-reports/org.apache.pulsar.client.api.NonPersistentTopicTest.txt/*view*/)
```
-------------------------------------------------------------------------------
Test set: org.apache.pulsar.client.api.NonPersistentTopicTest
-------------------------------------------------------------------------------
Tests run: 19, Failures: 1, Errors: 0, Skipped: 1, Time elapsed: 91.727 s <<< FAILURE! - in org.apache.pulsar.client.api.NonPersistentTopicTest
testMsgDropStat(org.apache.pulsar.client.api.NonPersistentTopicTest)  Time elapsed: 0.918 s  <<< FAILURE!
java.lang.AssertionError: expected [2018-08-16T19:29:27.772Z] but found [2018-08-16T19:29:27.625Z]
	at org.testng.Assert.fail(Assert.java:96)
	at org.testng.Assert.failNotEquals(Assert.java:776)
	at org.testng.Assert.assertEqualsImpl(Assert.java:137)
	at org.testng.Assert.assertEquals(Assert.java:118)
	at org.testng.Assert.assertEquals(Assert.java:453)
	at org.testng.Assert.assertEquals(Assert.java:463)
	at org.apache.pulsar.client.api.NonPersistentTopicTest.testMsgDropStat(NonPersistentTopicTest.java:818)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:124)
	at org.testng.internal.InvokeMethodRunnable.runOne(InvokeMethodRunnable.java:54)
	at org.testng.internal.InvokeMethodRunnable.run(InvokeMethodRunnable.java:44)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)

```

The problem came from producer reconnects on CI environment:

https://builds.apache.org/job/pulsar_precommit_java8/ws/pulsar-broker/target/surefire-reports/org.apache.pulsar.client.api.NonPersistentTopicTest-output.txt/*view*/
```
19:29:25.980 [pulsar-client-io-198-1:org.apache.pulsar.client.impl.ClientCnx@177] INFO  org.apache.pulsar.client.impl.ClientCnx - [id: 0x0e9cb22c, L:/127.0.0.1:54187 ! R:localhost/127.0.0.1:28701] Disconnected
19:29:25.981 [pulsar-client-io-198-1:org.apache.pulsar.client.impl.ConnectionHandler@110] INFO  org.apache.pulsar.client.impl.ConnectionHandler - [non-persistent://my-property/my-ns/stats-topic] [test-1-0] Closed connection [id: 0x0e9cb22c, L:/127.0.0.1:54187 ! R:localhost/127.0.0.1:28701] -- Will try again in 0.1 s
19:29:25.982 [pulsar-client-io-198-1:org.apache.pulsar.client.impl.ConnectionHandler@110] INFO  org.apache.pulsar.client.impl.ConnectionHandler - [non-persistent://my-property/my-ns/stats-topic] [subscriber-1] Closed connection [id: 0x0e9cb22c, L:/127.0.0.1:54187 ! R:localhost/127.0.0.1:28701] -- Will try again in 0.1 s
19:29:25.982 [pulsar-client-io-198-1:org.apache.pulsar.client.impl.ConnectionHandler@110] INFO  org.apache.pulsar.client.impl.ConnectionHandler - [non-persistent://my-property/my-ns/stats-topic] [subscriber-2] Closed connection [id: 0x0e9cb22c, L:/127.0.0.1:54187 ! R:localhost/127.0.0.1:28701] -- Will try again in 0.1 s
19:29:26.083 [pulsar-timer-201-1:org.apache.pulsar.client.impl.ConnectionHandler@113] INFO  org.apache.pulsar.client.impl.ConnectionHandler - [non-persistent://my-property/my-ns/stats-topic] [test-1-0] Reconnecting after timeout
19:29:26.083 [pulsar-timer-201-1:org.apache.pulsar.client.impl.ConnectionHandler@113] INFO  org.apache.pulsar.client.impl.ConnectionHandler - [non-persistent://my-property/my-ns/stats-topic] [subscriber-1] Reconnecting after timeout
19:29:26.086 [pulsar-timer-201-1:org.apache.pulsar.client.impl.ConnectionHandler@113] INFO  org.apache.pulsar.client.impl.ConnectionHandler - [non-persistent://my-property/my-ns/stats-topic] [subscriber-2] Reconnecting after timeout
19:29:26.097 [pulsar-client-io-198-1:org.apache.pulsar.client.impl.ConnectionPool@161] INFO  org.apache.pulsar.client.impl.ConnectionPool - [[id: 0x63f7f193, L:/127.0.0.1:54190 - R:localhost/127.0.0.1:28701]] Connected to server
```

The assertion is *non-deterministic* and doesn't seem to be really needed. so this change is to remove that assertion.
