### PR TITLE
Enforce boost-python was found by CMake

### DIFF
--- a/pulsar-client-cpp/docker/build-wheels.sh
+++ b/pulsar-client-cpp/docker/build-wheels.sh
@@ -33,6 +33,7 @@ PYTHON_VERSIONS=(
    '3.4 cp34-cp34m'
    '3.5 cp35-cp35m'
    '3.6 cp36-cp36m'
+   '3.7 cp37-cp37m'
 )
 
 function contains() {

--- a/pulsar-client-cpp/python/CMakeLists.txt
+++ b/pulsar-client-cpp/python/CMakeLists.txt
@@ -46,14 +46,18 @@ endif()
 
 # Try all possible boost-python variable namings
 set(PYTHON_WRAPPER_LIBS ${Boost_PYTHON_LIBRARY} ${Boost_PYTHON3_LIBRARY}
-                        ${Boost_PYTHON27-MT_LIBRARY} ${Boost_PYTHON37-MT_LIBRARY}
-                        ${Boost_PYTHON27-MT_LIBRARY_RELEASE} ${Boost_PYTHON37-MT_LIBRARY_RELEASE})
+                        ${Boost_PYTHON27-MT_LIBRARY} ${Boost_PYTHON37-MT_LIBRARY})
+
+if (APPLE)
+    set(PYTHON_WRAPPER_LIBS ${PYTHON_WRAPPER_LIBS}
+                         ${Boost_PYTHON27-MT_LIBRARY_RELEASE} ${Boost_PYTHON37-MT_LIBRARY_RELEASE})
+endif()
+
+message(STATUS "Using Boost Python libs: ${PYTHON_WRAPPER_LIBS}")
 
 if (NOT PYTHON_WRAPPER_LIBS)
     MESSAGE(FATAL_ERROR "Could not find Boost Python library")
 endif ()
-
-message(STATUS "Using Boost Python libs: ${PYTHON_WRAPPER_LIBS}")
 
 if (APPLE)
     target_link_libraries(_pulsar -Wl,-all_load pulsarStatic ${PYTHON_WRAPPER_LIBS})

--- a/pulsar-client-cpp/python/CMakeLists.txt
+++ b/pulsar-client-cpp/python/CMakeLists.txt
@@ -46,7 +46,12 @@ endif()
 
 # Try all possible boost-python variable namings
 set(PYTHON_WRAPPER_LIBS ${Boost_PYTHON_LIBRARY} ${Boost_PYTHON3_LIBRARY}
-                        ${Boost_PYTHON27-MT_LIBRARY} ${Boost_PYTHON37-MT_LIBRARY})
+                        ${Boost_PYTHON27-MT_LIBRARY} ${Boost_PYTHON37-MT_LIBRARY}
+                        ${Boost_PYTHON27-MT_LIBRARY_RELEASE} ${Boost_PYTHON37-MT_LIBRARY_RELEASE})
+
+if (NOT PYTHON_WRAPPER_LIBS)
+    MESSAGE(FATAL_ERROR "Could not find Boost Python library")
+endif ()
 
 message(STATUS "Using Boost Python libs: ${PYTHON_WRAPPER_LIBS}")
 


### PR DESCRIPTION
### Motivation

Ensure the CMake preparation fails when the correct Boost-Python library is not found. With the current behavior, the build goes through even when not found, and then the resulting `_pulsar.so` will not be linked with boost-python and will fail to load at runtime.