### PR TITLE
[functions][integration tests] Ensure function subscription exists before integration tests start producing messages

### DIFF
--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/functions/PulsarFunctionsTest.java
@@ -542,6 +542,19 @@ public abstract class PulsarFunctionsTest extends PulsarFunctionsTestBase {
         ContainerExecResult result = pulsarCluster.getAnyWorker().execCmd(
             commands);
         assertTrue(result.getStdout().contains("\"Created successfully\""));
+
+
+        // ensure the function subscription exists before we start producing messages
+        try (PulsarClient client = PulsarClient.builder()
+            .serviceUrl(pulsarCluster.getPlainTextServiceUrl())
+            .build()) {
+            try (Consumer<String> ignored = client.newConsumer(Schema.STRING)
+                .topic(inputTopicName)
+                .subscriptionType(SubscriptionType.Shared)
+                .subscriptionName(String.format("public/default/%s", functionName))
+                .subscribe()) {
+            }
+        }
     }
 
     private static void getFunctionInfoSuccess(String functionName) throws Exception {


### PR DESCRIPTION
 ### Motivation

There is a race condition in functions integration tests, where the producer used for validation can start before
function runs. So a function might be missing some messages produced by the producer. Hence it will fail the validation.

 ### Changes

Ensure function subscription exists before producer starts producing messages to input topic.

