### PR TITLE
Don't initialize /managed-ledgers on client creation (#2379)

### DIFF
--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/MetaStoreImplZookeeperTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/MetaStoreImplZookeeperTest.java
@@ -18,10 +18,13 @@
  */
 package org.apache.bookkeeper.mledger.impl;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.fail;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.bookkeeper.mledger.ManagedLedgerException.MetaStoreException;
 import org.apache.bookkeeper.mledger.impl.MetaStore.MetaStoreCallback;
@@ -31,6 +34,7 @@ import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedCursorInfo;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo;
 import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
 import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.Code;
 import org.apache.zookeeper.ZooDefs;
 import org.testng.annotations.Test;
@@ -213,5 +217,53 @@ public class MetaStoreImplZookeeperTest extends MockedBookKeeperTestCase {
         });
 
         latch.await();
+    }
+
+    @Test(timeOut = 20000)
+    public void createOptimisticBaseNotExist() throws Exception {
+        CompletableFuture<Void> promise = new CompletableFuture<>();
+        MetaStoreImplZookeeper.asyncCreateFullPathOptimistic(
+                zkc, "/foo", "bar/zar/gar", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT,
+                (rc, path, ctx, name) -> {
+                    if (rc != KeeperException.Code.OK.intValue()) {
+                        promise.completeExceptionally(KeeperException.create(rc));
+                    } else {
+                        promise.complete(null);
+                    }
+                });
+        try {
+            promise.get();
+            fail("should have failed");
+        } catch (ExecutionException ee) {
+            assertEquals(ee.getCause().getClass(), KeeperException.NoNodeException.class);
+        }
+    }
+
+    @Test(timeOut = 20000)
+    public void createOptimisticBaseExists() throws Exception {
+        zkc.create("/foo", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        CompletableFuture<Void> promise = new CompletableFuture<>();
+        MetaStoreImplZookeeper.asyncCreateFullPathOptimistic(
+                zkc, "/foo", "bar/zar/gar", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT,
+                (rc, path, ctx, name) -> {
+                    if (rc != KeeperException.Code.OK.intValue()) {
+                        promise.completeExceptionally(KeeperException.create(rc));
+                    } else {
+                        promise.complete(null);
+                    }
+                });
+        promise.get();
+
+        CompletableFuture<Void> promise2 = new CompletableFuture<>();
+        MetaStoreImplZookeeper.asyncCreateFullPathOptimistic(
+                zkc, "/foo", "blah", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT,
+                (rc, path, ctx, name) -> {
+                    if (rc != KeeperException.Code.OK.intValue()) {
+                        promise2.completeExceptionally(KeeperException.create(rc));
+                    } else {
+                        promise2.complete(null);
+                    }
+                });
+        promise2.get();
     }
 }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/test/BookKeeperClusterTestCase.java
@@ -47,7 +47,9 @@ import org.apache.bookkeeper.net.BookieSocketAddress;
 import org.apache.bookkeeper.proto.BookieServer;
 import org.apache.bookkeeper.replication.AutoRecoveryMain;
 import org.apache.commons.io.FileUtils;
+import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -97,6 +99,8 @@ public abstract class BookKeeperClusterTestCase {
             startZKCluster();
             // start bookkeeper service
             startBKCluster();
+
+            zkc.create("/managed-ledgers", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
         } catch (Exception e) {
             LOG.error("Error setting up", e);
             throw e;

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/test/MockedBookKeeperTestCase.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/test/MockedBookKeeperTestCase.java
@@ -28,7 +28,9 @@ import org.apache.bookkeeper.conf.ClientConfiguration;
 import org.apache.bookkeeper.mledger.ManagedLedgerFactoryConfig;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerFactoryImpl;
 import org.apache.bookkeeper.util.ZkUtils;
+import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.MockZooKeeper;
+import org.apache.zookeeper.ZooDefs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
@@ -79,6 +81,8 @@ public abstract class MockedBookKeeperTestCase {
 
         ManagedLedgerFactoryConfig conf = new ManagedLedgerFactoryConfig();
         factory = new ManagedLedgerFactoryImpl(bkc, zkc, conf);
+
+        zkc.create("/managed-ledgers", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
     }
 
     @AfterMethod


### PR DESCRIPTION
Normally the /managed-ledgers znode is created by the
initialize-cluster-metadata command when a cluster is being turned
up.

However, the ManagedLedger client also creates it on boot. This has
caused issues in the past, where if a broker is started before
initialize-cluster-metadata is run, then initialize-cluster-metadata
fails because it sees the /managed-ledger znode.

This patch removes the automatic creation of this znode from the
client boot process.
