### PR TITLE
Fix log4j conf

### DIFF
--- a/conf/log4j2.yaml
+++ b/conf/log4j2.yaml
@@ -35,10 +35,6 @@ Configuration:
         value: "info"
       - name: "pulsar.routing.appender.default"
         value: "Console"
-      - name: "bk.log.level"
-        value: "info"
-      - name: "bk.log.appender"
-        value: "BkRollingFile"
 
   # Example: logger-filter script
   Scripts:
@@ -82,34 +78,6 @@ Configuration:
             maxDepth: 2
             IfFileName:
               glob: "*/${sys:pulsar.log.file}*log.gz"
-            IfLastModified:
-              age: 30d
-
-    # Rolling file appender configuration for bk
-    RollingRandomAccessFile:
-      name: BkRollingFile
-      fileName: "${sys:pulsar.log.dir}/${sys:pulsar.log.file}.bk"
-      filePattern: "${sys:pulsar.log.dir}/${sys:pulsar.log.file}.bk-%d{MM-dd-yyyy}-%i.log.gz"
-      immediateFlush: true
-      PatternLayout:
-        Pattern: "%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"
-      Policies:
-        TimeBasedTriggeringPolicy:
-          interval: 1
-          modulate: true
-        SizeBasedTriggeringPolicy:
-          size: 1 GB
-        # Trigger every day at midnight that also scan
-        # roll-over strategy that deletes older file
-        CronTriggeringPolicy:
-          schedule: "0 0 0 * * ?"
-      # Delete file older than 30days
-      DefaultRolloverStrategy:
-          Delete:
-            basePath: ${sys:pulsar.log.dir}
-            maxDepth: 2
-            IfFileName:
-              glob: "*/${sys:pulsar.log.file}.bk*log.gz"
             IfLastModified:
               age: 30d
 
@@ -172,24 +140,6 @@ Configuration:
         additivity: false
         AppenderRef:
           - ref: Console
-
-      - name: org.apache.bookkeeper
-        level: "${sys:bk.log.level}"
-        additivity: false
-        AppenderRef:
-          - ref: "${sys:bk.log.appender}"
-
-      - name: org.apache.distributedlog
-        level: "${sys:bk.log.level}"
-        additivity: false
-        AppenderRef:
-          - ref: "${sys:bk.log.appender}"
-
-      - name: org.apache.zookeeper
-        level: "${sys:bk.log.level}"
-        additivity: false
-        AppenderRef:
-          - ref: "${sys:bk.log.appender}"
 
       - name: verbose
         level: info


### PR DESCRIPTION
### Motivation

Currently all `org.apache.bookkeeper` messages printed by broker are being routed to a different log file `broker.log.bk`. Removing for now the special config for BK logs.