### PR TITLE
Preserve filename of the original function submission

### DIFF
--- a/pulsar-functions/proto/src/main/proto/Function.proto
+++ b/pulsar-functions/proto/src/main/proto/Function.proto
@@ -116,6 +116,7 @@ message SinkSpec {
 
 message PackageLocationMetaData {
     string packagePath = 1;
+    string originalFileName = 2;
 }
 
 message FunctionMetaData {

--- a/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionDetailsUtils.java
+++ b/pulsar-functions/utils/src/main/java/org/apache/pulsar/functions/utils/FunctionDetailsUtils.java
@@ -19,6 +19,8 @@
 
 package org.apache.pulsar.functions.utils;
 
+import org.apache.commons.lang.StringUtils;
+import org.apache.pulsar.functions.proto.Function;
 import org.apache.pulsar.functions.proto.Function.FunctionDetails;
 
 public class FunctionDetailsUtils {
@@ -43,7 +45,11 @@ public class FunctionDetailsUtils {
         return fullyQualifiedName.split("/")[2];
     }
 
-    public static String getDownloadFileName(FunctionDetails FunctionDetails) {
+    public static String getDownloadFileName(FunctionDetails FunctionDetails,
+                                             Function.PackageLocationMetaData packageLocation) {
+        if (!StringUtils.isEmpty(packageLocation.getOriginalFileName())) {
+            return packageLocation.getOriginalFileName();
+        }
         String[] hierarchy = FunctionDetails.getClassName().split("\\.");
         String fileName;
         if (hierarchy.length <= 0) {

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/FunctionActioner.java
@@ -156,7 +156,7 @@ public class FunctionActioner implements AutoCloseable {
 
             pkgFile = new File(
                     pkgDir,
-                    new File(FunctionDetailsUtils.getDownloadFileName(functionMetaData.getFunctionDetails())).getName());
+                    new File(FunctionDetailsUtils.getDownloadFileName(functionMetaData.getFunctionDetails(), functionMetaData.getPackageLocation())).getName());
             downloadFile(pkgFile, isPkgUrlProvided, functionMetaData, instanceId);
         }
 

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
@@ -170,6 +170,7 @@ public class FunctionsImpl {
         } else {
             packageLocationMetaDataBuilder.setPackagePath(isPkgUrlProvided ? functionPkgUrl
                     : createPackagePath(tenant, namespace, functionName, fileDetail.getFileName()));
+            packageLocationMetaDataBuilder.setOriginalFileName(fileDetail.getFileName());
         }
 
         functionMetaDataBuilder.setPackageLocation(packageLocationMetaDataBuilder);
@@ -234,6 +235,7 @@ public class FunctionsImpl {
         } else {
             packageLocationMetaDataBuilder.setPackagePath(isPkgUrlProvided ? functionPkgUrl
                     : createPackagePath(tenant, namespace, functionName, fileDetail.getFileName()));
+            packageLocationMetaDataBuilder.setOriginalFileName(fileDetail.getFileName());
         }
 
         functionMetaDataBuilder.setPackageLocation(packageLocationMetaDataBuilder);

--- a/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
+++ b/pulsar-functions/worker/src/main/java/org/apache/pulsar/functions/worker/rest/api/FunctionsImpl.java
@@ -170,7 +170,9 @@ public class FunctionsImpl {
         } else {
             packageLocationMetaDataBuilder.setPackagePath(isPkgUrlProvided ? functionPkgUrl
                     : createPackagePath(tenant, namespace, functionName, fileDetail.getFileName()));
-            packageLocationMetaDataBuilder.setOriginalFileName(fileDetail.getFileName());
+            if (!isPkgUrlProvided) {
+                packageLocationMetaDataBuilder.setOriginalFileName(fileDetail.getFileName());
+            }
         }
 
         functionMetaDataBuilder.setPackageLocation(packageLocationMetaDataBuilder);
@@ -235,7 +237,9 @@ public class FunctionsImpl {
         } else {
             packageLocationMetaDataBuilder.setPackagePath(isPkgUrlProvided ? functionPkgUrl
                     : createPackagePath(tenant, namespace, functionName, fileDetail.getFileName()));
-            packageLocationMetaDataBuilder.setOriginalFileName(fileDetail.getFileName());
+            if (!isPkgUrlProvided) {
+                packageLocationMetaDataBuilder.setOriginalFileName(fileDetail.getFileName());
+            }
         }
 
         functionMetaDataBuilder.setPackageLocation(packageLocationMetaDataBuilder);


### PR DESCRIPTION
### Motivation

When we submit a function, currently we don't note down the original filename that was uploaded from the client. For regular java functions this works fine. For python workers we manage by doing tricks wrt tricks like filename using classnames. However when we add things like wheel support, the filename encodes information that cannot be discarded away.
This pr preserves that filename

### Modifications

Describe the modifications you've done.

### Result

After your change, what will change.
