### PR TITLE
Standalone bookie should always advertise 'localhost' when running in docker container

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
@@ -253,7 +253,8 @@ public class PulsarStandalone implements AutoCloseable {
         if (!this.isOnlyBroker()) {
             // Start LocalBookKeeper
             bkEnsemble = new LocalBookkeeperEnsemble(
-                this.getNumOfBk(), this.getZkPort(), this.getBkPort(), this.getStreamStoragePort(), this.getZkDir(), this.getBkDir(), this.isWipeData(), config.getAdvertisedAddress());
+                    this.getNumOfBk(), this.getZkPort(), this.getBkPort(), this.getStreamStoragePort(), this.getZkDir(),
+                    this.getBkDir(), this.isWipeData(), "127.0.0.1");
             bkEnsemble.startStandalone(!this.isNoStreamStorage());
         }
 
@@ -352,7 +353,7 @@ public class PulsarStandalone implements AutoCloseable {
             log.info(e.getMessage());
         }
     }
-    
+
     /** this methods gets a buidler to use to build and an embedded pulsar instance `
      * i.e.
      * <pre>

--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
@@ -229,6 +229,7 @@ public class LocalBookkeeperEnsemble {
             bsConfs[i].setJournalDirName(bkDataDir.getPath());
             bsConfs[i].setLedgerDirNames(new String[] { bkDataDir.getPath() });
             bsConfs[i].setAllowLoopback(true);
+            bsConfs[i].setAdvertisedAddress("localhost");
             bsConfs[i].setGcWaitTime(60000);
 
             try {

--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
@@ -229,7 +229,6 @@ public class LocalBookkeeperEnsemble {
             bsConfs[i].setJournalDirName(bkDataDir.getPath());
             bsConfs[i].setLedgerDirNames(new String[] { bkDataDir.getPath() });
             bsConfs[i].setAllowLoopback(true);
-            bsConfs[i].setAdvertisedAddress("localhost");
             bsConfs[i].setGcWaitTime(60000);
 
             try {


### PR DESCRIPTION
### Motivation

When pulsar standalone runs in normal mode, the bookie advertises itself with `localhost`. This is the expected behavior and works well when changing IP or hostname. 

When running with docker, mounting an external volume, eg: 

```
docker run -it \
  -p 6650:6650 \
  -p 8080:8080 \
  -v $PWD/data:/pulsar/data \
  apachepulsar/pulsar:2.1.0-incubating \
  bin/pulsar standalone
```

the bookie advertises itself with the docker container hostname. When restarting the container this will cause the bookie cookie not to match with the previous value and fail to start.

### Modifications

Force to always advertise localhost for standalone bookie.
