### PR TITLE
[schema] Add ByteBuf schema and fix ByteBuffer schema

### DIFF
--- a/pulsar-client-schema/src/main/java/org/apache/pulsar/client/impl/schema/ByteBufSchema.java
+++ b/pulsar-client-schema/src/main/java/org/apache/pulsar/client/impl/schema/ByteBufSchema.java
@@ -18,53 +18,43 @@
  */
 package org.apache.pulsar.client.impl.schema;
 
-import java.nio.ByteBuffer;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 
 /**
- * A bytebuffer schema is effectively a `BYTES` schema.
+ * A variant `Bytes` schema that takes {@link io.netty.buffer.ByteBuf}.
  */
-public class ByteBufferSchema implements Schema<ByteBuffer> {
+public class ByteBufSchema implements Schema<ByteBuf> {
 
-    public static ByteBufferSchema of() {
+    public static ByteBufSchema of() {
         return INSTANCE;
     }
 
-    private static final ByteBufferSchema INSTANCE = new ByteBufferSchema();
+    private static final ByteBufSchema INSTANCE = new ByteBufSchema();
     private static final SchemaInfo SCHEMA_INFO = new SchemaInfo()
-        .setName("ByteBuffer")
+        .setName("ByteBuf")
         .setType(SchemaType.BYTES)
         .setSchema(new byte[0]);
 
     @Override
-    public byte[] encode(ByteBuffer data) {
-        if (data == null) {
+    public byte[] encode(ByteBuf message) {
+        if (message == null) {
             return null;
         }
 
-        data.rewind();
-
-        if (data.hasArray()) {
-            byte[] arr = data.array();
-            if (data.arrayOffset() == 0 && arr.length == data.remaining()) {
-                return arr;
-            }
-        }
-
-        byte[] ret = new byte[data.remaining()];
-        data.get(ret, 0, ret.length);
-        data.rewind();
-        return ret;
+        return ByteBufUtil.getBytes(message);
     }
 
     @Override
-    public ByteBuffer decode(byte[] data) {
-        if (null == data) {
+    public ByteBuf decode(byte[] bytes) {
+        if (null == bytes) {
             return null;
         } else {
-            return ByteBuffer.wrap(data);
+            return Unpooled.wrappedBuffer(bytes);
         }
     }
 

--- a/pulsar-client-schema/src/test/java/org/apache/pulsar/client/schema/PrimitiveSchemaTest.java
+++ b/pulsar-client-schema/src/test/java/org/apache/pulsar/client/schema/PrimitiveSchemaTest.java
@@ -18,9 +18,11 @@
  */
 package org.apache.pulsar.client.schema;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
+import io.netty.buffer.Unpooled;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -28,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.schema.ByteBufSchema;
 import org.apache.pulsar.client.impl.schema.ByteBufferSchema;
 import org.apache.pulsar.client.impl.schema.ByteSchema;
 import org.apache.pulsar.client.impl.schema.BytesSchema;
@@ -55,8 +58,9 @@ public class PrimitiveSchemaTest {
             put(LongSchema.of(), Arrays.asList(922337203685477580L, -922337203685477581L));
             put(FloatSchema.of(), Arrays.asList(5678567.12312f, -5678567.12341f));
             put(DoubleSchema.of(), Arrays.asList(5678567.12312d, -5678567.12341d));
-            put(BytesSchema.of(), Arrays.asList("my string".getBytes()));
-            put(ByteBufferSchema.of(), Arrays.asList(ByteBuffer.allocate(10).put("my string".getBytes())));
+            put(BytesSchema.of(), Arrays.asList("my string".getBytes(UTF_8)));
+            put(ByteBufferSchema.of(), Arrays.asList(ByteBuffer.allocate(10).put("my string".getBytes(UTF_8))));
+            put(ByteBufSchema.of(), Arrays.asList(Unpooled.wrappedBuffer("my string".getBytes(UTF_8))));
         }
     };
 
@@ -94,8 +98,8 @@ public class PrimitiveSchemaTest {
         assertEquals(SchemaType.DOUBLE, DoubleSchema.of().getSchemaInfo().getType());
         assertEquals(SchemaType.STRING, StringSchema.utf8().getSchemaInfo().getType());
         assertEquals(SchemaType.BYTES, BytesSchema.of().getSchemaInfo().getType());
-        assertEquals(SchemaType.BYTEBUFFER, ByteBufferSchema.of().getSchemaInfo().getType());
-
+        assertEquals(SchemaType.BYTES, ByteBufferSchema.of().getSchemaInfo().getType());
+        assertEquals(SchemaType.BYTES, ByteBufSchema.of().getSchemaInfo().getType());
     }
 
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/schema/SchemaType.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/schema/SchemaType.java
@@ -68,11 +68,6 @@ public enum SchemaType {
     BYTES,
 
     /**
-     * A bytebuffer.
-     */
-    BYTEBUFFER,
-
-    /**
      * JSON object encoding and validation
      */
     JSON,

--- a/tests/scripts/pre-integ-tests.sh
+++ b/tests/scripts/pre-integ-tests.sh
@@ -24,7 +24,7 @@ ulimit -a
 pwd
 df -h
 ps -eo euser,pid,ppid,pgid,start,pcpu,pmem,cmd
-docker network prune -f --filter name=pulsarnet_*
+docker system prune -f
 docker system events > docker.debug-info & echo $! > docker-log.pid
 docker pull apachepulsar/s3mock:latest
 docker pull alpine/socat:latest


### PR DESCRIPTION
*Motivation*

ByteBuffer is a variant of `bytes`. so it should be `SchemaType.BYTES`, not `SchemaType.BYTEBUFFER`

*Changes*

- Fix bytebuffer schema type
- Add bytebuf schema
