### PR TITLE
Add backlog quota retention policy to server config.

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -68,7 +68,7 @@ backlogQuotaDefaultLimitGB=10
 # 'producer_request_hold' Policy which holds producer's send request until the resource becomes available (or holding times out)
 # 'producer_exception' Policy which throws javax.jms.ResourceAllocationException to the producer
 # 'consumer_backlog_eviction' Policy which evicts the oldest message from the slowest consumer's backlog
-backlogQuotaRetentionPolicy=producer_request_hold
+getBacklogQuotaDefaultRetentionPolicy=producer_request_hold
 
 # Enable the deletion of inactive topics
 brokerDeleteInactiveTopicsEnabled=true

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -64,6 +64,12 @@ backlogQuotaCheckIntervalInSeconds=60
 # Default per-topic backlog quota limit
 backlogQuotaDefaultLimitGB=10
 
+# Default backlog quota retention policy. Default is producer_request_hold
+# 'producer_request_hold' Policy which holds producer's send request until the resource becomes available (or holding times out)
+# 'producer_exception' Policy which throws javax.jms.ResourceAllocationException to the producer
+# 'consumer_backlog_eviction' Policy which evicts the oldest message from the slowest consumer's backlog
+backlogQuotaRetentionPolicy=producer_request_hold
+
 # Enable the deletion of inactive topics
 brokerDeleteInactiveTopicsEnabled=true
 

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -68,7 +68,7 @@ backlogQuotaDefaultLimitGB=10
 # 'producer_request_hold' Policy which holds producer's send request until the resource becomes available (or holding times out)
 # 'producer_exception' Policy which throws javax.jms.ResourceAllocationException to the producer
 # 'consumer_backlog_eviction' Policy which evicts the oldest message from the slowest consumer's backlog
-getBacklogQuotaDefaultRetentionPolicy=producer_request_hold
+backlogQuotaDefaultRetentionPolicy=producer_request_hold
 
 # Enable the deletion of inactive topics
 brokerDeleteInactiveTopicsEnabled=true

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -90,7 +90,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     //'producer_request_hold' Policy which holds producer's send request until the resource becomes available (or holding times out)
     //'producer_exception' Policy which throws javax.jms.ResourceAllocationException to the producer
     //'consumer_backlog_eviction' Policy which evicts the oldest message from the slowest consumer's backlog
-    private String backlogQuotaRetentionPolicy = "producer_request_hold";
+    private String backlogQuotaDefaultRetentionPolicy = "producer_request_hold";
     // Enable the deletion of inactive topics
     private boolean brokerDeleteInactiveTopicsEnabled = true;
     // How often to check for inactive topics
@@ -1814,11 +1814,11 @@ public class ServiceConfiguration implements PulsarConfiguration {
         return this.brokerServiceCompactionMonitorIntervalInSeconds;
     }
 
