### PR TITLE
 allow predicates concerning publish time to push down to pulsar

### DIFF
--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ManagedCursor.java
@@ -395,7 +395,7 @@ public interface ManagedCursor {
             final SkipEntriesCallback callback, Object ctx);
 
     /**
-     * Find the newest entry that matches the given predicate.
+     * Find the newest entry that matches the given predicate.  Will only search among active entries
      *
      * @param condition
      *            predicate that reads an entry an applies a condition
@@ -405,9 +405,25 @@ public interface ManagedCursor {
      */
     Position findNewestMatching(Predicate<Entry> condition) throws InterruptedException, ManagedLedgerException;
 
+
     /**
      * Find the newest entry that matches the given predicate.
      *
+     * @param constraint
+     *            search only active entries or all entries
+     * @param condition
+     *            predicate that reads an entry an applies a condition
+     * @return Position of the newest entry that matches the given predicate
+     * @throws InterruptedException
+     * @throws ManagedLedgerException
+     */
+    Position findNewestMatching(FindPositionConstraint constraint, Predicate<Entry> condition) throws InterruptedException, ManagedLedgerException;
+
+    /**
+     * Find the newest entry that matches the given predicate.
+     *
+     * @param constraint
+     *            search only active entries or all entries
      * @param condition
      *            predicate that reads an entry an applies a condition
      * @param callback

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ReadOnlyCursor.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/ReadOnlyCursor.java
@@ -20,14 +20,16 @@ package org.apache.bookkeeper.mledger;
 
 import java.util.List;
 
+import com.google.common.base.Predicate;
+import com.google.common.collect.Range;
 import org.apache.bookkeeper.mledger.AsyncCallbacks.ReadEntriesCallback;
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
 
 public interface ReadOnlyCursor {
     /**
      * Read entries from the ManagedLedger, up to the specified number. The returned list can be smaller.
      *
-     * @param numberOfEntriesToRead
-     *            maximum number of entries to return
+     * @param numberOfEntriesToRead maximum number of entries to return
      * @return the list of entries
      * @throws ManagedLedgerException
      */
