### PR TITLE
Stop all functions gracefully on closing worker-service

### DIFF
--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionRuntimeManager.java
@@ -403,6 +403,25 @@ public class FunctionRuntimeManager implements AutoCloseable{
         return Response.status(Status.OK).build();
     }
 
+    /**
+     * It stops all functions instances owned by current worker
+     * @throws Exception
+     */
+    public void stopAllOwnedFunctions() throws Exception {
+        final String workerId = this.workerConfig.getWorkerId();
+        Map<String, Assignment> assignments = workerIdToAssignments.get(workerId);
+        if (assignments != null) {
+            assignments.values().forEach(assignment -> {
+                String fullyQualifiedInstanceId = Utils.getFullyQualifiedInstanceId(assignment.getInstance());
+                try {
+                    stopFunction(fullyQualifiedInstanceId, false);
+                } catch (Exception e) {
+                    log.warn("Failed to stop function {} - {}", fullyQualifiedInstanceId, e.getMessage());
+                }
+            });
+        }
+    }
+
     private void stopFunction(String fullyQualifiedInstanceId, boolean restart) throws Exception {
         log.info("[{}] {}..", restart ? "restarting" : "stopping", fullyQualifiedInstanceId);
         FunctionRuntimeInfo functionRuntimeInfo = this.getFunctionRuntimeInfo(fullyQualifiedInstanceId);
@@ -658,6 +677,7 @@ public class FunctionRuntimeManager implements AutoCloseable{
 
     @Override
     public void close() throws Exception {
+        stopAllOwnedFunctions();
         this.functionActioner.close();
         this.functionAssignmentTailer.close();
         if (runtimeFactory != null) {


### PR DESCRIPTION
### Motivation

Right now, if stopping [WorkerService](https://github.com/apache/incubator-pulsar/blob/master/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/WorkerService.java#L189) doesn't stop functions and all the threads stayed alive event `WorkerService` is stopped.

### Modifications

Stop all function resource gracefully while stopping worker service.

### Result

Function threads will not stay alive while stopping worker-service.
