### PR TITLE
Allow to configure bookie settings when running in standalone mode

### DIFF
--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -420,3 +420,82 @@ exposePublisherStats=true
 # Deprecated. Use configurationStoreServers
 globalZookeeperServers=
 
+
+### --- BookKeeper Configuration --- #####
+
+ledgerStorageClass=org.apache.bookkeeper.bookie.storage.ldb.DbLedgerStorage
+
+# Size of Write Cache. Memory is allocated from JVM direct memory.
+# Write cache is used to buffer entries before flushing into the entry log
+# For good performance, it should be big enough to hold a sub
+dbStorage_writeCacheMaxSizeMb=256
+
+# Size of Read cache. Memory is allocated from JVM direct memory.
+# This read cache is pre-filled doing read-ahead whenever a cache miss happens
+dbStorage_readAheadCacheMaxSizeMb=64
+
+# How many entries to pre-fill in cache after a read cache miss
+dbStorage_readAheadCacheBatchSize=1000
+
+flushInterval=60000
+
+## RocksDB specific configurations
+## DbLedgerStorage uses RocksDB to store the indexes from
+## (ledgerId, entryId) -> (entryLog, offset)
+
+# Size of RocksDB block-cache. For best performance, this cache
+# should be big enough to hold a significant portion of the index
+# database which can reach ~2GB in some cases
+# Default is 16 MBytes
+dbStorage_rocksDB_blockCacheSize=16777216
+
+# Other RocksDB specific tunables
+dbStorage_rocksDB_writeBufferSizeMB=4
+dbStorage_rocksDB_sstSizeInMB=4
+dbStorage_rocksDB_blockSize=4096
+dbStorage_rocksDB_bloomFilterBitsPerKey=10
+dbStorage_rocksDB_numLevels=-1
+dbStorage_rocksDB_numFilesInLevel0=4
+dbStorage_rocksDB_maxSizeInLevel1MB=256
+
+# Maximum latency to impose on a journal write to achieve grouping
+journalMaxGroupWaitMSec=1
+
+# Should the data be fsynced on journal before acknowledgment.
+journalSyncData=false
+
+
+# For each ledger dir, maximum disk space which can be used.
+# Default is 0.95f. i.e. 95% of disk can be used at most after which nothing will
+# be written to that partition. If all ledger dir partions are full, then bookie
+# will turn to readonly mode if 'readOnlyModeEnabled=true' is set, else it will
+# shutdown.
+# Valid values should be in between 0 and 1 (exclusive).
+diskUsageThreshold=0.99
+
+# The disk free space low water mark threshold.
+# Disk is considered full when usage threshold is exceeded.
+# Disk returns back to non-full state when usage is below low water mark threshold.
+# This prevents it from going back and forth between these states frequently
+# when concurrent writes and compaction are happening. This also prevent bookie from
+# switching frequently between read-only and read-writes states in the same cases.
+diskUsageWarnThreshold=0.99
+
+# Whether the bookie allowed to use a loopback interface as its primary
+# interface(i.e. the interface it uses to establish its identity)?
+# By default, loopback interfaces are not allowed as the primary
+# interface.
+# Using a loopback interface as the primary interface usually indicates
+# a configuration error. For example, its fairly common in some VPS setups
+# to not configure a hostname, or to have the hostname resolve to
+# 127.0.0.1. If this is the case, then all bookies in the cluster will
+# establish their identities as 127.0.0.1:3181, and only one will be able
+# to join the cluster. For VPSs configured like this, you should explicitly
+# set the listening interface.
+allowLoopback=true
+
+# How long the interval to trigger next garbage collection, in milliseconds
+# Since garbage collection is running in background, too frequent gc
+# will heart performance. It is better to give a higher number of gc
+# interval if there is enough disk capacity.
+gcWaitTime=300000

--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarStandalone.java
@@ -21,6 +21,9 @@ package org.apache.pulsar;
 import com.beust.jcommander.Parameter;
 import com.ea.agentloader.AgentLoader;
 import com.google.common.collect.Sets;
+
+import org.apache.bookkeeper.conf.ServerConfiguration;
+import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.ServiceConfigurationUtils;
@@ -36,6 +39,7 @@ import org.aspectj.weaver.loadtime.Agent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.net.URL;
 import java.nio.file.Paths;
 import java.util.Optional;
@@ -251,11 +255,14 @@ public class PulsarStandalone implements AutoCloseable {
         AgentLoader.loadAgentClass(Agent.class.getName(), null);
 
         if (!this.isOnlyBroker()) {
+            ServerConfiguration bkServerConf = new ServerConfiguration();
+            bkServerConf.loadConf(new File(configFile).toURI().toURL());
+
             // Start LocalBookKeeper
             bkEnsemble = new LocalBookkeeperEnsemble(
                     this.getNumOfBk(), this.getZkPort(), this.getBkPort(), this.getStreamStoragePort(), this.getZkDir(),
                     this.getBkDir(), this.isWipeData(), "127.0.0.1");
-            bkEnsemble.startStandalone(!this.isNoStreamStorage());
+            bkEnsemble.startStandalone(bkServerConf, !this.isNoStreamStorage());
         }
 
         if (this.isNoBroker()) {


### PR DESCRIPTION
### Motivation

Most bookie configs are set in stone when running Pulsar in standalone mode.

We need to be able to tune these settings to have the Pulsar standalone to adapt for running with small memory settings.