### PR TITLE
 [tiered storage] store driver name and driver specific metadata in original ledger metadata

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloader.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/LedgerOffloader.java
@@ -20,6 +20,7 @@ package org.apache.bookkeeper.mledger;
 
 import com.google.common.annotations.Beta;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -31,6 +32,25 @@ import org.apache.bookkeeper.client.api.ReadHandle;
  */
 @Beta
 public interface LedgerOffloader {
+
+    /**
+     * Get offload driver name.
+     *
+     * @return offload driver name.
+     */
+    String getOffloadDriverName();
+
+    /**
+     * Get offload driver metadata.
+     *
+     * <p>The driver metadata will be recorded as part of the metadata of the original ledger.
+     *
+     * @return offload driver metadata.
+     */
+    default Map<String, String> getOffloadDriverMetadata() {
+        return Collections.emptyMap();
+    }
+
     /**
      * Offload the passed in ledger to longterm storage.
      * Metadata passed in is for inspection purposes only and should be stored
@@ -51,10 +71,9 @@ public interface LedgerOffloader {
      *
      * @param ledger the ledger to offload
      * @param uid unique id to identity this offload attempt
-     * @param extraMetadata metadata to be stored with the ledger for informational
+     * @param extraMetadata metadata to be stored with the offloaded ledger for informational
      *                      purposes
-     * @return a future, which when completed, denotes that the offload has been
-     *         successful
+     * @return a future, which when completed, denotes that the offload has been successful.
      */
     CompletableFuture<Void> offload(ReadHandle ledger,
                                     UUID uid,
@@ -69,9 +88,11 @@ public interface LedgerOffloader {
      *
      * @param ledgerId the ID of the ledger to load from longterm storage
      * @param uid unique ID for previous successful offload attempt
+     * @param offloadDriverMetadata offload driver metadata
      * @return a future, which when completed, returns a ReadHandle
      */
-    CompletableFuture<ReadHandle> readOffloaded(long ledgerId, UUID uid);
+    CompletableFuture<ReadHandle> readOffloaded(long ledgerId, UUID uid,
+                                                Map<String, String> offloadDriverMetadata);
 
     /**
      * Delete a ledger from long term storage.
@@ -81,9 +102,11 @@ public interface LedgerOffloader {
      *
      * @param ledgerId the ID of the ledger to delete from longterm storage
      * @param uid unique ID for previous offload attempt
+     * @param offloadDriverMetadata offload driver metadata
      * @return a future, which when completed, signifies that the ledger has
      *         been deleted
      */
-    CompletableFuture<Void> deleteOffloaded(long ledgerId, UUID uid);
+    CompletableFuture<Void> deleteOffloaded(long ledgerId, UUID uid,
+                                            Map<String, String> offloadDriverMetadata);
 }
 

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/NullLedgerOffloader.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/NullLedgerOffloader.java
@@ -32,6 +32,11 @@ public class NullLedgerOffloader implements LedgerOffloader {
     public static NullLedgerOffloader INSTANCE = new NullLedgerOffloader();
 
     @Override
+    public String getOffloadDriverName() {
+        return "NullLedgerOffloader";
+    }
+
+    @Override
     public CompletableFuture<Void> offload(ReadHandle ledger,
                                            UUID uid,
                                            Map<String, String> extraMetadata) {
@@ -41,14 +46,16 @@ public class NullLedgerOffloader implements LedgerOffloader {
     }
 
     @Override
-    public CompletableFuture<ReadHandle> readOffloaded(long ledgerId, UUID uid) {
+    public CompletableFuture<ReadHandle> readOffloaded(long ledgerId, UUID uid,
+                                                       Map<String, String> offloadDriverMetadata) {
         CompletableFuture<ReadHandle> promise = new CompletableFuture<>();
         promise.completeExceptionally(new UnsupportedOperationException());
         return promise;
     }
 
     @Override
-    public CompletableFuture<Void> deleteOffloaded(long ledgerId, UUID uid) {
+    public CompletableFuture<Void> deleteOffloaded(long ledgerId, UUID uid,
+                                                   Map<String, String> offloadDriverMetadata) {
         CompletableFuture<Void> promise = new CompletableFuture<>();
         promise.completeExceptionally(new UnsupportedOperationException());
         return promise;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/offload/OffloadUtils.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/offload/OffloadUtils.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.bookkeeper.mledger.offload;
+
+import com.google.common.collect.Maps;
+import java.util.Map;
+import org.apache.bookkeeper.mledger.proto.MLDataFormats.KeyValue;
+import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo;
+import org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadContext;
+import org.apache.bookkeeper.mledger.proto.MLDataFormats.OffloadDriverMetadata;
+
+public final class OffloadUtils {
+
+    private OffloadUtils() {}
+
+    public static Map<String, String> getOffloadDriverMetadata(LedgerInfo ledgerInfo) {
+        Map<String, String> metadata = Maps.newHashMap();
+        if (ledgerInfo.hasOffloadContext()) {
+            OffloadContext ctx = ledgerInfo.getOffloadContext();
+            if (ctx.hasDriverMetadata()) {
+                OffloadDriverMetadata driverMetadata = ctx.getDriverMetadata();
+                if (driverMetadata.getPropertiesCount() > 0) {
+                    driverMetadata.getPropertiesList().forEach(kv -> metadata.put(kv.getKey(), kv.getValue()));
+                }
+            }
+        }
+        return metadata;
+    }
+
+    public static Map<String, String> getOffloadDriverMetadata(LedgerInfo ledgerInfo,
+                                                               Map<String, String> defaultOffloadDriverMetadata) {
+        if (ledgerInfo.hasOffloadContext()) {
+            OffloadContext ctx = ledgerInfo.getOffloadContext();
+            if (ctx.hasDriverMetadata()) {
+                OffloadDriverMetadata driverMetadata = ctx.getDriverMetadata();
+                if (driverMetadata.getPropertiesCount() > 0) {
+                    Map<String, String> metadata = Maps.newHashMap();
+                    driverMetadata.getPropertiesList().forEach(kv -> metadata.put(kv.getKey(), kv.getValue()));
+                    return metadata;
+                }
+            }
+        }
+        return defaultOffloadDriverMetadata;
+    }
+
+    public static String getOffloadDriverName(LedgerInfo ledgerInfo, String defaultDriverName) {
+        if (ledgerInfo.hasOffloadContext()) {
+            OffloadContext ctx = ledgerInfo.getOffloadContext();
+            if (ctx.hasDriverMetadata()) {
+                OffloadDriverMetadata driverMetadata = ctx.getDriverMetadata();
+                if (driverMetadata.hasName()) {
+                    return driverMetadata.getName();
+                }
+            }
+        }
+        return defaultDriverName;
+    }
+
+    public static void setOffloadDriverMetadata(LedgerInfo.Builder infoBuilder,
+                                                String driverName,
+                                                Map<String, String> offloadDriverMetadata) {
+        infoBuilder.getOffloadContextBuilder()
+            .getDriverMetadataBuilder()
+            .setName(driverName);
+        offloadDriverMetadata.forEach((k, v) -> {
+            infoBuilder.getOffloadContextBuilder()
+                .getDriverMetadataBuilder()
+                .addProperties(KeyValue.newBuilder()
+                    .setKey(k)
+                    .setValue(v)
+                    .build());
+        });
+    }
+
+}

--- a/managed-ledger/src/main/proto/MLDataFormats.proto
+++ b/managed-ledger/src/main/proto/MLDataFormats.proto
@@ -21,12 +21,34 @@ syntax = "proto2";
 option java_package = "org.apache.bookkeeper.mledger.proto";
 option optimize_for = SPEED;
 
+enum OffloadDriverType {
+    NONE     = 0;
+    AWS_S3   = 1;
+    GCS      = 2;
+}
+
+message S3DriverContext {
+    required string bucket  = 1;
+    optional string region  = 2;
+    optional string serviceEndpoint = 3;
+}
+
+message GCSDriverContext {
+    required string bucket  = 1;
+    optional string region  = 2;
+}
+
 message OffloadContext {
     optional int64 uidMsb = 1;
     optional int64 uidLsb = 2;
     optional bool complete = 3;
     optional bool bookkeeperDeleted = 4;
     optional int64 timestamp = 5;
+    required OffloadDriverType driverType = 6;
+
+    // driver context
+    optional S3DriverContext s3DriverContext    = 20;
+    optional GCSDriverContext gcsDriverContext  = 21;
 }
 
 message ManagedLedgerInfo {

--- a/managed-ledger/src/main/proto/MLDataFormats.proto
+++ b/managed-ledger/src/main/proto/MLDataFormats.proto
@@ -21,21 +21,14 @@ syntax = "proto2";
 option java_package = "org.apache.bookkeeper.mledger.proto";
 option optimize_for = SPEED;
 
-enum OffloadDriverType {
-    NONE     = 0;
-    AWS_S3   = 1;
-    GCS      = 2;
+message KeyValue {
+	required string key = 1;
+	required string value = 2;
 }
 
-message S3DriverContext {
-    required string bucket  = 1;
-    optional string region  = 2;
-    optional string serviceEndpoint = 3;
-}
-
-message GCSDriverContext {
-    required string bucket  = 1;
-    optional string region  = 2;
+message OffloadDriverMetadata {
+    required string name = 1;
+    repeated KeyValue properties = 2;
 }
 
 message OffloadContext {
@@ -44,11 +37,7 @@ message OffloadContext {
     optional bool complete = 3;
     optional bool bookkeeperDeleted = 4;
     optional int64 timestamp = 5;
-    required OffloadDriverType driverType = 6;
-
-    // driver context
-    optional S3DriverContext s3DriverContext    = 20;
-    optional GCSDriverContext gcsDriverContext  = 21;
+    optional OffloadDriverMetadata driverMetadata = 6;
 }
 
 message ManagedLedgerInfo {

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
@@ -493,9 +493,10 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
                 }
 
                 @Override
-                public CompletableFuture<Void> deleteOffloaded(long ledgerId, UUID uuid) {
+                public CompletableFuture<Void> deleteOffloaded(long ledgerId, UUID uuid,
+                                                               Map<String, String> offloadDriverMetadata) {
                     deleted.add(Pair.of(ledgerId, uuid));
-                    return super.deleteOffloaded(ledgerId, uuid);
+                    return super.deleteOffloaded(ledgerId, uuid, offloadDriverMetadata);
                 }
             };
         ManagedLedgerConfig config = new ManagedLedgerConfig();
@@ -929,6 +930,11 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         }
 
         @Override
+        public String getOffloadDriverName() {
+            return "mock";
+        }
+
+        @Override
         public CompletableFuture<Void> offload(ReadHandle ledger,
                                                UUID uuid,
                                                Map<String, String> extraMetadata) {
@@ -942,14 +948,16 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         }
 
         @Override
-        public CompletableFuture<ReadHandle> readOffloaded(long ledgerId, UUID uuid) {
+        public CompletableFuture<ReadHandle> readOffloaded(long ledgerId, UUID uuid,
+                                                           Map<String, String> offloadDriverMetadata) {
             CompletableFuture<ReadHandle> promise = new CompletableFuture<>();
             promise.completeExceptionally(new UnsupportedOperationException());
             return promise;
         }
 
         @Override
-        public CompletableFuture<Void> deleteOffloaded(long ledgerId, UUID uuid) {
+        public CompletableFuture<Void> deleteOffloaded(long ledgerId, UUID uuid,
+                                                       Map<String, String> offloadDriverMetadata) {
             CompletableFuture<Void> promise = new CompletableFuture<>();
             if (offloads.remove(ledgerId, uuid)) {
                 deletes.put(ledgerId, uuid);

--- a/pom.xml
+++ b/pom.xml
@@ -1256,6 +1256,11 @@ flexible messaging model and an intuitive client API.</description>
         <artifactId>wagon-ssh-external</artifactId>
         <version>2.10</version>
       </extension>
+      <extension>
+        <groupId>kr.motd.maven</groupId>
+        <artifactId>os-maven-plugin</artifactId>
+        <version>1.4.1.Final</version>
+      </extension>
     </extensions>
   </build>
 

--- a/pulsar-client-schema/pom.xml
+++ b/pulsar-client-schema/pom.xml
@@ -86,13 +86,6 @@
                 <filtering>true</filtering>
             </resource>
         </resources>
-        <extensions>
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>1.4.1.Final</version>
-            </extension>
-        </extensions>
         <!-- Generate protobuf for testing purposes -->
         <plugins>
             <plugin>

--- a/pulsar-functions/proto-shaded/pom.xml
+++ b/pulsar-functions/proto-shaded/pom.xml
@@ -46,13 +46,6 @@
 	    </dependency>
     </dependencies>
     <build>
-        <extensions>
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>1.4.1.Final</version>
-            </extension>
-        </extensions>
         <plugins>
 	       <plugin>
 	        <groupId>org.apache.maven.plugins</groupId>

--- a/pulsar-functions/proto/pom.xml
+++ b/pulsar-functions/proto/pom.xml
@@ -54,13 +54,6 @@
 
     </dependencies>
     <build>
-        <extensions>
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>1.4.1.Final</version>
-            </extension>
-        </extensions>
         <plugins>
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>

--- a/tiered-storage/jcloud/pom.xml
+++ b/tiered-storage/jcloud/pom.xml
@@ -42,6 +42,7 @@
       <groupId>org.apache.pulsar</groupId>
       <artifactId>jclouds-shaded</artifactId>
       <version>${project.version}</version>
+        <!--
       <exclusions>
         <exclusion>
           <groupId>com.google.code.gson</groupId>
@@ -68,6 +69,7 @@
           <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
+      -->
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>

--- a/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderTest.java
+++ b/tiered-storage/jcloud/src/test/java/org/apache/bookkeeper/mledger/offload/jcloud/impl/BlobStoreManagedLedgerOffloaderTest.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -252,7 +253,7 @@ class BlobStoreManagedLedgerOffloaderTest extends BlobStoreTestBase {
         UUID uuid = UUID.randomUUID();
         offloader.offload(toWrite, uuid, new HashMap<>()).get();
 
-        ReadHandle toTest = offloader.readOffloaded(toWrite.getId(), uuid).get();
+        ReadHandle toTest = offloader.readOffloaded(toWrite.getId(), uuid, Collections.emptyMap()).get();
         Assert.assertEquals(toTest.getLastAddConfirmed(), toWrite.getLastAddConfirmed());
 
         try (LedgerEntries toWriteEntries = toWrite.read(0, toWrite.getLastAddConfirmed());
@@ -406,7 +407,7 @@ class BlobStoreManagedLedgerOffloaderTest extends BlobStoreTestBase {
         UUID uuid = UUID.randomUUID();
         offloader.offload(toWrite, uuid, new HashMap<>()).get();
 
-        ReadHandle toTest = offloader.readOffloaded(toWrite.getId(), uuid).get();
+        ReadHandle toTest = offloader.readOffloaded(toWrite.getId(), uuid, Collections.emptyMap()).get();
         Assert.assertEquals(toTest.getLastAddConfirmed(), toWrite.getLastAddConfirmed());
 
         for (long[] access : randomAccesses) {
@@ -438,7 +439,7 @@ class BlobStoreManagedLedgerOffloaderTest extends BlobStoreTestBase {
         UUID uuid = UUID.randomUUID();
         offloader.offload(toWrite, uuid, new HashMap<>()).get();
 
-        ReadHandle toTest = offloader.readOffloaded(toWrite.getId(), uuid).get();
+        ReadHandle toTest = offloader.readOffloaded(toWrite.getId(), uuid, Collections.emptyMap()).get();
         Assert.assertEquals(toTest.getLastAddConfirmed(), toWrite.getLastAddConfirmed());
 
         try {
@@ -467,7 +468,7 @@ class BlobStoreManagedLedgerOffloaderTest extends BlobStoreTestBase {
         Assert.assertTrue(blobStore.blobExists(BUCKET, BlobStoreManagedLedgerOffloader.indexBlockOffloadKey(readHandle.getId(), uuid)));
 
         // verify object deleted after delete
-        offloader.deleteOffloaded(readHandle.getId(), uuid).get();
+        offloader.deleteOffloaded(readHandle.getId(), uuid, Collections.emptyMap()).get();
         Assert.assertFalse(blobStore.blobExists(BUCKET, BlobStoreManagedLedgerOffloader.dataBlockOffloadKey(readHandle.getId(), uuid)));
         Assert.assertFalse(blobStore.blobExists(BUCKET, BlobStoreManagedLedgerOffloader.indexBlockOffloadKey(readHandle.getId(), uuid)));
     }
@@ -492,7 +493,7 @@ class BlobStoreManagedLedgerOffloaderTest extends BlobStoreTestBase {
             Assert.assertTrue(blobStore.blobExists(BUCKET, BlobStoreManagedLedgerOffloader.dataBlockOffloadKey(readHandle.getId(), uuid)));
             Assert.assertTrue(blobStore.blobExists(BUCKET, BlobStoreManagedLedgerOffloader.indexBlockOffloadKey(readHandle.getId(), uuid)));
 
-            offloader.deleteOffloaded(readHandle.getId(), uuid).get();
+            offloader.deleteOffloaded(readHandle.getId(), uuid, Collections.emptyMap()).get();
         } catch (Exception e) {
             // expected
             Assert.assertTrue(e.getCause().getMessage().contains(failureString));
@@ -542,7 +543,7 @@ class BlobStoreManagedLedgerOffloaderTest extends BlobStoreTestBase {
         userMeta.put(BlobStoreManagedLedgerOffloader.METADATA_FORMAT_VERSION_KEY.toLowerCase(), String.valueOf(-12345));
         blobStore.copyBlob(BUCKET, dataKey, BUCKET, dataKey, CopyOptions.builder().userMetadata(userMeta).build());
 
-        try (ReadHandle toRead = offloader.readOffloaded(toWrite.getId(), uuid).get()) {
+        try (ReadHandle toRead = offloader.readOffloaded(toWrite.getId(), uuid, Collections.emptyMap()).get()) {
             toRead.readAsync(0, 0).get();
             Assert.fail("Shouldn't have been able to read");
         } catch (ExecutionException e) {
@@ -554,7 +555,7 @@ class BlobStoreManagedLedgerOffloaderTest extends BlobStoreTestBase {
         userMeta.put(BlobStoreManagedLedgerOffloader.METADATA_FORMAT_VERSION_KEY.toLowerCase(), String.valueOf(12345));
         blobStore.copyBlob(BUCKET, dataKey, BUCKET, dataKey, CopyOptions.builder().userMetadata(userMeta).build());
 
-        try (ReadHandle toRead = offloader.readOffloaded(toWrite.getId(), uuid).get()) {
+        try (ReadHandle toRead = offloader.readOffloaded(toWrite.getId(), uuid, Collections.emptyMap()).get()) {
             toRead.readAsync(0, 0).get();
             Assert.fail("Shouldn't have been able to read");
         } catch (ExecutionException e) {
@@ -581,7 +582,7 @@ class BlobStoreManagedLedgerOffloaderTest extends BlobStoreTestBase {
         blobStore.copyBlob(BUCKET, indexKey, BUCKET, indexKey, CopyOptions.builder().userMetadata(userMeta).build());
 
         try {
-            offloader.readOffloaded(toWrite.getId(), uuid).get();
+            offloader.readOffloaded(toWrite.getId(), uuid, Collections.emptyMap()).get();
             Assert.fail("Shouldn't have been able to open");
         } catch (ExecutionException e) {
             Assert.assertEquals(e.getCause().getClass(), IOException.class);
@@ -592,7 +593,7 @@ class BlobStoreManagedLedgerOffloaderTest extends BlobStoreTestBase {
         blobStore.copyBlob(BUCKET, indexKey, BUCKET, indexKey, CopyOptions.builder().userMetadata(userMeta).build());
 
         try {
-            offloader.readOffloaded(toWrite.getId(), uuid).get();
+            offloader.readOffloaded(toWrite.getId(), uuid, Collections.emptyMap()).get();
             Assert.fail("Shouldn't have been able to open");
         } catch (ExecutionException e) {
             Assert.assertEquals(e.getCause().getClass(), IOException.class);


### PR DESCRIPTION
 ### Motivation

1) Currently the location of an offloaded ledger isn't stored in the original ledger metadata.
That means if configuration is changed or modified by mistake. We might potentially cause data loss.

2) The location of an offloaded ledger is needed by Pulsar SQL. so it is very inconvinient to
have the location information stored in a configuration and the approach is also problematic.

 ### Changes

Store `driverName` and driver-specific metadata (e.g. bucket name, region name, endpoint) in the
original ledger metadata. Change ManagedLedgerImpl to use the driver-specific metadata to read
the offloaded ledger. If the driver-specific metadata is missed, it will fall back to use the configuration.

 ### Tests

This change doesn't change the behavior. Existing unit tests and integration tests already covered the logic.

 ### NOTES

Currently the driver name in metadata is not used. We need to use driver name to load different offloader driver
after #2393 is implemented