@@ -36,13 +38,10 @@ public interface ReadOnlyCursor {
     /**
      * Asynchronously read entries from the ManagedLedger.
      *
+     * @param numberOfEntriesToRead maximum number of entries to return
+     * @param callback              callback object
+     * @param ctx                   opaque context
      * @see #readEntries(int)
-     * @param numberOfEntriesToRead
-     *            maximum number of entries to return
-     * @param callback
-     *            callback object
-     * @param ctx
-     *            opaque context
      */
     void asyncReadEntries(int numberOfEntriesToRead, ReadEntriesCallback callback, Object ctx);
 
@@ -55,7 +54,7 @@ public interface ReadOnlyCursor {
 
     /**
      * Tells whether this cursor has already consumed all the available entries.
-     *
+     * <p>
      * <p/>
      * This method is not blocking.
      *
@@ -65,7 +64,7 @@ public interface ReadOnlyCursor {
 
     /**
      * Return the number of messages that this cursor still has to read.
-     *
+     * <p>
      * <p/>
      * This method has linear time complexity on the number of ledgers included in the managed ledger.
      *
@@ -76,10 +75,30 @@ public interface ReadOnlyCursor {
     /**
      * Skip n entries from the read position of this cursor.
      *
-     * @param numEntriesToSkip
-     *            number of entries to skip
+     * @param numEntriesToSkip number of entries to skip
      */
     void skipEntries(int numEntriesToSkip);
+
+    /**
+     * Find the newest entry that matches the given predicate.
+     *
+     * @param constraint search only active entries or all entries
+     * @param condition  predicate that reads an entry an applies a condition
+     * @return Position of the newest entry that matches the given predicate
+     * @throws InterruptedException
+     * @throws ManagedLedgerException
+     */
+    Position findNewestMatching(ManagedCursor.FindPositionConstraint constraint, Predicate<Entry> condition) throws InterruptedException, ManagedLedgerException;
+
+    /**
+     * Return the number of messages that this cursor still has to read.
+     *
+     * <p/>This method has linear time complexity on the number of ledgers included in the managed ledger.
+     *
+     * @param range the range between two positions
+     * @return the number of entries in range
+     */
+    long getNumberOfEntries(Range<PositionImpl> range);
 
     /**
      * Close the cursor and releases the associated resources.
@@ -92,10 +111,8 @@ public interface ReadOnlyCursor {
     /**
      * Close the cursor asynchronously and release the associated resources.
      *
-     * @param callback
-     *            callback object
-     * @param ctx
-     *            opaque context
+     * @param callback callback object
+     * @param ctx      opaque context
      */
     void asyncClose(AsyncCallbacks.CloseCallback callback, Object ctx);
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedCursorImpl.java
@@ -687,6 +687,11 @@ public class ManagedCursorImpl implements ManagedCursor {
 
     @Override
     public Position findNewestMatching(Predicate<Entry> condition) throws InterruptedException, ManagedLedgerException {
+        return findNewestMatching(FindPositionConstraint.SearchActiveEntries, condition);
+    }
+
+    @Override
+    public Position findNewestMatching(FindPositionConstraint constraint, Predicate<Entry> condition) throws InterruptedException, ManagedLedgerException {
         final CountDownLatch counter = new CountDownLatch(1);
         class Result {
             ManagedLedgerException exception = null;
@@ -694,7 +699,7 @@ public class ManagedCursorImpl implements ManagedCursor {
         }
 
         final Result result = new Result();
-        asyncFindNewestMatching(FindPositionConstraint.SearchActiveEntries, condition, new FindEntryCallback() {
+        asyncFindNewestMatching(constraint, condition, new FindEntryCallback() {
             @Override
             public void findEntryComplete(Position position, Object ctx) {
                 result.position = position;

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyCursorImpl.java
@@ -32,7 +32,7 @@ import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl.PositionBound;
 public class ReadOnlyCursorImpl extends ManagedCursorImpl implements ReadOnlyCursor {
 
     public ReadOnlyCursorImpl(BookKeeper bookkeeper, ManagedLedgerConfig config, ManagedLedgerImpl ledger,
-            PositionImpl startPosition, String cursorName) {
+                              PositionImpl startPosition, String cursorName) {
         super(bookkeeper, config, ledger, cursorName);
 
         if (startPosition.equals(PositionImpl.earliest)) {
@@ -47,7 +47,9 @@ public class ReadOnlyCursorImpl extends ManagedCursorImpl implements ReadOnlyCur
             messagesConsumedCounter = -getNumberOfEntries(Range.closed(readPosition, ledger.getLastPosition()));
         }
 
-        state = State.NoLedger;
+        this.
+
+                state = State.NoLedger;
     }
 
     @Override
@@ -62,4 +64,7 @@ public class ReadOnlyCursorImpl extends ManagedCursorImpl implements ReadOnlyCur
         callback.closeComplete(ctx);
     }
 
+    public long getNumberOfEntries(Range<PositionImpl> range) {
+        return this.ledger.getNumberOfEntries(range);
+    }
 }

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyCursorImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ReadOnlyCursorImpl.java
@@ -47,9 +47,7 @@ public class ReadOnlyCursorImpl extends ManagedCursorImpl implements ReadOnlyCur
             messagesConsumedCounter = -getNumberOfEntries(Range.closed(readPosition, ledger.getLastPosition()));
         }
 
-        this.
-
-                state = State.NoLedger;
+        this.state = State.NoLedger;
     }
 
     @Override

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/ManagedCursorContainerTest.java
@@ -198,6 +198,11 @@ public class ManagedCursorContainerTest {
         }
 
         @Override
+        public Position findNewestMatching(FindPositionConstraint constraint, Predicate<Entry> condition) throws InterruptedException, ManagedLedgerException {
+            return null;
+        }
+
+        @Override
         public void asyncFindNewestMatching(FindPositionConstraint constraint, Predicate<Entry> condition,
                 AsyncCallbacks.FindEntryCallback callback, Object ctx) {
         }

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarConnectorUtils.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarConnectorUtils.java
@@ -22,6 +22,8 @@ import org.apache.avro.Schema;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.naming.TopicName;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
 
 public class PulsarConnectorUtils {
 

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarConnectorUtils.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarConnectorUtils.java
@@ -22,8 +22,6 @@ import org.apache.avro.Schema;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.common.naming.TopicName;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
 
 public class PulsarConnectorUtils {
 

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarInternalColumn.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarInternalColumn.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.sql.presto;
 
 import com.facebook.presto.spi.type.BigintType;
 import com.facebook.presto.spi.type.TimestampType;
+import com.facebook.presto.spi.type.TimestampWithTimeZoneType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.VarcharType;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -132,8 +133,9 @@ public abstract class PulsarInternalColumn {
     public static final PulsarInternalColumn EVENT_TIME = new EventTimeColumn("__event_time__", TimestampType
             .TIMESTAMP, "Application defined timestamp in milliseconds of when the event occurred");
 
-    public static final PulsarInternalColumn PUBLISH_TIME = new PublishTimeColumn("__publish_time__", TimestampType
-            .TIMESTAMP, "The timestamp in milliseconds of when event as published");
+    public static final PulsarInternalColumn PUBLISH_TIME = new PublishTimeColumn("__publish_time__",
+            TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE,
+            "The timestamp in milliseconds of when event as published");
 
     public static final PulsarInternalColumn MESSAGE_ID = new MessageIdColumn("__message_id__", VarcharType.VARCHAR,
             "The message ID of the message used to generate this row");

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarMetadata.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarMetadata.java
@@ -122,33 +122,6 @@ public class PulsarMetadata implements ConnectorMetadata {
                                                             Constraint<ColumnHandle> constraint,
                                                             Optional<Set<ColumnHandle>> desiredColumns) {
 
-        log.info("table: %s", table);
-
-        log.info("constraints: %s", constraint.getSummary().getDomains().get().entrySet());
-        log.info("getColumnDomains: %s", constraint.getSummary().getColumnDomains());
-        constraint.getSummary().getDomains().get().entrySet().forEach(new Consumer<Map.Entry<ColumnHandle, Domain>>() {
-            @Override
-            public void accept(Map.Entry<ColumnHandle, Domain> columnHandleDomainEntry) {
-                log.info("ColumnHandle: %s ranges: %s", columnHandleDomainEntry.getKey(),
-                        columnHandleDomainEntry.getValue().getValues().getRanges().getOrderedRanges().stream().map(new Function<Range, String>() {
-                    @Override
-                    public String apply(Range range) {
-                        return "high: " + range.getHigh().toString(session) + " low: " + range.getLow().toString(session);
-                    }
-                }).collect(Collectors.toList()));
-
-                columnHandleDomainEntry.getValue().getValues().getRanges().getOrderedRanges().forEach(new Consumer<Range>() {
-                    @Override
-                    public void accept(Range range) {
-                        log.info("high: %s low: %s ", range.getHigh().getValueBlock().isPresent() ? range.getHigh().getValueBlock().get().getLong(0, 0): null, range.getLow().getValueBlock().isPresent() ? range.getLow().getValueBlock().get().getLong(0,0) : null);
-                        log.info("high tz: %s low tz: %s ", range.getHigh().getValueBlock().isPresent() ? new SqlTimestampWithTimeZone(range.getHigh().getValueBlock().get().getLong(0, 0)).getTimeZoneKey(): null, range.getLow().getValueBlock().isPresent() ? new SqlTimestampWithTimeZone(range.getLow().getValueBlock().get().getLong(0,0)).getTimeZoneKey() : null);
-
-                    }
-                });
-
-            }
-        });
-
         PulsarTableHandle handle = convertTableHandle(table);
         ConnectorTableLayout layout = new ConnectorTableLayout(new PulsarTableLayoutHandle(handle, constraint.getSummary()));
         return ImmutableList.of(new ConnectorTableLayoutResult(layout, constraint.getSummary()));

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarRecordCursor.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarRecordCursor.java
@@ -20,6 +20,7 @@ package org.apache.pulsar.sql.presto;
 
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.RecordCursor;
+import com.facebook.presto.spi.type.TimestampWithTimeZoneType;
 import com.facebook.presto.spi.type.Type;
 import com.facebook.presto.spi.type.VarbinaryType;
 import com.facebook.presto.spi.type.VarcharType;
@@ -55,12 +56,15 @@ import java.util.concurrent.TimeUnit;
 
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DateTimeEncoding.packDateTimeWithZone;
+import static com.facebook.presto.spi.type.DateTimeEncoding.unpackMillisUtc;
 import static com.facebook.presto.spi.type.DateType.DATE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.type.RealType.REAL;
 import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
 import static com.facebook.presto.spi.type.TimeType.TIME;
 import static com.facebook.presto.spi.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -264,7 +268,7 @@ public class PulsarRecordCursor implements RecordCursor {
         if (type.equals(BIGINT)) {
             return ((Number) record).longValue();
         } else if (type.equals(DATE)) {
-            return MILLISECONDS.toDays(new Date(TimeUnit.DAYS.toMillis(((Number) record).longValue())).getTime());
+            return ((Number) record).longValue();
         } else if (type.equals(INTEGER)) {
             return (int) record;
         } else if (type.equals(REAL)) {
@@ -272,9 +276,11 @@ public class PulsarRecordCursor implements RecordCursor {
         } else if (type.equals(SMALLINT)) {
             return ((Number) record).shortValue();
         } else if (type.equals(TIME)) {
-            return new Time(((Number) record).longValue()).getTime();
+            return ((Number) record).longValue();
         } else if (type.equals(TIMESTAMP)) {
-            return new Timestamp(((Number) record).longValue()).getTime();
+            return ((Number) record).longValue();
+        } else if (type.equals(TIMESTAMP_WITH_TIME_ZONE)) {
+            return packDateTimeWithZone(((Number) record).longValue(), 0);
         } else if (type.equals(TINYINT)) {
             return Byte.parseByte(record.toString());
         } else {

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarSplit.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarSplit.java
@@ -18,8 +18,10 @@
  */
 package org.apache.pulsar.sql.presto;
 
+import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.predicate.TupleDomain;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
@@ -43,7 +45,7 @@ public class PulsarSplit implements ConnectorSplit {
     private final long endPositionEntryId;
     private final long startPositionLedgerId;
     private final long endPositionLedgerId;
-
+    private final TupleDomain<ColumnHandle> tupleDomain;
 
     @JsonCreator
     public PulsarSplit(
@@ -57,7 +59,8 @@ public class PulsarSplit implements ConnectorSplit {
             @JsonProperty("startPositionEntryId") long startPositionEntryId,
             @JsonProperty("endPositionEntryId") long endPositionEntryId,
             @JsonProperty("startPositionLedgerId") long startPositionLedgerId,
-            @JsonProperty("endPositionLedgerId") long endPositionLedgerId) {
+            @JsonProperty("endPositionLedgerId") long endPositionLedgerId,
+            @JsonProperty("tupleDomain") TupleDomain<ColumnHandle> tupleDomain) {
         this.splitId = splitId;
         this.schemaName = requireNonNull(schemaName, "schema name is null");
         this.connectorId = requireNonNull(connectorId, "connector id is null");
@@ -69,6 +72,7 @@ public class PulsarSplit implements ConnectorSplit {
         this.endPositionEntryId = endPositionEntryId;
         this.startPositionLedgerId = startPositionLedgerId;
         this.endPositionLedgerId = endPositionLedgerId;
+        this.tupleDomain = requireNonNull(tupleDomain, "tupleDomain is null");
     }
 
     @JsonProperty
@@ -124,6 +128,12 @@ public class PulsarSplit implements ConnectorSplit {
     @JsonProperty
     public long getEndPositionLedgerId() {
         return endPositionLedgerId;
+    }
+
+    @JsonProperty
+    public TupleDomain<ColumnHandle> getTupleDomain()
+    {
+        return tupleDomain;
     }
 
     public PositionImpl getStartPosition() {

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarSplit.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarSplit.java
@@ -131,8 +131,7 @@ public class PulsarSplit implements ConnectorSplit {
     }
 
     @JsonProperty
-    public TupleDomain<ColumnHandle> getTupleDomain()
-    {
+    public TupleDomain<ColumnHandle> getTupleDomain() {
         return tupleDomain;
     }
 

--- a/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarTableLayoutHandle.java
+++ b/pulsar-sql/presto-pulsar/src/main/java/org/apache/pulsar/sql/presto/PulsarTableLayoutHandle.java
@@ -18,18 +18,26 @@
  */
 package org.apache.pulsar.sql.presto;
 
+import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.predicate.TupleDomain;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
 public class PulsarTableLayoutHandle implements ConnectorTableLayoutHandle {
     private final PulsarTableHandle table;
+    private final TupleDomain<ColumnHandle> tupleDomain;
 
     @JsonCreator
-    public PulsarTableLayoutHandle(@JsonProperty("table") PulsarTableHandle table) {
+    public PulsarTableLayoutHandle(@JsonProperty("table") PulsarTableHandle table,
+                                   @JsonProperty("tupleDomain") TupleDomain<ColumnHandle> domain) {
+
         this.table = requireNonNull(table, "table is null");
+        this.tupleDomain = requireNonNull(domain, "tupleDomain is null");
     }
 
     @JsonProperty
@@ -37,8 +45,35 @@ public class PulsarTableLayoutHandle implements ConnectorTableLayoutHandle {
         return table;
     }
 
+    @JsonProperty
+    public TupleDomain<ColumnHandle> getTupleDomain()
+    {
+        return tupleDomain;
+    }
+
     @Override
-    public String toString() {
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PulsarTableLayoutHandle that = (PulsarTableLayoutHandle) o;
+        return Objects.equals(table, that.table) &&
+                Objects.equals(tupleDomain, that.tupleDomain);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(table, tupleDomain);
+    }
+
+    @Override
+    public String toString()
+    {
         return table.toString();
     }
 }

--- a/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarRecordCursor.java
+++ b/pulsar-sql/presto-pulsar/src/test/java/org/apache/pulsar/sql/presto/TestPulsarRecordCursor.java
@@ -71,7 +71,7 @@ public class TestPulsarRecordCursor extends TestPulsarConnector {
                 }
                 count++;
             }
-            Assert.assertEquals(count, topicsToEntries.get(topicName.getSchemaName()).longValue());
+            Assert.assertEquals(count, topicsToNumEntries.get(topicName.getSchemaName()).longValue());
             Assert.assertEquals(pulsarRecordCursor.getCompletedBytes(), completedBytes);
             cleanup();
         }


### PR DESCRIPTION
### Motivation

Since we can search through entries via publish time efficiently, we don't need to get return all the entries to presto when there is a predicate concerning publish time.  As an optimization when can only return the entries that satisfy the conditions in the predicate.
