### PR TITLE
Fix Description of Options on Pulsar Admin

### DIFF
--- a/site2/docs/reference-pulsar-admin.md
+++ b/site2/docs/reference-pulsar-admin.md
@@ -416,9 +416,9 @@ $ pulsar-admin functions get options
 Options
 |Flag|Description|Default|
 |---|---|---|
-|`--name`|The name of the function to delete||
-|`--namespace`|The namespace of the function to delete||
-|`--tenant`|The tenant of the function to delete||
+|`--name`|The name of the function||
+|`--namespace`|The namespace of the function||
+|`--tenant`|The tenant of the function||
 
 
 ### `getstatus`
@@ -432,9 +432,9 @@ $ pulsar-admin functions getstatus options
 Options
 |Flag|Description|Default|
 |---|---|---|
-|`--name`|The name of the function to delete||
-|`--namespace`|The namespace of the function to delete||
-|`--tenant`|The tenant of the function to delete||
+|`--name`|The name of the function||
+|`--namespace`|The namespace of the function||
+|`--tenant`|The tenant of the function||
 
 
 ### `list`
@@ -448,8 +448,8 @@ $ pulsar-admin functions list options
 Options
 |Flag|Description|Default|
 |---|---|---|
-|`--namespace`|The namespace of the function to delete||
-|`--tenant`|The tenant of the function to delete||
+|`--namespace`|The namespace of the function||
+|`--tenant`|The tenant of the function||
 
 
 ### `querystate`

--- a/site2/website/versioned_docs/version-2.1.0-incubating/reference-pulsar-admin.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/reference-pulsar-admin.md
@@ -417,9 +417,9 @@ $ pulsar-admin functions get options
 Options
 |Flag|Description|Default|
 |---|---|---|
-|`--name`|The name of the function to delete||
-|`--namespace`|The namespace of the function to delete||
-|`--tenant`|The tenant of the function to delete||
+|`--name`|The name of the function||
+|`--namespace`|The namespace of the function||
+|`--tenant`|The tenant of the function||
 
 
 ### `getstatus`
@@ -433,9 +433,9 @@ $ pulsar-admin functions getstatus options
 Options
 |Flag|Description|Default|
 |---|---|---|
-|`--name`|The name of the function to delete||
-|`--namespace`|The namespace of the function to delete||
-|`--tenant`|The tenant of the function to delete||
+|`--name`|The name of the function||
+|`--namespace`|The namespace of the function||
+|`--tenant`|The tenant of the function||
 
 
 ### `list`
@@ -449,8 +449,8 @@ $ pulsar-admin functions list options
 Options
 |Flag|Description|Default|
 |---|---|---|
-|`--namespace`|The namespace of the function to delete||
-|`--tenant`|The tenant of the function to delete||
+|`--namespace`|The namespace of the function||
+|`--tenant`|The tenant of the function||
 
 
 ### `querystate`


### PR DESCRIPTION
### Motivation

https://pulsar.incubator.apache.org/docs/en/pulsar-admin/#get-1
https://pulsar.incubator.apache.org/docs/en/pulsar-admin/#getstatus
https://pulsar.incubator.apache.org/docs/en/pulsar-admin/#list-2

All `to delete` in description of options of the above URLs are unnecessary.

### Modifications

Remove `to delete`.
