### PR TITLE
Prepare website for future releases without '-incubating' suffix

### DIFF
--- a/site2/website/pages/en/download.js
+++ b/site2/website/pages/en/download.js
@@ -28,16 +28,13 @@ function archiveUrl(version, type) {
 
 class Download extends React.Component {
   render() {
-    const latestRelease = releases[0];
-
-    const latestVersion = `${latestRelease}-incubating`
+    const latestVersion = releases[0];
     const latestArchiveMirrorUrl = getLatestArchiveMirrorUrl(latestVersion, 'bin');
     const latestSrcArchiveMirrorUrl = getLatestArchiveMirrorUrl(latestVersion, 'src');
     const latestArchiveUrl = distUrl(latestVersion, 'bin');
     const latestSrcArchiveUrl = distUrl(latestVersion, 'src')
 
-    const releaseInfo = releases.map(r => {
-      const version = `${r}-incubating`;
+    const releaseInfo = releases.map(version => {
       return {
         version: version,
         binArchiveUrl: archiveUrl(version, 'bin'),

--- a/site2/website/releases.json
+++ b/site2/website/releases.json
@@ -1,10 +1,10 @@
 [
-  "2.1.1",
-  "2.1.0",
-  "2.0.1",
-  "1.22.1",
-  "1.22.0",
-  "1.21.0",
-  "1.20.0",
-  "1.19.0"
+  "2.1.1-incubating",
+  "2.1.0-incubating",
+  "2.0.1-incubating",
+  "1.22.1-incubating",
+  "1.22.0-incubating",
+  "1.21.0-incubating",
+  "1.20.0-incubating",
+  "1.19.0-incubating"
 ]


### PR DESCRIPTION
### Motivation

The `-incubating` suffix is a property of a particular release. We shouldn't add it to all releases in the download page. 