### PR TITLE
[build] Configure os extension plugin at root pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1256,6 +1256,11 @@ flexible messaging model and an intuitive client API.</description>
         <artifactId>wagon-ssh-external</artifactId>
         <version>2.10</version>
       </extension>
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>1.4.1.Final</version>
+      </extension>
     </extensions>
   </build>
 

--- a/pulsar-client-schema/pom.xml
+++ b/pulsar-client-schema/pom.xml
@@ -86,13 +86,6 @@
                 <filtering>true</filtering>
             </resource>
         </resources>
-        <extensions>
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>1.4.1.Final</version>
-            </extension>
-        </extensions>
         <!-- Generate protobuf for testing purposes -->
         <plugins>
             <plugin>

--- a/pulsar-functions/proto-shaded/pom.xml
+++ b/pulsar-functions/proto-shaded/pom.xml
@@ -46,13 +46,6 @@
 	    </dependency>
     </dependencies>
     <build>
-        <extensions>
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>1.4.1.Final</version>
-            </extension>
-        </extensions>
         <plugins>
 	       <plugin>
 	        <groupId>org.apache.maven.plugins</groupId>

--- a/pulsar-functions/proto/pom.xml
+++ b/pulsar-functions/proto/pom.xml
@@ -54,13 +54,6 @@
 
     </dependencies>
     <build>
-        <extensions>
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>1.4.1.Final</version>
-            </extension>
-        </extensions>
         <plugins>
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>


### PR DESCRIPTION
 ### Motivation

os extension plugin is required by managed-ledger as well.

 ### Change

move the extension to the root pom file.

