### PR TITLE
Clarified project roles in team page

### DIFF
--- a/site2/website/pages/en/team.js
+++ b/site2/website/pages/en/team.js
@@ -29,18 +29,19 @@ class Team extends React.Component {
             </header>
             <p>
             <translate>
-              A successful project requires many people to play many roles.
-              Some members write code or documentation, while others are valuable as testers,
-              submitting patches and suggestions.
+              A successful project requires many people to play many roles. Some write
+              code or documentation, while others are valuable as testers, submitting
+              patches and suggestions.
             </translate>
             </p>
             <p>
             <translate>
-              The team is comprised of Members and Contributors.
-              Members have direct access to the source of a project and actively evolve the codebase.
-              Contributors improve the project through submission of patches and
-              suggestions to the Members. The number of Contributors to the project is unbounded.
-              Get involved today. All contributions to the project are greatly appreciated.
+              The team is comprised of PMC members, Committers and Contributors.
+              Committers have direct access to the source of a project and actively
+              evolve the codebase. Contributors improve the project through submission of
+              patches and suggestions to be reviewed by the Committers. The number of
+              Committers and Contributors to the project is unbounded. Get involved
+              today. All contributions to the project are greatly appreciated.
             </translate>
             </p>
 


### PR DESCRIPTION
### Motivation

As @dave2wave mentioned in dev mailing list: 

>  The descriptions on the team page are a little off - Members are both Committers and PPMC members. Please make that distinct. (In the ASF there is a difference between an Apache Member and a PMC Member.)

Trying to clarify here the term "Member" by specifying "PMC Member" vs "Committer" vs "Contributor".
