### PR TITLE
 [tests] Flaky Test ZooKeeperCacheTest#testChildrenCacheZnodeCreatedAfterCache

### DIFF
--- a/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZookeeperCacheTest.java
+++ b/pulsar-zookeeper-utils/src/test/java/org/apache/pulsar/zookeeper/ZookeeperCacheTest.java
@@ -25,6 +25,7 @@ import static org.testng.Assert.fail;
 import static org.testng.AssertJUnit.assertNotNull;
 import static org.testng.AssertJUnit.assertNull;
 
+import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
@@ -39,6 +40,8 @@ import org.apache.bookkeeper.common.util.OrderedScheduler;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.KeeperException.Code;
 import org.apache.zookeeper.MockZooKeeper;
+import org.apache.zookeeper.Op;
+import org.apache.zookeeper.OpResult;
 import org.apache.zookeeper.WatchedEvent;
 import org.apache.zookeeper.Watcher.Event;
 import org.apache.zookeeper.Watcher.Event.KeeperState;
@@ -201,8 +204,10 @@ public class ZookeeperCacheTest {
             // correct
         }
 
-        zkClient.create("/test", new byte[0], null, null);
-        zkClient.create("/test/z1", new byte[0], null, null);
+        List<OpResult> results = zkClient.multi(Lists.newArrayList(
+            Op.create("/test", new byte[0], null, null),
+            Op.create("/test/z1", new byte[0], null, null)
+        ));
 
         // Wait for cache to be updated in background
         while (notificationCount.get() < 1) {


### PR DESCRIPTION
*Motivation*

The problem is zookeeper watcher notification is non-deterministic. That says if you create N paths in zookeeper, you might receive
x notification. x is between 1 and N. so the test is written in a very non-deterministic way.

```
java.lang.AssertionError: expected [1] but found [2]
	at org.testng.Assert.fail(Assert.java:96)
	at org.testng.Assert.failNotEquals(Assert.java:776)
	at org.testng.Assert.assertEqualsImpl(Assert.java:137)
	at org.testng.Assert.assertEquals(Assert.java:118)
	at org.testng.Assert.assertEquals(Assert.java:652)
	at org.testng.Assert.assertEquals(Assert.java:662)
	at org.apache.pulsar.zookeeper.ZookeeperCacheTest.testChildrenCacheZnodeCreatedAfterCache(ZookeeperCacheTest.java:214)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:124)
	at org.testng.internal.InvokeMethodRunnable.runOne(InvokeMethodRunnable.java:54)
	at org.testng.internal.InvokeMethodRunnable.run(InvokeMethodRunnable.java:44)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

*Changes*

rewrite the test to make it more robust.