### PR TITLE
Use SigKill to kill python process as opposed to sigterm which can be caught

### DIFF
--- a/pulsar-functions/instance/src/main/python/python_instance.py
+++ b/pulsar-functions/instance/src/main/python/python_instance.py
@@ -148,7 +148,7 @@ class PythonInstance(object):
   def process_spawner_health_check_timer(self):
     if time.time() - self.last_health_check_ts > 90:
       Log.critical("Haven't received health check from spawner in a while. Stopping instance...")
-      os.kill(os.getpid(), signal.SIGTERM)
+      os.kill(os.getpid(), signal.SIGKILL)
       sys.exit(1)
 
     Timer(30, self.process_spawner_health_check_timer).start()


### PR DESCRIPTION

### Motivation

Explain here the context, and why you're making that change.
What is the problem you're trying to solve.

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
