### PR TITLE
leak assign schema in MessageImpl constructor

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -155,6 +155,7 @@ public class MessageImpl<T> implements Message<T> {
         this.cnx = null;
         this.payload = payload;
         this.properties = Collections.unmodifiableMap(properties);
+        this.schema = schema;
     }
 
     public static MessageImpl<byte[]> deserialize(ByteBuf headersAndPayload) throws IOException {


### PR DESCRIPTION
schema was not assigned in MessageImpl constructor, it will report NPE when using it, this change try to fix it.
