### PR TITLE
Enable C++ AuthFactory to parse Athenz params string

### DIFF
--- a/pulsar-client-cpp/include/pulsar/Authentication.h
+++ b/pulsar-client-cpp/include/pulsar/Authentication.h
@@ -61,6 +61,7 @@ class Authentication {
         authDataContent = authData_;
         return ResultOk;
     }
+    static ParamMap parseDefaultFormatAuthParams(const std::string& authParamsString);
 
    protected:
     Authentication();
@@ -104,6 +105,7 @@ class AuthTls : public Authentication {
     AuthTls(AuthenticationDataPtr&);
     ~AuthTls();
     static AuthenticationPtr create(ParamMap& params);
+    static AuthenticationPtr create(const std::string& authParamsString);
     static AuthenticationPtr create(const std::string& certificatePath, const std::string& privateKeyPath);
     const std::string getAuthMethodName() const;
     Result getAuthData(AuthenticationDataPtr& authDataTls) const;

--- a/pulsar-client-cpp/lib/auth/AuthTls.cc
+++ b/pulsar-client-cpp/lib/auth/AuthTls.cc
@@ -36,6 +36,11 @@ AuthTls::AuthTls(AuthenticationDataPtr& authDataTls) { authDataTls_ = authDataTl
 
 AuthTls::~AuthTls() {}
 
+AuthenticationPtr AuthTls::create(const std::string& authParamsString) {
+    ParamMap params = parseDefaultFormatAuthParams(authParamsString);
+    return create(params);
+}
+
 AuthenticationPtr AuthTls::create(ParamMap& params) {
     return create(params["tlsCertFile"], params["tlsKeyFile"]);
 }

--- a/pulsar-client-cpp/tests/AuthPluginTest.cc
+++ b/pulsar-client-cpp/tests/AuthPluginTest.cc
@@ -234,3 +234,61 @@ TEST(AuthPluginTest, testDisable) {
     ASSERT_EQ(data->getCommandData(), "none");
     ASSERT_EQ(auth.use_count(), 1);
 }
+
+TEST(AuthPluginTest, testAuthFactoryTls) {
+    pulsar::AuthenticationDataPtr data;
+    std::string tlsCertFile = "../../pulsar-broker/src/test/resources/authentication/tls/client-cert.pem";
+    std::string tlsKeyFile = "../../pulsar-broker/src/test/resources/authentication/tls/client-key.pem";
+    AuthenticationPtr auth =
+        pulsar::AuthFactory::create("tls", "tlsCertFile:" + tlsCertFile + ",tlsKeyFile:" + tlsKeyFile);
+    ASSERT_EQ(auth->getAuthMethodName(), "tls");
+    ASSERT_EQ(auth->getAuthData(data), pulsar::ResultOk);
+    ASSERT_EQ(data->hasDataForTls(), true);
+    ASSERT_EQ(data->getTlsCertificates(), tlsCertFile);
+    ASSERT_EQ(data->getTlsPrivateKey(), tlsKeyFile);
+
+    ClientConfiguration config = ClientConfiguration();
+    config.setAuth(auth);
+    config.setTlsTrustCertsFilePath("../../pulsar-broker/src/test/resources/authentication/tls/cacert.pem");
+    config.setTlsAllowInsecureConnection(false);
+    Client client("pulsar+ssl://localhost:9886", config);
+
+    std::string topicName = "persistent://property/cluster/namespace/test-tls-factory";
+    Producer producer;
+    Promise<Result, Producer> producerPromise;
+    client.createProducerAsync(topicName, WaitForCallbackValue<Producer>(producerPromise));
+    Future<Result, Producer> producerFuture = producerPromise.getFuture();
+    Result result = producerFuture.get(producer);
+    ASSERT_EQ(ResultOk, result);
+}
+
+TEST(AuthPluginTest, testAuthFactoryAthenz) {
+    boost::thread zts(&testAthenz::mockZTS);
+    pulsar::AuthenticationDataPtr data;
+    std::string params = R"({
+        "tenantDomain": "pulsar.test.tenant",
+        "tenantService": "service",
+        "providerDomain": "pulsar.test.provider",
+        "privateKey": "file:../../pulsar-broker/src/test/resources/authentication/tls/client-key.pem",
+        "ztsUrl": "http://localhost:9999"
+    })";
+    pulsar::AuthenticationPtr auth = pulsar::AuthFactory::create("athenz", params);
+    ASSERT_EQ(auth->getAuthMethodName(), "athenz");
+    ASSERT_EQ(auth->getAuthData(data), pulsar::ResultOk);
+    ASSERT_EQ(data->hasDataForHttp(), true);
+    ASSERT_EQ(data->hasDataFromCommand(), true);
+    ASSERT_EQ(data->getHttpHeaders(), "Athenz-Role-Auth: mockToken");
+    ASSERT_EQ(data->getCommandData(), "mockToken");
+    zts.join();
+    std::vector<std::string> kvs;
+    boost::algorithm::split(kvs, testAthenz::principalToken, boost::is_any_of(";"));
+    for (std::vector<std::string>::iterator itr = kvs.begin(); itr != kvs.end(); itr++) {
+        std::vector<std::string> kv;
+        boost::algorithm::split(kv, *itr, boost::is_any_of("="));
+        if (kv[0] == "d") {
+            ASSERT_EQ(kv[1], "pulsar.test.tenant");
+        } else if (kv[0] == "n") {
+            ASSERT_EQ(kv[1], "service");
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

Currently, we can not create an Athenz authentication object using the following C++ method:
```cpp
AuthenticationPtr AuthFactory::create(const std::string& pluginNameOrDynamicLibPath, const std::string& authParamsString)
```
This is because the auth parameters is parsed as a format like `k1:v1,k2:v2`, not as json.
https://github.com/apache/incubator-pulsar/blob/a5c339b4e84d037e6739e70f8467b6d2d2486178/pulsar-client-cpp/lib/Authentication.cc#L114-L135

For this reason, python function can not connect to topic with Athenz authentication enabled.
https://github.com/apache/incubator-pulsar/blob/669196c27d3c2028a112d939774744dae8ab1b88/pulsar-functions/instance/src/main/python/python_instance_main.py#L90

### Modifications

Pass the auth parameters string as it is to AuthAthenz or AuthTls, and make those plugins parse the string.

### Result

We will be able to parse json format parameters correctly using AuthFactory.
This fix will enable python function to connect to broker using Athenz.