### PR TITLE
Remove schema validator from annotations

### DIFF
--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfig.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionConfig.java
@@ -29,7 +29,6 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-import org.apache.pulsar.functions.api.Function;
 import org.apache.pulsar.functions.api.SerDe;
 import org.apache.pulsar.functions.utils.validation.ConfigValidation;
 
@@ -82,8 +81,6 @@ public class FunctionConfig {
     private Map<String, String> customSerdeInputs;
     @isValidTopicName
     private String topicsPattern;
-    @isMapEntryCustom(keyValidatorClasses = { ValidatorImpls.TopicNameValidator.class },
-            valueValidatorClasses = { ValidatorImpls.SchemaValidator.class }, targetRuntime = ConfigValidation.Runtime.JAVA)
     @isMapEntryCustom(keyValidatorClasses = { ValidatorImpls.TopicNameValidator.class }, targetRuntime = ConfigValidation.Runtime.PYTHON)
     private Map<String, String> customSchemaInputs;
 

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfig.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SinkConfig.java
@@ -66,8 +66,7 @@ public class SinkConfig {
     @isValidTopicName
     private String topicsPattern;
 
-    @isMapEntryCustom(keyValidatorClasses = { ValidatorImpls.TopicNameValidator.class },
-            valueValidatorClasses = { ValidatorImpls.SchemaValidator.class })
+    @isMapEntryCustom(keyValidatorClasses = { ValidatorImpls.TopicNameValidator.class })
     private Map<String, String> topicToSchemaType;
 
     private Map<String, ConsumerConfig> inputSpecs = new TreeMap<>();

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfig.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/SourceConfig.java
@@ -58,7 +58,6 @@ public class SourceConfig {
     @isImplementationOfClass(implementsClass = SerDe.class)
     private String serdeClassName;
 
-    @isImplementationOfClass(implementsClass = Schema.class)
     private String schemaType;
 
     private Map<String, Object> configs;


### PR DESCRIPTION
### Motivation

Complete Schema Validation requires extraction of types from the source/sink and thus cannot be done with annotations. Since we are already doing its validation, removes the annotated part.

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
