### PR TITLE
Change repository tag for test image

### DIFF
--- a/tests/docker-images/latest-version-image/pom.xml
+++ b/tests/docker-images/latest-version-image/pom.xml
@@ -68,13 +68,13 @@
                   <goal>tag</goal>
                 </goals>
                 <configuration>
-                  <repository>apachepulsar/pulsar-test-latest-version</repository>
+                  <repository>${docker.organization}/pulsar-test-latest-version</repository>
                   <tag>latest</tag>
                 </configuration>
               </execution>
             </executions>
             <configuration>
-              <repository>apachepulsar/pulsar-test-latest-version</repository>
+              <repository>${docker.organization}/pulsar-test-latest-version</repository>
               <tag>${project.version}</tag>
               <pullNewerImage>false</pullNewerImage>
               <noCache>true</noCache>


### PR DESCRIPTION
This uses the docker.organization property to tag the test image to make it consistent with other pom files