### PR TITLE
Revert "Fix: Function assignment can support large number of topics (#2438)"

### DIFF
--- a/conf/functions_worker.yml
+++ b/conf/functions_worker.yml
@@ -27,7 +27,6 @@ connectorsDirectory: ./connectors
 functionMetadataTopicName: metadata
 clusterCoordinationTopicName: coordinate
 pulsarFunctionsNamespace: public/functions
-pulsarAssignmentNamespace: public/assignment
 pulsarFunctionsCluster: standalone
 pulsarServiceUrl: pulsar://localhost:6650
 pulsarWebServiceUrl: http://localhost:8080

--- a/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarSinkE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/io/PulsarSinkE2ETest.java
@@ -105,7 +105,6 @@ public class PulsarSinkE2ETest {
     WorkerService functionsWorkerService;
     final String tenant = "external-repl-prop";
     String pulsarFunctionsNamespace = tenant + "/use/pulsar-function-admin";
-    String pulsarAssignmentNamespace = tenant + "/use/pulsar-assignment";
     String primaryHost;
     String workerId;
 
@@ -213,7 +212,6 @@ public class PulsarSinkE2ETest {
     private WorkerService createPulsarFunctionWorker(ServiceConfiguration config) {
         workerConfig = new WorkerConfig();
         workerConfig.setPulsarFunctionsNamespace(pulsarFunctionsNamespace);
-        workerConfig.setPulsarAssignmentNamespace(pulsarAssignmentNamespace);
         workerConfig.setSchedulerClassName(
                 org.apache.pulsar.functions.worker.scheduler.RoundRobinScheduler.class.getName());
         workerConfig.setThreadContainerFactory(new WorkerConfig.ThreadContainerFactory().setThreadGroupName("use"));

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/MembershipManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/MembershipManager.java
@@ -21,7 +21,6 @@ package org.apache.pulsar.functions.worker;
 import com.google.common.annotations.VisibleForTesting;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -44,7 +43,6 @@ import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.ConsumerImpl;
 import org.apache.pulsar.common.policies.data.ConsumerStats;
-import org.apache.pulsar.common.policies.data.SubscriptionStats;
 import org.apache.pulsar.common.policies.data.TopicStats;
 import org.apache.pulsar.functions.proto.Function;
 import org.apache.pulsar.functions.utils.FunctionDetailsUtils;

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerConfig.java
@@ -61,7 +61,6 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
     private String pulsarWebServiceUrl;
     private String clusterCoordinationTopicName;
     private String pulsarFunctionsNamespace;
-    private String pulsarAssignmentNamespace;
     private String pulsarFunctionsCluster;
     private int numFunctionPackageReplicas;
     private String downloadDirectory;
@@ -134,7 +133,7 @@ public class WorkerConfig implements Serializable, PulsarConfiguration {
     }
 
     public String getFunctionAssignmentTopic() {
-        return String.format("persistent://%s/%s", pulsarAssignmentNamespace, functionAssignmentTopicName);
+        return String.format("persistent://%s/%s", pulsarFunctionsNamespace, functionAssignmentTopicName);
     }
 
     public static WorkerConfig load(String yamlFile) throws IOException {

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionRuntimeManagerTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/FunctionRuntimeManagerTest.java
@@ -20,16 +20,10 @@ package org.apache.pulsar.functions.worker;
 
 import org.apache.distributedlog.api.namespace.Namespace;
 import org.apache.pulsar.client.admin.PulsarAdmin;
-import org.apache.pulsar.client.api.ConsumerBuilder;
-import org.apache.pulsar.client.api.ConsumerEventListener;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClient;
-import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Reader;
 import org.apache.pulsar.client.api.ReaderBuilder;
-import org.apache.pulsar.client.api.SubscriptionType;
-import org.apache.pulsar.client.impl.ConsumerImpl;
-import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.functions.proto.Function;
 import org.apache.pulsar.functions.proto.InstanceCommunication;
 import org.apache.pulsar.functions.proto.Request;
@@ -51,7 +45,6 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class FunctionRuntimeManagerTest {
 
@@ -88,7 +81,7 @@ public class FunctionRuntimeManagerTest {
         workerConfig.setStateStorageServiceUrl("foo");
         workerConfig.setFunctionAssignmentTopicName("assignments");
 
-        PulsarClient pulsarClient = mockPulsarClient();
+        PulsarClient pulsarClient = mock(PulsarClient.class);
         ReaderBuilder readerBuilder = mock(ReaderBuilder.class);
         doReturn(readerBuilder).when(pulsarClient).newReader();
         doReturn(readerBuilder).when(readerBuilder).topic(anyString());
@@ -185,7 +178,7 @@ public class FunctionRuntimeManagerTest {
         workerConfig.setPulsarServiceUrl("pulsar://localhost:6650");
         workerConfig.setStateStorageServiceUrl("foo");
 
-        PulsarClient pulsarClient = mockPulsarClient();
+        PulsarClient pulsarClient = mock(PulsarClient.class);
         ReaderBuilder readerBuilder = mock(ReaderBuilder.class);
         doReturn(readerBuilder).when(pulsarClient).newReader();
         doReturn(readerBuilder).when(readerBuilder).topic(anyString());
@@ -286,7 +279,7 @@ public class FunctionRuntimeManagerTest {
         workerConfig.setPulsarServiceUrl("pulsar://localhost:6650");
         workerConfig.setStateStorageServiceUrl("foo");
 
-        PulsarClient pulsarClient = mockPulsarClient();
+        PulsarClient pulsarClient = mock(PulsarClient.class);
         ReaderBuilder readerBuilder = mock(ReaderBuilder.class);
         doReturn(readerBuilder).when(pulsarClient).newReader();
         doReturn(readerBuilder).when(readerBuilder).topic(anyString());
@@ -400,25 +393,5 @@ public class FunctionRuntimeManagerTest {
                 .get("worker-1").get("test-tenant/test-namespace/func-1:0"), assignment1);
         Assert.assertEquals(functionRuntimeManager.workerIdToAssignments
                 .get("worker-1").get("test-tenant/test-namespace/func-2:0"), assignment3);
-    }
-    
-    private static PulsarClient mockPulsarClient() throws PulsarClientException {
-        PulsarClientImpl mockClient = mock(PulsarClientImpl.class);
-
-        ConsumerImpl<byte[]> mockConsumer = mock(ConsumerImpl.class);
-        ConsumerBuilder<byte[]> mockConsumerBuilder = mock(ConsumerBuilder.class);
-
-        when(mockConsumerBuilder.topic(anyString())).thenReturn(mockConsumerBuilder);
-        when(mockConsumerBuilder.subscriptionName(anyString())).thenReturn(mockConsumerBuilder);
-        when(mockConsumerBuilder.subscriptionType(any(SubscriptionType.class))).thenReturn(mockConsumerBuilder);
-        when(mockConsumerBuilder.property(anyString(), anyString())).thenReturn(mockConsumerBuilder);
-
-        when(mockConsumerBuilder.subscribe()).thenReturn(mockConsumer);
-
-        when(mockConsumerBuilder.consumerEventListener(any(ConsumerEventListener.class))).thenReturn(mockConsumerBuilder);
-
-        when(mockClient.newConsumer()).thenReturn(mockConsumerBuilder);
-        
-        return mockClient;
     }
 }

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/MembershipManagerTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/MembershipManagerTest.java
@@ -76,6 +76,7 @@ public class MembershipManagerTest {
         when(mockConsumerBuilder.subscriptionName(anyString())).thenReturn(mockConsumerBuilder);
         when(mockConsumerBuilder.subscriptionType(any(SubscriptionType.class))).thenReturn(mockConsumerBuilder);
         when(mockConsumerBuilder.property(anyString(), anyString())).thenReturn(mockConsumerBuilder);
+
         when(mockConsumerBuilder.subscribe()).thenReturn(mockConsumer);
         WorkerService workerService = mock(WorkerService.class);
         doReturn(workerConfig).when(workerService).getWorkerConfig();
@@ -119,7 +120,7 @@ public class MembershipManagerTest {
         when(mockConsumerBuilder.consumerEventListener(any(ConsumerEventListener.class))).thenReturn(mockConsumerBuilder);
 
         when(mockClient.newConsumer()).thenReturn(mockConsumerBuilder);
-        
+
         return mockClient;
     }
 

--- a/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/SchedulerManagerTest.java
+++ b/pulsar-functions/worker/src/test/java/org/apache/pulsar/functions/worker/SchedulerManagerTest.java
@@ -111,7 +111,6 @@ public class SchedulerManagerTest {
 
         schedulerManager = spy(new SchedulerManager(workerConfig, pulsarClient));
         functionRuntimeManager = mock(FunctionRuntimeManager.class);
-        when(functionRuntimeManager.isInitialized()).thenReturn(true);
         functionMetaDataManager = mock(FunctionMetaDataManager.class);
         membershipManager = mock(MembershipManager.class);
         schedulerManager.setFunctionMetaDataManager(functionMetaDataManager);
@@ -146,7 +145,6 @@ public class SchedulerManagerTest {
 
         //set version
         doReturn(version).when(functionRuntimeManager).getCurrentAssignmentVersion();
-        doReturn(true).when(functionRuntimeManager).isInitialized();
 
         // single node
         List<WorkerInfo> workerInfoList = new LinkedList<>();
@@ -188,7 +186,6 @@ public class SchedulerManagerTest {
         assignmentEntry1.put(Utils.getFullyQualifiedInstanceId(assignment1.getInstance()), assignment1);
         currentAssignments.put("worker-1", assignmentEntry1);
         doReturn(currentAssignments).when(functionRuntimeManager).getCurrentAssignments();
-        doReturn(true).when(functionRuntimeManager).isInitialized();
 
         //set version
         doReturn(version).when(functionRuntimeManager).getCurrentAssignmentVersion();
@@ -245,7 +242,6 @@ public class SchedulerManagerTest {
         assignmentEntry1.put(Utils.getFullyQualifiedInstanceId(assignment1.getInstance()), assignment1);
         currentAssignments.put("worker-1", assignmentEntry1);
         doReturn(currentAssignments).when(functionRuntimeManager).getCurrentAssignments();
-        doReturn(true).when(functionRuntimeManager).isInitialized();
 
         //set version
         doReturn(version).when(functionRuntimeManager).getCurrentAssignmentVersion();
@@ -317,7 +313,6 @@ public class SchedulerManagerTest {
 
         currentAssignments.put("worker-1", assignmentEntry1);
         doReturn(currentAssignments).when(functionRuntimeManager).getCurrentAssignments();
-        doReturn(true).when(functionRuntimeManager).isInitialized();
 
         //set version
         doReturn(version).when(functionRuntimeManager).getCurrentAssignmentVersion();
@@ -377,7 +372,6 @@ public class SchedulerManagerTest {
 
         currentAssignments.put("worker-1", assignmentEntry1);
         doReturn(currentAssignments).when(functionRuntimeManager).getCurrentAssignments();
-        doReturn(true).when(functionRuntimeManager).isInitialized();
 
         //set version
         doReturn(version).when(functionRuntimeManager).getCurrentAssignmentVersion();
@@ -484,7 +478,6 @@ public class SchedulerManagerTest {
 
         currentAssignments.put("worker-1", assignmentEntry1);
         doReturn(currentAssignments).when(functionRuntimeManager).getCurrentAssignments();
-        doReturn(true).when(functionRuntimeManager).isInitialized();
 
         //set version
         doReturn(version).when(functionRuntimeManager).getCurrentAssignmentVersion();
@@ -653,7 +646,6 @@ public class SchedulerManagerTest {
 
         //set version
         doReturn(version).when(functionRuntimeManager).getCurrentAssignmentVersion();
-        doReturn(true).when(functionRuntimeManager).isInitialized();
 
         // single node
         List<WorkerInfo> workerInfoList = new LinkedList<>();


### PR DESCRIPTION
This reverts commit b283ebd3e51aa86f6b9f0a6607f430996f0032f7.

### Motivation

The commit broke master branch build.  There are a couple issues with the PR:

1. Didn't create namespace for new assignments topic in standalone mode
2. Caused non expected behavior in SchedulerManager:

12:34:10.207 [pool-49-thread-1] INFO  org.apache.pulsar.functions.worker.SchedulerManager - Waiting for assignments to propagate...
12:34:10.711 [pool-49-thread-1] INFO  org.apache.pulsar.functions.worker.SchedulerManager - Waiting for assignments to propagate...
12:34:11.214 [pool-49-thread-1] INFO  org.apache.pulsar.functions.worker.SchedulerManager - Waiting for assignments to propagate...
12:34:11.718 [pool-49-thread-1] INFO  org.apache.pulsar.functions.worker.SchedulerManager - Waiting for assignments to propagate...
12:34:12.223 [pool-49-thread-1] INFO  org.apache.pulsar.functions.worker.SchedulerManager - Waiting for assignments to propagate...
12:34:12.497 [pulsar-web-55-23] INFO  org.eclipse.jetty.server.RequestLog - 127.0.0.1 - - [29/Aug/2018:12:34:12 -0700] "GET //127.0.0.1:8080/admin/v2/persistent/public/functions/coordinate/stats HTTP/1.1" 200 795 "-" "Jersey/2.25 (HttpUrlConnection 1.8.0_144)" 3
12:34:12.728 [pool-49-thread-1] WARN  org.apache.pulsar.functions.worker.SchedulerManager - Max number of retries reached for waiting for assignment to propagate. Will continue now.


Lets revert this PR for now since it is making the master branch usable.  After we have addressed these issues we can decide on merging it back in