### PR TITLE
[java-client] Issue #2384: ConnectionHandler: Log stack trace instead of printing

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionHandler.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConnectionHandler.java
@@ -71,7 +71,6 @@ class ConnectionHandler {
     }
 
     private Void handleConnectionError(Throwable exception) {
-        exception.printStackTrace();
         log.warn("[{}] [{}] Error connecting to broker: {}", state.topic, state.getHandlerName(), exception.getMessage());
         connection.connectionFailed(new PulsarClientException(exception));
 


### PR DESCRIPTION

*Motivation*

Fixes #2384.

The pulsar java client is currently very noisy in case of connection loss and it cannot be muted, as the stack trace is printed with .printStackTrace(). Moving this to the logging system will allow developers to configure this behavior.

*Changes*

Remove `printStackTrace`.

