### PR TITLE
When WindowConfig is set, automatically default autoAck to false

### DIFF
--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdFunctions.java
@@ -569,11 +569,6 @@ public class CmdFunctions extends CmdBase {
             WindowConfig windowConfig = functionConfig.getWindowConfig();
             if (windowConfig != null) {
                 WindowUtils.inferDefaultConfigs(windowConfig);
-                // set auto ack to false since windowing framework is responsible
-                // for acking and not the function framework
-                if (autoAck) {
-                    throw new ParameterException("Cannot enable auto ack when using windowing functionality");
-                }
                 functionConfig.setAutoAck(false);
             }
         }


### PR DESCRIPTION
### Motivation

We set the value of autoAck true by default. This is done so because users should not need to set another variable when executing regular simple functions. However for window functions, the window library does ack management by itself, which means autoAck should be set to false. However this means that for submitting windowing functions, users have to explicitly set autoAck to be false which is not the seemless experience. This pr automatically sets the autoAck to false for window functions

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
