### PR TITLE
fix behavior of JSONSchema for derived classes

### DIFF
--- a/pulsar-client-schema/pom.xml
+++ b/pulsar-client-schema/pom.xml
@@ -70,6 +70,12 @@
             <artifactId>jackson-module-jsonSchema</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>${gson.version}</version>
+        </dependency>
+
         <!-- Testing dependencies -->
         <dependency>
             <groupId>org.apache.pulsar</groupId>

--- a/pulsar-client-schema/src/main/java/org/apache/pulsar/client/impl/schema/JSONSchema.java
+++ b/pulsar-client-schema/src/main/java/org/apache/pulsar/client/impl/schema/JSONSchema.java
@@ -22,13 +22,16 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
 import com.fasterxml.jackson.module.jsonSchema.JsonSchemaGenerator;
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import org.apache.avro.reflect.ReflectData;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SchemaSerializationException;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 
@@ -36,14 +39,24 @@ public class JSONSchema<T> implements Schema<T>{
 
     private final org.apache.avro.Schema schema;
     private final SchemaInfo schemaInfo;
-    private final ObjectMapper objectMapper;
+    private final Gson gson;
     private final Class<T> pojo;
     private Map<String, String> properties;
 
     private JSONSchema(Class<T> pojo, Map<String, String> properties) {
         this.pojo = pojo;
         this.properties = properties;
-        this.objectMapper = new ObjectMapper();
+        this.gson = new GsonBuilder().addSerializationExclusionStrategy(new ExclusionStrategy() {
+            @Override
+            public boolean shouldSkipField(FieldAttributes f) {
+                return !f.getDeclaringClass().equals(pojo);
+            }
+
+            @Override
+            public boolean shouldSkipClass(Class<?> clazz) {
+                return false;
+            }
+        }).create();
 
         this.schema = ReflectData.AllowNull.get().getSchema(pojo);
         this.schemaInfo = new SchemaInfo();
@@ -55,9 +68,10 @@ public class JSONSchema<T> implements Schema<T>{
 
     @Override
     public byte[] encode(T message) throws SchemaSerializationException {
+
         try {
-            return objectMapper.writeValueAsBytes(message);
-        } catch (JsonProcessingException e) {
+            return this.gson.toJson(message).getBytes();
+        } catch (RuntimeException e) {
             throw new SchemaSerializationException(e);
         }
     }
@@ -65,8 +79,8 @@ public class JSONSchema<T> implements Schema<T>{
     @Override
     public T decode(byte[] bytes) {
         try {
-            return objectMapper.readValue(new String(bytes), pojo);
-        } catch (IOException e) {
+            return this.gson.fromJson(new String(bytes), this.pojo);
+        } catch (RuntimeException e) {
             throw new RuntimeException(new SchemaSerializationException(e));
         }
     }
@@ -85,6 +99,7 @@ public class JSONSchema<T> implements Schema<T>{
     public SchemaInfo getBackwardsCompatibleJsonSchemaInfo() {
         SchemaInfo backwardsCompatibleSchemaInfo;
         try {
+            ObjectMapper objectMapper = new ObjectMapper();
             JsonSchemaGenerator schemaGen = new JsonSchemaGenerator(objectMapper);
             JsonSchema jsonBackwardsCompatibileSchema = schemaGen.generateSchema(pojo);
             backwardsCompatibleSchemaInfo = new SchemaInfo();

--- a/pulsar-client-schema/src/test/java/org/apache/pulsar/client/schema/JSONSchemaTest.java
+++ b/pulsar-client-schema/src/test/java/org/apache/pulsar/client/schema/JSONSchemaTest.java
@@ -40,6 +40,7 @@ public class JSONSchemaTest {
         Assert.assertEquals(jsonSchema.getSchemaInfo().getType(), SchemaType.JSON);
         Schema.Parser parser = new Schema.Parser();
         String schemaJson = new String(jsonSchema.getSchemaInfo().getSchema());
+        log.info("schemaJson: {}", schemaJson);
         Assert.assertEquals(schemaJson, SCHEMA_JSON);
         Schema schema = parser.parse(schemaJson);
 
@@ -64,6 +65,7 @@ public class JSONSchemaTest {
         foo1.setField1("foo1");
         foo1.setField2("bar1");
         foo1.setField4(bar);
+        foo1.setColor(SchemaTestUtils.Color.BLUE);
 
         Foo foo2 = new Foo();
         foo2.setField1("foo2");
@@ -84,7 +86,6 @@ public class JSONSchemaTest {
 
     @Test
     public void testCorrectPolymorphism() {
-        JSONSchema<Foo> jsonSchema = JSONSchema.of(Foo.class);
 
         Bar bar = new Bar();
         bar.setField1(true);
@@ -103,6 +104,34 @@ public class JSONSchemaTest {
         foo.setField3(4);
         foo.setField4(bar);
 
-        Assert.assertEquals(jsonSchema.decode(jsonSchema.encode(derivedFoo)), foo);
+        SchemaTestUtils.DerivedDerivedFoo derivedDerivedFoo = new SchemaTestUtils.DerivedDerivedFoo();
+        derivedDerivedFoo.setField1("foo1");
+        derivedDerivedFoo.setField2("bar2");
+        derivedDerivedFoo.setField3(4);
+        derivedDerivedFoo.setField4(bar);
+        derivedDerivedFoo.setField5("derived1");
+        derivedDerivedFoo.setField6(2);
+        derivedDerivedFoo.setFoo2(foo);
+        derivedDerivedFoo.setDerivedFoo(derivedFoo);
+
+        // schema for base class
+        JSONSchema<Foo> baseJsonSchema = JSONSchema.of(Foo.class);
+        Assert.assertEquals(baseJsonSchema.decode(baseJsonSchema.encode(foo)), foo);
+        Assert.assertEquals(baseJsonSchema.decode(baseJsonSchema.encode(derivedFoo)), foo);
+        Assert.assertEquals(baseJsonSchema.decode(baseJsonSchema.encode(derivedDerivedFoo)), foo);
+
+        // schema for derived class
+        JSONSchema<DerivedFoo> derivedJsonSchema = JSONSchema.of(DerivedFoo.class);
+        Assert.assertEquals(derivedJsonSchema.decode(derivedJsonSchema.encode(derivedFoo)), derivedFoo);
+        log.info("derivedJsonSchema.encode(derivedDerivedFoo)): {}", derivedJsonSchema.decode(derivedJsonSchema.encode(derivedDerivedFoo)));
+        Assert.assertEquals(derivedJsonSchema.decode(derivedJsonSchema.encode(derivedDerivedFoo)), derivedFoo);
+
+        //schema for derived derived class
+        JSONSchema<SchemaTestUtils.DerivedDerivedFoo> derivedDerivedJsonSchema
+                = JSONSchema.of(SchemaTestUtils.DerivedDerivedFoo.class);
+        Assert.assertEquals(derivedDerivedJsonSchema.decode(derivedDerivedJsonSchema.encode(derivedDerivedFoo)), derivedDerivedFoo);
+
+
+
     }
 }

--- a/pulsar-client-schema/src/test/java/org/apache/pulsar/client/schema/JSONSchemaTest.java
+++ b/pulsar-client-schema/src/test/java/org/apache/pulsar/client/schema/JSONSchemaTest.java
@@ -78,8 +78,6 @@ public class JSONSchemaTest {
         Foo object1 = jsonSchema.decode(bytes1);
         Foo object2 = jsonSchema.decode(bytes2);
 
-        log.info("object1: {}", object1);
-
         Assert.assertEquals(object1, foo1);
         Assert.assertEquals(object2, foo2);
     }

--- a/pulsar-client-schema/src/test/java/org/apache/pulsar/client/schema/JSONSchemaTest.java
+++ b/pulsar-client-schema/src/test/java/org/apache/pulsar/client/schema/JSONSchemaTest.java
@@ -88,10 +88,14 @@ public class JSONSchemaTest {
     public void testCorrectPolymorphism() {
         JSONSchema<Foo> jsonSchema = JSONSchema.of(Foo.class);
 
+        Bar bar = new Bar();
+        bar.setField1(true);
+
         DerivedFoo derivedFoo = new DerivedFoo();
         derivedFoo.setField1("foo1");
         derivedFoo.setField2("bar2");
         derivedFoo.setField3(4);
+        derivedFoo.setField4(bar);
         derivedFoo.setField5("derived1");
         derivedFoo.setField6(2);
 
@@ -99,6 +103,7 @@ public class JSONSchemaTest {
         foo.setField1("foo1");
         foo.setField2("bar2");
         foo.setField3(4);
+        foo.setField4(bar);
 
         Assert.assertEquals(jsonSchema.decode(jsonSchema.encode(derivedFoo)), foo);
     }

--- a/pulsar-client-schema/src/test/java/org/apache/pulsar/client/schema/JSONSchemaTest.java
+++ b/pulsar-client-schema/src/test/java/org/apache/pulsar/client/schema/JSONSchemaTest.java
@@ -18,16 +18,17 @@
  */
 package org.apache.pulsar.client.schema;
 
-import static org.apache.pulsar.client.schema.SchemaTestUtils.FOO_FIELDS;
-import static org.apache.pulsar.client.schema.SchemaTestUtils.SCHEMA_JSON;
-
 import org.apache.avro.Schema;
 import org.apache.pulsar.client.impl.schema.JSONSchema;
 import org.apache.pulsar.client.schema.SchemaTestUtils.Bar;
+import org.apache.pulsar.client.schema.SchemaTestUtils.DerivedFoo;
 import org.apache.pulsar.client.schema.SchemaTestUtils.Foo;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static org.apache.pulsar.client.schema.SchemaTestUtils.FOO_FIELDS;
+import static org.apache.pulsar.client.schema.SchemaTestUtils.SCHEMA_JSON;
 
 public class JSONSchemaTest {
 
@@ -74,5 +75,24 @@ public class JSONSchemaTest {
 
         Assert.assertEquals(object1, foo1);
         Assert.assertEquals(object2, foo2);
+    }
+
+    @Test
+    public void testCorrectPolymorphism() {
+        JSONSchema<Foo> jsonSchema = JSONSchema.of(Foo.class);
+
+        DerivedFoo derivedFoo = new DerivedFoo();
+        derivedFoo.setField1("foo1");
+        derivedFoo.setField2("bar2");
+        derivedFoo.setField3(4);
+        derivedFoo.setField5("derived1");
+        derivedFoo.setField6(2);
+
+        Foo foo = new Foo();
+        foo.setField1("foo1");
+        foo.setField2("bar2");
+        foo.setField3(4);
+
+        Assert.assertEquals(jsonSchema.decode(jsonSchema.encode(derivedFoo)), foo);
     }
 }

--- a/pulsar-client-schema/src/test/java/org/apache/pulsar/client/schema/JSONSchemaTest.java
+++ b/pulsar-client-schema/src/test/java/org/apache/pulsar/client/schema/JSONSchemaTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.schema;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.avro.Schema;
 import org.apache.pulsar.client.impl.schema.JSONSchema;
 import org.apache.pulsar.client.schema.SchemaTestUtils.Bar;
@@ -30,6 +31,7 @@ import org.testng.annotations.Test;
 import static org.apache.pulsar.client.schema.SchemaTestUtils.FOO_FIELDS;
 import static org.apache.pulsar.client.schema.SchemaTestUtils.SCHEMA_JSON;
 
+@Slf4j
 public class JSONSchemaTest {
 
     @Test
@@ -55,10 +57,13 @@ public class JSONSchemaTest {
     public void testEncodeAndDecode() {
         JSONSchema<Foo> jsonSchema = JSONSchema.of(Foo.class, null);
 
+        Bar bar = new Bar();
+        bar.setField1(true);
+
         Foo foo1 = new Foo();
         foo1.setField1("foo1");
         foo1.setField2("bar1");
-        foo1.setField4(new Bar());
+        foo1.setField4(bar);
 
         Foo foo2 = new Foo();
         foo2.setField1("foo2");
@@ -72,6 +77,8 @@ public class JSONSchemaTest {
 
         Foo object1 = jsonSchema.decode(bytes1);
         Foo object2 = jsonSchema.decode(bytes2);
+
+        log.info("object1: {}", object1);
 
         Assert.assertEquals(object1, foo1);
         Assert.assertEquals(object2, foo2);

--- a/pulsar-client-schema/src/test/java/org/apache/pulsar/client/schema/SchemaTestUtils.java
+++ b/pulsar-client-schema/src/test/java/org/apache/pulsar/client/schema/SchemaTestUtils.java
@@ -44,6 +44,14 @@ public class SchemaTestUtils {
         private boolean field1;
     }
 
+    @Data
+    @ToString
+    @EqualsAndHashCode
+    public static class DerivedFoo extends Foo {
+        private String field5;
+        private int field6;
+    }
+
     public static final String SCHEMA_JSON = "{\"type\":\"record\",\"name\":\"Foo\",\"namespace\":\"org.apache" +
             ".pulsar.client" +
             ".schema.SchemaTestUtils$\",\"fields\":[{\"name\":\"field1\",\"type\":[\"null\",\"string\"]," +

--- a/pulsar-client-schema/src/test/java/org/apache/pulsar/client/schema/SchemaTestUtils.java
+++ b/pulsar-client-schema/src/test/java/org/apache/pulsar/client/schema/SchemaTestUtils.java
@@ -35,6 +35,7 @@ public class SchemaTestUtils {
         private String field2;
         private int field3;
         private Bar field4;
+        private Color color;
     }
 
     @Data
@@ -50,20 +51,39 @@ public class SchemaTestUtils {
     public static class DerivedFoo extends Foo {
         private String field5;
         private int field6;
+        private Foo foo;
     }
 
-    public static final String SCHEMA_JSON = "{\"type\":\"record\",\"name\":\"Foo\",\"namespace\":\"org.apache" +
-            ".pulsar.client" +
-            ".schema.SchemaTestUtils$\",\"fields\":[{\"name\":\"field1\",\"type\":[\"null\",\"string\"]," +
-            "\"default\":null},{\"name\":\"field2\",\"type\":[\"null\",\"string\"],\"default\":null}," +
-            "{\"name\":\"field3\",\"type\":\"int\"},{\"name\":\"field4\",\"type\":[\"null\",{\"type\":\"record\"," +
-            "\"name\":\"Bar\",\"fields\":[{\"name\":\"field1\",\"type\":\"boolean\"}]}],\"default\":null}]}";
+    public enum  Color {
+        RED,
+        BLUE
+    }
+
+    @Data
+    @ToString
+    @EqualsAndHashCode
+    public static class DerivedDerivedFoo extends DerivedFoo {
+        private String field7;
+        private int field8;
+        private DerivedFoo derivedFoo;
+        private Foo foo2;
+    }
+
+    public static final String SCHEMA_JSON
+            = "{\"type\":\"record\",\"name\":\"Foo\",\"namespace\":\"org.apache.pulsar.client.schema" +
+            ".SchemaTestUtils$\",\"fields\":[{\"name\":\"field1\",\"type\":[\"null\",\"string\"],\"default\":null}," +
+            "{\"name\":\"field2\",\"type\":[\"null\",\"string\"],\"default\":null},{\"name\":\"field3\"," +
+            "\"type\":\"int\"},{\"name\":\"field4\",\"type\":[\"null\",{\"type\":\"record\",\"name\":\"Bar\"," +
+            "\"fields\":[{\"name\":\"field1\",\"type\":\"boolean\"}]}],\"default\":null},{\"name\":\"color\"," +
+            "\"type\":[\"null\",{\"type\":\"enum\",\"name\":\"Color\",\"symbols\":[\"RED\",\"BLUE\"]}]," +
+            "\"default\":null}]}";
 
     public static String[] FOO_FIELDS = {
             "field1",
             "field2",
             "field3",
-            "field4"
+            "field4",
+            "color"
     };
 
 }


### PR DESCRIPTION
### Motivation

Currently declaring a JSONSchema of a certain class and serializing a instance of a derived class does not produce the correct behavior