### PR TITLE
Shorten the timeout value of C++ ZTS client

### DIFF
--- a/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
+++ b/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
@@ -45,7 +45,7 @@ namespace pulsar {
 
 const static std::string DEFAULT_PRINCIPAL_HEADER = "Athenz-Principal-Auth";
 const static std::string DEFAULT_ROLE_HEADER = "Athenz-Role-Auth";
-const static int REQUEST_TIMEOUT = 10000;
+const static int REQUEST_TIMEOUT = 30000;
 const static int DEFAULT_TOKEN_EXPIRATION_TIME_SEC = 3600;
 const static int MIN_TOKEN_EXPIRATION_TIME_SEC = 900;
 const static int MAX_HTTP_REDIRECTS = 20;

--- a/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
+++ b/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc
@@ -272,7 +272,7 @@ const std::string ZTSClient::getRoleToken() const {
     curl_easy_setopt(handle, CURLOPT_NOSIGNAL, 1L);
 
     // Timer
-    curl_easy_setopt(handle, CURLOPT_TIMEOUT, REQUEST_TIMEOUT);
+    curl_easy_setopt(handle, CURLOPT_TIMEOUT_MS, REQUEST_TIMEOUT);
 
     // Redirects
     curl_easy_setopt(handle, CURLOPT_FOLLOWLOCATION, 1L);


### PR DESCRIPTION
Currently, C++ ZTS client waits 10000 seconds for a response from ZTS server even if there is no response. It is too long.
I think there is a mistake in specifying curl options. The second argument of `curl_easy_setopt()` should be `CURLOPT_TIMEOUT_MS`, not `CURLOPT_TIMEOUT`.
https://github.com/apache/incubator-pulsar/blob/8b2929b3e5403fb44653976dc74be287666f7b96/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc#L48
https://github.com/apache/incubator-pulsar/blob/8b2929b3e5403fb44653976dc74be287666f7b96/pulsar-client-cpp/lib/auth/athenz/ZTSClient.cc#L275