### PR TITLE
[schema] enable Schema.AUTO if functions or connectors are using GenericRecord

### DIFF
--- a/pulsar-functions/api-java/pom.xml
+++ b/pulsar-functions/api-java/pom.xml
@@ -38,6 +38,12 @@
     </dependency>
 
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-client-schema</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>net.jodah</groupId>
       <artifactId>typetools</artifactId>
       <scope>test</scope>

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
@@ -78,7 +78,7 @@ public class PulsarSource<T> extends PushSource<T> implements MessageListener<T>
         inputConsumers = configs.entrySet().stream().map(e -> {
             String topic = e.getKey();
             ConsumerConfig<T> conf = e.getValue();
-            log.info("Creating consumers for topic : {}",  topic);
+            log.info("Creating consumers for topic : {}, schema : {}",  topic, conf.getSchema());
             ConsumerBuilder<T> cb = pulsarClient.newConsumer(conf.getSchema())
                     // consume message even if can't decrypt and deliver it along with encryption-ctx
                     .cryptoFailureAction(ConsumerCryptoFailureAction.CONSUME)

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/TopicSchema.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/TopicSchema.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
 import org.apache.pulsar.client.impl.schema.AvroSchema;
 import org.apache.pulsar.client.impl.schema.JSONSchema;
@@ -68,24 +69,31 @@ public class TopicSchema {
     }
 
     public Schema<?> getSchema(String topic, Class<?> clazz, SchemaType schemaType) {
-        return cachedSchemas.computeIfAbsent(topic, t -> extractSchema(clazz, schemaType));
+        return cachedSchemas.computeIfAbsent(topic, t -> newSchemaInstance(clazz, schemaType));
     }
 
     /**
      * If the topic is already created, we should be able to fetch the schema type (avro, json, ...)
      */
     private SchemaType getSchemaTypeOrDefault(String topic, Class<?> clazz) {
-        Optional<SchemaInfo> schema = ((PulsarClientImpl) client).getSchema(topic).join();
-        if (schema.isPresent()) {
-            return schema.get().getType();
+        if (GenericRecord.class.isAssignableFrom(clazz)) {
+            return SchemaType.AUTO;
         } else {
-            return getDefaultSchemaType(clazz);
+            Optional<SchemaInfo> schema = ((PulsarClientImpl) client).getSchema(topic).join();
+            if (schema.isPresent()) {
+                return schema.get().getType();
+            } else {
+                return getDefaultSchemaType(clazz);
+            }
         }
     }
 
     private static SchemaType getDefaultSchemaType(Class<?> clazz) {
         if (byte[].class.equals(clazz)) {
             return SchemaType.NONE;
+        } else if (GenericRecord.class.isAssignableFrom(clazz)) {
+            // the function is taking generic record, so we do auto schema detection
+            return SchemaType.AUTO;
         } else if (String.class.equals(clazz)) {
             // If type is String, then we use schema type string, otherwise we fallback on default schema
             return SchemaType.STRING;
@@ -101,6 +109,9 @@ public class TopicSchema {
         switch (type) {
         case NONE:
             return (Schema<T>) Schema.BYTES;
+
+        case AUTO:
+            return (Schema<T>) Schema.AUTO();
 
         case STRING:
             return (Schema<T>) Schema.STRING;
@@ -163,29 +174,6 @@ public class TopicSchema {
             SerDe<T> serDe = (SerDe<T>) InstanceUtils.initializeSerDe(schemaTypeOrClassName,
                     Thread.currentThread().getContextClassLoader(), clazz, input);
             return new SerDeSchema<>(serDe);
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <T> Schema<T> extractSchema(Class<T> clazz, SchemaType type) {
-        switch (type) {
-        case NONE:
-            return (Schema<T>) Schema.BYTES;
-
-        case STRING:
-            return (Schema<T>) Schema.STRING;
-
-        case AVRO:
-            return AvroSchema.of(clazz);
-
-        case JSON:
-            return JSONSchema.of(clazz);
-
-        case PROTOBUF:
-            return ProtobufSchema.ofGenericClass(clazz, Collections.emptyMap());
-
-        default:
-            throw new RuntimeException("Unsupported schema type" + type);
         }
     }
 }

--- a/pulsar-functions/java-examples/pom.xml
+++ b/pulsar-functions/java-examples/pom.xml
@@ -42,11 +42,6 @@
       <version>${project.version}</version>
     </dependency>
 
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>pulsar-client-schema</artifactId>
-      <version>${project.version}</version>
-    </dependency>
   </dependencies>
 
 </project>

--- a/pulsar-functions/java-examples/pom.xml
+++ b/pulsar-functions/java-examples/pom.xml
@@ -41,6 +41,12 @@
       <artifactId>pulsar-functions-api</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>pulsar-client-schema</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
 </project>

--- a/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/AutoSchemaFunction.java
+++ b/pulsar-functions/java-examples/src/main/java/org/apache/pulsar/functions/api/examples/AutoSchemaFunction.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.functions.api.examples;
+
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.functions.api.Context;
+import org.apache.pulsar.functions.api.Function;
+
+/**
+ * Function that deals with Schema.Auto.
+ */
+public class AutoSchemaFunction implements Function<GenericRecord, String> {
+    @Override
+    public String process(GenericRecord input, Context context) {
+        return "value-" + input.getField("value");
+    }
+}

--- a/tests/integration/pom.xml
+++ b/tests/integration/pom.xml
@@ -46,6 +46,18 @@
     </dependency>
     <dependency>
       <groupId>org.apache.pulsar</groupId>
+      <artifactId>pulsar-functions-api-examples</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.pulsar</groupId>
+          <artifactId>pulsar-client-schema</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pulsar</groupId>
       <artifactId>pulsar-client</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>


### PR DESCRIPTION

### Motivation

For connectors like JDBC connector, we will be using `GenericRecord` for mapping individual fields to the sink destination. If a function or connector is programming using the `GenericRecord`, pulsar should use Schema.AUTO to detect schema automatically.

### Modifications

Enable `Schema.AUTO` in functions and connectors

### Result

We are able to use `GenericRecord` in functions and connectors.