### PR TITLE
Fixed the issue 2481 by not to take PULSAR_MEM from env.

### DIFF
--- a/conf/pulsar_tools_env.sh
+++ b/conf/pulsar_tools_env.sh
@@ -42,7 +42,7 @@
 # PULSAR_GLOBAL_ZK_CONF=
 
 # Extra options to be passed to the jvm
-PULSAR_MEM=${PULSAR_TOOLS_MEM:-"-Xmx128m -XX:MaxDirectMemorySize=128m"}
+PULSAR_MEM="-Xmx128m -XX:MaxDirectMemorySize=128m"
 
 # Garbage collection options
 PULSAR_GC=" -client "


### PR DESCRIPTION
### Motivation

Command `./bin/pulsar-admin clusters list` failed with `Error: Could not find or load main class "` in my k8s deployment by using helm charts.

### Modifications

With helm deployment the env var PULSAR_MEM is quoted with `"`, taking it for `pulsar-admin` will make the exec command to be:

```exec /docker-java-home/bin/java -cp '/pulsar/conf:::/pulsar/lib/*:' -Dlog4j.configurationFile=log4j2.yaml -Djava.net.preferIPv4Stack=true '"' -Xms1g -Xmx1g '-XX:MaxDirectMemorySize=1g"' -client -Dio.netty.leakDetectionLevel=disabled ... org.apache.pulsar.admin.cli.PulsarAdminTool /pulsar/conf/client.conf clusters list```

The fix is to take out the use of env var PULSAR_MEM in `conf/pulsar_tools_env.sh`.

### Result

`pulsar-admin` works as expected.

Fixes #2481