### PR TITLE
Typo in CSR generation docs (#2530)

### DIFF
--- a/site2/docs/security-tls-authentication.md
+++ b/site2/docs/security-tls-authentication.md
@@ -30,7 +30,7 @@ Generate the certificate request. When asked for a **common name**, enter the **
 
 ```bash
 $ openssl req -config openssl.cnf \
-      -key admin.key.pem -new -sha256 -out admin.cert.pem
+      -key admin.key.pem -new -sha256 -out admin.csr.pem
 ```
 
 Sign with request with the certificate authority. Note that that client certs uses the **usr_cert** extension, which allows the cert to be used for client authentication.

--- a/site2/docs/security-tls-transport.md
+++ b/site2/docs/security-tls-transport.md
@@ -96,7 +96,7 @@ Generate the certificate request...
 
 ```bash
 $ openssl req -config openssl.cnf \
-      -key broker.key.pem -new -sha256 -out broker.cert.pem
+      -key broker.key.pem -new -sha256 -out broker.csr.pem
 ```
 
 ... and sign it with the certificate authority.

--- a/site2/website/versioned_docs/version-2.1.0-incubating/security-tls-authentication.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/security-tls-authentication.md
@@ -31,7 +31,7 @@ Generate the certificate request. When asked for a **common name**, enter the **
 
 ```bash
 $ openssl req -config openssl.cnf \
-      -key admin.key.pem -new -sha256 -out admin.cert.pem
+      -key admin.key.pem -new -sha256 -out admin.csr.pem
 ```
 
 Sign with request with the certificate authority. Note that that client certs uses the **usr_cert** extension, which allows the cert to be used for client authentication.

--- a/site2/website/versioned_docs/version-2.1.0-incubating/security-tls-transport.md
+++ b/site2/website/versioned_docs/version-2.1.0-incubating/security-tls-transport.md
@@ -97,7 +97,7 @@ Generate the certificate request...
 
 ```bash
 $ openssl req -config openssl.cnf \
-      -key broker.key.pem -new -sha256 -out broker.cert.pem
+      -key broker.key.pem -new -sha256 -out broker.csr.pem
 ```
 
 ... and sign it with the certificate authority.


### PR DESCRIPTION
The output file for CSR generation was .cert.pem rather than .csr.pem,
which causes confusion. It should be .csr.pem
