### PR TITLE
Ensure standalone service comes back quickly after ungraceful restarts

### DIFF
--- a/conf/standalone.conf
+++ b/conf/standalone.conf
@@ -320,6 +320,8 @@ autoSkipNonRecoverableData=false
 
 ### --- Load balancer --- ###
 
+loadManagerClassName=org.apache.pulsar.broker.loadbalance.NoopLoadManager
+
 # Enable load balancer
 loadBalancerEnabled=false
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/NoopLoadManager.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/NoopLoadManager.java
@@ -1,0 +1,158 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.loadbalance;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.bookkeeper.util.ZkUtils;
+import org.apache.pulsar.broker.PulsarServerException;
+import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.loadbalance.impl.PulsarResourceDescription;
+import org.apache.pulsar.broker.loadbalance.impl.SimpleResourceUnit;
+import org.apache.pulsar.common.naming.ServiceUnitId;
+import org.apache.pulsar.common.stats.Metrics;
+import org.apache.pulsar.common.util.ObjectMapperFactory;
+import org.apache.pulsar.policies.data.loadbalancer.LoadManagerReport;
+import org.apache.pulsar.policies.data.loadbalancer.LocalBrokerData;
+import org.apache.pulsar.policies.data.loadbalancer.ServiceLookupData;
+import org.apache.pulsar.zookeeper.ZooKeeperCache.Deserializer;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException.NoNodeException;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+
+public class NoopLoadManager implements LoadManager {
+
+    private String lookupServiceAddress;
+    private ResourceUnit localResourceUnit;
+    private ZooKeeper zkClient;
+
+    LocalBrokerData localData;
+
+    private static final Deserializer<LocalBrokerData> loadReportDeserializer = (key, content) -> ObjectMapperFactory
+            .getThreadLocal()
+            .readValue(content, LocalBrokerData.class);
+
+    @Override
+    public void initialize(PulsarService pulsar) {
+        lookupServiceAddress = pulsar.getAdvertisedAddress() + ":" + pulsar.getConfiguration().getWebServicePort();
+        localResourceUnit = new SimpleResourceUnit(String.format("http://%s", lookupServiceAddress),
+                new PulsarResourceDescription());
+        zkClient = pulsar.getZkClient();
+
+        localData = new LocalBrokerData(pulsar.getWebServiceAddress(), pulsar.getWebServiceAddressTls(),
+                pulsar.getBrokerServiceUrl(), pulsar.getBrokerServiceUrlTls());
+    }
+
+    @Override
+    public void start() throws PulsarServerException {
+        String brokerZnodePath = LoadManager.LOADBALANCE_BROKERS_ROOT + "/" + lookupServiceAddress;
+
+        try {
+            // When running in standalone, this error can happen when killing the "standalone" process
+            // ungracefully since the ZK session will not be closed and it will take some time for ZK server
+            // to prune the expired sessions after startup.
+            // Since there's a single broker instance running, it's safe, in this mode, to remove the old lock
+
+            // Delete and recreate z-node
+            try {
+                if (zkClient.exists(brokerZnodePath, null) != null) {
+                    zkClient.delete(brokerZnodePath, -1);
+                }
+            } catch (NoNodeException nne) {
+                // Ignore if z-node was just expired
+            }
+
+            ZkUtils.createFullPathOptimistic(zkClient, brokerZnodePath, localData.getJsonBytes(),
+                    ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
+
+        } catch (Exception e) {
+            throw new PulsarServerException(e);
+        }
+    }
+
+    @Override
+    public boolean isCentralized() {
+        return false;
+    }
+
+    @Override
+    public Optional<ResourceUnit> getLeastLoaded(ServiceUnitId su) throws Exception {
+        return Optional.of(localResourceUnit);
+    }
+
+    @Override
+    public LoadManagerReport generateLoadReport() throws Exception {
+        return null;
+    }
+
+    @Override
+    public Deserializer<? extends ServiceLookupData> getLoadReportDeserializer() {
+        return loadReportDeserializer;
+    }
+
+    @Override
+    public void setLoadReportForceUpdateFlag() {
+        // do nothing
+    }
+
+    @Override
+    public void writeLoadReportOnZookeeper() throws Exception {
+        // do nothing
+    }
+
+    @Override
+    public void writeResourceQuotasToZooKeeper() throws Exception {
+        // do nothing
+    }
+
+    @Override
+    public List<Metrics> getLoadBalancingMetrics() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void doLoadShedding() {
+        // do nothing
+    }
+
+    @Override
+    public void doNamespaceBundleSplit() throws Exception {
+        // do nothing
+    }
+
+    @Override
+    public void disableBroker() throws Exception {
+        // do nothing
+    }
+
+    @Override
+    public Set<String> getAvailableBrokers() throws Exception {
+        return Collections.singleton(lookupServiceAddress);
+    }
+
+    @Override
+    public void stop() throws PulsarServerException {
+        // do nothing
+    }
+
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -791,26 +791,10 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
             } catch (KeeperException.NodeExistsException e) {
                 long ownerZkSessionId = getBrokerZnodeOwner();
                 if (ownerZkSessionId != 0 && ownerZkSessionId != zkClient.getSessionId()) {
-                    if (conf.isRunningStandalone()) {
-                        // When running in standalone, this error can happen when killing the "standalone" process
-                        // ungracefully since the ZK session will not be closed and it will take some time for ZK server
-                        // to prune the expired sessions after startup.
-                        // Since there's a single broker instance running, it's safe, in this mode, to remove the old lock
-
-                        // Delete and recreate z-node
-                        try {
-                            zkClient.delete(brokerZnodePath, -1);
-                        } catch (NoNodeException nne) {
-                            // Ignore if z-node was just expired
-                        }
-                        ZkUtils.createFullPathOptimistic(zkClient, brokerZnodePath, localData.getJsonBytes(),
-                                ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
-                    } else {
-                        log.error("Broker znode - [{}] is own by different zookeeper-ssession {} ", brokerZnodePath,
-                                ownerZkSessionId);
-                        throw new PulsarServerException(
-                                "Broker-znode owned by different zk-session " + ownerZkSessionId);
-                    }
+                    log.error("Broker znode - [{}] is own by different zookeeper-ssession {} ", brokerZnodePath,
+                            ownerZkSessionId);
+                    throw new PulsarServerException(
+                            "Broker-znode owned by different zk-session " + ownerZkSessionId);
                 }
                 // Node may already be created by another load manager: in this case update the data.
                 zkClient.setData(brokerZnodePath, localData.getJsonBytes(), -1);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/ModularLoadManagerImpl.java
@@ -798,7 +798,11 @@ public class ModularLoadManagerImpl implements ModularLoadManager, ZooKeeperCach
                         // Since there's a single broker instance running, it's safe, in this mode, to remove the old lock
 
                         // Delete and recreate z-node
-                        zkClient.delete(brokerZnodePath, -1);
+                        try {
+                            zkClient.delete(brokerZnodePath, -1);
+                        } catch (NoNodeException nne) {
+                            // Ignore if z-node was just expired
+                        }
                         ZkUtils.createFullPathOptimistic(zkClient, brokerZnodePath, localData.getJsonBytes(),
                                 ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.EPHEMERAL);
                     } else {

--- a/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
+++ b/pulsar-zookeeper-utils/src/main/java/org/apache/pulsar/zookeeper/LocalBookkeeperEnsemble.java
@@ -222,9 +222,17 @@ public class LocalBookkeeperEnsemble {
                 cleanDirectory(bkDataDir);
             }
 
+            int bookiePort = initialPort + i;
+
+            // Ensure registration Z-nodes are cleared when standalone service is restarted ungracefully
+            String registrationZnode = String.format("/ledgers/available/%s:%d", baseConf.getAdvertisedAddress(), bookiePort);
+            if (zkc.exists(registrationZnode, null) != null) {
+                zkc.delete(registrationZnode, -1);
+            }
+
             bsConfs[i] = new ServerConfiguration(baseConf);
             // override settings
-            bsConfs[i].setBookiePort(initialPort + i);
+            bsConfs[i].setBookiePort(bookiePort);
             bsConfs[i].setZkServers("127.0.0.1:" + ZooKeeperDefaultPort);
             bsConfs[i].setJournalDirName(bkDataDir.getPath());
             bsConfs[i].setLedgerDirNames(new String[] { bkDataDir.getPath() });


### PR DESCRIPTION
### Motivation

After an ungraceful restart of Pulsar standalone, it might take few iterations of restart to get the service back up. 

This is due to the previous ZK sessions not being "expired". 

The main problem is that by having broker & zk combined the 2 behaviors clash:
  * Broker try to register z-node and finds it there from other session (and restart) — which is correct for a regular broker
  * ZK server doesn’t have the time to actually expire the session because broker exits immediately


### Modifications

In standalone mode, clear the registration z-nodes from the previous processes.