### PR TITLE
Fix status code of REST API to get partitioned topic stats

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -604,6 +604,12 @@ public class PersistentTopicsBase extends AdminResource {
                 stats.add(partitionStats);
                 stats.partitions.put(topicName.getPartition(i).toString(), partitionStats);
             }
+        } catch (PulsarAdminException e) {
+            if (e.getStatusCode() == Status.NOT_FOUND.getStatusCode()) {
+                throw new RestException(Status.NOT_FOUND, "Internal topics have not been generated yet");
+            } else {
+                throw new RestException(e);
+            }
         } catch (Exception e) {
             throw new RestException(e);
         }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiTest.java
@@ -53,6 +53,7 @@ import java.util.concurrent.TimeUnit;
 
 import javax.ws.rs.client.InvocationCallback;
 import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response.Status;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -786,6 +787,16 @@ public class AdminApiTest extends MockedPulsarServiceBaseTest {
 
         assertEquals(admin.topics().getPartitionedTopicMetadata("persistent://prop-xyz/ns1/ds2").partitions,
                 0);
+
+        try {
+            admin.topics().getPartitionedStats(partitionedTopicName, false);
+            fail("should have failed");
+        } catch (PulsarAdminException e) {
+            // ok
+            assertEquals(e.getStatusCode(), Status.NOT_FOUND.getStatusCode());
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
 
         // create consumer and subscription
         URL pulsarUrl = new URL("http://127.0.0.1" + ":" + BROKER_WEBSERVICE_PORT);


### PR DESCRIPTION
### Motivation

If trying to get stats of partitioned topic whose internal topics have not been generated, `500 Internal Server Error` is returned. I think that the status code in this case should be 404 rather than 500.

### Modifications

If broker has failed to get stats of the internal topics and its status code is 404, the broker returns 404 error to the client.

### Result

Appropriate error response will be returned to the client.