-    public String getBacklogQuotaRetentionPolicy() {
-        return backlogQuotaRetentionPolicy;
+    public String getBacklogQuotaDefaultRetentionPolicy() {
+        return backlogQuotaDefaultRetentionPolicy;
     }
 
-    public void setBacklogQuotaRetentionPolicy(String backlogQuotaRetentionPolicy) {
-        this.backlogQuotaRetentionPolicy = backlogQuotaRetentionPolicy;
+    public void setBacklogQuotaDefaultRetentionPolicy(String backlogQuotaDefaultRetentionPolicy) {
+        this.backlogQuotaDefaultRetentionPolicy = backlogQuotaDefaultRetentionPolicy;
     }
 }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -31,6 +31,7 @@ import org.apache.pulsar.common.configuration.FieldContext;
 import org.apache.pulsar.common.configuration.PulsarConfiguration;
 
 import com.google.common.collect.Sets;
+import org.apache.pulsar.common.policies.data.BacklogQuota;
 
 /**
  * Pulsar service configuration object.
@@ -90,7 +91,7 @@ public class ServiceConfiguration implements PulsarConfiguration {
     //'producer_request_hold' Policy which holds producer's send request until the resource becomes available (or holding times out)
     //'producer_exception' Policy which throws javax.jms.ResourceAllocationException to the producer
     //'consumer_backlog_eviction' Policy which evicts the oldest message from the slowest consumer's backlog
-    private String backlogQuotaDefaultRetentionPolicy = "producer_request_hold";
+    private BacklogQuota.RetentionPolicy backlogQuotaDefaultRetentionPolicy = BacklogQuota.RetentionPolicy.producer_request_hold;
     // Enable the deletion of inactive topics
     private boolean brokerDeleteInactiveTopicsEnabled = true;
     // How often to check for inactive topics
@@ -1814,11 +1815,11 @@ public class ServiceConfiguration implements PulsarConfiguration {
         return this.brokerServiceCompactionMonitorIntervalInSeconds;
     }
 
-    public String getBacklogQuotaDefaultRetentionPolicy() {
+    public BacklogQuota.RetentionPolicy getBacklogQuotaDefaultRetentionPolicy() {
         return backlogQuotaDefaultRetentionPolicy;
     }
 
-    public void setBacklogQuotaDefaultRetentionPolicy(String backlogQuotaDefaultRetentionPolicy) {
+    public void setBacklogQuotaDefaultRetentionPolicy(BacklogQuota.RetentionPolicy backlogQuotaDefaultRetentionPolicy) {
         this.backlogQuotaDefaultRetentionPolicy = backlogQuotaDefaultRetentionPolicy;
     }
 }

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -86,6 +86,11 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private int backlogQuotaCheckIntervalInSeconds = 60;
     // Default per-topic backlog quota limit
     private long backlogQuotaDefaultLimitGB = 50;
+    //Default backlog quota retention policy. Default is producer_request_hold
+    //'producer_request_hold' Policy which holds producer's send request until the resource becomes available (or holding times out)
+    //'producer_exception' Policy which throws javax.jms.ResourceAllocationException to the producer
+    //'consumer_backlog_eviction' Policy which evicts the oldest message from the slowest consumer's backlog
+    private String backlogQuotaRetentionPolicy = "producer_request_hold";
     // Enable the deletion of inactive topics
     private boolean brokerDeleteInactiveTopicsEnabled = true;
     // How often to check for inactive topics
@@ -1807,5 +1812,13 @@ public class ServiceConfiguration implements PulsarConfiguration {
 
     public int getBrokerServiceCompactionMonitorIntervalInSeconds() {
         return this.brokerServiceCompactionMonitorIntervalInSeconds;
+    }
+
+    public String getBacklogQuotaRetentionPolicy() {
+        return backlogQuotaRetentionPolicy;
+    }
+
+    public void setBacklogQuotaRetentionPolicy(String backlogQuotaRetentionPolicy) {
+        this.backlogQuotaRetentionPolicy = backlogQuotaRetentionPolicy;
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
@@ -50,9 +50,9 @@ public class BacklogQuotaManager {
     public BacklogQuotaManager(PulsarService pulsar) {
         RetentionPolicy retentionPolicy = null;
         try {
-            retentionPolicy = RetentionPolicy.valueOf(pulsar.getConfiguration().getBacklogQuotaRetentionPolicy());
+            retentionPolicy = RetentionPolicy.valueOf(pulsar.getConfiguration().getBacklogQuotaDefaultRetentionPolicy());
         } catch (IllegalArgumentException e) {
-            log.error("Invalid Backlog retention policy: {} in broker.conf ", pulsar.getConfiguration().getBacklogQuotaRetentionPolicy(), e);
+            log.error("Invalid Backlog retention policy: {} in broker.conf ", pulsar.getConfiguration().getBacklogQuotaDefaultRetentionPolicy(), e);
         }
         this.defaultQuota = new BacklogQuota(
                 pulsar.getConfiguration().getBacklogQuotaDefaultLimitGB() * 1024 * 1024 * 1024,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
@@ -48,15 +48,9 @@ public class BacklogQuotaManager {
     private final ZooKeeperDataCache<Policies> zkCache;
 
     public BacklogQuotaManager(PulsarService pulsar) {
-        RetentionPolicy retentionPolicy = null;
-        try {
-            retentionPolicy = RetentionPolicy.valueOf(pulsar.getConfiguration().getBacklogQuotaDefaultRetentionPolicy());
-        } catch (IllegalArgumentException e) {
-            log.error("Invalid Backlog retention policy: {} in broker.conf ", pulsar.getConfiguration().getBacklogQuotaDefaultRetentionPolicy(), e);
-        }
         this.defaultQuota = new BacklogQuota(
                 pulsar.getConfiguration().getBacklogQuotaDefaultLimitGB() * 1024 * 1024 * 1024,
-                retentionPolicy == null ? RetentionPolicy.producer_request_hold : retentionPolicy);
+                pulsar.getConfiguration().getBacklogQuotaDefaultRetentionPolicy());
         this.zkCache = pulsar.getConfigurationCache().policiesCache();
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BacklogQuotaManager.java
@@ -48,9 +48,15 @@ public class BacklogQuotaManager {
     private final ZooKeeperDataCache<Policies> zkCache;
 
     public BacklogQuotaManager(PulsarService pulsar) {
+        RetentionPolicy retentionPolicy = null;
+        try {
+            retentionPolicy = RetentionPolicy.valueOf(pulsar.getConfiguration().getBacklogQuotaRetentionPolicy());
+        } catch (IllegalArgumentException e) {
+            log.error("Invalid Backlog retention policy: {} in broker.conf ", pulsar.getConfiguration().getBacklogQuotaRetentionPolicy(), e);
+        }
         this.defaultQuota = new BacklogQuota(
                 pulsar.getConfiguration().getBacklogQuotaDefaultLimitGB() * 1024 * 1024 * 1024,
-                RetentionPolicy.producer_request_hold);
+                retentionPolicy == null ? RetentionPolicy.producer_request_hold : retentionPolicy);
         this.zkCache = pulsar.getConfigurationCache().policiesCache();
     }
 


### PR DESCRIPTION
### Motivation

Enable setting default backlog quota retention from server config file(broker.conf)

### Modifications

Add backlogQuotaRetentionPolicy to broker.conf
Add backlogQuotaRetentionPolicy to ServiceConfiguration
Modify BacklogQuotaManager create logic, when backlogQuotaRetentionPolicy in ServiceConfiguration is not null, BacklogQuotaManager will use the ServiceConfiguration's backlogQuotaRetentionPolicy.
