### PR TITLE
Pulsar Java Client Interceptors.

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/client/impl/RawReaderImpl.java
@@ -111,7 +111,7 @@ public class RawReaderImpl implements RawReader {
                 consumerFuture,
                 SubscriptionMode.Durable,
                 MessageId.earliest,
-                Schema.BYTES);
+                Schema.BYTES, null);
             incomingRawMessages = new GrowableArrayBlockingQueue<>();
             pendingRawReceives = new ConcurrentLinkedQueue<>();
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -1213,7 +1213,7 @@ public class PersistentTopicTest {
         PulsarClient client = spy(PulsarClient.builder().serviceUrl(brokerUrl.toString()).build());
         PulsarClientImpl clientImpl = (PulsarClientImpl) client;
         doReturn(new CompletableFuture<Producer>()).when(clientImpl)
-            .createProducerAsync(any(ProducerConfigurationData.class), any(Schema.class));
+            .createProducerAsync(any(ProducerConfigurationData.class), any(Schema.class), null);
 
         ManagedCursor cursor = mock(ManagedCursorImpl.class);
         doReturn(remoteCluster).when(cursor).getName();
@@ -1224,7 +1224,7 @@ public class PersistentTopicTest {
         verify(clientImpl)
             .createProducerAsync(
                 any(ProducerConfigurationData.class),
-                any(Schema.class)
+                any(Schema.class), null
             );
 
         replicator.disconnect(false);
@@ -1235,7 +1235,7 @@ public class PersistentTopicTest {
         verify(clientImpl, Mockito.times(2))
             .createProducerAsync(
                 any(ProducerConfigurationData.class),
-                any(Schema.class)
+                any(Schema.class), null
             );
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ReplicatorTest.java
@@ -242,7 +242,7 @@ public class ReplicatorTest extends ReplicatorTestBase {
         Thread.sleep(3000);
 
         Mockito.verify(pulsarClient, Mockito.times(1)).createProducerAsync(Mockito.any(ProducerConfigurationData.class),
-                Mockito.any(Schema.class));
+                Mockito.any(Schema.class), null);
 
         client1.shutdown();
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/v1/V1_ReplicatorTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/v1/V1_ReplicatorTest.java
@@ -241,7 +241,7 @@ public class V1_ReplicatorTest extends V1_ReplicatorTestBase {
         Thread.sleep(3000);
 
         Mockito.verify(pulsarClient, Mockito.times(1)).createProducerAsync(Mockito.any(ProducerConfigurationData.class),
-                Mockito.any(Schema.class));
+                Mockito.any(Schema.class), null);
 
         client1.shutdown();
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/InterceptorsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/InterceptorsTest.java
@@ -1,0 +1,111 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+import org.apache.pulsar.client.impl.MessageImpl;
+import org.apache.pulsar.common.api.proto.PulsarApi;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class InterceptorsTest extends ProducerConsumerBase {
+
+    private static final Logger log = LoggerFactory.getLogger(InterceptorsTest.class);
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        super.internalSetup();
+        super.producerBaseSetup();
+    }
+
+    @AfterMethod
+    @Override
+    protected void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testProducerBeforeSend() throws PulsarClientException {
+        ProducerInterceptor<String> interceptor1 = new ProducerInterceptor<String>() {
+            @Override
+            public void close() {
+
+            }
+
+            @Override
+            public Message<String> beforeSend(Message<String> message) {
+                MessageImpl<String> msg = (MessageImpl<String>) message;
+                log.info("Before send message: {}", new String(msg.getData()));
+                java.util.List<org.apache.pulsar.common.api.proto.PulsarApi.KeyValue> properties = msg.getMessageBuilder().getPropertiesList();
+                for (int i = 0; i < properties.size(); i++) {
+                    if ("key".equals(properties.get(i).getKey())) {
+                        msg.getMessageBuilder().setProperties(i, PulsarApi.KeyValue.newBuilder().setKey("key").setValue("after").build());
+                    }
+                }
+                return msg;
+            }
+
+            @Override
+            public void onSendAcknowledgement(Message<String> message, MessageId msgId, Throwable cause) {
+                message.getProperties();
+                Assert.assertEquals("complete", message.getProperty("key"));
+                log.info("Send acknowledgement message: {}, msgId: {}", new String(message.getData()), msgId, cause);
+            }
+        };
+
+        ProducerInterceptor<String> interceptor2 = new ProducerInterceptor<String>() {
+            @Override
+            public void close() {
+
+            }
+
+            @Override
+            public Message<String> beforeSend(Message<String> message) {
+                MessageImpl<String> msg = (MessageImpl<String>) message;
+                log.info("Before send message: {}", new String(msg.getData()));
+                java.util.List<org.apache.pulsar.common.api.proto.PulsarApi.KeyValue> properties = msg.getMessageBuilder().getPropertiesList();
+                for (int i = 0; i < properties.size(); i++) {
+                    if ("key".equals(properties.get(i).getKey())) {
+                        msg.getMessageBuilder().setProperties(i, PulsarApi.KeyValue.newBuilder().setKey("key").setValue("complete").build());
+                    }
+                }
+                return msg;
+            }
+
+            @Override
+            public void onSendAcknowledgement(Message<String> message, MessageId msgId, Throwable cause) {
+                message.getProperties();
+                Assert.assertEquals("complete", message.getProperty("key"));
+                log.info("Send acknowledgement message: {}, msgId: {}", new String(message.getData()), msgId, cause);
+            }
+        };
+
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .topic("persistent://my-property/my-ns/my-topic")
+                .intercept(interceptor1, interceptor2)
+                .create();
+
+        MessageId messageId = producer.newMessage().property("key", "before").value("Hello Pulsar!").send();
+        log.info("Send result messageId: {}", messageId);
+    }
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerBuilder.java
@@ -330,4 +330,12 @@ public interface ConsumerBuilder<T> extends Cloneable {
      * Set subscriptionInitialPosition for the consumer
     */
     ConsumerBuilder<T> subscriptionInitialPosition(SubscriptionInitialPosition subscriptionInitialPosition);
+
+    /**
+     * Intercept {@link Consumer}.
+     *
+     * @param interceptors the list of interceptors to intercept the consumer created by this builder.
+     * @return consumer builder.
+     */
+    ConsumerBuilder<T> intercept(ConsumerInterceptor<T> ...interceptors);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerInterceptor.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerInterceptor.java
@@ -79,18 +79,18 @@ public interface ConsumerInterceptor<T> extends AutoCloseable {
      *
      * <p>Any exception thrown by this method will be ignored by the caller.
      *
-     * @param message message to ack, null if acknowledge fail.
+     * @param messageId message to ack, null if acknowledge fail.
      * @param cause the exception on acknowledge.
      */
-    void onAcknowledge(Message<T> message, Throwable cause);
+    void onAcknowledge(MessageId messageId, Throwable cause);
 
     /**
      * This is called consumer send the cumulative acknowledgment to the broker.
      *
      * <p>Any exception thrown by this method will be ignored by the caller.
      *
-     * @param messages messages to ack cumulative, null if acknowledge fail.
+     * @param messageId message to ack, null if acknowledge fail.
      * @param cause the exception on acknowledge.
      */
-    void onAcknowledgeCumulative(List<Message<T>> messages, Throwable cause);
+    void onAcknowledgeCumulative(MessageId messageId, Throwable cause);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerInterceptor.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ConsumerInterceptor.java
@@ -1,0 +1,96 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+import java.util.List;
+
+/**
+ * A plugin interface that allows you to intercept (and possibly mutate)
+ * messages received by the consumer.
+ * <p>
+ * A primary use case is to hook into consumer applications for custom
+ * monitoring, logging, etc.
+ * <p>
+ * Exceptions thrown by interceptor methods will be caught, logged, but
+ * not propagated further.
+ */
+public interface ConsumerInterceptor<T> extends AutoCloseable {
+
+    /**
+     * Close the interceptor.
+     */
+    void close();
+
+    /**
+     * This is called just before the message is returned by
+     * {@link Consumer#receive()}, {@link MessageListener#received(Consumer,
+     * Message)} or the {@link java.util.concurrent.CompletableFuture} returned by
+     * {@link Consumer#receiveAsync()} completes.
+     * <p>
+     * This method is allowed to modify message, in which case the new message
+     * will be returned.
+     * <p>
+     * Any exception thrown by this method will be caught by the caller, logged,
+     * but not propagated to client.
+     * <p>
+     * Since the consumer may run multiple interceptors, a particular
+     * interceptor's
+     * <tt>beforeConsume</tt> callback will be called in the order specified by
+     * {@link ConsumerBuilder#intercept(ConsumerInterceptor[])}. The first
+     * interceptor in the list gets the consumed message, the following
+     * interceptor will be passed
+     * the message returned by the previous interceptor, and so on. Since
+     * interceptors are allowed to modify message, interceptors may potentially
+     * get the messages already modified by other interceptors. However building a
+     * pipeline of mutable
+     * interceptors that depend on the output of the previous interceptor is
+     * discouraged, because of potential side-effects caused by interceptors
+     * potentially failing to modify the message and throwing an exception.
+     * if one of interceptors in the list throws an exception from
+     * <tt>beforeConsume</tt>, the exception is caught, logged,
+     * and the next interceptor is called with the message returned by the last
+     * successful interceptor in the list, or otherwise the original consumed
+     * message.
+     *
+     * @param message the message to be consumed by the client.
+     * @return message that is either modified by the interceptor or same message
+     *         passed into the method.
+     */
+    Message<T> beforeConsume(Message<T> message);
+
+    /**
+     * This is called consumer sends the acknowledgment to the broker.
+     *
+     * <p>Any exception thrown by this method will be ignored by the caller.
+     *
+     * @param message message to ack, null if acknowledge fail.
+     * @param cause the exception on acknowledge.
+     */
+    void onAcknowledge(Message<T> message, Throwable cause);
+
+    /**
+     * This is called consumer send the cumulative acknowledgment to the broker.
+     *
+     * <p>Any exception thrown by this method will be ignored by the caller.
+     *
+     * @param messages messages to ack cumulative, null if acknowledge fail.
+     * @param cause the exception on acknowledge.
+     */
+    void onAcknowledgeCumulative(List<Message<T>> messages, Throwable cause);
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ProducerBuilder.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ProducerBuilder.java
@@ -318,4 +318,12 @@ public interface ProducerBuilder<T> extends Cloneable {
      * @return
      */
     ProducerBuilder<T> properties(Map<String, String> properties);
+
+    /**
+     * Intercept {@link Producer}.
+     *
+     * @param interceptors the list of interceptors to intercept the producer created by this builder.
+     * @return producer builder.
+     */
+    ProducerBuilder<T> intercept(ProducerInterceptor<T> ... interceptors);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/api/ProducerInterceptor.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/api/ProducerInterceptor.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.api;
+
+/**
+ * A plugin interface that allows you to intercept (and possibly mutate) the
+ * messages received by the producer before they are published to the Pulsar
+ * brokers.
+ * <p>
+ * Exceptions thrown by ProducerInterceptor methods will be caught, logged, but
+ * not propagated further.
+ * <p>
+ * ProducerInterceptor callbacks may be called from multiple threads. Interceptor
+ * implementation must ensure thread-safety, if needed.
+ */
+public interface ProducerInterceptor<T> extends AutoCloseable {
+
+    /**
+     * Close the interceptor.
+     */
+    void close();
+
+    /**
+     * This is called from {@link Producer#send(Object)} and {@link
+     * Producer#sendAsync(Object)} methods, before
+     * send the message to the brokers. This method is allowed to modify the
+     * record, in which case, the new record
+     * will be returned.
+     * <p>
+     * Any exception thrown by this method will be caught by the caller and
+     * logged, but not propagated further.
+     * <p>
+     * Since the producer may run multiple interceptors, a particular
+     * interceptor's {@link #beforeSend(Message)} callback will be called in the
+     * order specified by
+     * {@link ProducerBuilder#intercept(ProducerInterceptor[])}.
+     * <p>
+     * The first interceptor in the list gets the message passed from the client,
+     * the following interceptor will be passed the message returned by the
+     * previous interceptor, and so on. Since interceptors are allowed to modify
+     * messages, interceptors may potentially get the message already modified by
+     * other interceptors. However, building a pipeline of mutable interceptors
+     * that depend on the output of the previous interceptor is discouraged,
+     * because of potential side-effects caused by interceptors potentially
+     * failing to modify the message and throwing an exception. If one of the
+     * interceptors in the list throws an exception from
+     * {@link#beforeSend(Message)}, the exception is caught, logged, and the next
+     * interceptor is called with the message returned by the last successful
+     * interceptor in the list, or otherwise the client.
+     *
+     * @param message message to send
+     * @return the intercepted message
+     */
+    Message<T> beforeSend(Message<T> message);
+
+    /**
+     * This method is called when the message sent to the broker has been
+     * acknowledged, or when sending the message fails.
+     * This method is generally called just before the user callback is
+     * called, and in additional cases when an exception on the producer side.
+     * <p>
+     * Any exception thrown by this method will be ignored by the caller.
+     * <p>
+     * This method will generally execute in the background I/O thread, so the
+     * implementation should be reasonably fast. Otherwise, sending of messages
+     * from other threads could be delayed.
+     *
+     * @param message the message that application sends
+     * @param msgId the message id that assigned by the broker; null if send failed.
+     * @param cause the exception on sending messages, null indicates send has succeed.
+     */
+    void onSendAcknowledgement(Message<T> message, MessageId msgId, Throwable cause);
+
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainer.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/BatchMessageContainer.java
@@ -105,7 +105,6 @@ class BatchMessageContainer {
         batchedMessageMetadataAndPayload = Commands.serializeSingleMessageInBatchWithPayload(msgBuilder,
                 msg.getDataBuffer(), batchedMessageMetadataAndPayload);
         messages.add(msg);
-        msgBuilder.recycle();
     }
 
     ByteBuf getCompressedBatchMetadataAndPayload() {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBase.java
@@ -20,7 +20,6 @@ package org.apache.pulsar.client.impl;
 
 import com.google.common.collect.Queues;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
@@ -367,15 +366,15 @@ public abstract class ConsumerBase<T> extends HandlerState implements Consumer<T
         }
     }
 
-    protected void onAcknowledge(Message<T> message, Throwable cause) {
+    protected void onAcknowledge(MessageId messageId, Throwable cause) {
         if (interceptors != null) {
-            interceptors.onAcknowledge(message, cause);
+            interceptors.onAcknowledge(messageId, cause);
         }
     }
 
-    protected void onAcknowledgeCumulative(List<Message<T>> messages, Throwable cause) {
+    protected void onAcknowledgeCumulative(MessageId messageId, Throwable cause) {
         if (interceptors != null) {
-            interceptors.onAcknowledgeCumulative(messages, cause);
+            interceptors.onAcknowledgeCumulative(messageId, cause);
         }
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerBuilderImpl.java
@@ -20,6 +20,8 @@ package org.apache.pulsar.client.impl;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -32,6 +34,7 @@ import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerBuilder;
 import org.apache.pulsar.client.api.ConsumerCryptoFailureAction;
 import org.apache.pulsar.client.api.ConsumerEventListener;
+import org.apache.pulsar.client.api.ConsumerInterceptor;
 import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.MessageListener;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -52,6 +55,7 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
     private final PulsarClientImpl client;
     private ConsumerConfigurationData<T> conf;
     private final Schema<T> schema;
+    private List<ConsumerInterceptor<T>> interceptorList;
 
     private static long MIN_ACK_TIMEOUT_MILLIS = 1000;
 
@@ -104,8 +108,9 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
             return FutureUtil.failedFuture(
                     new InvalidConfigurationException("Subscription name must be set on the consumer builder"));
         }
-
-        return client.subscribeAsync(conf, schema);
+        return interceptorList == null || interceptorList.size() == 0 ?
+                client.subscribeAsync(conf, schema, null) :
+                client.subscribeAsync(conf, schema, new ConsumerInterceptors<>(interceptorList));
     }
 
     @Override
@@ -242,7 +247,16 @@ public class ConsumerBuilderImpl<T> implements ConsumerBuilder<T> {
 		return this;
 	}
 
-	public ConsumerConfigurationData<T> getConf() {
+    @Override
+    public ConsumerBuilder<T> intercept(ConsumerInterceptor<T>... interceptors) {
+        if (interceptorList == null) {
+            interceptorList = new ArrayList<>();
+        }
+        interceptorList.addAll(Arrays.asList(interceptors));
+        return this;
+    }
+
+    public ConsumerConfigurationData<T> getConf() {
 	    return conf;
 	}
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -141,14 +141,14 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
     }
 
     ConsumerImpl(PulsarClientImpl client, String topic, ConsumerConfigurationData<T> conf,
-            ExecutorService listenerExecutor, int partitionIndex, CompletableFuture<Consumer<T>> subscribeFuture, Schema<T> schema) {
-        this(client, topic, conf, listenerExecutor, partitionIndex, subscribeFuture, SubscriptionMode.Durable, null, schema);
+            ExecutorService listenerExecutor, int partitionIndex, CompletableFuture<Consumer<T>> subscribeFuture, Schema<T> schema, ConsumerInterceptors interceptors) {
+        this(client, topic, conf, listenerExecutor, partitionIndex, subscribeFuture, SubscriptionMode.Durable, null, schema, interceptors);
     }
 
     ConsumerImpl(PulsarClientImpl client, String topic, ConsumerConfigurationData<T> conf,
                  ExecutorService listenerExecutor, int partitionIndex, CompletableFuture<Consumer<T>> subscribeFuture,
-                 SubscriptionMode subscriptionMode, MessageId startMessageId, Schema<T> schema) {
-        super(client, topic, conf, conf.getReceiverQueueSize(), listenerExecutor, subscribeFuture, schema);
+                 SubscriptionMode subscriptionMode, MessageId startMessageId, Schema<T> schema, ConsumerInterceptors interceptors) {
+        super(client, topic, conf, conf.getReceiverQueueSize(), listenerExecutor, subscribeFuture, schema, interceptors);
         this.consumerId = client.newConsumerId();
         this.subscriptionMode = subscriptionMode;
         this.startMessageId = startMessageId != null ? new BatchMessageIdImpl((MessageIdImpl) startMessageId) : null;
@@ -259,8 +259,9 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         Message<T> message;
         try {
             message = incomingMessages.take();
-            messageProcessed(message);
-            return message;
+            Message<T> interceptMsg = beforeConsume(message);
+            messageProcessed(interceptMsg);
+            return interceptMsg;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             stats.incrementNumReceiveFailed();
@@ -289,8 +290,9 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         if (message == null && conf.getReceiverQueueSize() == 0) {
             sendFlowPermitsToBroker(cnx(), 1);
         } else if (message != null) {
-            messageProcessed(message);
-            result.complete(message);
+            Message<T> interceptMsg = beforeConsume(message);
+            messageProcessed(interceptMsg);
+            result.complete(interceptMsg);
         }
 
         return result;
@@ -348,10 +350,11 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
         Message<T> message;
         try {
             message = incomingMessages.poll(timeout, unit);
-            if (message != null) {
-                messageProcessed(message);
+            Message<T> interceptMsg = beforeConsume(message);
+            if (interceptMsg != null) {
+                messageProcessed(interceptMsg);
             }
-            return message;
+            return interceptMsg;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
 
@@ -833,9 +836,10 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
                         receivedFuture.complete(message);
                     } else {
                         // increase permits for available message-queue
-                        messageProcessed(message);
+                        Message<T> interceptMsg = beforeConsume(message);
+                        messageProcessed(interceptMsg);
                         // return message to receivedCallback
-                        listenerExecutor.execute(() -> receivedFuture.complete(message));
+                        listenerExecutor.execute(() -> receivedFuture.complete(interceptMsg));
                     }
                 }
             } else {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerInterceptors.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerInterceptors.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import org.apache.pulsar.client.api.ConsumerInterceptor;
+import org.apache.pulsar.client.api.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * A container that hold the list {@link org.apache.pulsar.client.api.ConsumerInterceptor} and wraps calls to the chain
+ * of custom interceptors.
+ */
+public class ConsumerInterceptors<T> implements Closeable {
+
+    private static final Logger log = LoggerFactory.getLogger(ConsumerInterceptors.class);
+
+    private final List<ConsumerInterceptor<T>> interceptors;
+
+    public ConsumerInterceptors(List<ConsumerInterceptor<T>> interceptors) {
+        this.interceptors = interceptors;
+    }
+
+    public Message<T> beforeConsume(Message<T> message) {
+        Message<T> interceptorMessage = message;
+        for (ConsumerInterceptor<T> interceptor : this.interceptors) {
+            try {
+                interceptorMessage = interceptor.beforeConsume(interceptorMessage);
+            } catch (Exception e) {
+                log.warn("Error executing interceptor beforeConsume callback ", e);
+            }
+        }
+        return interceptorMessage;
+    }
+
+    public void onAcknowledge(Message<T> message, Throwable cause) {
+        for (ConsumerInterceptor<T> interceptor : interceptors) {
+            try {
+                interceptor.onAcknowledge(message, cause);
+            } catch (Exception e) {
+                log.warn("Error executing interceptor onAcknowledge callback ", e);
+            }
+        }
+    }
+
+    public void onAcknowledgeCumulative(List<Message<T>> messages, Throwable cause) {
+        for (ConsumerInterceptor<T> interceptor : interceptors) {
+            try {
+                interceptor.onAcknowledgeCumulative(messages, cause);
+            } catch (Exception e) {
+                log.warn("Error executing interceptor onAcknowledgeCumulative callback ", e);
+            }
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.interceptors.forEach(interceptor -> {
+            try {
+                interceptor.close();
+            } catch (Exception e) {
+                log.error("Fail to close consumer interceptor ", e);
+            }
+        });
+    }
+
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerInterceptors.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerInterceptors.java
@@ -21,6 +21,7 @@ package org.apache.pulsar.client.impl;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerInterceptor;
 import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MessageListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,17 +74,17 @@ public class ConsumerInterceptors<T> implements Closeable {
     /**
      * This is called when acknowledge request return from the broker.
      * <p>
-     * This method calls {@link ConsumerInterceptor#onAcknowledge(Message, Throwable)} method for each interceptor.
+     * This method calls {@link ConsumerInterceptor#onAcknowledge(MessageId, Throwable)} method for each interceptor.
      * <p>
      * This method does not throw exceptions. Exceptions thrown by any of interceptors in the chain are logged, but not propagated.
      *
-     * @param message message to acknowledge.
+     * @param messageId message to acknowledge.
      * @param cause exception returned by broker.
      */
-    public void onAcknowledge(Message<T> message, Throwable cause) {
+    public void onAcknowledge(MessageId messageId, Throwable cause) {
         for (ConsumerInterceptor<T> interceptor : interceptors) {
             try {
-                interceptor.onAcknowledge(message, cause);
+                interceptor.onAcknowledge(messageId, cause);
             } catch (Exception e) {
                 log.warn("Error executing interceptor onAcknowledge callback ", e);
             }
@@ -93,17 +94,17 @@ public class ConsumerInterceptors<T> implements Closeable {
     /**
      * This is called when acknowledge cumulative request return from the broker.
      * <p>
-     * This method calls {@link ConsumerInterceptor#onAcknowledgeCumulative(List, Throwable)} (Message, Throwable)} method for each interceptor.
+     * This method calls {@link ConsumerInterceptor#onAcknowledgeCumulative(MessageId, Throwable)} (Message, Throwable)} method for each interceptor.
      * <p>
      * This method does not throw exceptions. Exceptions thrown by any of interceptors in the chain are logged, but not propagated.
      *
-     * @param messages messages to acknowledge.
+     * @param messageId messages to acknowledge.
      * @param cause exception returned by broker.
      */
-    public void onAcknowledgeCumulative(List<Message<T>> messages, Throwable cause) {
+    public void onAcknowledgeCumulative(MessageId messageId, Throwable cause) {
         for (ConsumerInterceptor<T> interceptor : interceptors) {
             try {
-                interceptor.onAcknowledgeCumulative(messages, cause);
+                interceptor.onAcknowledgeCumulative(messageId, cause);
             } catch (Exception e) {
                 log.warn("Error executing interceptor onAcknowledgeCumulative callback ", e);
             }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -240,7 +240,7 @@ public class MessageImpl<T> implements Message<T> {
         return null;
     }
 
-    ByteBuf getDataBuffer() {
+    public ByteBuf getDataBuffer() {
         return payload;
     }
 
@@ -273,7 +273,7 @@ public class MessageImpl<T> implements Message<T> {
         return properties.get(name);
     }
 
-    MessageMetadata.Builder getMessageBuilder() {
+    public MessageMetadata.Builder getMessageBuilder() {
         return msgMetadataBuilder;
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PartitionedProducerImpl.java
@@ -53,8 +53,8 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
     private final TopicMetadata topicMetadata;
 
     public PartitionedProducerImpl(PulsarClientImpl client, String topic, ProducerConfigurationData conf, int numPartitions,
-            CompletableFuture<Producer<T>> producerCreatedFuture, Schema<T> schema) {
-        super(client, topic, conf, producerCreatedFuture, schema);
+            CompletableFuture<Producer<T>> producerCreatedFuture, Schema<T> schema, ProducerInterceptors<T> interceptors) {
+        super(client, topic, conf, producerCreatedFuture, schema, interceptors);
         this.producers = Lists.newArrayListWithCapacity(numPartitions);
         this.topicMetadata = new TopicMetadataImpl(numPartitions);
         this.routerPolicy = getMessageRouter();
@@ -111,7 +111,7 @@ public class PartitionedProducerImpl<T> extends ProducerBase<T> {
         for (int partitionIndex = 0; partitionIndex < topicMetadata.numPartitions(); partitionIndex++) {
             String partitionName = TopicName.get(topic).getPartition(partitionIndex).toString();
             ProducerImpl<T> producer = new ProducerImpl<>(client, partitionName, conf, new CompletableFuture<>(),
-                    partitionIndex, schema);
+                    partitionIndex, schema, interceptors);
             producers.add(producer);
             producer.producerCreatedFuture().handle((prod, createException) -> {
                 if (createException != null) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PatternMultiTopicsConsumerImpl.java
@@ -51,8 +51,8 @@ public class PatternMultiTopicsConsumerImpl<T> extends MultiTopicsConsumerImpl<T
                                           ConsumerConfigurationData<T> conf,
                                           ExecutorService listenerExecutor,
                                           CompletableFuture<Consumer<T>> subscribeFuture,
-                                          Schema<T> schema) {
-        super(client, conf, listenerExecutor, subscribeFuture, schema);
+                                          Schema<T> schema, ConsumerInterceptors<T> interceptors) {
+        super(client, conf, listenerExecutor, subscribeFuture, schema, interceptors);
         this.topicsPattern = topicsPattern;
 
         if (this.namespaceName == null) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBase.java
@@ -36,13 +36,15 @@ public abstract class ProducerBase<T> extends HandlerState implements Producer<T
     protected final CompletableFuture<Producer<T>> producerCreatedFuture;
     protected final ProducerConfigurationData conf;
     protected final Schema<T> schema;
+    protected final ProducerInterceptors<T> interceptors;
 
     protected ProducerBase(PulsarClientImpl client, String topic, ProducerConfigurationData conf,
-            CompletableFuture<Producer<T>> producerCreatedFuture, Schema<T> schema) {
+            CompletableFuture<Producer<T>> producerCreatedFuture, Schema<T> schema, ProducerInterceptors<T> interceptors) {
         super(client, topic);
         this.producerCreatedFuture = producerCreatedFuture;
         this.conf = conf;
         this.schema = schema;
+        this.interceptors = interceptors;
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBase.java
@@ -150,6 +150,20 @@ public abstract class ProducerBase<T> extends HandlerState implements Producer<T
         return producerCreatedFuture;
     }
 
+    protected Message<T> callInterceptorsForBeforeSend(Message<T> message) {
+        if (interceptors != null) {
+            return interceptors.beforeSend(message);
+        } else {
+            return message;
+        }
+    }
+
+    protected void callInterceptorsForOnSendAcknowledgement(Message<T> message, MessageId msgId, Throwable cause) {
+        if (interceptors != null) {
+            interceptors.onSendAcknowledgement(message, msgId, cause);
+        }
+    }
+
     @Override
     public String toString() {
         return "ProducerBase{" + "topic='" + topic + '\'' + '}';

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBase.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBase.java
@@ -150,7 +150,7 @@ public abstract class ProducerBase<T> extends HandlerState implements Producer<T
         return producerCreatedFuture;
     }
 
-    protected Message<T> callInterceptorsForBeforeSend(Message<T> message) {
+    protected Message<T> beforeSend(Message<T> message) {
         if (interceptors != null) {
             return interceptors.beforeSend(message);
         } else {
@@ -158,7 +158,7 @@ public abstract class ProducerBase<T> extends HandlerState implements Producer<T
         }
     }
 
-    protected void callInterceptorsForOnSendAcknowledgement(Message<T> message, MessageId msgId, Throwable cause) {
+    protected void onSendAcknowledgement(Message<T> message, MessageId msgId, Throwable cause) {
         if (interceptors != null) {
             interceptors.onSendAcknowledgement(message, msgId, cause);
         }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
@@ -48,7 +48,6 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
         this.client = client;
         this.conf = conf;
         this.schema = schema;
-        this.interceptorList = new ArrayList<>();
     }
 
     @Override
@@ -80,7 +79,7 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
                     .failedFuture(new IllegalArgumentException("Topic name must be set on the producer builder"));
         }
 
-        return interceptorList.size() == 0 ?
+        return interceptorList == null || interceptorList.size() == 0 ?
                 client.createProducerAsync(conf, schema, null) :
                 client.createProducerAsync(conf, schema, new ProducerInterceptors<>(interceptorList));
     }
@@ -214,6 +213,9 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
 
     @Override
     public ProducerBuilder<T> intercept(ProducerInterceptor<T>... interceptors) {
+        if (interceptorList == null) {
+            interceptorList = new ArrayList<>();
+        }
         interceptorList.addAll(Arrays.asList(interceptors));
         return this;
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerBuilderImpl.java
@@ -18,21 +18,15 @@
  */
 package org.apache.pulsar.client.impl;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.pulsar.client.api.CompressionType;
-import org.apache.pulsar.client.api.CryptoKeyReader;
-import org.apache.pulsar.client.api.HashingScheme;
-import org.apache.pulsar.client.api.MessageRouter;
-import org.apache.pulsar.client.api.MessageRoutingMode;
-import org.apache.pulsar.client.api.Producer;
-import org.apache.pulsar.client.api.ProducerBuilder;
-import org.apache.pulsar.client.api.ProducerCryptoFailureAction;
-import org.apache.pulsar.client.api.PulsarClientException;
-import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.*;
 import org.apache.pulsar.client.impl.conf.ConfigurationDataUtils;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 import org.apache.pulsar.common.util.FutureUtil;
@@ -44,6 +38,7 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
     private final PulsarClientImpl client;
     private ProducerConfigurationData conf;
     private final Schema<T> schema;
+    private List<ProducerInterceptor<T>> interceptorList;
 
     ProducerBuilderImpl(PulsarClientImpl client, Schema<T> schema) {
         this(client, new ProducerConfigurationData(), schema);
@@ -53,6 +48,7 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
         this.client = client;
         this.conf = conf;
         this.schema = schema;
+        this.interceptorList = new ArrayList<>();
     }
 
     @Override
@@ -84,7 +80,9 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
                     .failedFuture(new IllegalArgumentException("Topic name must be set on the producer builder"));
         }
 
-        return client.createProducerAsync(conf, schema);
+        return interceptorList.size() == 0 ?
+                client.createProducerAsync(conf, schema, null) :
+                client.createProducerAsync(conf, schema, new ProducerInterceptors<>(interceptorList));
     }
 
     @Override
@@ -211,6 +209,12 @@ public class ProducerBuilderImpl<T> implements ProducerBuilder<T> {
     @Override
     public ProducerBuilder<T> properties(@NonNull Map<String, String> properties) {
         conf.getProperties().putAll(properties);
+        return this;
+    }
+
+    @Override
+    public ProducerBuilder<T> intercept(ProducerInterceptor<T>... interceptors) {
+        interceptorList.addAll(Arrays.asList(interceptors));
         return this;
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -207,7 +207,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
     @Override
     CompletableFuture<MessageId> internalSendAsync(Message<T> message) {CompletableFuture<MessageId> future = new CompletableFuture<>();
 
-        MessageImpl<T> interceptorMessage = (MessageImpl<T>) callInterceptorsForBeforeSend(message);
+        MessageImpl<T> interceptorMessage = (MessageImpl<T>) beforeSend(message);
         interceptorMessage.getDataBuffer().retain();
 
         sendAsync(interceptorMessage, new SendCallback() {
@@ -234,10 +234,10 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             public void sendComplete(Exception e) {
                 if (e != null) {
                     stats.incrementSendFailed();
-                    callInterceptorsForOnSendAcknowledgement(interceptorMessage, null, e);
+                    onSendAcknowledgement(interceptorMessage, null, e);
                     future.completeExceptionally(e);
                 } else {
-                    callInterceptorsForOnSendAcknowledgement(interceptorMessage, interceptorMessage.getMessageId(), null);
+                    onSendAcknowledgement(interceptorMessage, interceptorMessage.getMessageId(), null);
                     future.complete(interceptorMessage.getMessageId());
                     stats.incrementNumAcksReceived(System.nanoTime() - createdAt);
                 }
@@ -249,10 +249,10 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                     msg.getDataBuffer().retain();
                     if (e != null) {
                         stats.incrementSendFailed();
-                        callInterceptorsForOnSendAcknowledgement((Message<T>) msg, null, e);
+                        onSendAcknowledgement((Message<T>) msg, null, e);
                         sendCallback.getFuture().completeExceptionally(e);
                     } else {
-                        callInterceptorsForOnSendAcknowledgement((Message<T>) msg, msg.getMessageId(), null);
+                        onSendAcknowledgement((Message<T>) msg, msg.getMessageId(), null);
                         sendCallback.getFuture().complete(msg.getMessageId());
                         stats.incrementNumAcksReceived(System.nanoTime() - createdAt);
                     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -121,8 +121,9 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             .newUpdater(ProducerImpl.class, "msgIdGenerator");
 
     public ProducerImpl(PulsarClientImpl client, String topic, ProducerConfigurationData conf,
-                        CompletableFuture<Producer<T>> producerCreatedFuture, int partitionIndex, Schema<T> schema) {
-        super(client, topic, conf, producerCreatedFuture, schema);
+                        CompletableFuture<Producer<T>> producerCreatedFuture, int partitionIndex, Schema<T> schema,
+                        ProducerInterceptors<T> interceptors) {
+        super(client, topic, conf, producerCreatedFuture, schema, interceptors);
         this.producerId = client.newProducerId();
         this.producerName = conf.getProducerName();
         this.partitionIndex = partitionIndex;

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerInterceptors.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerInterceptors.java
@@ -60,7 +60,7 @@ public class ProducerInterceptors<T> implements Closeable {
         Message<T> interceptorMessage = message;
         for (ProducerInterceptor<T> interceptor : this.interceptors) {
             try {
-                interceptorMessage = interceptor.beforeSend(message);
+                interceptorMessage = interceptor.beforeSend(interceptorMessage);
             } catch (Exception e) {
                 if (message != null) {
                     log.warn("Error executing interceptor beforeSend callback for messageId: {}", message.getMessageId(), e);
@@ -80,7 +80,7 @@ public class ProducerInterceptors<T> implements Closeable {
      *
      * This method does not throw exceptions. Exceptions thrown by any of interceptor methods are caught and ignored.
      *
-     * @param message The message for producer that was send.
+     * @param message The message returned from the last interceptor is returned from {@link ProducerInterceptor#beforeSend(Message)}
      * @param msgId The message id that broker returned. Null if has error occurred.
      * @param cause The exception thrown during processing of this message. Null if no error occurred.
      */

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerInterceptors.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerInterceptors.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl;
+
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.ProducerInterceptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * A container that holds the list{@link org.apache.pulsar.client.api.ProducerInterceptor}
+ * and wraps calls to the chain of custom interceptors.
+ */
+public class ProducerInterceptors<T> implements Closeable {
+
+    private static final Logger log = LoggerFactory.getLogger(ProducerInterceptors.class);
+
+    private final List<ProducerInterceptor<T>> interceptors;
+
+    public ProducerInterceptors(List<ProducerInterceptor<T>> interceptors) {
+        this.interceptors = interceptors;
+    }
+
+    /**
+     * This is called when client sends message to pulsar broker, before key and value gets serialized.
+     * The method calls {@link ProducerInterceptor#beforeSend(Message)} method. Message returned from
+     * first interceptor's beforeSend() is passed to the second interceptor beforeSend(), and so on in the
+     * interceptor chain. The message returned from the last interceptor is returned from this method.
+     *
+     * This method does not throw exceptions. Exceptions thrown by any interceptor methods are caught and ignored.
+     * If a interceptor in the middle of the chain, that normally modifies the message, throws an exception,
+     * the next interceptor in the chain will be called with a message returned by the previous interceptor that did
+     * not throw an exception.
+     *
+     * @param message the message from client
+     * @return the message to send to topic/partition
+     */
+    public Message<T> beforeSend(Message<T> message) {
+        Message<T> interceptorMessage = message;
+        for (ProducerInterceptor<T> interceptor : this.interceptors) {
+            try {
+                interceptorMessage = interceptor.beforeSend(message);
+            } catch (Exception e) {
+                if (message != null) {
+                    log.warn("Error executing interceptor beforeSend callback for messageId: {}", message.getMessageId(), e);
+                } else {
+                    log.warn("Error Error executing interceptor beforeSend callback ", e);
+                }
+            }
+        }
+        return interceptorMessage;
+    }
+
+    /**
+     * This method is called when the message send to the broker has been acknowledged, or when sending the record fails
+     * before it gets send to the broker.
+     * This method calls {@link ProducerInterceptor#onSendAcknowledgement(Message, MessageId, Throwable)} method for
+     * each interceptor.
+     *
+     * This method does not throw exceptions. Exceptions thrown by any of interceptor methods are caught and ignored.
+     *
+     * @param message The message for producer that was send.
+     * @param msgId The message id that broker returned. Null if has error occurred.
+     * @param cause The exception thrown during processing of this message. Null if no error occurred.
+     */
+    public void onSendAcknowledgement(Message<T> message, MessageId msgId, Throwable cause) {
+        this.interceptors.forEach(interceptor -> {
+            try {
+                interceptor.onSendAcknowledgement(message, msgId, cause);
+            } catch (Exception e) {
+                log.warn("Error executing interceptor onSendAcknowledgement callback ", e);
+            }
+        });
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.interceptors.forEach(interceptor -> {
+            try {
+                interceptor.close();
+            } catch (Exception e) {
+                log.error("Fail to close producer interceptor ", e);
+            }
+        });
+    }
+}

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/PulsarClientImpl.java
@@ -234,10 +234,11 @@ public class PulsarClientImpl implements PulsarClient {
     }
 
     public CompletableFuture<Producer<byte[]>> createProducerAsync(ProducerConfigurationData conf) {
-        return createProducerAsync(conf, Schema.BYTES);
+        return createProducerAsync(conf, Schema.BYTES, null);
     }
 
-    public <T> CompletableFuture<Producer<T>> createProducerAsync(ProducerConfigurationData conf, Schema<T> schema) {
+    public <T> CompletableFuture<Producer<T>> createProducerAsync(ProducerConfigurationData conf, Schema<T> schema,
+          ProducerInterceptors<T> interceptors) {
         if (conf == null) {
             return FutureUtil.failedFuture(
                     new PulsarClientException.InvalidConfigurationException("Producer configuration undefined"));
@@ -264,9 +265,9 @@ public class PulsarClientImpl implements PulsarClient {
             ProducerBase<T> producer;
             if (metadata.partitions > 1) {
                 producer = new PartitionedProducerImpl<>(PulsarClientImpl.this, topic, conf, metadata.partitions,
-                        producerCreatedFuture, schema);
+                        producerCreatedFuture, schema, interceptors);
             } else {
-                producer = new ProducerImpl<>(PulsarClientImpl.this, topic, conf, producerCreatedFuture, -1, schema);
+                producer = new ProducerImpl<>(PulsarClientImpl.this, topic, conf, producerCreatedFuture, -1, schema, interceptors);
             }
 
             synchronized (producers) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ReaderImpl.java
@@ -85,7 +85,7 @@ public class ReaderImpl<T> implements Reader<T> {
 
         final int partitionIdx = TopicName.getPartitionIndex(readerConfiguration.getTopicName());
         consumer = new ConsumerImpl<>(client, readerConfiguration.getTopicName(), consumerConfiguration, listenerExecutor,
-                partitionIdx, consumerFuture, SubscriptionMode.NonDurable, readerConfiguration.getStartMessageId(), schema);
+                partitionIdx, consumerFuture, SubscriptionMode.NonDurable, readerConfiguration.getStartMessageId(), schema, null);
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageImpl.java
@@ -115,4 +115,8 @@ public class TopicMessageImpl<T> implements Message<T> {
     public Optional<EncryptionContext> getEncryptionCtx() {
         return msg.getEncryptionCtx();
     }
+
+    public Message<T> getMessage() {
+        return msg;
+    }
 }

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/producers/MultiConsumersOneOutputTopicProducersTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/producers/MultiConsumersOneOutputTopicProducersTest.java
@@ -18,12 +18,10 @@
  */
 package org.apache.pulsar.functions.instance.producers;
 
-import static org.apache.pulsar.functions.instance.producers.MultiConsumersOneOuputTopicProducers.makeProducerName;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
@@ -33,7 +31,18 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
-import org.apache.pulsar.client.api.*;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerBuilder;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.MessageRoutingMode;
+import org.apache.pulsar.client.api.HashingScheme;
+import org.apache.pulsar.client.api.CompressionType;
+import org.apache.pulsar.client.api.MessageRouter;
+import org.apache.pulsar.client.api.CryptoKeyReader;
+import org.apache.pulsar.client.api.ProducerCryptoFailureAction;
+import org.apache.pulsar.client.api.ProducerInterceptor;
+
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/producers/MultiConsumersOneOutputTopicProducersTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/producers/MultiConsumersOneOutputTopicProducersTest.java
@@ -33,16 +33,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.apache.bookkeeper.common.concurrent.FutureUtils;
-import org.apache.pulsar.client.api.CompressionType;
-import org.apache.pulsar.client.api.CryptoKeyReader;
-import org.apache.pulsar.client.api.HashingScheme;
-import org.apache.pulsar.client.api.MessageRouter;
-import org.apache.pulsar.client.api.MessageRoutingMode;
-import org.apache.pulsar.client.api.Producer;
-import org.apache.pulsar.client.api.ProducerBuilder;
-import org.apache.pulsar.client.api.ProducerCryptoFailureAction;
-import org.apache.pulsar.client.api.PulsarClient;
-import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.*;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -188,6 +179,11 @@ public class MultiConsumersOneOutputTopicProducersTest {
 
         @Override
         public ProducerBuilder<byte[]> properties(Map<String, String> properties) {
+            return this;
+        }
+
+        @Override
+        public ProducerBuilder<byte[]> intercept(ProducerInterceptor<byte[]>... interceptors) {
             return this;
         }
     }


### PR DESCRIPTION
### Motivation

Support user to add interceptors to producer and consumer.

### Modifications

Add Consumer interceptors.
```java
Message<T> beforeConsume(Message<T> message);
void onAcknowledge(MessageId messageId, Throwable cause);
void onAcknowledgeCumulative(MessageId messageId, Throwable cause);
```
Add Producer interceptors.
```java
Message<T> beforeSend(Message<T> message);
void onSendAcknowledgement(Message<T> message, MessageId msgId, Throwable cause);
```
### Result
Users can using interceptors in multiple scenarios, such as for applications to add
custom logging or processing.