### PR TITLE
Handle /managed-ledgers znode existence on cluster init (#2379)

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/PulsarClusterMetadataSetup.java
@@ -147,7 +147,12 @@ public class PulsarClusterMetadataSetup {
             }
         }
 
-        localZk.create("/managed-ledgers", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        try {
+            localZk.create("/managed-ledgers", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+        } catch (NodeExistsException e) {
+            // Ignore
+        }
+
         localZk.create("/namespace", new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
 
         try {


### PR DESCRIPTION
ManagedLedger clients may create the /managed-ledger znode on boot, so
if a broker starts before the metadata is initialized, it could
potentially block initialization.

This patch changes this by making the existence of /managed-ledger a
non-error condition.
