### PR TITLE
update jclouds version to 2.1.1

### DIFF
--- a/jclouds-shaded/pom.xml
+++ b/jclouds-shaded/pom.xml
@@ -42,19 +42,9 @@
     <dependency>
       <groupId>org.apache.jclouds</groupId>
       <artifactId>jclouds-allblobstore</artifactId>
-      <version>2.2.0-SNAPSHOT</version>
+      <version>2.1.1</version>
     </dependency>
   </dependencies>
-
-  <repositories>
-    <repository>
-      <id>jclouds-snapshots</id>
-      <url>https://repository.apache.org/content/repositories/snapshots</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 
   <build>
     <plugins>


### PR DESCRIPTION
### Motivation

This is a part of tracking work in #2164. currently we use a snapshot version of jclouds for some jclouds bug fix. This change will remove the snapshot version and use latest release 2.1.1.

### Modifications

update jclouds-shaded/pom.xml to use 2.1.1

### Result
tired storage ut should pass
