### PR TITLE
set correct guice version to prevent dependency inject errors in docker container

### DIFF
--- a/pulsar-sql/presto-distribution/LICENSE
+++ b/pulsar-sql/presto-distribution/LICENSE
@@ -230,7 +230,7 @@ The Apache Software License, Version 2.0
     - guava-24.1-jre.jar
  * Google Guice
     - guice-4.2.0.jar
-    - guice-multibindings-4.0.jar
+    - guice-multibindings-4.2.0.jar
  * Apache Commons
     - commons-math3-3.6.1.jar
     - commons-beanutils-core-1.8.3.jar

--- a/pulsar-sql/presto-distribution/pom.xml
+++ b/pulsar-sql/presto-distribution/pom.xml
@@ -32,6 +32,7 @@
         <airlift.version>0.170</airlift.version>
         <objenesis.version>2.6</objenesis.version>
         <objectsize.version>0.0.12</objectsize.version>
+        <guice.version>4.2.0</guice.version>
         <!-- Launcher properties -->
         <main-class>com.facebook.presto.server.PrestoServer</main-class>
         <process-name>${project.artifactId}</process-name>
@@ -92,6 +93,13 @@
             <groupId>com.twitter.common</groupId>
             <artifactId>objectsize</artifactId>
             <version>${objectsize.version}</version>
+        </dependency>
+
+        <!-- make sure guice is set to the correct version -->
+        <dependency>
+            <groupId>com.google.inject.extensions</groupId>
+            <artifactId>guice-multibindings</artifactId>
+            <version>${guice.version}</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
### Motivation

Dependency injection errors are thrown while starting up in docker container when using an older version of guice-multibindings
