### PR TITLE
Fixed {{pulsar.version}} into {{pulsar:version}} in few pages

### DIFF
--- a/site2/docs/client-libraries-go.md
+++ b/site2/docs/client-libraries-go.md
@@ -34,7 +34,7 @@ $ go get -u github.com/apache/incubator-pulsar/pulsar-client-go/pulsar
 Or you can use [dep](https://github.com/golang/dep) for managing the dependencies.
 
 ```bash
-$ dep ensure -add github.com/apache/incubator-pulsar/pulsar-client-go/pulsar@v{{pulsar.version}}
+$ dep ensure -add github.com/apache/incubator-pulsar/pulsar-client-go/pulsar@v{{pulsar:version}}
 ```
 
 Once installed locally, you can import it into your project:

--- a/site2/docs/deploy-bare-metal.md
+++ b/site2/docs/deploy-bare-metal.md
@@ -125,12 +125,12 @@ $ tar xvfz apache-pulsar-io-connectors-{{pulsar:version}}-bin.tar.gz
 $ mv apache-pulsar-io-connectors-{{pulsar:version}}/connectors connectors
 
 $ ls connectors
-pulsar-io-aerospike-{{pulsar.version}}.nar
-pulsar-io-cassandra-{{pulsar.version}}.nar 
-pulsar-io-kafka-{{pulsar.version}}.nar     
-pulsar-io-kinesis-{{pulsar.version}}.nar   
-pulsar-io-rabbitmq-{{pulsar.version}}.nar  
-pulsar-io-twitter-{{pulsar.version}}.nar
+pulsar-io-aerospike-{{pulsar:version}}.nar
+pulsar-io-cassandra-{{pulsar:version}}.nar
+pulsar-io-kafka-{{pulsar:version}}.nar
+pulsar-io-kinesis-{{pulsar:version}}.nar
+pulsar-io-rabbitmq-{{pulsar:version}}.nar
+pulsar-io-twitter-{{pulsar:version}}.nar
 ...
 ```
 

--- a/site2/docs/getting-started-standalone.md
+++ b/site2/docs/getting-started-standalone.md
@@ -87,12 +87,12 @@ $ tar xvfz /path/to/apache-pulsar-io-connectors-{{pulsar:version}}-bin.tar.gz
 $ cd apache-pulsar-io-connectors-{{pulsar:version}}/connectors connectors
 
 $ ls connectors
-pulsar-io-aerospike-{{pulsar.version}}.nar
-pulsar-io-cassandra-{{pulsar.version}}.nar 
-pulsar-io-kafka-{{pulsar.version}}.nar     
-pulsar-io-kinesis-{{pulsar.version}}.nar   
-pulsar-io-rabbitmq-{{pulsar.version}}.nar  
-pulsar-io-twitter-{{pulsar.version}}.nar
+pulsar-io-aerospike-{{pulsar:version}}.nar
+pulsar-io-cassandra-{{pulsar:version}}.nar
+pulsar-io-kafka-{{pulsar:version}}.nar
+pulsar-io-kinesis-{{pulsar:version}}.nar
+pulsar-io-rabbitmq-{{pulsar:version}}.nar
+pulsar-io-twitter-{{pulsar:version}}.nar
 ...
 ```
 

--- a/site2/docs/io-quickstart.md
+++ b/site2/docs/io-quickstart.md
@@ -69,12 +69,12 @@ $ tar xvfz /path/to/apache-pulsar-io-connectors-{{pulsar:version}}-bin.tar.gz
 $ cp -r apache-pulsar-io-connectors-{{pulsar:version}}/connectors connectors
 
 $ ls connectors
-pulsar-io-aerospike-{{pulsar.version}}.nar
-pulsar-io-cassandra-{{pulsar.version}}.nar 
-pulsar-io-kafka-{{pulsar.version}}.nar     
-pulsar-io-kinesis-{{pulsar.version}}.nar   
-pulsar-io-rabbitmq-{{pulsar.version}}.nar  
-pulsar-io-twitter-{{pulsar.version}}.nar
+pulsar-io-aerospike-{{pulsar:version}}.nar
+pulsar-io-cassandra-{{pulsar:version}}.nar
+pulsar-io-kafka-{{pulsar:version}}.nar
+pulsar-io-kinesis-{{pulsar:version}}.nar
+pulsar-io-rabbitmq-{{pulsar:version}}.nar
+pulsar-io-twitter-{{pulsar:version}}.nar
 ...
 ```
 

--- a/site2/website/versioned_docs/version-2.1.0-incubating/client-libraries-go.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/client-libraries-go.md
@@ -35,7 +35,7 @@ $ go get -u github.com/apache/incubator-pulsar/pulsar-client-go/pulsar
 Or you can use [dep](https://github.com/golang/dep) for managing the dependencies.
 
 ```bash
-$ dep ensure -add github.com/apache/incubator-pulsar/pulsar-client-go/pulsar@v{{pulsar.version}}
+$ dep ensure -add github.com/apache/incubator-pulsar/pulsar-client-go/pulsar@v{{pulsar:version}}
 ```
 
 Once installed locally, you can import it into your project:

--- a/site2/website/versioned_docs/version-2.1.0-incubating/deploy-bare-metal.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/deploy-bare-metal.md
@@ -126,12 +126,12 @@ $ tar xvfz apache-pulsar-io-connectors-{{pulsar:version}}-bin.tar.gz
 $ mv apache-pulsar-io-connectors-{{pulsar:version}}/connectors connectors
 
 $ ls connectors
-pulsar-io-aerospike-{{pulsar.version}}.nar
-pulsar-io-cassandra-{{pulsar.version}}.nar 
-pulsar-io-kafka-{{pulsar.version}}.nar     
-pulsar-io-kinesis-{{pulsar.version}}.nar   
-pulsar-io-rabbitmq-{{pulsar.version}}.nar  
-pulsar-io-twitter-{{pulsar.version}}.nar
+pulsar-io-aerospike-{{pulsar:version}}.nar
+pulsar-io-cassandra-{{pulsar:version}}.nar
+pulsar-io-kafka-{{pulsar:version}}.nar
+pulsar-io-kinesis-{{pulsar:version}}.nar
+pulsar-io-rabbitmq-{{pulsar:version}}.nar
+pulsar-io-twitter-{{pulsar:version}}.nar
 ...
 ```
 

--- a/site2/website/versioned_docs/version-2.1.0-incubating/getting-started-standalone.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/getting-started-standalone.md
@@ -88,12 +88,12 @@ $ tar xvfz /path/to/apache-pulsar-io-connectors-{{pulsar:version}}-bin.tar.gz
 $ cd apache-pulsar-io-connectors-{{pulsar:version}}/connectors connectors
 
 $ ls connectors
-pulsar-io-aerospike-{{pulsar.version}}.nar
-pulsar-io-cassandra-{{pulsar.version}}.nar 
-pulsar-io-kafka-{{pulsar.version}}.nar     
-pulsar-io-kinesis-{{pulsar.version}}.nar   
-pulsar-io-rabbitmq-{{pulsar.version}}.nar  
-pulsar-io-twitter-{{pulsar.version}}.nar
+pulsar-io-aerospike-{{pulsar:version}}.nar
+pulsar-io-cassandra-{{pulsar:version}}.nar
+pulsar-io-kafka-{{pulsar:version}}.nar
+pulsar-io-kinesis-{{pulsar:version}}.nar
+pulsar-io-rabbitmq-{{pulsar:version}}.nar
+pulsar-io-twitter-{{pulsar:version}}.nar
 ...
 ```
 

--- a/site2/website/versioned_docs/version-2.1.0-incubating/io-quickstart.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/io-quickstart.md
@@ -70,12 +70,12 @@ $ tar xvfz /path/to/apache-pulsar-io-connectors-{{pulsar:version}}-bin.tar.gz
 $ cp -r apache-pulsar-io-connectors-{{pulsar:version}}/connectors connectors
 
 $ ls connectors
-pulsar-io-aerospike-{{pulsar.version}}.nar
-pulsar-io-cassandra-{{pulsar.version}}.nar 
-pulsar-io-kafka-{{pulsar.version}}.nar     
-pulsar-io-kinesis-{{pulsar.version}}.nar   
-pulsar-io-rabbitmq-{{pulsar.version}}.nar  
-pulsar-io-twitter-{{pulsar.version}}.nar
+pulsar-io-aerospike-{{pulsar:version}}.nar
+pulsar-io-cassandra-{{pulsar:version}}.nar
+pulsar-io-kafka-{{pulsar:version}}.nar
+pulsar-io-kinesis-{{pulsar:version}}.nar
+pulsar-io-rabbitmq-{{pulsar:version}}.nar
+pulsar-io-twitter-{{pulsar:version}}.nar
 ...
 ```
 


### PR DESCRIPTION
### Motivation

In few places in website we're displaying the literal `{{pulsar.version}}` instead of the actual Pulsar version string. The correct variable name is expected to use `:` as separator.