### PR TITLE
Fix: failover sub keep sending invalid ack

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PersistentAcknowledgmentsGroupingTracker.java
@@ -164,6 +164,8 @@ public class PersistentAcknowledgmentsGroupingTracker implements Acknowledgments
             ByteBuf cmd = Commands.newAck(consumer.consumerId, lastCumulativeAck.ledgerId, lastCumulativeAck.entryId,
                     AckType.Cumulative, null, Collections.emptyMap());
             cnx.ctx().write(cmd, cnx.ctx().voidPromise());
+            lastCumulativeAck = (MessageIdImpl) MessageId.earliest;
+            return;
         }
 
         // Flush all individual acks


### PR DESCRIPTION
### Motivation

Consumer with FailOver-Subscription is not reseting `lastCumulativeAck` so, ack-tracker task keeps sending invalid ack to broker.

### Modifications

- Reset `lastCumulativeAck` and return to avoid sending duplicate ack.
