### PR TITLE
Fix: function worker startup with empty assignments

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/SchedulerManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/SchedulerManager.java
@@ -159,8 +159,11 @@ public class SchedulerManager implements AutoCloseable {
             log.debug("New assignments computed: {}", assignments);
         }
 
-        long assignmentVersion = this.functionRuntimeManager.getCurrentAssignmentVersion() + 1;
-        publishAssignmentUpdate(assignmentVersion, assignments);
+        long assignmentVersion = this.functionRuntimeManager.getCurrentAssignmentVersion();
+        if (!assignments.isEmpty()) {
+            assignmentVersion += 1;
+            publishAssignmentUpdate(assignmentVersion, assignments);
+        }
 
         // wait for assignment update to go throw the pipeline
         int retries = 0;


### PR DESCRIPTION
### Motivation

This will fix #2474, when function-worker startup stuck if worker has empty assignments. 
