### PR TITLE
Log and Return error-message on function-stats failure

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
@@ -360,12 +360,8 @@ public class FunctionsImpl {
             functionStatus = functionRuntimeManager.getFunctionInstanceStatus(tenant, namespace, functionName,
                     Integer.parseInt(instanceId));
         } catch (Exception e) {
-            log.error("Got Exception Getting Status", e);
-            FunctionStatus.Builder functionStatusBuilder = FunctionStatus.newBuilder();
-            functionStatusBuilder.setRunning(false);
-            String functionDetailsJson = org.apache.pulsar.functions.utils.Utils
-                    .printJson(functionStatusBuilder.build());
-            return Response.status(Status.OK).entity(functionDetailsJson).build();
+            log.error("{}/{}/{} Got Exception Getting Status", tenant, namespace, functionName, e);
+            return Response.status(Status.INTERNAL_SERVER_ERROR.getStatusCode(), e.getMessage()).build();
         }
 
         String jsonResponse = org.apache.pulsar.functions.utils.Utils.printJson(functionStatus);


### PR DESCRIPTION
### Motivation

Right now, for some-reason when get-function-status api call fails then , app-log doesn't log exception with function reference and it doesn't give correct failure-response code.

### Modifications

Fix error-logging and response code on function get status ap call.

