### PR TITLE
Enclose client_auth_params value in single quotes

### DIFF
--- a/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntime.java
+++ b/pulsar-functions/runtime/src/main/java/org/apache/pulsar/functions/runtime/ProcessRuntime.java
@@ -136,7 +136,7 @@ class ProcessRuntime implements Runtime {
                 args.add("--client_auth_plugin");
                 args.add(authConfig.getClientAuthenticationPlugin());
                 args.add("--client_auth_params");
-                args.add(authConfig.getClientAuthenticationParameters());
+                args.add("'" + authConfig.getClientAuthenticationParameters() + "'");
             }
             args.add("--use_tls");
             args.add(Boolean.toString(authConfig.isUseTls()));


### PR DESCRIPTION
### Motivation
Currently,  we can't specify json string to `clientAuthenticationParameters` in `functions_worker.yaml` because we can't pass it to`instance` correctly.
```
# functions_worker.yaml
clientAuthenticationPlugin: org.apache.pulsar.client.impl.auth.AuthenticationAthenz
clientAuthenticationParameters: '{"tenantDomain":"aa"....}'

# instance process
java -cp /path/to/java-instance.jar ...... --client_auth_params {"tenantDomain":"aa"....} --use_tls false ....
```


### Modifications
Enclose `client_auth_params` value in single quotes.
```
# process
java -cp /path/to/java-instance.jar ...... --client_auth_params '{"tenantDomain":"aa"....}' --use_tls false ....

```

### Result
 We can specify json string to `clientAuthenticationParameters` in `functions_worker.yaml` 