### PR TITLE
[proxy][functions] Issue #2154: proxy should be able to forward rest requests to function workers cluster

### DIFF
--- a/conf/proxy.conf
+++ b/conf/proxy.conf
@@ -23,6 +23,11 @@ zookeeperServers=
 # Configuration store connection string (as a comma-separated list)
 configurationStoreServers=
 
+# If function workers are setup in a separate cluster, configure the following 2 settings
+# to point to the function workers cluster
+functionWorkerWebServiceURL=
+functionWorkerWebServiceURLTLS=
+
 # ZooKeeper session timeout (in milliseconds)
 zookeeperSessionTimeoutMs=30000
 

--- a/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
+++ b/pulsar-proxy/src/main/java/org/apache/pulsar/proxy/server/ProxyConfiguration.java
@@ -48,6 +48,10 @@ public class ProxyConfiguration implements PulsarConfiguration {
     private String brokerWebServiceURL;
     private String brokerWebServiceURLTLS;
 
+    // function worker web services
+    private String functionWorkerWebServiceURL;
+    private String functionWorkerWebServiceURLTLS;
+
     // Port to use to server binary-proto request
     private int servicePort = 6650;
     // Port to use to server binary-proto-tls request
@@ -156,6 +160,14 @@ public class ProxyConfiguration implements PulsarConfiguration {
 
     public void setBrokerWebServiceURLTLS(String brokerWebServiceURLTLS) {
         this.brokerWebServiceURLTLS = brokerWebServiceURLTLS;
+    }
+
+    public String getFunctionWorkerWebServiceURL() {
+        return functionWorkerWebServiceURL;
+    }
+
+    public String getFunctionWorkerWebServiceURLTLS() {
+        return functionWorkerWebServiceURLTLS;
     }
 
     public String getZookeeperServers() {


### PR DESCRIPTION
*Motivation*

Fixes #2154 

Function workers can be deployed as a separate cluster. If so, proxy is not able to forward the functions
related rest calls to the correct server.

*Changes*

Add two settings in proxy configuration to allow proxy configuring forwarding functions related rest calls
to function worker cluster.

*Tests*

Verified with changes in integration tests (manually). It is hard to add the integration tests based on
current integration tests. will add them in a separate PR.
