### PR TITLE
Remove property term from dashboard.

### DIFF
--- a/dashboard/django/stats/templates/stats/base.html
+++ b/dashboard/django/stats/templates/stats/base.html
@@ -50,7 +50,7 @@
         </div>
         {% block nav-global %}
             <h2> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-                <a href="{% url 'home' %}">Properties</a> &nbsp; | &nbsp;
+                <a href="{% url 'home' %}">Tenants</a> &nbsp; | &nbsp;
                 <a href="{% url 'brokers' %}">Brokers</a> &nbsp; | &nbsp;
                 <a href="{% url 'topics' %}">Topics</a> &nbsp; | &nbsp;
                 <a href="{% url 'clusters' %}">Clusters</a>

--- a/dashboard/django/stats/templates/stats/home.html
+++ b/dashboard/django/stats/templates/stats/home.html
@@ -30,7 +30,7 @@
 <table>
 <thead>
     <tr>
-        {% column_header properties 'name' 'Property' %}
+        {% column_header properties 'name' 'Tenant' %}
         {% column_header properties 'numNamespaces' 'Namespaces' %}
         {% column_header properties 'numTopics' 'Topics' %}
         {% column_header properties 'numProducers' 'Producers' %}
@@ -64,7 +64,7 @@
         <td>{{property.storage | filesizeformat}}</td>
     </tr>
 {% empty %}
-    <tr><td>No properties</td></tr>
+    <tr><td>No tenants</td></tr>
 {% endfor %}
 </tbody>
 </table>

--- a/dashboard/django/stats/views.py
+++ b/dashboard/django/stats/views.py
@@ -62,7 +62,7 @@ def home(request):
 
     return render(request, 'stats/home.html', {
         'properties': properties,
-        'title' : 'Properties',
+        'title' : 'Tenants',
     })
 
 def property(request, property_name):


### PR DESCRIPTION
This updates the html to display the new v2 naming.

### Motivation

This brings the dashboard up to date with the new v2 naming. Property/properties are now tenant/tenants.