### PR TITLE
Fix: auto-ack flag always set true

### DIFF
--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/CmdFunctionsTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/CmdFunctionsTest.java
@@ -200,6 +200,7 @@ public class CmdFunctionsTest {
             "--inputs", inputTopicName,
             "--output", outputTopicName,
             "--jar", "SomeJar.jar",
+            "--auto-ack", "false",
             "--tenant", "sample",
             "--namespace", "ns1",
             "--className", DummyFunction.class.getName(),
@@ -209,6 +210,7 @@ public class CmdFunctionsTest {
         assertEquals(fnName, creater.getFunctionName());
         assertEquals(inputTopicName, creater.getInputs());
         assertEquals(outputTopicName, creater.getOutput());
+        assertEquals(false, creater.isAutoAck());
 
         verify(functions, times(1)).createFunction(any(FunctionDetails.class), anyString());
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -311,8 +311,8 @@ public class CmdFunctions extends CmdBase {
         // for backwards compatibility purposes
         @Parameter(names = "--autoAck", description = "Whether or not the framework will automatically acknowleges messages", hidden = true)
         protected Boolean DEPRECATED_autoAck = null;
-        @Parameter(names = "--auto-ack", description = "Whether or not the framework will automatically acknowleges messages")
-        protected Boolean autoAck ;
+        @Parameter(names = "--auto-ack", description = "Whether or not the framework will automatically acknowleges messages", arity = 1)
+        protected boolean autoAck = true;
         // for backwards compatibility purposes
         @Parameter(names = "--timeoutMs", description = "The message timeout in milliseconds", hidden = true)
         protected Long DEPRECATED_timeoutMs;
@@ -451,11 +451,7 @@ public class CmdFunctions extends CmdBase {
 
             functionConfig.setWindowConfig(windowConfig);
 
-            if  (null != autoAck) {
-                functionConfig.setAutoAck(autoAck);
-            } else {
-                functionConfig.setAutoAck(true);
-            }
+            functionConfig.setAutoAck(autoAck);
 
             if (null != jarFile) {
                 functionConfig.setJar(jarFile);
@@ -570,7 +566,7 @@ public class CmdFunctions extends CmdBase {
                 WindowUtils.inferDefaultConfigs(windowConfig);
                 // set auto ack to false since windowing framework is responsible
                 // for acking and not the function framework
-                if (autoAck != null && autoAck == true) {
+                if (autoAck) {
                     throw new ParameterException("Cannot enable auto ack when using windowing functionality");
                 }
                 functionConfig.setAutoAck(false);


### PR DESCRIPTION
### Motivation

cli should have primitive boolean for any flag but it wasn't there for auto-ack because of that we were also setting auto-ack flag true. because of below logic

